### PR TITLE
style: Shorten browser tab titles

### DIFF
--- a/agent-farm/templates/dashboard-split.html
+++ b/agent-farm/templates/dashboard-split.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Agent Farm - {{PROJECT_NAME}}</title>
+  <title>AF: {{PROJECT_NAME}}</title>
   <style>
     * {
       box-sizing: border-box;

--- a/agent-farm/templates/dashboard.html
+++ b/agent-farm/templates/dashboard.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Agent Farm - {{PROJECT_NAME}}</title>
+  <title>AF: {{PROJECT_NAME}}</title>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; padding: 20px; background: #1a1a1a; color: #fff; }

--- a/agent-farm/templates/tower.html
+++ b/agent-farm/templates/tower.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Agent Farm Tower</title>
+  <title>AF Control Tower</title>
   <style>
     * {
       box-sizing: border-box;
@@ -558,7 +558,7 @@
   <header class="header">
     <h1>
       <span class="emoji">🗼</span>
-      Agent Farm Tower
+      Agent Farm Control Tower
     </h1>
     <div class="header-actions">
       <button class="btn" onclick="refresh()">Refresh</button>


### PR DESCRIPTION
## Summary

Shortened browser tab titles for better readability:

- Dashboard: `Agent Farm - projectname` → `AF: projectname`
- Tower: `Agent Farm Tower` → `AF Control Tower`
- Tower header: `Agent Farm Tower` → `Agent Farm Control Tower`

## Test plan

- [x] Refresh dashboard - tab shows "AF: codev"
- [x] Refresh tower - tab shows "AF Control Tower", header shows "Agent Farm Control Tower"