### PR TITLE
[Bugfix #353] Add label tags to backlog issues and PR links to GitHub

### DIFF
--- a/packages/codev/dashboard/src/components/PRList.tsx
+++ b/packages/codev/dashboard/src/components/PRList.tsx
@@ -30,12 +30,12 @@ export function PRList({ prs }: PRListProps) {
       {prs.map(pr => {
         const status = STATUS_MAP[pr.reviewStatus] ?? STATUS_MAP.REVIEW_REQUIRED;
         return (
-          <div key={pr.number} className="pr-row">
+          <a key={pr.number} className="pr-row" href={pr.url} target="_blank" rel="noopener noreferrer">
             <span className="pr-row-number">#{pr.number}</span>
             <span className="pr-row-title">{pr.title}</span>
             <span className={`pr-row-status ${status.className}`}>{status.label}</span>
             <span className="pr-row-age">{timeAgo(pr.createdAt)}</span>
-          </div>
+          </a>
         );
       })}
     </div>

--- a/packages/codev/dashboard/src/index.css
+++ b/packages/codev/dashboard/src/index.css
@@ -931,6 +931,12 @@ body {
   gap: 4px;
 }
 
+a.pr-row {
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+}
+
 .pr-row {
   display: flex;
   align-items: center;

--- a/packages/codev/dashboard/src/lib/api.ts
+++ b/packages/codev/dashboard/src/lib/api.ts
@@ -93,6 +93,7 @@ export interface OverviewBuilder {
 export interface OverviewPR {
   number: number;
   title: string;
+  url: string;
   reviewStatus: string;
   linkedIssue: number | null;
   createdAt: string;

--- a/packages/codev/src/__tests__/github.test.ts
+++ b/packages/codev/src/__tests__/github.test.ts
@@ -127,4 +127,32 @@ describe('parseLabelDefaults', () => {
       { name: 'priority:high' },
     ])).toEqual({ type: 'feature', priority: 'high' });
   });
+
+  it('matches bare "bug" label when no type: prefix exists', () => {
+    expect(parseLabelDefaults([{ name: 'bug' }])).toEqual({
+      type: 'bug',
+      priority: 'medium',
+    });
+  });
+
+  it('matches bare "project" label when no type: prefix exists', () => {
+    expect(parseLabelDefaults([{ name: 'project' }])).toEqual({
+      type: 'project',
+      priority: 'medium',
+    });
+  });
+
+  it('prefers type: prefixed label over bare label', () => {
+    expect(parseLabelDefaults([
+      { name: 'bug' },
+      { name: 'type:project' },
+    ])).toEqual({ type: 'project', priority: 'medium' });
+  });
+
+  it('ignores bare labels that are not known types', () => {
+    expect(parseLabelDefaults([
+      { name: 'help-wanted' },
+      { name: 'good-first-issue' },
+    ])).toEqual({ type: 'feature', priority: 'medium' });
+  });
 });

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -915,7 +915,7 @@ describe('overview', () => {
       ].join('\n'), '0042-test');
 
       mockFetchPRList.mockResolvedValue([
-        { number: 10, title: '[Spec 42] Add feature', reviewDecision: 'APPROVED', body: '', createdAt: '2026-01-10T00:00:00Z' },
+        { number: 10, title: '[Spec 42] Add feature', url: 'https://github.com/org/repo/pull/10', reviewDecision: 'APPROVED', body: '', createdAt: '2026-01-10T00:00:00Z' },
       ]);
       mockFetchIssueList.mockResolvedValue([
         { number: 99, title: 'Backlog item', labels: [], createdAt: '2026-01-01T00:00:00Z' },
@@ -1017,7 +1017,7 @@ describe('overview', () => {
 
       // Second call: gh succeeds
       mockFetchPRList.mockResolvedValueOnce([
-        { number: 1, title: 'Test', reviewDecision: '', body: '', createdAt: '2026-01-01T00:00:00Z' },
+        { number: 1, title: 'Test', url: 'https://github.com/org/repo/pull/1', reviewDecision: '', body: '', createdAt: '2026-01-01T00:00:00Z' },
       ]);
 
       const data2 = await cache.getOverview(tmpDir);
@@ -1027,7 +1027,7 @@ describe('overview', () => {
 
     it('filters backlog issues that are linked to PRs', async () => {
       mockFetchPRList.mockResolvedValue([
-        { number: 10, title: 'Fix', reviewDecision: '', body: 'Fixes #42', createdAt: '2026-01-10T00:00:00Z' },
+        { number: 10, title: 'Fix', url: 'https://github.com/org/repo/pull/10', reviewDecision: '', body: 'Fixes #42', createdAt: '2026-01-10T00:00:00Z' },
       ]);
       mockFetchIssueList.mockResolvedValue([
         { number: 42, title: 'Bug 42', labels: [], createdAt: '2026-01-01T00:00:00Z' },
@@ -1045,11 +1045,23 @@ describe('overview', () => {
       expect(data.pendingPRs[0].linkedIssue).toBe(42);
     });
 
+    it('passes through PR url field', async () => {
+      mockFetchPRList.mockResolvedValue([
+        { number: 5, title: 'Test PR', url: 'https://github.com/org/repo/pull/5', reviewDecision: 'APPROVED', body: '', createdAt: '2026-01-05T00:00:00Z' },
+      ]);
+      mockFetchIssueList.mockResolvedValue([]);
+
+      const cache = new OverviewCache();
+      const data = await cache.getOverview(tmpDir);
+
+      expect(data.pendingPRs[0].url).toBe('https://github.com/org/repo/pull/5');
+    });
+
     it('parses PR review statuses', async () => {
       mockFetchPRList.mockResolvedValue([
-        { number: 1, title: 'Approved', reviewDecision: 'APPROVED', body: '', createdAt: '2026-01-01T00:00:00Z' },
-        { number: 2, title: 'Changes', reviewDecision: 'CHANGES_REQUESTED', body: '', createdAt: '2026-01-02T00:00:00Z' },
-        { number: 3, title: 'Pending', reviewDecision: '', body: '', createdAt: '2026-01-03T00:00:00Z' },
+        { number: 1, title: 'Approved', url: 'https://github.com/org/repo/pull/1', reviewDecision: 'APPROVED', body: '', createdAt: '2026-01-01T00:00:00Z' },
+        { number: 2, title: 'Changes', url: 'https://github.com/org/repo/pull/2', reviewDecision: 'CHANGES_REQUESTED', body: '', createdAt: '2026-01-02T00:00:00Z' },
+        { number: 3, title: 'Pending', url: 'https://github.com/org/repo/pull/3', reviewDecision: '', body: '', createdAt: '2026-01-03T00:00:00Z' },
       ]);
       mockFetchIssueList.mockResolvedValue([]);
 

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -45,6 +45,7 @@ export interface BuilderOverview {
 export interface PROverview {
   number: number;
   title: string;
+  url: string;
   reviewStatus: string;
   linkedIssue: number | null;
   createdAt: string;
@@ -586,6 +587,7 @@ export class OverviewCache {
       pendingPRs = prs.map(pr => ({
         number: pr.number,
         title: pr.title,
+        url: pr.url,
         reviewStatus: pr.reviewDecision || 'REVIEW_REQUIRED',
         linkedIssue: parseLinkedIssue(pr.body || '', pr.title),
         createdAt: pr.createdAt,


### PR DESCRIPTION
## Summary
Fixes #353
Fixes #351

## Root Cause

### 1. Backlog issues show wrong type labels
`parseLabelDefaults()` in `github.ts` only matched `type:*` prefixed labels (e.g. `type:bug`), but the actual GitHub labels are bare names (`bug`, `project`). Every issue defaulted to "feature" — no visual distinction.

### 2. PRs don't link to GitHub
The PR data pipeline (`GitHubPR` → `PROverview` → `OverviewPR`) had no `url` field. PR rows in the Work view rendered as plain `<div>` elements with no clickable link.

## Fix

### 1. Bare label matching
Updated `parseLabelDefaults()` to fall back to matching bare `bug` and `project` labels when no `type:*` prefixed labels exist. Prefixed labels still take priority.

### 2. PR links
- Added `url` field to `GitHubPR`, `PROverview`, and `OverviewPR` interfaces
- Updated `fetchPRList()` to request `url` from `gh pr list --json`
- Changed PR row from `<div>` to `<a>` with `target="_blank"` linking to the GitHub PR URL

## Test Plan
- [x] Added 4 regression tests for bare label matching (bug, project, prefix-priority, unknown-labels)
- [x] Added regression test for PR url passthrough in overview
- [x] All 115 relevant tests pass (github: 28/28, overview: 87/87)
- [x] Build passes
- [x] Type checking passes