### PR TITLE
[Bugfix #280] Fix consult models reading git diffs instead of files

### DIFF
--- a/codev-skeleton/roles/consultant.md
+++ b/codev-skeleton/roles/consultant.md
@@ -25,3 +25,9 @@ You are a consultant providing a second perspective to support decision-making.
 | Consultant | Provides perspective, supports decisions |
 
 You think alongside the other agents, helping them see blind spots. You have filesystem access — use it to verify your claims against the actual codebase.
+
+## File Access Rules
+
+- **ALWAYS read files directly from disk** when reviewing specs, plans, or code. File paths are provided in the query — open and read them.
+- **NEVER rely on `git diff` or `git log -p` as your primary review source.** Diffs are lossy, get truncated, and miss uncommitted work. Read the actual files instead.
+- If you need to understand what changed, read the full file first, then optionally use `git diff` as a secondary reference.

--- a/codev/roles/consultant.md
+++ b/codev/roles/consultant.md
@@ -25,3 +25,9 @@ You are a consultant providing a second perspective to support decision-making.
 | Consultant | Provides perspective, supports decisions |
 
 You think alongside the other agents, helping them see blind spots. You have filesystem access — use it to verify your claims against the actual codebase.
+
+## File Access Rules
+
+- **ALWAYS read files directly from disk** when reviewing specs, plans, or code. File paths are provided in the query — open and read them.
+- **NEVER rely on `git diff` or `git log -p` as your primary review source.** Diffs are lossy, get truncated, and miss uncommitted work. Read the actual files instead.
+- If you need to understand what changed, read the full file first, then optionally use `git diff` as a secondary reference.

--- a/packages/codev/src/__tests__/bugfix-280-consult-diff.test.ts
+++ b/packages/codev/src/__tests__/bugfix-280-consult-diff.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression test for bugfix #280:
+ * Consult: Codex still reviewing git diff instead of reading files directly
+ *
+ * The bug: buildImplQuery used `git diff ${mergeBase}..HEAD` (commit-to-commit)
+ * which missed uncommitted changes in builder worktrees. Models would get an
+ * incomplete file list and fall back to git diffs, producing false positives.
+ *
+ * The fix: Use `git diff ${mergeBase}` (working tree diff) to include both
+ * committed and uncommitted changes.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+// _getDiffStat is exported for testing from the consult module
+import { _getDiffStat as getDiffStat } from '../commands/consult/index.js';
+
+describe('bugfix #280: getDiffStat includes uncommitted changes', () => {
+  let tmpDir: string;
+  let mergeBase: string;
+
+  beforeEach(() => {
+    // Create a temporary git repo
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bugfix-280-'));
+
+    // Initialize repo with a main branch
+    execSync('git init -b main', { cwd: tmpDir });
+    execSync('git config user.email "test@test.com"', { cwd: tmpDir });
+    execSync('git config user.name "Test"', { cwd: tmpDir });
+
+    // Create initial commit on main
+    fs.writeFileSync(path.join(tmpDir, 'base.txt'), 'base content');
+    execSync('git add base.txt', { cwd: tmpDir });
+    execSync('git commit -m "initial"', { cwd: tmpDir });
+
+    // Create a feature branch
+    execSync('git checkout -b feature', { cwd: tmpDir });
+
+    // Add a committed change on feature branch
+    fs.writeFileSync(path.join(tmpDir, 'committed.txt'), 'committed content');
+    execSync('git add committed.txt', { cwd: tmpDir });
+    execSync('git commit -m "add committed file"', { cwd: tmpDir });
+
+    // Add an uncommitted modification to a tracked file (the scenario that caused the bug).
+    // Note: git diff only shows changes to tracked files, not untracked files.
+    // In builder worktrees, the common case is modifying existing files without committing.
+    fs.writeFileSync(path.join(tmpDir, 'base.txt'), 'modified base content');
+
+    // Get merge base for diffing
+    mergeBase = execSync('git merge-base HEAD main', { cwd: tmpDir, encoding: 'utf-8' }).trim();
+  });
+
+  afterEach(() => {
+    // Clean up temp directory
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('getDiffStat with mergeBase (fixed) includes uncommitted modifications', () => {
+    // This is the FIXED behavior: git diff <mergeBase> compares merge-base to working tree,
+    // so it includes both committed changes AND uncommitted modifications to tracked files.
+    const result = getDiffStat(tmpDir, mergeBase);
+
+    expect(result.files).toContain('committed.txt');
+    // base.txt was modified but not committed — working tree diff catches it
+    expect(result.files).toContain('base.txt');
+  });
+
+  it('getDiffStat with mergeBase..HEAD (old bug) misses uncommitted modifications', () => {
+    // This demonstrates the BUG: git diff <mergeBase>..HEAD is commit-to-commit only,
+    // so uncommitted working tree changes are invisible.
+    const result = getDiffStat(tmpDir, `${mergeBase}..HEAD`);
+
+    expect(result.files).toContain('committed.txt');
+    // base.txt was modified but not committed — commit-to-commit diff misses it
+    expect(result.files).not.toContain('base.txt');
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #280

## Root Cause
Three factors caused consultation models (especially Codex) to review git diffs instead of reading files directly:

1. **Missing "How to Review" instructions**: `buildSpecQuery` and `buildPlanQuery` lacked explicit instructions to read files from disk, unlike `buildPRQuery` and `buildImplQuery` which already had them. Without guidance, Codex autonomously chose `git diff` as its review strategy.

2. **Missing `cwd` for CLI model spawns**: The `spawn()` call for Codex and Gemini didn't set `cwd: workspaceRoot`, so they inherited `process.cwd()` which could differ from the workspace root.

3. **Commit-to-commit diff in `buildImplQuery`**: The `getDiffStat` call used `mergeBase..HEAD` (commit-to-commit) which missed uncommitted working tree changes in builder worktrees.

## Fix
- Added "How to Review" sections to `buildSpecQuery` and `buildPlanQuery` with explicit instructions to read files from disk and not rely on git diffs
- Updated `consultant.md` role with "File Access Rules" section prohibiting reliance on git diff as primary review source
- Added `cwd: workspaceRoot` to CLI model subprocess spawns
- Changed `buildImplQuery` to use `git diff mergeBase` (includes working tree) instead of `git diff mergeBase..HEAD` (commits only)

## Test Plan
- [x] Added regression tests for `buildSpecQuery` and `buildPlanQuery` containing file-read instructions
- [x] Added integration test proving `getDiffStat(ref)` includes uncommitted modifications while `getDiffStat(ref..HEAD)` misses them
- [x] All existing tests pass (35/35 + 2 new + 5 new = 42 total)
- [x] Build passes
- [x] Net diff: 82 insertions, 4 deletions (well under 300 LOC threshold)

## CMAP Review
To be added after review.