### PR TITLE
[Bugfix #332] Fix porch project ID detection for bugfix builders

### DIFF
--- a/packages/codev/src/agent-farm/commands/spawn.ts
+++ b/packages/codev/src/agent-farm/commands/spawn.ts
@@ -611,9 +611,12 @@ async function spawnBugfix(options: SpawnOptions, config: Config): Promise<void>
   } else {
     await createWorktree(config, branchName, worktreePath);
 
-    // Pre-initialize porch so the builder doesn't need to figure out project ID
+    // Pre-initialize porch so the builder doesn't need to figure out project ID.
+    // Use bugfix-{N} as the porch project ID (not the builder agent name).
+    // This aligns with porch's CWD-based detection from worktree paths.
+    const porchProjectId = `bugfix-${issueNumber}`;
     const slug = slugify(issue.title);
-    await initPorchInWorktree(worktreePath, protocol, builderId, slug);
+    await initPorchInWorktree(worktreePath, protocol, porchProjectId, slug);
   }
 
   const templateContext: TemplateContext = {

--- a/packages/codev/src/commands/porch/__tests__/state.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/state.test.ts
@@ -303,6 +303,14 @@ updated_at: "${state.updated_at}"
       expect(detectProjectIdFromCwd('/repo/.builders/bugfix-12345')).toBe('bugfix-12345');
     });
 
+    it('should detect bugfix ID from worktree with slug suffix', () => {
+      expect(detectProjectIdFromCwd('/repo/.builders/bugfix-332-fix-login-bug')).toBe('bugfix-332');
+    });
+
+    it('should detect bugfix ID from slug-suffixed worktree subdirectory', () => {
+      expect(detectProjectIdFromCwd('/repo/.builders/bugfix-332-fix-login-bug/src/commands/')).toBe('bugfix-332');
+    });
+
     it('should return null for task worktrees', () => {
       expect(detectProjectIdFromCwd('/repo/.builders/task-aB2C')).toBeNull();
     });
@@ -363,6 +371,11 @@ updated_at: "${state.updated_at}"
 
     it('step 2: CWD bugfix worktree resolves to full bugfix ID', () => {
       const result = resolveProjectId(undefined, '/repo/.builders/bugfix-42', singleProjectRoot);
+      expect(result).toEqual({ id: 'bugfix-42', source: 'cwd' });
+    });
+
+    it('step 2: CWD bugfix worktree with slug suffix resolves to bugfix ID', () => {
+      const result = resolveProjectId(undefined, '/repo/.builders/bugfix-42-fix-login-bug', singleProjectRoot);
       expect(result).toEqual({ id: 'bugfix-42', source: 'cwd' });
     });
 

--- a/packages/codev/src/commands/porch/state.ts
+++ b/packages/codev/src/commands/porch/state.ts
@@ -165,7 +165,9 @@ export function findStatusPath(workspaceRoot: string, projectId: string): string
  */
 export function detectProjectIdFromCwd(cwd: string): string | null {
   const normalized = path.resolve(cwd).split(path.sep).join('/');
-  const match = normalized.match(/\/\.builders\/(bugfix-(\d+)|(\d{4}))(\/|$)/);
+  // Bugfix worktrees: .builders/bugfix-{N}-{slug} (slug is optional for legacy paths)
+  // Spec worktrees (legacy): .builders/{NNNN} (bare 4-digit ID, no slug)
+  const match = normalized.match(/\/\.builders\/(bugfix-(\d+)(?:-[^/]*)?|(\d{4}))(\/|$)/);
   if (!match) return null;
   // Bugfix worktrees use "bugfix-N" as the porch project ID
   if (match[2]) return `bugfix-${match[2]}`;


### PR DESCRIPTION
## Summary
Fixes #332

Bugfix builders wasted 4-5 API turns discovering their own project ID because porch's auto-detection couldn't find the project state initialized by `af spawn`.

## Root Cause
Two compounding issues:

1. **Project ID mismatch**: `spawnBugfix` passed the builder agent name (`builder-bugfix-332`) as the porch project ID, but `detectProjectIdFromCwd` returns `bugfix-332`. When `findStatusPath` searched for a directory starting with `bugfix-332-`, it couldn't find `builder-bugfix-332-slug/`.

2. **Regex too strict**: `detectProjectIdFromCwd` regex expected `.builders/bugfix-N/` (exact match), but actual worktree paths include slug suffixes from issue titles (e.g., `.builders/bugfix-332-fix-login-bug/`).

## Fix
- Use `bugfix-{N}` as the porch project ID (separating it from the agent farm builder name)
- Update the CWD detection regex to optionally consume slug suffixes after the numeric ID

## Test Plan
- [x] Added 3 new unit tests for slug-suffixed worktree detection
- [x] All 39 porch state tests pass
- [x] All 119 spawn tests pass
- [x] Build succeeds
- [x] Pre-existing test failures in unrelated files confirmed unaffected

## Files Changed
- `packages/codev/src/agent-farm/commands/spawn.ts` — Use `bugfix-{N}` as porch project ID
- `packages/codev/src/commands/porch/state.ts` — Fix CWD detection regex
- `packages/codev/src/commands/porch/__tests__/state.test.ts` — Add regression tests