### PR TITLE
[Bugfix #319] Fix duplicate notifications in bugfix protocol

### DIFF
--- a/codev-skeleton/protocols/bugfix/prompts/pr.md
+++ b/codev-skeleton/protocols/bugfix/prompts/pr.md
@@ -63,11 +63,15 @@ Review the consultation results:
 
 ### 4. Notify Architect
 
-After CMAP review is complete and feedback is addressed, notify the architect:
+After CMAP review is complete and feedback is addressed, send a **single** notification
+with both the PR link and the review verdict:
 
 ```bash
-af send architect "PR #<number> ready for review (fixes issue #{{issue.number}})"
+af send architect "PR #<number> ready for review (fixes issue #{{issue.number}}). CMAP: <verdict summary, e.g. 'all approve' or '2 approve, 1 request changes (addressed)'>"
 ```
+
+**This is the only notification you send.** After this, your work is done — the architect
+takes it from here (reviews, merges, cleans up).
 
 ## Signals
 

--- a/codev/protocols/bugfix/prompts/pr.md
+++ b/codev/protocols/bugfix/prompts/pr.md
@@ -63,11 +63,15 @@ Review the consultation results:
 
 ### 4. Notify Architect
 
-After CMAP review is complete and feedback is addressed, notify the architect:
+After CMAP review is complete and feedback is addressed, send a **single** notification
+with both the PR link and the review verdict:
 
 ```bash
-af send architect "PR #<number> ready for review (fixes issue #{{issue.number}})"
+af send architect "PR #<number> ready for review (fixes issue #{{issue.number}}). CMAP: <verdict summary, e.g. 'all approve' or '2 approve, 1 request changes (addressed)'>"
 ```
+
+**This is the only notification you send.** After this, your work is done — the architect
+takes it from here (reviews, merges, cleans up).
 
 ## Signals
 

--- a/codev/protocols/bugfix/protocol.json
+++ b/codev/protocols/bugfix/protocol.json
@@ -83,37 +83,7 @@
         "max_rounds": 1
       },
       "transition": {
-        "on_complete": "review"
-      }
-    },
-    {
-      "id": "review",
-      "name": "Review",
-      "description": "Address review feedback",
-      "type": "once",
-      "steps": [
-        "address_feedback",
-        "update_pr"
-      ],
-      "transition": {
-        "on_complete": "merge"
-      }
-    },
-    {
-      "id": "merge",
-      "name": "Merge",
-      "description": "Merge the fix and close the issue",
-      "type": "once",
-      "steps": [
-        "merge_pr",
-        "verify_main",
-        "close_issue"
-      ],
-      "gate": {
-        "name": "merge-approval",
-        "description": "Architect approves merge",
-        "requires": ["review_complete", "tests_pass"],
-        "next": null
+        "on_complete": null
       }
     }
   ],

--- a/packages/codev/src/commands/porch/next.ts
+++ b/packages/codev/src/commands/porch/next.ts
@@ -225,6 +225,17 @@ export async function next(workspaceRoot: string, projectId: string): Promise<Po
 
   // Protocol complete
   if (state.phase === 'complete' || !phaseConfig) {
+    // Bugfix builders are done after PR + CMAP — architect handles merge/cleanup
+    if (state.protocol === 'bugfix') {
+      return {
+        status: 'complete',
+        phase: state.phase,
+        iteration: state.iteration,
+        summary: `Project ${state.id} has completed the ${state.protocol} protocol. The architect will review, merge, and clean up.`,
+        tasks: [],
+      };
+    }
+
     return {
       status: 'complete',
       phase: state.phase,


### PR DESCRIPTION
## Summary

The bugfix protocol was sending two separate notifications to the architect: one when the PR was created (from pr.md prompt) and another when the merge-approval gate was triggered. The first notification was premature — the architect can't act on a PR that hasn't been reviewed yet.

Fixes #319

## Root Cause

Our `codev/protocols/bugfix/protocol.json` had extra `review` and `merge` phases with a `merge-approval` gate that the skeleton template correctly omitted. This caused:
1. pr.md prompt instructed the builder to `af send` after CMAP review
2. The merge gate triggered another notification via porch's `notifyArchitect()`
3. The `next.ts` complete handler also told ALL builders to merge + notify, including bugfix builders who should be done

## Fix

- Removed `review` and `merge` phases (+ `merge-approval` gate) from `codev/protocols/bugfix/protocol.json`, aligning with the skeleton
- Updated pr.md prompts (both `codev/` and `codev-skeleton/`) to include review verdict in the single notification and clarify the builder is done after
- Added bugfix-specific completion handling in `next.ts`: returns empty tasks array (builder has nothing left to do) instead of merge instructions

## Test Plan

- [x] Regression test added (bugfix completion returns empty tasks, non-bugfix still returns merge task)
- [x] Build passes
- [x] All tests pass (73 files, 1371 tests)