### PR TITLE
feat(consult): Add Claude support to consult tool

### DIFF
--- a/codev/bin/consult
+++ b/codev/bin/consult
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Consult tool - wrapper for gemini-cli and codex CLI.
+"""Consult tool - wrapper for gemini-cli, codex CLI, and claude CLI.
 
 Provides a unified interface for single-agent consultation via external AI CLIs.
 Each invocation is stateless (fresh process).
@@ -7,8 +7,10 @@ Each invocation is stateless (fresh process).
 Usage:
     consult gemini "Review this design"
     consult codex "What do you think of this API?"
+    consult claude "Review this implementation"
     consult pro "Review this"         # alias for gemini
     consult gpt "Review this"         # alias for codex
+    consult opus "Review this"        # alias for claude
     echo "Review this" | consult pro
 
 For parallel consultation, run multiple consult commands in separate shells.
@@ -33,6 +35,7 @@ except ImportError:
 MODEL_MAP = {
     "pro": "gemini",
     "gpt": "codex",
+    "opus": "claude",
 }
 
 
@@ -99,7 +102,7 @@ def log_query(log_dir: Path, model: str, query: str, duration_secs: float | None
 
 def consult(
     model: str = typer.Argument(
-        ..., help="Model: gemini, codex (or aliases: pro, gpt)"
+        ..., help="Model: gemini, codex, claude (or aliases: pro, gpt, opus)"
     ),
     query: str = typer.Argument(
         None, help="Query (or pipe via stdin)"
@@ -113,7 +116,9 @@ def consult(
     Examples:
         consult gemini "Review this architecture"
         consult codex "What's wrong with this code?"
+        consult claude "Review this design"
         consult pro "Review this"   # alias for gemini
+        consult opus "Review this"  # alias for claude
         echo "Review this" | consult gpt
     """
     # Lazy load paths
@@ -174,10 +179,22 @@ def consult(
             raise typer.Exit(1)
         cmd = ["codex", "exec", "--full-auto", query]
         env = {"CODEX_SYSTEM_MESSAGE": role}
+    elif resolved == "claude":
+        if not shutil.which("claude"):
+            typer.echo(
+                "Error: claude not found.\n"
+                "Install: npm install -g @anthropic-ai/claude-code",
+                err=True,
+            )
+            raise typer.Exit(1)
+        # Claude Code: prepend role to query, use prompt mode with permission skip
+        full_query = f"{role}\n\n---\n\nConsultation Request:\n{query}"
+        cmd = ["claude", "--print", "-p", full_query, "--dangerously-skip-permissions"]
+        env = {}
     else:
         typer.echo(
             f"Unknown model: {model}\n"
-            f"Available: gemini, codex (aliases: pro, gpt)",
+            f"Available: gemini, codex, claude (aliases: pro, gpt, opus)",
             err=True,
         )
         raise typer.Exit(1)


### PR DESCRIPTION
## Summary

- Adds `claude` and `opus` as model options in the consult tool
- Enables 3-way parallel consultations (Gemini + Codex + Claude)
- Uses `claude --print -p <query> --dangerously-skip-permissions` for autonomous mode
- Role is prepended to query (Claude CLI has no system prompt flag)

## Changes

- `codev/bin/consult`: Added claude handler with opus alias
- `CLAUDE.md` / `AGENTS.md`: Updated documentation with:
  - Prerequisites (Claude CLI install)
  - Usage examples
  - Parallel consultation patterns
  - Model aliases table
  - Performance characteristics
  - How It Works section

## Test plan

- [x] Dry-run test: `./codev/bin/consult claude "test" --dry-run`
- [x] Reviewed by Gemini Pro: "implementation is solid and documentation is comprehensive"
- [x] Reviewed by GPT-5 Codex: Concerns about system prompt and model pinning addressed in docs