### PR TITLE
[Spec 0010] Add annotation editor for inline file editing

### DIFF
--- a/codev/templates/annotate.html
+++ b/codev/templates/annotate.html
@@ -497,7 +497,7 @@
 
     // ==================== Edit Mode Functions ====================
 
-    function toggleEditMode() {
+    async function toggleEditMode() {
       const viewMode = document.getElementById('viewMode');
       const editor = document.getElementById('editor');
       const editBtn = document.getElementById('editBtn');
@@ -510,7 +510,8 @@
         const scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
 
         currentContent = fileLines.join('\n');
-        originalContent = currentContent;
+        // Note: originalContent is set only in init() and after successful saves
+        // to ensure Cancel always reverts to the true disk state
         editor.value = currentContent;
         viewMode.style.display = 'none';
         editor.style.display = 'block';
@@ -523,9 +524,14 @@
         editor.scrollTop = scrollTop;
         editor.focus();
       } else {
-        // Exit to view mode (apply changes to fileLines)
+        // Exit to view mode - auto-save changes per spec
         // Capture scroll position from editor
         const scrollTop = editor.scrollTop;
+
+        // Auto-save if there are changes (spec requires: "Edit text, click View → changes saved")
+        if (hasUnsavedChanges) {
+          await saveEdit();
+        }
 
         currentContent = editor.value;
         fileLines = currentContent.split('\n');


### PR DESCRIPTION
## Summary

- Adds edit mode to the annotation viewer allowing users to make quick edits without switching editors
- Implements textarea swap approach (recommended in spec) for simplicity and reliability
- Includes all UX considerations: scroll sync, tab handling, unsaved indicators, keyboard shortcuts

## Changes

- **Edit button**: Toggles between view and edit modes
- **Save button**: Saves content via `/save` endpoint with success/error notifications  
- **Cancel button**: Reverts changes and returns to view mode
- **Unsaved indicator**: Yellow dot shows when changes haven't been saved
- **Keyboard shortcuts**: Cmd/Ctrl+S to save
- **Tab handling**: Tab key inserts 2 spaces instead of changing focus
- **Scroll sync**: Maintains scroll position when switching modes
- **beforeunload**: Browser warns before closing with unsaved changes

## Test Plan

- [ ] Click Edit - textarea appears, code hides
- [ ] Click View (in edit mode) - code appears with changes, textarea hides
- [ ] Type in textarea - unsaved indicator appears
- [ ] Click Save - file saved, indicator clears, notification shows
- [ ] Click Cancel - reverts to original, exits edit mode
- [ ] Press Cmd+S - saves file
- [ ] Close tab with unsaved changes - browser warns
- [ ] Tab key inserts spaces, not focus change
- [ ] Scroll position preserved between mode switches

## Related

- Spec: `codev/specs/0010-annotation-editor.md`