### PR TITLE
Fix terminal WebGL context loss on Chrome/macOS

### DIFF
--- a/packages/codev/dashboard/package.json
+++ b/packages/codev/dashboard/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.12.0",
+    "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-webgl": "^0.18.0",
     "@xterm/xterm": "^5.5.0",
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary

- Adds `@xterm/addon-canvas` as a fallback renderer for the terminal component
- When WebGL context is lost (common Chrome/macOS bug with Metal ANGLE backend), the terminal now falls back to the canvas renderer instead of going blank
- Also falls back to canvas if WebGL fails to initialize at all

**Background**: Chrome on macOS defaults to the Metal ANGLE graphics backend, which has known rendering bugs that can cause WebGL context loss — especially on Apple Silicon after sleep/resume or display switching. Previously, context loss disposed the WebGL addon but left no renderer, causing a blank terminal with no recovery path.

## Test plan

- [ ] Verify terminal still renders with WebGL normally
- [ ] Simulate WebGL context loss (DevTools > More tools > Rendering > WebGL context lost) and confirm canvas fallback activates
- [ ] Verify `tsc --noEmit` passes in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)