### PR TITLE
[Bugfix #205] Fix terminal garbled output and replay scroll

### DIFF
--- a/packages/codev/dashboard/__tests__/Terminal.replay-scroll.test.tsx
+++ b/packages/codev/dashboard/__tests__/Terminal.replay-scroll.test.tsx
@@ -25,8 +25,6 @@ let mockWsInstance: {
   onmessage: ((ev: { data: ArrayBuffer }) => void) | null;
   readyState: number;
 };
-let mockFitFn: ReturnType<typeof vi.fn>;
-
 // Mock @xterm/xterm — capture scrollToBottom calls
 vi.mock('@xterm/xterm', () => {
   class MockTerminal {
@@ -53,15 +51,9 @@ vi.mock('@xterm/xterm', () => {
   return { Terminal: MockTerminal };
 });
 
-// Mock addons — capture fit() calls
+// Mock addons
 vi.mock('@xterm/addon-fit', () => ({
-  FitAddon: class {
-    fit = vi.fn();
-    dispose = vi.fn();
-    constructor() {
-      mockFitFn = this.fit;
-    }
-  },
+  FitAddon: class { fit = vi.fn(); dispose = vi.fn(); },
 }));
 vi.mock('@xterm/addon-webgl', () => ({
   WebglAddon: class { constructor() { throw new Error('no webgl'); } },


### PR DESCRIPTION
## Summary

Adds regression test for the reopened scroll-to-bottom aspect of issue #205. The code fix (scrollToBottom after replay buffer flush + deferred resize to PTY) was previously applied in bd55422.

Fixes #205

## Root Cause

Two related issues:

1. **Garbled output on tab switch** (original): Terminal components were unmounted/remounted on every tab switch, triggering WebSocket reconnection and full ring-buffer replay on fresh xterm.js instances.

2. **Viewport stuck at top after replay** (reopened): After Tower restart, replay buffer data was rendered but `scrollToBottom()` was never called, leaving the viewport at line 0.

## Fix

1. **Tab persistence** (PR #207): Keep Terminal components mounted via CSS `display:none` instead of unmounting. Track activated terminals to avoid pre-mounting unvisited tabs.

2. **Scroll after replay** (bd55422): Call `scrollToBottom()` in the `term.write()` callback after initial buffer flush, plus a deferred `scrollToBottom()` after 350ms to account for `fitAddon.fit()` resetting the viewport. Also sends a forced resize to the PTY so the shell redraws at correct dimensions.

## Test Plan

- [x] Regression test added (`Terminal.replay-scroll.test.tsx`) — 5 test cases
- [x] Existing persistence tests pass (`App.terminal-persistence.test.tsx`) — 3 test cases
- [x] Build passes
- [x] All tests pass (excluding pre-existing IME dedup test failures)

## CMAP Review

| Model | Verdict | Notes |
|-------|---------|-------|
| Gemini | APPROVE | Tests comprehensive, correctly target replay-buffer flush logic |
| Claude | APPROVE | Well-structured, aligned with Terminal.tsx implementation |
| Codex | REQUEST_CHANGES → addressed | Removed unused `mockFitFn`; CI dashboard coverage is pre-existing issue (all 10+ dashboard tests are in the same situation) |