### PR TITLE
Fix dashboard auth: localStorage key consistency + CORS for proxy

### DIFF
--- a/packages/codev/src/agent-farm/servers/tower-server.ts
+++ b/packages/codev/src/agent-farm/servers/tower-server.ts
@@ -1867,13 +1867,17 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
-  // CORS headers
+  // CORS headers — allow localhost and tunnel proxy origins
   const origin = req.headers.origin;
-  if (origin && (origin.startsWith('http://localhost:') || origin.startsWith('http://127.0.0.1:'))) {
+  if (origin && (
+    origin.startsWith('http://localhost:') ||
+    origin.startsWith('http://127.0.0.1:') ||
+    origin.startsWith('https://')
+  )) {
     res.setHeader('Access-Control-Allow-Origin', origin);
   }
-  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
   res.setHeader('Cache-Control', 'no-store');
 
   if (req.method === 'OPTIONS') {

--- a/packages/codev/templates/tower.html
+++ b/packages/codev/templates/tower.html
@@ -1017,7 +1017,7 @@
 
     // Auth helper: get headers with auth token if available
     function getAuthHeaders() {
-      const key = localStorage.getItem('codev_web_key');
+      const key = localStorage.getItem('codev-web-key');
       return key ? { 'Authorization': `Bearer ${key}` } : {};
     }
 
@@ -1028,7 +1028,7 @@
 
       // If 401, clear key and redirect to login
       if (response.status === 401) {
-        localStorage.removeItem('codev_web_key');
+        localStorage.removeItem('codev-web-key');
         location.reload();
         throw new Error('Unauthorized');
       }
@@ -1037,7 +1037,7 @@
 
     // Logout function
     function logout() {
-      localStorage.removeItem('codev_web_key');
+      localStorage.removeItem('codev-web-key');
       window.location.href = './';
     }
 


### PR DESCRIPTION
## Summary
- **localStorage key mismatch**: `tower.html` used `codev_web_key` (underscore) while `dashboard/api.ts` used `codev-web-key` (hyphen). Standardized on hyphen form to match `tower-client.ts`.
- **CORS origin whitelist**: Only allowed `http://localhost:` and `http://127.0.0.1:`. Now also allows `https://` origins for CodevOS tunnel proxy access.
- **CORS headers**: Added `Authorization` to `Access-Control-Allow-Headers` and `DELETE` to allowed methods.

**Note**: The 403 errors when accessing Tower through CodevOS proxy may also require CodevOS-side fixes (possible slug vs UUID path mismatch). These Tower-side fixes address the CORS and auth token inconsistency.

## Test plan
- [ ] Tower dashboard loads locally with no regressions
- [ ] API calls include correct auth headers when `codev-web-key` is in localStorage
- [ ] CORS preflight succeeds from `https://` origins

🤖 Generated with [Claude Code](https://claude.com/claude-code)