### PR TITLE
fix(dashboard): Auto-close shell tabs when process exits

### DIFF
--- a/agent-farm/src/servers/dashboard-server.ts
+++ b/agent-farm/src/servers/dashboard-server.ts
@@ -59,6 +59,10 @@ function loadState(): DashboardState {
     if (fs.existsSync(stateFile)) {
       const state = JSON.parse(fs.readFileSync(stateFile, 'utf-8')) as DashboardState;
 
+      // Defensively normalize arrays before filtering (handles upgrade/corruption)
+      state.utils = Array.isArray(state.utils) ? state.utils : [];
+      state.annotations = Array.isArray(state.annotations) ? state.annotations : [];
+
       // Clean up dead shell processes (auto-close tabs when shell exits normally)
       const originalUtilCount = state.utils.length;
       state.utils = state.utils.filter((util) => {


### PR DESCRIPTION
## Summary
- Shell tabs now automatically close when the process exits (e.g., user types `exit`)
- No more "Press Enter to Reconnect" prompt for normally terminated shells
- Dashboard detects dead processes during state polling and removes them

## Test plan
- [ ] Start agent-farm dashboard
- [ ] Open a new shell tab
- [ ] Type `exit` in the shell
- [ ] Verify the tab disappears automatically within ~1 second
- [ ] Verify no "Press Enter to Reconnect" message is shown