### PR TITLE
[Bugfix #203] Fix copy/paste in dashboard terminals

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/clipboard.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/clipboard.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for clipboard functionality in dashboard terminals
- * Ensures iframes have clipboard permissions
+ * Ensures iframes have clipboard permissions and React dashboard
+ * handles copy/paste via navigator.clipboard API.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -46,5 +47,61 @@ describe('Dashboard clipboard permissions', () => {
       expect(iframe).toMatch(/allow="[^"]*clipboard-read[^"]*"/);
       expect(iframe).toMatch(/allow="[^"]*clipboard-write[^"]*"/);
     });
+  });
+});
+
+describe('React dashboard Terminal clipboard handling (Bugfix #203)', () => {
+  // Resolve Terminal.tsx relative to the test file location to avoid
+  // findProjectRoot path ambiguity (packages/codev/ dir matches 'codev').
+  const terminalPath = resolve(__dirname, '../../../dashboard/src/components/Terminal.tsx');
+
+  it('Terminal.tsx uses attachCustomKeyEventHandler for explicit clipboard handling', () => {
+    const content = readFileSync(terminalPath, 'utf-8');
+
+    // Must use attachCustomKeyEventHandler for clipboard operations
+    expect(content).toContain('attachCustomKeyEventHandler');
+
+    // Must use navigator.clipboard API for reading (paste)
+    expect(content).toContain('navigator.clipboard.readText');
+
+    // Must use navigator.clipboard API for writing (copy)
+    expect(content).toContain('navigator.clipboard.writeText');
+
+    // Must call term.paste() to write pasted text to terminal
+    expect(content).toContain('term.paste(');
+
+    // Must call term.getSelection() to read selected text for copy
+    expect(content).toContain('term.getSelection()');
+
+    // Must handle both Mac (metaKey) and non-Mac (ctrlKey+shiftKey) platforms
+    expect(content).toContain('ev.metaKey');
+    expect(content).toContain('ev.ctrlKey');
+    expect(content).toContain('ev.shiftKey');
+  });
+
+  it('Terminal.tsx handles paste with Cmd+V (Mac) and Ctrl+Shift+V (other)', () => {
+    const content = readFileSync(terminalPath, 'utf-8');
+
+    // Paste detection for Mac: Cmd+V (metaKey + 'v')
+    expect(content).toMatch(/ev\.metaKey && ev\.key === 'v'/);
+
+    // Paste detection for non-Mac: Ctrl+Shift+V
+    expect(content).toMatch(/ev\.ctrlKey && ev\.shiftKey && ev\.key === 'V'/);
+
+    // Must prevent default to avoid double-paste from native handler
+    expect(content).toContain('ev.preventDefault()');
+  });
+
+  it('Terminal.tsx handles copy with Cmd+C (Mac) and Ctrl+Shift+C (other)', () => {
+    const content = readFileSync(terminalPath, 'utf-8');
+
+    // Copy detection for Mac: Cmd+C (metaKey + 'c')
+    expect(content).toMatch(/ev\.metaKey && ev\.key === 'c'/);
+
+    // Copy detection for non-Mac: Ctrl+Shift+C
+    expect(content).toMatch(/ev\.ctrlKey && ev\.shiftKey && ev\.key === 'C'/);
+
+    // Must check for selection before copying
+    expect(content).toContain('term.hasSelection()');
   });
 });


### PR DESCRIPTION
## Summary
Fixes #203

## Root Cause
xterm.js relies on the browser firing native `paste` events on a hidden `<textarea>` element (zero-size, opacity 0, positioned off-screen at `left: -9999em`). This doesn't work reliably across all browser contexts — the browser may not fire clipboard events on invisible/zero-dimension elements.

The React dashboard renders xterm.js terminals directly (not in iframes like the legacy dashboard), so the `allow="clipboard-read; clipboard-write"` iframe permissions used by the legacy dashboard don't apply.

## Fix
Added explicit clipboard handling via `navigator.clipboard` API using xterm.js's `attachCustomKeyEventHandler`:

- **Paste**: Cmd+V (Mac) / Ctrl+Shift+V (other platforms) → reads clipboard text via `navigator.clipboard.readText()` and calls `term.paste()` 
- **Copy**: Cmd+C (Mac) / Ctrl+Shift+C (other platforms) → writes terminal selection to clipboard via `navigator.clipboard.writeText()`

Key behaviors preserved:
- Ctrl+C still sends SIGINT (^C) to the terminal on all platforms
- Cmd+C only copies when there's an active selection; otherwise falls through to xterm.js default
- `ev.preventDefault()` prevents double-paste from the native handler

## Test Plan
- [x] Added regression tests verifying clipboard handler presence and platform detection
- [x] Existing clipboard tests pass (legacy iframe permissions)
- [x] TypeScript compiles clean
- [x] Dashboard builds successfully

## CMAP Review
To be added after review.