### PR TITLE
[Bugfix #173] Add 'af attach' command to attach to builder terminals

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/attach.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/attach.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for attach command
+ *
+ * These are unit tests for the attach command logic. Integration tests
+ * that attach to actual builders require git, tmux, and ttyd to be running.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Builder } from '../types.js';
+
+// Mock state module
+const mockBuilders: Builder[] = [];
+vi.mock('../state.js', () => ({
+  loadState: () => ({ builders: mockBuilders, architect: null, utils: [], annotations: [] }),
+  getBuilder: (id: string) => mockBuilders.find(b => b.id === id) ?? null,
+  getBuilders: () => mockBuilders,
+}));
+
+// Mock shell utilities
+vi.mock('../utils/shell.js', () => ({
+  run: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+  isProcessRunning: vi.fn().mockResolvedValue(true),
+  openBrowser: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock logger
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    header: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    kv: vi.fn(),
+    row: vi.fn(),
+    blank: vi.fn(),
+    debug: vi.fn(),
+  },
+  fatal: vi.fn((msg: string) => { throw new Error(msg || 'Fatal error'); }),
+}));
+
+describe('attach command', () => {
+  beforeEach(() => {
+    mockBuilders.length = 0;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('findBuilderByIssue', () => {
+    it('should find builder by issue number', async () => {
+      // Add a bugfix builder
+      mockBuilders.push({
+        id: 'bugfix-42',
+        name: 'Bugfix #42: Test issue',
+        port: 4210,
+        pid: 12345,
+        status: 'implementing',
+        phase: 'init',
+        worktree: '/path/to/.builders/bugfix-42',
+        branch: 'builder/bugfix-42-test-issue',
+        tmuxSession: 'builder-project-bugfix-42',
+        type: 'bugfix',
+        issueNumber: 42,
+      });
+
+      // Import after mocks are set up
+      const { attach } = await import('../commands/attach.js');
+      const { openBrowser } = await import('../utils/shell.js');
+
+      // Attach with --browser to avoid actually attaching to tmux
+      await attach({ issue: 42, browser: true });
+
+      expect(openBrowser).toHaveBeenCalledWith('http://localhost:4210');
+    });
+
+    it('should error when issue not found', async () => {
+      const { attach } = await import('../commands/attach.js');
+      const { fatal } = await import('../utils/logger.js');
+
+      await expect(attach({ issue: 999 })).rejects.toThrow();
+      expect(fatal).toHaveBeenCalledWith(expect.stringContaining('No builder found for issue #999'));
+    });
+  });
+
+  describe('findBuilderById', () => {
+    it('should find builder by exact ID', async () => {
+      mockBuilders.push({
+        id: '0073',
+        name: '0073-feature',
+        port: 4211,
+        pid: 12346,
+        status: 'implementing',
+        phase: 'init',
+        worktree: '/path/to/.builders/0073',
+        branch: 'builder/0073-feature',
+        tmuxSession: 'builder-project-0073',
+        type: 'spec',
+      });
+
+      const { attach } = await import('../commands/attach.js');
+      const { openBrowser } = await import('../utils/shell.js');
+
+      await attach({ project: '0073', browser: true });
+
+      expect(openBrowser).toHaveBeenCalledWith('http://localhost:4211');
+    });
+
+    it('should find builder by prefix match', async () => {
+      mockBuilders.push({
+        id: 'bugfix-173',
+        name: 'Bugfix #173: Test',
+        port: 4212,
+        pid: 12347,
+        status: 'implementing',
+        phase: 'init',
+        worktree: '/path/to/.builders/bugfix-173',
+        branch: 'builder/bugfix-173-test',
+        tmuxSession: 'builder-project-bugfix-173',
+        type: 'bugfix',
+        issueNumber: 173,
+      });
+
+      const { attach } = await import('../commands/attach.js');
+      const { openBrowser } = await import('../utils/shell.js');
+
+      // Use partial match
+      await attach({ project: 'bugfix-173', browser: true });
+
+      expect(openBrowser).toHaveBeenCalledWith('http://localhost:4212');
+    });
+
+    it('should error when builder not found', async () => {
+      const { attach } = await import('../commands/attach.js');
+      const { fatal } = await import('../utils/logger.js');
+
+      await expect(attach({ project: 'nonexistent' })).rejects.toThrow();
+      expect(fatal).toHaveBeenCalledWith(expect.stringContaining('Builder "nonexistent" not found'));
+    });
+  });
+
+  describe('displayBuilderList', () => {
+    it('should display list when no args provided', async () => {
+      mockBuilders.push({
+        id: 'bugfix-42',
+        name: 'Bugfix #42: Test',
+        port: 4210,
+        pid: 12345,
+        status: 'implementing',
+        phase: 'init',
+        worktree: '/path',
+        branch: 'branch',
+        tmuxSession: 'session',
+        type: 'bugfix',
+        issueNumber: 42,
+      });
+
+      const { attach } = await import('../commands/attach.js');
+      const { logger } = await import('../utils/logger.js');
+
+      await attach({});
+
+      expect(logger.header).toHaveBeenCalledWith('Running Builders');
+      expect(logger.row).toHaveBeenCalled();
+    });
+
+    it('should show helpful message when no builders running', async () => {
+      const { attach } = await import('../commands/attach.js');
+      const { logger } = await import('../utils/logger.js');
+
+      await attach({});
+
+      expect(logger.info).toHaveBeenCalledWith('No builders running.');
+      expect(logger.info).toHaveBeenCalledWith('Spawn a builder with:');
+    });
+  });
+
+  describe('browser option', () => {
+    it('should open browser when --browser flag is set', async () => {
+      mockBuilders.push({
+        id: '0073',
+        name: 'Test',
+        port: 4211,
+        pid: 12346,
+        status: 'implementing',
+        phase: 'init',
+        worktree: '/path',
+        branch: 'branch',
+        tmuxSession: 'session',
+        type: 'spec',
+      });
+
+      const { attach } = await import('../commands/attach.js');
+      const { openBrowser } = await import('../utils/shell.js');
+
+      await attach({ project: '0073', browser: true });
+
+      expect(openBrowser).toHaveBeenCalledWith('http://localhost:4211');
+    });
+  });
+});

--- a/packages/codev/src/agent-farm/cli.ts
+++ b/packages/codev/src/agent-farm/cli.ts
@@ -117,6 +117,28 @@ export async function runAgentFarm(args: string[]): Promise<void> {
       }
     });
 
+  // Attach command
+  program
+    .command('attach')
+    .description('Attach to a running builder terminal')
+    .option('-p, --project <id>', 'Builder ID / project ID to attach to')
+    .option('-i, --issue <number>', 'Issue number (for bugfix builders)')
+    .option('-b, --browser', 'Open in browser instead of tmux attach')
+    .action(async (options) => {
+      const { attach } = await import('./commands/attach.js');
+      try {
+        const issue = options.issue ? parseInt(options.issue, 10) : undefined;
+        await attach({
+          project: options.project,
+          issue,
+          browser: options.browser,
+        });
+      } catch (error) {
+        logger.error(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+    });
+
   // Spawn command
   program
     .command('spawn')

--- a/packages/codev/src/agent-farm/commands/attach.ts
+++ b/packages/codev/src/agent-farm/commands/attach.ts
@@ -1,0 +1,207 @@
+/**
+ * Attach command - attach to a running builder terminal
+ */
+
+import type { Builder } from '../types.js';
+import { logger, fatal } from '../utils/logger.js';
+import { run, isProcessRunning, openBrowser } from '../utils/shell.js';
+import { loadState, getBuilder, getBuilders } from '../state.js';
+import chalk from 'chalk';
+
+export interface AttachOptions {
+  project?: string;     // Builder ID / project ID
+  issue?: number;       // Issue number (for bugfix builders)
+  browser?: boolean;    // Open in browser instead of attaching
+}
+
+/**
+ * Find a builder by issue number
+ */
+function findBuilderByIssue(issueNumber: number): Builder | null {
+  const builders = getBuilders();
+  return builders.find((b) => b.issueNumber === issueNumber) ?? null;
+}
+
+/**
+ * Find a builder by ID (supports partial matching)
+ */
+function findBuilderById(id: string): Builder | null {
+  // First try exact match
+  const exact = getBuilder(id);
+  if (exact) return exact;
+
+  // Try prefix match (e.g., "0073" matches "0073-feature-name")
+  const builders = getBuilders();
+  const matches = builders.filter((b) => b.id.startsWith(id) || b.id.includes(id));
+
+  if (matches.length === 1) {
+    return matches[0];
+  }
+
+  if (matches.length > 1) {
+    logger.error(`Ambiguous builder ID "${id}". Matches:`);
+    for (const b of matches) {
+      logger.info(`  - ${b.id}`);
+    }
+    return null;
+  }
+
+  return null;
+}
+
+/**
+ * Verify that a tmux session exists and is accessible
+ */
+async function verifyTmuxSession(sessionName: string): Promise<boolean> {
+  try {
+    await run(`tmux has-session -t "${sessionName}" 2>/dev/null`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Display a list of running builders for interactive selection
+ */
+async function displayBuilderList(): Promise<void> {
+  const state = loadState();
+  const builders = state.builders;
+
+  if (builders.length === 0) {
+    logger.info('No builders running.');
+    logger.blank();
+    logger.info('Spawn a builder with:');
+    logger.info('  af spawn -p <project-id>');
+    logger.info('  af spawn --issue <number>');
+    logger.info('  af spawn --task "description"');
+    return;
+  }
+
+  logger.header('Running Builders');
+  logger.blank();
+
+  const widths = [15, 30, 8, 10, 6];
+  logger.row(['ID', 'Name', 'Type', 'Status', 'Port'], widths);
+  logger.row(['──', '────', '────', '──────', '────'], widths);
+
+  for (const builder of builders) {
+    const running = await isProcessRunning(builder.pid);
+    const statusText = running ? chalk.green(builder.status) : chalk.red('stopped');
+    const typeColor = getTypeColor(builder.type);
+
+    logger.row([
+      builder.id,
+      builder.name.substring(0, 28),
+      typeColor(builder.type),
+      statusText,
+      String(builder.port),
+    ], widths);
+  }
+
+  logger.blank();
+  logger.info('Attach with:');
+  logger.info('  af attach -p <id>         # by builder/project ID');
+  logger.info('  af attach --issue <num>   # by issue number');
+  logger.info('  af attach -p <id> --browser  # open in browser');
+}
+
+/**
+ * Get color function for builder type
+ */
+function getTypeColor(type: string): (text: string) => string {
+  switch (type) {
+    case 'spec':
+      return chalk.cyan;
+    case 'bugfix':
+      return chalk.red;
+    case 'task':
+      return chalk.magenta;
+    case 'protocol':
+      return chalk.yellow;
+    case 'worktree':
+      return chalk.blue;
+    case 'shell':
+      return chalk.gray;
+    default:
+      return chalk.white;
+  }
+}
+
+/**
+ * Attach to builder terminal
+ */
+export async function attach(options: AttachOptions): Promise<void> {
+  // If no arguments provided, show list of builders
+  if (!options.project && !options.issue) {
+    await displayBuilderList();
+    return;
+  }
+
+  // Find the builder
+  let builder: Builder | null = null;
+
+  if (options.issue) {
+    builder = findBuilderByIssue(options.issue);
+    if (!builder) {
+      fatal(`No builder found for issue #${options.issue}. Use 'af status' to see running builders.`);
+    }
+  } else if (options.project) {
+    builder = findBuilderById(options.project);
+    if (!builder) {
+      fatal(`Builder "${options.project}" not found. Use 'af status' to see running builders.`);
+    }
+  }
+
+  if (!builder) {
+    fatal('No builder specified. Use --project (-p) or --issue (-i).');
+    return; // TypeScript doesn't know fatal() never returns
+  }
+
+  // Check if the builder's process is still running
+  const isRunning = await isProcessRunning(builder.pid);
+  if (!isRunning) {
+    logger.warn(`Builder ${builder.id} process is not running (PID ${builder.pid})`);
+    logger.info(`Terminal may still be accessible at: http://localhost:${builder.port}`);
+  }
+
+  // Option 1: Open in browser
+  if (options.browser) {
+    const url = `http://localhost:${builder.port}`;
+    logger.info(`Opening ${url} in browser...`);
+    await openBrowser(url);
+    logger.success(`Opened builder ${builder.id} in browser`);
+    return;
+  }
+
+  // Option 2: Attach to tmux session
+  if (!builder.tmuxSession) {
+    fatal(`Builder ${builder.id} has no tmux session recorded. Try opening in browser with --browser`);
+  }
+
+  // Verify tmux session exists
+  const sessionExists = await verifyTmuxSession(builder.tmuxSession);
+  if (!sessionExists) {
+    logger.error(`tmux session "${builder.tmuxSession}" not found.`);
+    logger.info(`The builder may have exited. Terminal may still be accessible at:`);
+    logger.info(`  http://localhost:${builder.port}`);
+    fatal('');
+  }
+
+  logger.info(`Attaching to builder ${builder.id}...`);
+  logger.info(chalk.gray(`(Detach with Ctrl+B, D)`));
+  logger.blank();
+
+  // Attach to tmux session (this replaces the current terminal)
+  // We use execSync to properly hand over the terminal
+  const { execSync } = await import('node:child_process');
+  try {
+    execSync(`tmux attach-session -t "${builder.tmuxSession}"`, {
+      stdio: 'inherit',
+    });
+  } catch {
+    // User detached or session ended - this is normal
+    logger.blank();
+    logger.info('Detached from builder session.');
+  }
+}

--- a/packages/codev/src/agent-farm/commands/index.ts
+++ b/packages/codev/src/agent-farm/commands/index.ts
@@ -9,3 +9,4 @@ export { spawn } from './spawn.js';
 export { shell } from './shell.js';
 export { open } from './open.js';
 export { send } from './send.js';
+export { attach } from './attach.js';


### PR DESCRIPTION
## Summary
Fixes #173

Adds the `af attach` command to easily attach to running builder terminals from the command line.

## Root Cause
There was no CLI command to attach to a running builder terminal. Users had to either open the browser URL or manually find and use the tmux session name.

## Fix
Added `af attach` command with the following options:
- `af attach` - Lists all running builders with their IDs and ports
- `af attach -p <id>` - Attach by builder/project ID
- `af attach --issue <num>` - Attach by issue number (for bugfix builders)
- `af attach -p <id> --browser` - Open in browser instead of tmux attach

The command supports:
- Exact and partial ID matching
- Process status checking (warns if process not running)
- tmux session verification before attaching
- Helpful error messages with suggestions

## Test Plan
- [x] Added unit tests (8 tests for builder lookup, listing, and browser option)
- [x] Verified command appears in `af --help`
- [x] Verified `af attach --help` shows correct options
- [x] Verified `af attach` with no args shows running builders
- [x] All existing tests pass (503 tests)