### PR TITLE
[Bugfix #331] Add missing calculateProgress test case for 3/5 phases

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -289,6 +289,19 @@ describe('overview', () => {
       }))).toBe(50);
     });
 
+    it('returns 74 for implement phase with 3 of 5 complete', () => {
+      expect(calculateProgress(makeParsed({
+        phase: 'implement',
+        planPhases: [
+          { id: 'p1', title: 'A', status: 'complete' },
+          { id: 'p2', title: 'B', status: 'complete' },
+          { id: 'p3', title: 'C', status: 'complete' },
+          { id: 'p4', title: 'D', status: 'in_progress' },
+          { id: 'p5', title: 'E', status: 'pending' },
+        ],
+      }))).toBe(74);
+    });
+
     it('returns 66 for implement phase with 2 of 5 complete', () => {
       expect(calculateProgress(makeParsed({
         phase: 'implement',


### PR DESCRIPTION
## Summary
Fixes #331

## Root Cause
The overview test file was missing one specific data point from the issue requirements: the "3 of 5 plan phases complete → 74%" test case for `calculateProgress()`. All other 6 requirements from the issue were already fully implemented.

## Fix
Added the explicit "3 of 5 phases complete" test case to `calculateProgress` tests, verifying the formula yields 74% (50 + round(3/5 * 40) = 74).

## Test Plan
- [x] Added regression test for 3/5 phases → 74%
- [x] All 86 overview tests pass
- [x] Build succeeds
- [x] Full test suite: 75/76 files pass (1 pre-existing flaky test in send-integration.test.ts — known issue, unrelated)

## Requirements Checklist (Issue #331)
- [x] Tests for `extractProjectIdFromWorktreeName()` (all naming patterns) — already present
- [x] Tests for `calculateProgress()` (specify ~15%, plan ~40%, implement 3/5 ~74%, blocked, complete 100%) — added 3/5 case
- [x] `createBuilderWorktree()` accepts `projectDirName` — already present
- [x] All callers use matching project dir names — already correct
- [x] Regression test: multiple worktrees with inherited project dirs — already present
- [x] Mock PR data includes `createdAt` — already present
- [x] `parseStatusYaml` with `plan_phases` block test — already present