### PR TITLE
Rename 'af annotate' command to 'af open'

### DIFF
--- a/.claude/commands/af.md
+++ b/.claude/commands/af.md
@@ -14,7 +14,7 @@ af spawn -p 0003      # Spawn builder for spec 0003
 af cleanup -p 0003    # Clean up builder (safe)
 af cleanup -p 0003 -f # Force cleanup
 af util               # Open utility shell
-af annotate file.ts   # Annotate file for review
+af open file.ts       # Open file in annotation viewer
 af ports list         # List port allocations
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,8 +266,8 @@ The Architect-Builder pattern enables parallel AI-assisted development by separa
 # Open a utility shell
 ./codev/bin/agent-farm util
 
-# Annotate files with review comments
-./codev/bin/agent-farm annotate src/auth/login.ts
+# Open files in annotation viewer
+./codev/bin/agent-farm open src/auth/login.ts
 
 # Clean up a builder (checks for uncommitted work first)
 ./codev/bin/agent-farm cleanup --project 0003

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,8 +266,8 @@ The Architect-Builder pattern enables parallel AI-assisted development by separa
 # Open a utility shell
 ./codev/bin/agent-farm util
 
-# Annotate files with review comments
-./codev/bin/agent-farm annotate src/auth/login.ts
+# Open files in annotation viewer
+./codev/bin/agent-farm open src/auth/login.ts
 
 # Clean up a builder (checks for uncommitted work first)
 ./codev/bin/agent-farm cleanup --project 0003

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -431,8 +431,8 @@ Override via CLI:
 # Open a utility shell
 ./codev/bin/agent-farm util
 
-# Annotate a file for review
-./codev/bin/agent-farm annotate src/auth/login.ts
+# Open a file in annotation viewer
+./codev/bin/agent-farm open src/auth/login.ts
 
 # Clean up a builder (checks for uncommitted changes first)
 ./codev/bin/agent-farm cleanup --project 0003

--- a/agent-farm/src/commands/index.ts
+++ b/agent-farm/src/commands/index.ts
@@ -7,5 +7,5 @@ export { stop } from './stop.js';
 export { status } from './status.js';
 export { spawn } from './spawn.js';
 export { util } from './util.js';
-export { annotate } from './annotate.js';
+export { open } from './open.js';
 export { send } from './send.js';

--- a/agent-farm/src/commands/open.ts
+++ b/agent-farm/src/commands/open.ts
@@ -1,5 +1,5 @@
 /**
- * Annotate command - opens file annotation viewer
+ * Open command - opens file annotation viewer
  *
  * When the dashboard is running, this creates a tab in the dashboard.
  * When the dashboard is not running, it opens the annotation viewer directly.
@@ -13,7 +13,7 @@ import { logger, fatal } from '../utils/logger.js';
 import { spawnDetached, findAvailablePort, openBrowser } from '../utils/shell.js';
 import { addAnnotation, loadState } from '../state.js';
 
-interface AnnotateOptions {
+interface OpenOptions {
   file: string;
 }
 
@@ -60,7 +60,7 @@ async function tryDashboardApi(filePath: string): Promise<boolean> {
 /**
  * Open file annotation viewer
  */
-export async function annotate(options: AnnotateOptions): Promise<void> {
+export async function open(options: OpenOptions): Promise<void> {
   const config = getConfig();
 
   // Resolve file path relative to current directory (works correctly in worktrees)

--- a/agent-farm/src/index.ts
+++ b/agent-farm/src/index.ts
@@ -154,14 +154,14 @@ program
     }
   });
 
-// Annotate command (placeholder)
+// Open command - opens file annotation viewer
 program
-  .command('annotate <file>')
+  .command('open <file>')
   .description('Open file annotation viewer')
   .action(async (file) => {
-    const { annotate } = await import('./commands/annotate.js');
+    const { open } = await import('./commands/open.js');
     try {
-      await annotate({ file });
+      await open({ file });
     } catch (error) {
       logger.error(error instanceof Error ? error.message : String(error));
       process.exit(1);

--- a/agent-farm/src/tutorial/steps/implementation.ts
+++ b/agent-farm/src/tutorial/steps/implementation.ts
@@ -55,7 +55,7 @@ af spawn --task "Fix the login validation"`);
     prompts.step(2, 'af spawn -p X  - Spawn a builder for spec X');
     prompts.step(3, 'af status      - Check status of all agents');
     prompts.step(4, 'af send X      - Send instructions to a builder');
-    prompts.step(5, 'af annotate F  - Open file F in annotation viewer');
+    prompts.step(5, 'af open F      - Open file F in annotation viewer');
     prompts.step(6, 'af stop        - Stop all agent farm processes');
     console.log();
 

--- a/agent-farm/src/tutorial/steps/review.ts
+++ b/agent-farm/src/tutorial/steps/review.ts
@@ -25,7 +25,7 @@ export const reviewStep: Step = {
     prompts.content('The Annotation Viewer\n');
     prompts.content('Agent Farm includes an annotation viewer for reviewing code:\n');
     prompts.code(`# Open a file for annotation
-af annotate src/path/to/file.ts
+af open src/path/to/file.ts
 
 # This opens a web viewer where you can:
 # - See the code with syntax highlighting
@@ -60,7 +60,7 @@ af annotate src/path/to/file.ts
 af start              # Start architect dashboard
 af spawn -p 0001      # Spawn builder for spec
 af status             # Check agent status
-af annotate <file>    # Open annotation viewer
+af open <file>        # Open annotation viewer
 af tutorial --status  # Check tutorial progress
 af tutorial --reset   # Reset tutorial
 

--- a/agent-farm/templates/dashboard.html
+++ b/agent-farm/templates/dashboard.html
@@ -63,7 +63,7 @@
     <strong>Commands:</strong>
     <code>architect start</code> ·
     <code>architect spawn --project XXXX</code> ·
-    <code>architect annotate XXXX FILE</code> ·
+    <code>architect open XXXX FILE</code> ·
     <code>architect stop</code>
   </div>
 

--- a/codev-skeleton/roles/architect.md
+++ b/codev-skeleton/roles/architect.md
@@ -172,7 +172,7 @@ af cleanup -p 0003 --force    # Force cleanup (lose uncommitted work)
 
 # Utilities
 af util                       # Open a utility shell terminal
-af annotate src/file.ts       # Open file annotation viewer
+af open src/file.ts           # Open file annotation viewer
 
 # Port management (for multi-project support)
 af ports list                 # List port allocations

--- a/codev/resources/agent-farm.md
+++ b/codev/resources/agent-farm.md
@@ -97,7 +97,7 @@ af cleanup -p 0003 --force      # Force cleanup (lose uncommitted work)
 
 ```bash
 af util                         # Open a utility shell terminal
-af annotate src/file.ts         # Open file annotation viewer
+af open src/file.ts             # Open file annotation viewer
 af rename 0013 "auth-builder"   # Rename a builder or utility
 ```
 

--- a/codev/resources/arch.md
+++ b/codev/resources/arch.md
@@ -102,7 +102,7 @@ codev/                                  # Project root (git repository)
 │   │   │   ├── status.ts               # Show status
 │   │   │   ├── cleanup.ts              # Clean up builder
 │   │   │   ├── util.ts                 # Utility shell
-│   │   │   └── annotate.ts             # File annotation
+│   │   │   └── open.ts                 # File annotation viewer
 │   │   ├── utils/                      # Utilities
 │   │   │   ├── config.ts               # Configuration management
 │   │   │   ├── port-registry.ts        # Global port allocation
@@ -387,7 +387,7 @@ af cleanup -p 0003 --force    # Force cleanup (lose uncommitted work)
 # Utilities
 af util                       # Open a utility shell terminal
 af shell                      # Alias for util
-af annotate src/file.ts       # Open file annotation viewer
+af open src/file.ts           # Open file annotation viewer
 
 # Port management (multi-project support)
 af ports list                 # List port allocations
@@ -1342,7 +1342,7 @@ The architect-builder system was consolidated to eliminate brittleness from trip
 #### Agent-Farm TypeScript CLI
 - **Single canonical implementation** in `agent-farm/src/`
 - **Thin bash wrappers** at `codev/bin/agent-farm` and `codev-skeleton/bin/agent-farm`
-- **CLI commands**: start, stop, status, spawn, util, annotate, cleanup, ports
+- **CLI commands**: start, stop, status, spawn, util, open, cleanup, ports
 - **Alias recommended**: `alias af='./codev/bin/agent-farm'`
 
 #### Global Port Registry

--- a/codev/roles/architect.md
+++ b/codev/roles/architect.md
@@ -14,7 +14,7 @@ The `af` command orchestrates builders, manages worktrees, and coordinates devel
 - `af send` - Send short messages to builders
 - `af cleanup` - Remove completed builders
 - `af status` - Check builder status
-- `af annotate <file>` - Open file for human review
+- `af open <file>` - Open file for human review
 
 **Full reference:** See [codev/resources/agent-farm.md](../resources/agent-farm.md)
 
@@ -157,7 +157,7 @@ The Architect uses SPIDER or TICK protocols. The Architect is responsible for th
 5. Address concerns raised by the reviewers
 6. **Present to human** for final review:
    ```bash
-   af annotate codev/specs/0034-feature-name.md
+   af open codev/specs/0034-feature-name.md
    ```
 
 ### Phase 2: Plan (Architect)
@@ -173,7 +173,7 @@ The Architect uses SPIDER or TICK protocols. The Architect is responsible for th
 5. Address concerns raised by the reviewers
 6. **Present to human** for final review:
    ```bash
-   af annotate codev/plans/0034-feature-name.md
+   af open codev/plans/0034-feature-name.md
    ```
 
 ### Phases 3-6: IDER (Builder)

--- a/codev/roles/builder.md
+++ b/codev/roles/builder.md
@@ -4,11 +4,11 @@ A Builder is a focused implementation agent that works on a single spec in an is
 
 ## Output Formatting
 
-When referencing files, use standard file paths or open them directly with `af annotate`:
+When referencing files, use standard file paths or open them directly with `af open`:
 
 ```bash
 # Open a file for review in the dashboard
-af annotate src/lib/auth.ts
+af open src/lib/auth.ts
 
 # Check your status
 af status


### PR DESCRIPTION
## Summary

- Renames the `af annotate` command to `af open` for better clarity
- Updates all code and documentation references across the codebase
- Command functionality remains identical - only the name changed

## Changes

**Code:**
- Renamed `agent-farm/src/commands/annotate.ts` → `open.ts`
- Updated function from `annotate()` to `open()` 
- Updated CLI registration and exports

**Documentation (15 files):**
- CLAUDE.md, AGENTS.md, INSTALL.md
- codev/roles/architect.md, codev/roles/builder.md
- codev-skeleton/roles/architect.md
- codev/resources/arch.md, codev/resources/agent-farm.md
- .claude/commands/af.md
- agent-farm/templates/dashboard.html
- Tutorial steps (implementation.ts, review.ts)

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 107 tests pass (`npm test`)
- [x] `af open --help` shows correct command
- [x] Old `annotate` command no longer exists in CLI