### PR TITLE
[Spec 0041] E2E Test Suite for @cluesmith/codev

### DIFF
--- a/codev/plans/0041-e2e-test-suite.md
+++ b/codev/plans/0041-e2e-test-suite.md
@@ -1,0 +1,233 @@
+# Plan: E2E Test Suite for @cluesmith/codev
+
+## Metadata
+- **Spec**: [0041-e2e-test-suite.md](../specs/0041-e2e-test-suite.md)
+- **Status**: draft
+- **Created**: 2025-12-08
+- **Protocol**: SPIDER
+
+## Overview
+
+Implement BATS-based end-to-end tests that verify the `@cluesmith/codev` npm package works correctly after installation. Tests run against a local tarball (for PRs) or published package (post-release).
+
+## Phase 1: Test Infrastructure Setup
+
+**Goal**: Create test directory structure and common setup
+
+### Tasks
+
+- [ ] Create `tests/e2e/` directory
+- [ ] Create `tests/e2e/helpers.bash` with e2e-specific helpers:
+  - `install_codev()` - npm init + npm install $E2E_TARBALL
+  - `run_codev()` - wrapper for ./node_modules/.bin/codev
+  - `run_af()` - wrapper for ./node_modules/.bin/af
+- [ ] Create `tests/e2e/setup_suite.bash`:
+  - Verify E2E_TARBALL env var is set
+  - Validate tarball exists
+- [ ] Create common `setup()` function with XDG sandboxing:
+  - Isolated HOME, XDG_CONFIG_HOME, XDG_DATA_HOME, XDG_CACHE_HOME
+  - Isolated npm_config_prefix, npm_config_cache
+- [ ] Create common `teardown()` function to cleanup TEST_DIR
+
+### Exit Criteria
+- `bats tests/e2e/` runs (even with no tests) without error
+- XDG sandboxing verified (test doesn't touch real $HOME)
+
+## Phase 2: Installation Tests (TC-001)
+
+**Goal**: Verify package installs correctly and binaries are available
+
+### Tasks
+
+- [ ] Create `tests/e2e/install.bats`
+- [ ] Implement tests:
+  - `npm install from tarball creates binaries`
+  - `codev --version returns expected version`
+  - `af --version returns expected version`
+  - `consult --help works`
+  - `codev unknown-command fails gracefully`
+
+### Exit Criteria
+- All installation tests pass
+- Version output matches package.json
+
+## Phase 3: codev init Tests (TC-002)
+
+**Goal**: Verify project initialization works correctly
+
+### Tasks
+
+- [ ] Create `tests/e2e/init.bats`
+- [ ] Implement tests:
+  - `codev init creates project structure`
+  - `codev init replaces PROJECT_NAME placeholder`
+  - `codev init fails if directory exists`
+  - `codev init --yes requires project name`
+  - `codev init creates .gitignore with correct entries`
+  - `codev init initializes git repository`
+
+### Exit Criteria
+- All init tests pass
+- Project structure matches expected layout
+
+## Phase 4: codev adopt Tests (TC-003)
+
+**Goal**: Verify adoption into existing projects works
+
+### Tasks
+
+- [ ] Create `tests/e2e/adopt.bats`
+- [ ] Implement tests:
+  - `codev adopt adds codev to existing project`
+  - `codev adopt preserves existing files`
+  - `codev adopt is idempotent`
+
+### Exit Criteria
+- Adoption tests pass
+- Existing files not modified
+
+## Phase 5: codev doctor Tests (TC-004)
+
+**Goal**: Verify dependency checking works
+
+### Tasks
+
+- [ ] Create `tests/e2e/doctor.bats`
+- [ ] Implement tests:
+  - `codev doctor checks core dependencies`
+  - `codev doctor handles missing optional deps gracefully`
+  - `codev doctor output includes expected entries`
+
+### Exit Criteria
+- Doctor tests pass on macOS and Linux
+
+## Phase 6: af command Tests (TC-005)
+
+**Goal**: Verify agent-farm CLI works
+
+### Tasks
+
+- [ ] Create `tests/e2e/af.bats`
+- [ ] Implement tests:
+  - `af --help shows available commands`
+  - `af status works without running dashboard`
+  - `af --version returns version`
+
+### Exit Criteria
+- af tests pass in clean environment
+
+## Phase 7: consult Tests (TC-006)
+
+**Goal**: Verify consult subcommand help works
+
+### Tasks
+
+- [ ] Create `tests/e2e/consult.bats`
+- [ ] Implement tests:
+  - `codev consult --help shows subcommands`
+  - `codev consult pr --help shows pr options`
+
+### Exit Criteria
+- Consult help tests pass
+
+## Phase 8: CI Workflow - PR Tests
+
+**Goal**: Run e2e tests on every PR against local tarball
+
+### Tasks
+
+- [ ] Create `.github/workflows/e2e.yml`
+- [ ] Configure matrix for ubuntu-latest and macos-latest
+- [ ] Install BATS on each platform
+- [ ] Build package and create tarball
+- [ ] Run tests with E2E_TARBALL env var
+- [ ] Add to repo's required checks (optional)
+
+### Exit Criteria
+- Workflow runs on PRs
+- Tests pass on both macOS and Linux
+
+## Phase 9: CI Workflow - Post-Release
+
+**Goal**: Verify published package after npm release
+
+### Tasks
+
+- [ ] Create `.github/workflows/post-release-e2e.yml`
+- [ ] Trigger on release published
+- [ ] Wait for npm propagation (120s)
+- [ ] Download published tarball via `npm pack @cluesmith/codev@version`
+- [ ] Run tests against downloaded tarball
+
+### Exit Criteria
+- Workflow triggers on releases
+- Tests verify published package
+
+## Phase 10: Documentation & Verification
+
+**Goal**: Document how to run tests and verify all works
+
+### Tasks
+
+- [ ] Add "E2E Tests" section to CLAUDE.md
+- [ ] Add npm script: `npm run e2e` in packages/codev/package.json
+- [ ] Verify tests pass locally on macOS
+- [ ] Verify CI workflow passes on a test PR
+
+### Exit Criteria
+- Documentation updated
+- Full test suite passes
+
+## Implementation Order
+
+```
+Phase 1 (Infrastructure) ──> Phase 2 (Install) ──> Phase 3 (Init) ──> Phase 4 (Adopt)
+                                    │                                        │
+                                    v                                        v
+                             Phase 5 (Doctor) ──> Phase 6 (af) ──> Phase 7 (Consult)
+                                                                            │
+                                                                            v
+                                                              Phase 8 (CI-PR) ──> Phase 9 (CI-Release)
+                                                                                        │
+                                                                                        v
+                                                                                 Phase 10 (Docs)
+```
+
+Phases 2-7 can be parallelized after Phase 1. Phases 8-9 can be done after any test phase.
+
+## Estimated Effort
+
+| Phase | Effort |
+|-------|--------|
+| Phase 1: Infrastructure | 30 min |
+| Phase 2: Install tests | 20 min |
+| Phase 3: Init tests | 20 min |
+| Phase 4: Adopt tests | 15 min |
+| Phase 5: Doctor tests | 15 min |
+| Phase 6: af tests | 15 min |
+| Phase 7: Consult tests | 10 min |
+| Phase 8: CI-PR workflow | 30 min |
+| Phase 9: CI-Release workflow | 20 min |
+| Phase 10: Documentation | 15 min |
+| **Total** | ~3 hours |
+
+## Testing Requirements
+
+- Run `bats tests/e2e/` locally before each commit
+- Verify on both macOS (dev machine) and Linux (Docker or CI)
+- Use `E2E_TARBALL` from fresh `npm pack` output
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| BATS version mismatch | Document required version, pin in CI |
+| npm pack creates different filename | Use glob pattern `cluesmith-codev-*.tgz` |
+| Tests interfere with each other | Strong isolation via setup()/teardown() |
+| CI caching issues | Don't cache npm in e2e tests |
+
+## Notes
+
+- All tests use `npm install` not `npx` (per user requirement)
+- XDG sandboxing pattern from spec 0001
+- Existing `tests/helpers/common.bash` provides assertion helpers

--- a/codev/projectlist.md
+++ b/codev/projectlist.md
@@ -126,7 +126,7 @@ Projects currently in development (conceived through committed), sorted by prior
   - id: "0039"
     title: "Codev CLI (First-Class Command)"
     summary: "Unified codev command as primary entry point: init, adopt, doctor, update, tower, consult"
-    status: implementing
+    status: committed
     priority: high
     release: null
     files:
@@ -755,9 +755,23 @@ Projects that are paused or canceled.
     tags: [cli, consultation, performance]
     notes: "TICK protocol. Pre-fetch PR diff/comments/specs to tmp files (6 commands vs 19+), extract verdict from output. 30% faster than current approach (138s vs 200s+)."
 
+  - id: "0041"
+    title: "E2E Test Suite"
+    summary: "Automated end-to-end tests for @cluesmith/codev npm package installation and CLI commands"
+    status: planned
+    priority: high
+    release: null
+    files:
+      spec: codev/specs/0041-e2e-test-suite.md
+      plan: codev/plans/0041-e2e-test-suite.md
+      review: null
+    dependencies: ["0039"]
+    tags: [testing, npm, ci]
+    notes: "SPIDER protocol. 3-way reviewed. BATS-based tests with XDG sandboxing, tarball testing before publish, CI for macOS+Linux."
+
 ## Next Available Number
 
-**0040** - Reserve this number for your next project
+**0042** - Reserve this number for your next project
 
 ---
 

--- a/codev/specs/0041-e2e-test-suite.md
+++ b/codev/specs/0041-e2e-test-suite.md
@@ -1,0 +1,467 @@
+# Specification: E2E Test Suite for @cluesmith/codev
+
+## Metadata
+- **ID**: 0041
+- **Title**: E2E Test Suite
+- **Status**: draft
+- **Created**: 2025-12-08
+- **Protocol**: SPIDER
+
+## Problem Statement
+
+The `@cluesmith/codev` npm package has 162 unit tests that test internal functions, but no automated end-to-end tests that verify the installed package works correctly from a user's perspective.
+
+**Current gaps:**
+1. No automated verification that the npm package installs correctly
+2. No tests that run CLI commands as users would (`npm install`, then run commands)
+3. No CI pipeline tests for the published package
+4. Manual verification required after each release
+
+**Risk:** A release could break the user experience even if all unit tests pass (e.g., bin paths misconfigured, templates missing from package, dependencies not bundled).
+
+## Goals
+
+1. Automated e2e tests that verify the npm package works after installation
+2. Tests run in isolated environments (XDG sandboxing, no pollution from dev environment)
+3. Tests cover critical user journeys AND error cases
+4. Run in CI **before** npm publish (test the tarball)
+5. Also run post-release to verify npm registry propagation
+6. Fast enough to run on every PR (<2 minutes)
+
+## Non-Goals
+
+- Testing the AI CLI integrations (gemini, codex, claude) - these require credentials
+- Testing the full agent-farm workflow with tmux sessions - too complex for e2e
+- Load testing or performance benchmarks
+- Testing upgrade paths between versions
+- Windows support (lower priority - most devs on macOS/Linux)
+
+## Proposed Solution
+
+### Use Existing BATS Framework
+
+Leverage the existing `tests/` BATS infrastructure instead of creating new raw shell scripts. This reuses:
+- `tests/helpers/common.bash` - assertion helpers (`assert_file_exists`, `assert_output_contains`, etc.)
+- XDG sandboxing patterns from spec 0001
+- Established test isolation approach
+
+**New test location:** `tests/e2e/` (alongside existing `tests/lib/`, `tests/install/`)
+
+```
+tests/
+├── helpers/
+│   └── common.bash          # Existing assertion helpers
+├── e2e/
+│   ├── setup_suite.bash     # One-time setup: npm pack, create tarball
+│   ├── install.bats         # TC-001: Package installation
+│   ├── init.bats            # TC-002: codev init
+│   ├── adopt.bats           # TC-003: codev adopt
+│   ├── doctor.bats          # TC-004: codev doctor
+│   ├── af.bats              # TC-005: af commands
+│   └── consult.bats         # TC-006: consult help
+├── install/                 # Existing installation tests
+└── lib/                     # Existing library tests
+```
+
+### Test Environment Isolation
+
+Following spec 0001 patterns for hermetic tests:
+
+```bash
+setup() {
+  # Create isolated test directory
+  TEST_DIR="$(mktemp -d)"
+
+  # XDG sandboxing - prevent touching real user config
+  export XDG_CONFIG_HOME="$TEST_DIR/.xdg/config"
+  export XDG_DATA_HOME="$TEST_DIR/.xdg/data"
+  export XDG_CACHE_HOME="$TEST_DIR/.xdg/cache"
+  export HOME="$TEST_DIR/home"
+  mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
+
+  # npm isolation
+  export npm_config_prefix="$TEST_DIR/.npm-global"
+  export npm_config_cache="$TEST_DIR/.npm-cache"
+  mkdir -p "$npm_config_prefix" "$npm_config_cache"
+
+  # Use pre-built tarball (set by setup_suite)
+  export E2E_TARBALL="${E2E_TARBALL:-}"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+```
+
+### Test Cases
+
+#### TC-001: Package Installation (install.bats)
+
+**Happy path:**
+```bash
+@test "npm install @cluesmith/codev from tarball" {
+  cd "$TEST_DIR"
+  npm init -y
+  npm install "$E2E_TARBALL"
+
+  # Verify binaries are installed
+  assert_file_exists "node_modules/.bin/codev"
+  assert_file_exists "node_modules/.bin/af"
+  assert_file_exists "node_modules/.bin/consult"
+}
+
+@test "codev --version returns expected version" {
+  cd "$TEST_DIR"
+  npm init -y
+  npm install "$E2E_TARBALL"
+
+  run ./node_modules/.bin/codev --version
+  assert_success
+  assert_output --partial "1.1.0"
+}
+
+@test "af --version returns expected version" {
+  # Similar pattern
+}
+```
+
+**Error cases:**
+```bash
+@test "codev fails gracefully with unknown command" {
+  cd "$TEST_DIR"
+  npm init -y
+  npm install "$E2E_TARBALL"
+
+  run ./node_modules/.bin/codev unknown-command
+  assert_failure
+  assert_output --partial "Unknown command"
+}
+```
+
+#### TC-002: codev init (init.bats)
+
+**Happy path:**
+```bash
+@test "codev init creates project structure" {
+  cd "$TEST_DIR"
+  npm init -y
+  npm install "$E2E_TARBALL"
+
+  run ./node_modules/.bin/codev init my-project --yes
+  assert_success
+
+  # Verify structure
+  assert_file_exists "my-project/codev/protocols/spider/protocol.md"
+  assert_file_exists "my-project/codev/roles/architect.md"
+  assert_file_exists "my-project/CLAUDE.md"
+  assert_file_exists "my-project/AGENTS.md"
+  assert_file_exists "my-project/.gitignore"
+
+  # Verify git initialized
+  assert_dir_exists "my-project/.git"
+}
+
+@test "codev init replaces PROJECT_NAME placeholder" {
+  cd "$TEST_DIR"
+  npm init -y
+  npm install "$E2E_TARBALL"
+
+  ./node_modules/.bin/codev init my-custom-project --yes
+
+  run cat my-custom-project/CLAUDE.md
+  assert_output --partial "my-custom-project"
+  refute_output --partial "{{PROJECT_NAME}}"
+}
+```
+
+**Error cases:**
+```bash
+@test "codev init fails if directory exists" {
+  cd "$TEST_DIR"
+  npm init -y
+  npm install "$E2E_TARBALL"
+  mkdir existing-dir
+
+  run ./node_modules/.bin/codev init existing-dir --yes
+  assert_failure
+  assert_output --partial "already exists"
+}
+
+@test "codev init --yes requires project name" {
+  cd "$TEST_DIR"
+  npm init -y
+  npm install "$E2E_TARBALL"
+
+  run ./node_modules/.bin/codev init --yes
+  assert_failure
+}
+```
+
+#### TC-003: codev adopt (adopt.bats)
+
+**Happy path:**
+```bash
+@test "codev adopt adds codev to existing project" {
+  cd "$TEST_DIR"
+  npm init -y
+  npm install "$E2E_TARBALL"
+
+  # Create existing project
+  mkdir existing-project
+  cd existing-project
+  echo "# My Project" > README.md
+  git init
+
+  run ../node_modules/.bin/codev adopt --yes
+  assert_success
+
+  # Verify codev added
+  assert_file_exists "codev/protocols/spider/protocol.md"
+  assert_file_exists "CLAUDE.md"
+
+  # Verify existing file preserved
+  run cat README.md
+  assert_output "# My Project"
+}
+```
+
+**Error cases:**
+```bash
+@test "codev adopt is idempotent" {
+  cd "$TEST_DIR"
+  npm init -y
+  npm install "$E2E_TARBALL"
+  mkdir project && cd project && git init
+
+  ../node_modules/.bin/codev adopt --yes
+  run ../node_modules/.bin/codev adopt --yes
+  # Should warn but not fail
+  assert_success
+}
+```
+
+#### TC-004: codev doctor (doctor.bats)
+
+```bash
+@test "codev doctor checks dependencies" {
+  cd "$TEST_DIR"
+  npm init -y
+  npm install "$E2E_TARBALL"
+
+  run ./node_modules/.bin/codev doctor
+  # May exit non-zero if deps missing, but should not crash
+  assert_output --partial "Node.js"
+  assert_output --partial "git"
+}
+
+@test "codev doctor handles missing optional deps gracefully" {
+  cd "$TEST_DIR"
+  npm init -y
+  npm install "$E2E_TARBALL"
+
+  # Remove tmux from PATH
+  PATH="/usr/bin" run ./node_modules/.bin/codev doctor
+  # Should still complete, just report missing
+  assert_output --partial "tmux"
+}
+```
+
+#### TC-005: af commands (af.bats)
+
+```bash
+@test "af --help shows available commands" {
+  cd "$TEST_DIR"
+  npm init -y
+  npm install "$E2E_TARBALL"
+
+  run ./node_modules/.bin/af --help
+  assert_success
+  assert_output --partial "start"
+  assert_output --partial "spawn"
+  assert_output --partial "status"
+}
+
+@test "af status works without running dashboard" {
+  cd "$TEST_DIR"
+  npm init -y
+  npm install "$E2E_TARBALL"
+  ./node_modules/.bin/codev init project --yes
+  cd project
+
+  run ../node_modules/.bin/af status
+  # Should report no builders, not crash
+  assert_success
+  assert_output --partial "Architect"
+}
+```
+
+#### TC-006: consult help (consult.bats)
+
+```bash
+@test "codev consult --help shows subcommands" {
+  cd "$TEST_DIR"
+  npm init -y
+  npm install "$E2E_TARBALL"
+
+  run ./node_modules/.bin/codev consult --help
+  assert_success
+  assert_output --partial "pr"
+  assert_output --partial "spec"
+  assert_output --partial "plan"
+  assert_output --partial "general"
+}
+```
+
+### CI Integration
+
+**Test tarball BEFORE publish** (PR workflow):
+
+```yaml
+# .github/workflows/e2e.yml
+name: E2E Tests
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install BATS
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            sudo apt-get update && sudo apt-get install -y bats
+          else
+            brew install bats-core
+          fi
+
+      - name: Build package
+        working-directory: packages/codev
+        run: |
+          npm install
+          npm run build
+
+      - name: Create tarball
+        working-directory: packages/codev
+        run: npm pack
+
+      - name: Run E2E tests
+        env:
+          E2E_TARBALL: ${{ github.workspace }}/packages/codev/cluesmith-codev-*.tgz
+        run: bats tests/e2e/
+```
+
+**Post-release verification** (release workflow):
+
+```yaml
+# .github/workflows/post-release-e2e.yml
+name: Post-Release E2E
+on:
+  release:
+    types: [published]
+
+jobs:
+  verify:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Wait for npm propagation
+        run: sleep 120
+
+      - name: Verify package available
+        run: |
+          npm view @cluesmith/codev@${{ github.event.release.tag_name }}
+
+      - name: Install BATS
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            sudo apt-get update && sudo apt-get install -y bats
+          else
+            brew install bats-core
+          fi
+
+      - name: Download published package
+        run: |
+          mkdir /tmp/e2e-verify
+          cd /tmp/e2e-verify
+          npm pack @cluesmith/codev@${{ github.event.release.tag_name }}
+          echo "E2E_TARBALL=$(ls *.tgz)" >> $GITHUB_ENV
+
+      - name: Run E2E tests
+        env:
+          E2E_TARBALL: /tmp/e2e-verify/${{ env.E2E_TARBALL }}
+        run: bats tests/e2e/
+```
+
+### Local Testing
+
+```bash
+# Build and test locally
+cd packages/codev
+npm run build
+npm pack
+E2E_TARBALL=$(pwd)/cluesmith-codev-*.tgz bats ../../tests/e2e/
+
+# Or run individual test file
+E2E_TARBALL=$(pwd)/cluesmith-codev-*.tgz bats ../../tests/e2e/init.bats
+```
+
+## Success Criteria
+
+1. All test cases pass on both macOS and Linux
+2. Tests complete in <2 minutes
+3. Tests can run against local tarball (PR workflow) or published package (post-release)
+4. XDG sandboxing prevents pollution of dev environment
+5. Clear error output when tests fail (BATS tap output)
+6. Error cases covered, not just happy paths
+
+## Implementation Notes
+
+- Reuse `tests/helpers/common.bash` assertion helpers
+- `setup_suite.bash` runs once to create tarball, `setup()` runs per test for isolation
+- Tests must be independent (can run in any order)
+- Use `npm install` not `npx` per user requirement - tests the actual install process
+
+## Consultation Summary
+
+**3-Way Review (2025-12-08):**
+- Gemini: Use existing BATS framework; test tarball before publish
+- Codex: Complete CI workflow; macOS coverage; XDG isolation; edge cases
+- Claude: Assertion helpers; negative test cases; test independence
+
+All feedback incorporated in this revision.
+
+## Dependencies
+
+- Depends on: 0039 (Codev CLI) - the package being tested
+- Depends on: 0001 (Test Infrastructure) - BATS framework and patterns
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| npm publish propagation delay | 120s wait + retry in post-release workflow |
+| Flaky tests due to network | Primary workflow uses local tarball |
+| Tests pass locally but fail in CI | Matrix testing on both macOS and Linux |
+| BATS version differences | Pin BATS version in CI |


### PR DESCRIPTION
## Summary

- Add BATS-based end-to-end tests for the @cluesmith/codev npm package
- Tests verify installation, CLI commands (init, adopt, doctor, af, consult) work correctly
- CI workflows for testing tarball before publish and post-release verification

## Key Features

- **XDG sandboxing**: Tests run in isolated environments, never touching real $HOME
- **Tarball testing**: Test the actual npm package before publishing
- **Dual platform**: CI matrix for both macOS and Linux
- **Error cases**: Not just happy paths, but graceful failure handling

## Files

- `codev/specs/0041-e2e-test-suite.md` - Specification (3-way reviewed)
- `codev/plans/0041-e2e-test-suite.md` - 10-phase implementation plan
- `codev/projectlist.md` - Updated to reflect planned status

## Test Plan

- [ ] Spec and plan review

---
🏗️ Spec + Plan only (no implementation code)