### PR TITLE
[Bugfix #304] Remove redundant 'Builder' prefix from terminal tab labels

### DIFF
--- a/packages/codev/dashboard/__tests__/App.terminal-persistence.test.tsx
+++ b/packages/codev/dashboard/__tests__/App.terminal-persistence.test.tsx
@@ -19,7 +19,7 @@ vi.mock('../src/hooks/useBuilderStatus.js', () => ({
       architect: { port: 4201, pid: 1234, terminalId: 'arch-1' },
       builders: [
         {
-          id: 'B1', name: 'Builder 1', port: 4210, pid: 2345,
+          id: 'B1', name: 'builder-spir-001', port: 4210, pid: 2345,
           status: 'running', phase: 'phase-1', worktree: '.builders/0001',
           branch: 'builder/0001', type: 'spec', terminalId: 'term-b1',
         },

--- a/packages/codev/dashboard/__tests__/StatusPanel.test.tsx
+++ b/packages/codev/dashboard/__tests__/StatusPanel.test.tsx
@@ -16,7 +16,7 @@ const populatedState: DashboardState = {
   architect: { port: 4201, pid: 1234 },
   builders: [
     {
-      id: 'B1', name: 'Builder 0085', port: 4210, pid: 2345,
+      id: 'B1', name: 'builder-spir-0085', port: 4210, pid: 2345,
       status: 'implementing', phase: 'phase-1', worktree: '.builders/0085',
       branch: 'builder/0085', type: 'spec',
     },
@@ -56,7 +56,7 @@ describe('StatusPanel', () => {
 
   it('shows builders, shells, and files', () => {
     render(<StatusPanel state={populatedState} onRefresh={() => {}} />);
-    expect(screen.getByText('Builder 0085')).toBeTruthy();
+    expect(screen.getByText('builder-spir-0085')).toBeTruthy();
     expect(screen.getByText('Shell 1')).toBeTruthy();
     expect(screen.getByText('main.ts')).toBeTruthy();
   });

--- a/packages/codev/dashboard/src/hooks/useTabs.ts
+++ b/packages/codev/dashboard/src/hooks/useTabs.ts
@@ -27,7 +27,7 @@ function buildTabs(state: DashboardState | null): Tab[] {
     tabs.push({
       id: builder.id,
       type: 'builder',
-      label: builder.name || `Builder ${builder.id}`,
+      label: builder.name || builder.id,
       closable: true,
       projectId: builder.id,
       terminalId: builder.terminalId,

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -1190,7 +1190,7 @@ async function handleWorkspaceState(
     if (session) {
       state.builders.push({
         id: builderId,
-        name: `Builder ${builderId}`,
+        name: builderId,
         port: 0,
         pid: session.pid || 0,
         status: 'running',

--- a/packages/codev/src/agent-farm/servers/tower-terminals.ts
+++ b/packages/codev/src/agent-farm/servers/tower-terminals.ts
@@ -447,7 +447,7 @@ async function _reconcileTerminalSessionsInner(): Promise<void> {
       }
 
       const replayData = client.getReplayData() ?? Buffer.alloc(0);
-      const label = dbSession.type === 'architect' ? 'Architect' : `${dbSession.type} ${dbSession.role_id || 'unknown'}`;
+      const label = dbSession.type === 'architect' ? 'Architect' : (dbSession.role_id || 'unknown');
 
       // Create a PtySession backed by the reconnected shellper client
       const session = manager.createSessionRaw({ label, cwd: workspacePath });
@@ -601,7 +601,7 @@ export async function getTerminalsForWorkspace(
         );
         if (client) {
           const replayData = client.getReplayData() ?? Buffer.alloc(0);
-          const label = dbSession.type === 'architect' ? 'Architect' : `${dbSession.type} ${dbSession.role_id || dbSession.id}`;
+          const label = dbSession.type === 'architect' ? 'Architect' : (dbSession.role_id || dbSession.id);
           const newSession = manager.createSessionRaw({ label, cwd: dbSession.workspace_path });
           const ptySession = manager.getSession(newSession.id);
           if (ptySession) {
@@ -650,7 +650,7 @@ export async function getTerminalsForWorkspace(
       terminals.push({
         type: 'builder',
         id: builderId,
-        label: `Builder ${builderId}`,
+        label: builderId,
         url: `${proxyUrl}?tab=${builderId}`,
         active: true,
       });
@@ -691,7 +691,7 @@ export async function getTerminalsForWorkspace(
           terminals.push({
             type: 'builder',
             id: builderId,
-            label: `Builder ${builderId}`,
+            label: builderId,
             url: `${proxyUrl}?tab=${builderId}`,
             active: true,
           });


### PR DESCRIPTION
## Summary
Fixes #304

## Root Cause
Terminal tabs displayed "Builder builder-spir-118" because the code prepended "Builder " (or `${dbSession.type} `) to a role ID that already contained "builder-" in its name. This happened in 5 server-side locations across `tower-terminals.ts` and `tower-routes.ts`, plus a dashboard fallback in `useTabs.ts`.

## Fix
Removed the redundant "Builder " prefix from all label/name generation for builder terminals:
- **tower-terminals.ts** (4 locations): Changed session labels to use `role_id` directly instead of `"${type} ${role_id}"` or `"Builder ${builderId}"`
- **tower-routes.ts** (1 location): Changed builder name in status API response from `"Builder ${builderId}"` to `builderId`
- **useTabs.ts** (1 location): Changed dashboard fallback from `"Builder ${builder.id}"` to `builder.id`

## Test Plan
- [x] Updated test fixtures in `StatusPanel.test.tsx` and `App.terminal-persistence.test.tsx`
- [x] Dashboard tests pass (12 passed, 1 pre-existing failure in ime-dedup)
- [x] TypeScript compilation passes
- [x] Build succeeds
- [x] Pre-existing test failure in `porch/next.test.ts` confirmed on main — not caused by this change

## Note
`porch check` fails due to pre-existing test failure in `src/commands/porch/__tests__/next.test.ts` ("emits FIX tasks when reviewers request changes") which also fails on main. This is unrelated to the bugfix.