### PR TITLE
[Spec 0011] Multi-Instance Support

### DIFF
--- a/agent-farm/src/servers/dashboard-server.ts
+++ b/agent-farm/src/servers/dashboard-server.ts
@@ -47,6 +47,29 @@ function findProjectRoot(): string {
   return process.cwd();
 }
 
+// Get project name from root path, with truncation for long names
+function getProjectName(projectRoot: string): string {
+  const baseName = path.basename(projectRoot);
+  const maxLength = 30;
+
+  if (baseName.length <= maxLength) {
+    return baseName;
+  }
+
+  // Truncate with ellipsis for very long names
+  return '...' + baseName.slice(-(maxLength - 3));
+}
+
+// HTML-escape a string to prevent XSS
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 // Find template (in codev/templates/)
 const projectRoot = findProjectRoot();
 const templatePath = path.join(projectRoot, 'codev/templates/dashboard-split.html');
@@ -890,6 +913,10 @@ const server = http.createServer(async (req, res) => {
       try {
         let template = fs.readFileSync(finalTemplatePath, 'utf-8');
         const state = loadState();
+
+        // Inject project name into template (HTML-escaped for security)
+        const projectName = escapeHtml(getProjectName(projectRoot));
+        template = template.replace(/\{\{PROJECT_NAME\}\}/g, projectName);
 
         // Inject state into template
         const stateJson = JSON.stringify(state);

--- a/codev-skeleton/templates/dashboard-split.html
+++ b/codev-skeleton/templates/dashboard-split.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Agent Farm Dashboard</title>
+  <title>Agent Farm - {{PROJECT_NAME}}</title>
   <style>
     * {
       box-sizing: border-box;
@@ -483,7 +483,7 @@
 </head>
 <body>
   <header class="header">
-    <h1>Agent Farm Dashboard</h1>
+    <h1>Agent Farm - {{PROJECT_NAME}}</h1>
     <div class="header-actions">
       <button class="btn" onclick="refresh()">Refresh</button>
       <button class="btn btn-danger" onclick="stopAll()">Stop All</button>

--- a/codev-skeleton/templates/dashboard.html
+++ b/codev-skeleton/templates/dashboard.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Architect Dashboard</title>
+  <title>Agent Farm - {{PROJECT_NAME}}</title>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; padding: 20px; background: #1a1a1a; color: #fff; }
@@ -53,7 +53,7 @@
 </head>
 <body>
   <button class="refresh-btn" onclick="location.reload()">Refresh</button>
-  <h1>Architect Dashboard</h1>
+  <h1>Agent Farm - {{PROJECT_NAME}}</h1>
 
   <div class="layout" id="layout">
     <!-- Content inserted by JavaScript -->

--- a/codev/plans/0011-multi-instance-support.md
+++ b/codev/plans/0011-multi-instance-support.md
@@ -1,0 +1,89 @@
+# Plan: Multi-Instance Support
+
+## Metadata
+- **Spec**: codev/specs/0011-multi-instance-support.md
+- **Protocol**: TICK
+- **Created**: 2025-12-04
+
+## Implementation Overview
+
+This is a simple UX improvement to show the project directory name in the dashboard title, making it easier to distinguish between multiple agent-farm instances running in different browser tabs.
+
+## Implementation Steps
+
+### Step 1: Update Dashboard HTML Template
+
+**File**: `codev/templates/dashboard-split.html`
+
+1. Change the `<title>` tag to include a placeholder:
+   ```html
+   <title>Agent Farm - {{PROJECT_NAME}}</title>
+   ```
+
+2. Change the `<h1>` tag in the header to include the same placeholder:
+   ```html
+   <h1>Agent Farm - {{PROJECT_NAME}}</h1>
+   ```
+
+### Step 2: Update Dashboard Server
+
+**File**: `agent-farm/src/servers/dashboard-server.ts`
+
+1. Get the project name from the project root path:
+   ```typescript
+   const projectName = path.basename(projectRoot);
+   ```
+
+2. Add template substitution for the project name when serving the dashboard (around line 896):
+   ```typescript
+   // Inject project name into template
+   template = template.replace(/\{\{PROJECT_NAME\}\}/g, projectName);
+   ```
+
+3. Handle long path truncation as recommended by experts:
+   - If project name is very long, truncate with ellipsis
+   - Example: A 50+ character name becomes "...project-name"
+
+### Step 3: Update codev-skeleton Template
+
+**File**: `codev-skeleton/templates/dashboard-split.html`
+
+Same changes as Step 1 - this is the template used when codev is installed in other projects.
+
+### Step 4: Update Legacy Dashboard Template (if exists)
+
+**File**: `codev/templates/dashboard.html` (if it exists and is still used)
+
+Same changes as Step 1 for backwards compatibility with any remaining references.
+
+## Testing
+
+1. Start dashboard: `./codev/bin/agent-farm start`
+2. Open browser to dashboard URL
+3. Verify:
+   - Browser tab shows "Agent Farm - codev" (or current directory name)
+   - Page header shows "Agent Farm - codev"
+4. Stop dashboard
+
+## Files Modified
+
+1. `codev/templates/dashboard-split.html` - Add PROJECT_NAME placeholder
+2. `codev/templates/dashboard.html` - Add PROJECT_NAME placeholder (legacy)
+3. `codev-skeleton/templates/dashboard-split.html` - Add PROJECT_NAME placeholder
+4. `codev-skeleton/templates/dashboard.html` - Add PROJECT_NAME placeholder (legacy)
+5. `agent-farm/src/servers/dashboard-server.ts` - Inject project name
+
+## Estimated Effort
+
+- Template changes: ~5 minutes
+- Server changes: ~10 minutes
+- Testing: ~5 minutes
+- Total: ~20 minutes
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Long project names break layout | Truncate to reasonable length (30 chars) |
+| Special characters in directory name | HTML escape the project name |
+| Template placeholder conflicts | Use distinctive placeholder format `{{PROJECT_NAME}}` |

--- a/codev/templates/dashboard-split.html
+++ b/codev/templates/dashboard-split.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Agent Farm Dashboard</title>
+  <title>Agent Farm - {{PROJECT_NAME}}</title>
   <style>
     * {
       box-sizing: border-box;
@@ -483,7 +483,7 @@
 </head>
 <body>
   <header class="header">
-    <h1>Agent Farm Dashboard</h1>
+    <h1>Agent Farm - {{PROJECT_NAME}}</h1>
     <div class="header-actions">
       <button class="btn" onclick="refresh()">Refresh</button>
       <button class="btn btn-danger" onclick="stopAll()">Stop All</button>

--- a/codev/templates/dashboard.html
+++ b/codev/templates/dashboard.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Architect Dashboard</title>
+  <title>Agent Farm - {{PROJECT_NAME}}</title>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; padding: 20px; background: #1a1a1a; color: #fff; }
@@ -53,7 +53,7 @@
 </head>
 <body>
   <button class="refresh-btn" onclick="location.reload()">Refresh</button>
-  <h1>Architect Dashboard</h1>
+  <h1>Agent Farm - {{PROJECT_NAME}}</h1>
 
   <div class="layout" id="layout">
     <!-- Content inserted by JavaScript -->


### PR DESCRIPTION
## Summary

- Dashboard title now shows project directory name for easy identification when running multiple instances
- Browser tabs show "Agent Farm - [project-name]" instead of generic "Agent Farm Dashboard"
- Long directory names (>30 chars) are truncated with ellipsis for clean display

## Changes

- Updated `codev/templates/dashboard-split.html` with `{{PROJECT_NAME}}` placeholder
- Updated `codev/templates/dashboard.html` (legacy) with same placeholder
- Updated `codev-skeleton/templates/` versions for new installations
- Added `getProjectName()` helper with truncation logic
- Added `escapeHtml()` helper for XSS prevention
- Server injects project name when serving dashboard HTML

## Test plan

- [ ] Start dashboard in project directory
- [ ] Verify browser tab shows "Agent Farm - [directory-name]"
- [ ] Verify page header shows same
- [ ] Test with very long directory name (>30 chars) to verify truncation