### PR TITLE
[Bugfix #326] Filter dead builders from Work view

### DIFF
--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -561,7 +561,17 @@ async function handleOverview(res: http.ServerResponse, url: URL, workspaceOverr
     return;
   }
 
-  const data = await overviewCache.getOverview(workspaceRoot);
+  // Build set of active builder role_ids (lowercased) from live terminal sessions
+  const wsTerminals = getWorkspaceTerminals();
+  const entry = wsTerminals.get(normalizeWorkspacePath(workspaceRoot));
+  const activeBuilderRoleIds = new Set<string>();
+  if (entry) {
+    for (const key of entry.builders.keys()) {
+      activeBuilderRoleIds.add(key.toLowerCase());
+    }
+  }
+
+  const data = await overviewCache.getOverview(workspaceRoot, activeBuilderRoleIds);
   res.writeHead(200, { 'Content-Type': 'application/json' });
   res.end(JSON.stringify(data));
 }


### PR DESCRIPTION
## Summary
Fixes #326

`discoverBuilders()` was listing ALL worktrees in `.builders/` as active builders — including dead ones with no running terminal session. The dashboard showed 18 "active builders" when only 1 was actually alive.

## Root Cause
PR #334 fixed project-to-worktree matching (so each builder shows its own project, not #87), but did not filter by whether the builder actually has a live terminal session in Tower. Every `.builders/` directory was treated as an active builder regardless of session state.

## Fix
- Added `worktreeNameToRoleId()` helper in `overview.ts` that maps worktree directory names to the terminal role_id format used by `buildAgentName()` during spawn
- Modified `OverviewCache.getOverview()` to accept an optional `activeBuilderRoleIds` set and filter discovered builders against it
- Updated the overview route handler in `tower-routes.ts` to pass the active builder role IDs from `WorkspaceTerminals.builders` registry

Only worktrees with a live terminal session in Tower's in-memory registry now appear in the Work view.

## Test Plan
- [x] Added 10 unit tests for `worktreeNameToRoleId()` covering all worktree naming patterns (spir, tick, bugfix, task, worktree, legacy numeric, generic protocol)
- [x] Added 2 integration tests for active-session filtering in `OverviewCache.getOverview()`
- [x] All 52 overview tests pass
- [x] Backward-compatible: `getOverview()` without `activeBuilderRoleIds` returns all discovered builders (existing tests unchanged)