### PR TITLE
fix: copy consult-types/ during adopt and init

### DIFF
--- a/packages/codev/src/commands/adopt.ts
+++ b/packages/codev/src/commands/adopt.ts
@@ -15,6 +15,7 @@ import {
   createUserDirs,
   copyProjectlist,
   copyProjectlistArchive,
+  copyConsultTypes,
   copyResourceTemplates,
   copyRootFiles,
   updateGitignore,
@@ -131,6 +132,17 @@ export async function adopt(options: AdoptOptions = {}): Promise<void> {
   const resourcesResult = copyResourceTemplates(targetDir, skeletonDir, { skipExisting: true });
   for (const file of resourcesResult.copied) {
     console.log(chalk.green('  +'), `codev/resources/${file}`);
+    fileCount++;
+  }
+
+  // Copy consult-types - skip existing
+  const consultTypesResult = copyConsultTypes(targetDir, skeletonDir, { skipExisting: true });
+  if (consultTypesResult.directoryCreated) {
+    console.log(chalk.green('  +'), 'codev/consult-types/');
+    fileCount++;
+  }
+  for (const file of consultTypesResult.copied) {
+    console.log(chalk.green('  +'), `codev/consult-types/${file}`);
     fileCount++;
   }
 

--- a/packages/codev/src/commands/init.ts
+++ b/packages/codev/src/commands/init.ts
@@ -14,6 +14,7 @@ import {
   createUserDirs,
   copyProjectlist,
   copyProjectlistArchive,
+  copyConsultTypes,
   copyResourceTemplates,
   copyRootFiles,
   createGitignore,
@@ -99,6 +100,17 @@ export async function init(projectName?: string, options: InitOptions = {}): Pro
   const resourcesResult = copyResourceTemplates(targetDir, skeletonDir);
   for (const file of resourcesResult.copied) {
     console.log(chalk.green('  +'), `codev/resources/${file}`);
+    fileCount++;
+  }
+
+  // Copy consult-types (review type prompts)
+  const consultTypesResult = copyConsultTypes(targetDir, skeletonDir);
+  if (consultTypesResult.directoryCreated) {
+    console.log(chalk.green('  +'), 'codev/consult-types/');
+    fileCount++;
+  }
+  for (const file of consultTypesResult.copied) {
+    console.log(chalk.green('  +'), `codev/consult-types/${file}`);
     fileCount++;
   }
 

--- a/packages/codev/src/lib/scaffold.ts
+++ b/packages/codev/src/lib/scaffold.ts
@@ -157,6 +157,61 @@ export function copyProjectlistArchive(
   return { copied: true };
 }
 
+interface CopyConsultTypesOptions {
+  skipExisting?: boolean;
+}
+
+interface CopyConsultTypesResult {
+  copied: string[];
+  skipped: string[];
+  directoryCreated: boolean;
+}
+
+/**
+ * Copy consult-types directory from skeleton.
+ * Contains review type prompts that users can customize.
+ */
+export function copyConsultTypes(
+  targetDir: string,
+  skeletonDir: string,
+  options: CopyConsultTypesOptions = {}
+): CopyConsultTypesResult {
+  const { skipExisting = false } = options;
+  const consultTypesDir = path.join(targetDir, 'codev', 'consult-types');
+  const srcDir = path.join(skeletonDir, 'consult-types');
+  const copied: string[] = [];
+  const skipped: string[] = [];
+  let directoryCreated = false;
+
+  // Ensure consult-types directory exists
+  if (!fs.existsSync(consultTypesDir)) {
+    fs.mkdirSync(consultTypesDir, { recursive: true });
+    directoryCreated = true;
+  }
+
+  // If source directory doesn't exist, return early
+  if (!fs.existsSync(srcDir)) {
+    return { copied, skipped, directoryCreated };
+  }
+
+  // Copy all .md files from skeleton consult-types
+  const files = fs.readdirSync(srcDir).filter(f => f.endsWith('.md'));
+  for (const file of files) {
+    const destPath = path.join(consultTypesDir, file);
+    const srcPath = path.join(srcDir, file);
+
+    if (skipExisting && fs.existsSync(destPath)) {
+      skipped.push(file);
+      continue;
+    }
+
+    fs.copyFileSync(srcPath, destPath);
+    copied.push(file);
+  }
+
+  return { copied, skipped, directoryCreated };
+}
+
 interface CopyResourceTemplatesOptions {
   skipExisting?: boolean;
 }


### PR DESCRIPTION
Fixes #127

## Summary

- Adds `copyConsultTypes()` function to `scaffold.ts` that copies review type templates from the skeleton
- Calls the function from both `adopt.ts` (with `skipExisting: true`) and `init.ts`
- Allows users to customize review types after adoption

## Test plan

- [x] Added 3 regression tests in `scaffold.test.ts`:
  - Copies all .md files from consult-types directory
  - Skips existing files in adopt mode
  - Handles missing source directory gracefully
- [x] All 20 scaffold tests pass
- [x] 3-way CMAP review completed (Gemini, Codex, Claude)