### PR TITLE
[Bugfix #330] Clean up Work view CSS — adjust section header size, remove dead comment

### DIFF
--- a/packages/codev/dashboard/src/index.css
+++ b/packages/codev/dashboard/src/index.css
@@ -789,7 +789,7 @@ body {
 }
 
 .work-section-title {
-  font-size: 13px;
+  font-size: 11px;
   font-weight: 600;
   color: var(--text-secondary);
   text-transform: uppercase;
@@ -799,8 +799,6 @@ body {
   align-items: center;
   gap: 6px;
 }
-
-/* work-section-count: removed (no count badges in redesign) */
 
 .work-empty {
   color: var(--text-muted);


### PR DESCRIPTION
## Summary
Fixes #330

## Root Cause
Issue #329 (UI redesign) already removed most dead CSS classes and added the row-based layout. However, two items remained:
1. Section header font-size was 13px instead of the spec's 11px
2. A stale comment about `work-section-count` removal was left behind

## Fix
- Changed `.work-section-title` font-size from 13px to 11px to match the issue spec for compact section headers
- Removed dead `/* work-section-count: removed */` comment
- Verified all dead CSS classes listed in the issue (`.builder-grid`, `.builder-card`, `.builder-mode-badge`, `.gate-badge`, `.pr-item`, `.backlog-item`, etc.) were already removed by #329

## Test Plan
- [x] Verified no dead CSS classes remain (grep across dashboard)
- [x] Build passes
- [x] All 1500 tests pass (76 test files)
- [x] Net diff: 1 insertion, 3 deletions (well under 300 LOC)

## CMAP Review
To be added after review.