### PR TITLE
[Bugfix #326] Fix discoverBuilders() to match project per worktree

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -163,8 +163,8 @@ describe('overview', () => {
       expect(extractProjectIdFromWorktreeName('tick-130-slug')).toBe('0130');
     });
 
-    it('extracts bugfix-N from bugfix worktree', () => {
-      expect(extractProjectIdFromWorktreeName('bugfix-296-slug')).toBe('bugfix-296');
+    it('extracts builder-bugfix-N from bugfix worktree', () => {
+      expect(extractProjectIdFromWorktreeName('bugfix-296-slug')).toBe('builder-bugfix-296');
     });
 
     it('extracts legacy numeric ID', () => {
@@ -284,6 +284,37 @@ describe('overview', () => {
       // Must match 0126, NOT 0087
       expect(builders[0].id).toBe('0126');
       expect(builders[0].issueNumber).toBe(126);
+      expect(builders[0].mode).toBe('strict');
+    });
+
+    it('discovers bugfix builder matching builder-bugfix-N project dir', () => {
+      // Bugfix worktree with matching project dir (as created by af spawn)
+      const builderDir = path.join(tmpDir, '.builders', 'bugfix-326-fix-discover');
+      const projectsBase = path.join(builderDir, 'codev', 'projects');
+
+      // Inherited from main
+      const inheritedDir = path.join(projectsBase, '0087-porch-timeout');
+      fs.mkdirSync(inheritedDir, { recursive: true });
+      fs.writeFileSync(path.join(inheritedDir, 'status.yaml'), [
+        "id: '0087'",
+        'protocol: spider',
+        'phase: complete',
+      ].join('\n'));
+
+      // The bugfix's own project dir (created by porch init via af spawn)
+      const bugfixDir = path.join(projectsBase, 'builder-bugfix-326-fix-discover');
+      fs.mkdirSync(bugfixDir, { recursive: true });
+      fs.writeFileSync(path.join(bugfixDir, 'status.yaml'), [
+        'id: builder-bugfix-326',
+        'title: fix-discover',
+        'protocol: bugfix',
+        'phase: investigate',
+      ].join('\n'));
+
+      const builders = discoverBuilders(tmpDir);
+      expect(builders).toHaveLength(1);
+      expect(builders[0].id).toBe('builder-bugfix-326');
+      expect(builders[0].issueNumber).toBe(326);
       expect(builders[0].mode).toBe('strict');
     });
 

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -150,9 +150,10 @@ export function extractProjectIdFromWorktreeName(dirName: string): string | null
   const tickMatch = dirName.match(/^tick-(\d+)/);
   if (tickMatch) return tickMatch[1].padStart(4, '0');
 
-  // Bugfix: bugfix-296-slug → "bugfix-296"
+  // Bugfix: bugfix-296-slug → "builder-bugfix-296"
+  // Porch project dirs are created via buildAgentName('bugfix', N) → "builder-bugfix-N"
   const bugfixMatch = dirName.match(/^bugfix-(\d+)/);
-  if (bugfixMatch) return `bugfix-${bugfixMatch[1]}`;
+  if (bugfixMatch) return `builder-bugfix-${bugfixMatch[1]}`;
 
   // Legacy numeric: 0110 or 0110-slug → "0110"
   const numericMatch = dirName.match(/^(\d+)(?:-|$)/);


### PR DESCRIPTION
## Summary
Fixes #326

## Root Cause
`discoverBuilders()` iterates `codev/projects/*/status.yaml` and picks the **first alphabetical** match. Since `codev/projects/` is tracked in git, every worktree inherits ALL project directories from main. Result: every builder reports project #87 (first alphabetically).

## Fix
- Added `extractProjectIdFromWorktreeName(dirName)` helper that maps worktree directory names to project IDs:
  - `spir-126-slug` → `"0126"` (zero-padded)
  - `tick-130-slug` → `"0130"` (zero-padded)
  - `bugfix-296-slug` → `"bugfix-296"`
  - `0110` → `"0110"` (legacy numeric)
  - `task-NAvW` / `worktree-foIg` → `null` (soft mode)
- Rewrote `discoverBuilders()` inner loop to only match `codev/projects/{ID}-*/status.yaml`
- When no match found, falls back to soft mode but still extracts issue number from directory name

## Test Plan
- [x] Added 10 unit tests for `extractProjectIdFromWorktreeName`
- [x] Added regression test: multiple worktrees each with all project dirs — each matches only its own
- [x] Updated existing `discoverBuilders` tests for new matching behavior
- [x] All 37 overview tests pass
- [x] Net diff under 300 LOC (284)

## CMAP Review
To be added after review.