### PR TITLE
fix: Use pbcopy for clipboard in tmux terminals (fixes #42)

### DIFF
--- a/agent-farm/src/commands/spawn.ts
+++ b/agent-farm/src/commands/spawn.ts
@@ -243,6 +243,12 @@ async function startBuilderSession(
 
   // Enable mouse scrolling in tmux
   await run('tmux set -g mouse on');
+  await run('tmux set -g set-clipboard on');
+  await run('tmux set -g allow-passthrough on');
+
+  // Copy selection to clipboard when mouse is released (pbcopy for macOS)
+  await run('tmux bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"');
+  await run('tmux bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"');
 
   // Start ttyd connecting to the tmux session
   logger.info('Starting builder terminal...');
@@ -290,6 +296,12 @@ async function startShellSession(
 
   // Enable mouse scrolling in tmux
   await run('tmux set -g mouse on');
+  await run('tmux set -g set-clipboard on');
+  await run('tmux set -g allow-passthrough on');
+
+  // Copy selection to clipboard when mouse is released (pbcopy for macOS)
+  await run('tmux bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"');
+  await run('tmux bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"');
 
   // Start ttyd
   logger.info('Starting shell terminal...');
@@ -605,6 +617,12 @@ async function spawnWorktree(options: SpawnOptions, config: Config): Promise<voi
 
   // Enable mouse scrolling in tmux
   await run('tmux set -g mouse on');
+  await run('tmux set -g set-clipboard on');
+  await run('tmux set -g allow-passthrough on');
+
+  // Copy selection to clipboard when mouse is released (pbcopy for macOS)
+  await run('tmux bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"');
+  await run('tmux bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"');
 
   // Start ttyd
   logger.info('Starting worktree terminal...');

--- a/agent-farm/src/commands/start.ts
+++ b/agent-farm/src/commands/start.ts
@@ -110,6 +110,12 @@ export async function start(options: StartOptions = {}): Promise<void> {
   // Create tmux session with the command
   await run(`tmux new-session -d -s ${sessionName} -x 200 -y 50 '${cmd}'`, { cwd: config.projectRoot });
   await run(`tmux set-option -t ${sessionName} -g mouse on`);
+  await run(`tmux set-option -t ${sessionName} -g set-clipboard on`);
+  await run(`tmux set-option -t ${sessionName} -g allow-passthrough on`);
+
+  // Copy selection to clipboard when mouse is released (pbcopy for macOS)
+  await run(`tmux bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"`);
+  await run(`tmux bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"`);
 
   // Start ttyd attached to the tmux session
   // Use custom index.html for file path click-to-open functionality (optional)

--- a/agent-farm/templates/dashboard-split.html
+++ b/agent-farm/templates/dashboard-split.html
@@ -561,7 +561,7 @@
         <div class="tabs-scroll" id="tabs-container"></div>
         <div class="add-buttons">
           <button class="add-btn" onclick="showFileDialog()" title="Open file">+ 📄</button>
-          <button class="add-btn" onclick="showBuilderDialog()" title="Spawn builder">+ 🔨</button>
+          <button class="add-btn" onclick="spawnBuilder()" title="Spawn worktree builder">+ 🔨</button>
           <button class="add-btn" onclick="spawnShell()" title="New shell">+ >_</button>
         </div>
       </div>
@@ -598,18 +598,6 @@
       <div class="dialog-actions">
         <button class="btn" onclick="hideFileDialog()">Cancel</button>
         <button class="btn" onclick="openFile()">Open</button>
-      </div>
-    </div>
-  </div>
-
-  <!-- Builder dialog -->
-  <div class="dialog-overlay hidden" id="builder-dialog">
-    <div class="dialog">
-      <h3>Spawn Builder</h3>
-      <input type="text" id="project-id-input" placeholder="Enter project ID (e.g., 0003)..." />
-      <div class="dialog-actions">
-        <button class="btn" onclick="hideBuilderDialog()">Cancel</button>
-        <button class="btn" onclick="spawnBuilder()">Spawn</button>
       </div>
     </div>
   </div>
@@ -1100,35 +1088,32 @@
       }
     }
 
-    // Builder dialog
-    function showBuilderDialog() {
-      document.getElementById('builder-dialog').classList.remove('hidden');
-      document.getElementById('project-id-input').focus();
-    }
-
-    function hideBuilderDialog() {
-      document.getElementById('builder-dialog').classList.add('hidden');
-      document.getElementById('project-id-input').value = '';
-    }
-
+    // Spawn worktree builder (no dialog - spawns with random ID)
     async function spawnBuilder() {
-      const projectId = document.getElementById('project-id-input').value.trim();
-      if (!projectId) return;
-
       try {
         const response = await fetch('/api/tabs/builder', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ projectId })
+          body: JSON.stringify({})
         });
 
         if (!response.ok) {
           throw new Error(await response.text());
         }
 
-        hideBuilderDialog();
-        await refresh();
-        showToast(`Builder ${projectId} spawned`, 'success');
+        const result = await response.json();
+
+        // Add to local tabs and select it
+        const newTab = {
+          id: `builder-${result.id}`,
+          type: 'builder',
+          name: result.name,
+          port: result.port
+        };
+        localTabs.push(newTab);
+        selectedTabId = newTab.id;
+        renderTabs();
+        showToast(`Builder ${result.name} spawned`, 'success');
       } catch (err) {
         showToast('Failed to spawn builder: ' + err.message, 'error');
       }


### PR DESCRIPTION
## Summary

- Fixed clipboard copy not working in dashboard terminals
- Root cause: OSC 52 clipboard sequences don't work reliably through ttyd -> xterm.js -> browser chain
- Solution: Use `copy-pipe-and-cancel pbcopy` instead of `copy-selection-and-cancel` in tmux bindings

## Changes

- `dashboard-server.ts`: Use pbcopy in MouseDragEnd bindings
- `start.ts`: Add clipboard settings and pbcopy bindings  
- `spawn.ts`: Add clipboard settings and pbcopy bindings (3 locations)

Also includes worktree builder improvements:
- Simplified builder spawn from dashboard (no dialog, random ID)
- Added spawnWorktreeBuilder function to dashboard-server

## Test plan

- [x] Verified selecting text in tmux terminal now copies to system clipboard
- [x] Plain ttyd (without tmux) still works
- [x] TypeScript builds without errors

Resolves #42