### PR TITLE
[Bugfix #347] Fix: Make task builders first-class in af CLI

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/cleanup-task-builders.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/cleanup-task-builders.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for cleanup command — task builder lookup logic (Bugfix #347)
+ *
+ * Task builders use worktree names like "task-bEPd" but their state DB IDs
+ * are "builder-task-bepd" (via buildAgentName). Cleanup must normalize
+ * these lookups correctly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Builder } from '../types.js';
+
+/**
+ * Re-implement the cleanup lookup logic for testing.
+ * Mirrors the task lookup in cleanup.ts without requiring DB or git side effects.
+ */
+function findTaskBuilder(builders: Builder[], taskName: string): Builder | undefined {
+  // Task builder IDs are "builder-task-<lowercased shortId>" (via buildAgentName)
+  // Extract the shortId from the worktree name (e.g., "task-bEPd" → "bEPd" → "bepd")
+  const shortId = taskName.startsWith('task-') ? taskName.slice(5) : taskName;
+  const normalizedId = `builder-task-${shortId.toLowerCase()}`;
+  let builder = builders.find((b) => b.id === normalizedId);
+
+  if (!builder) {
+    // Fallback: check by worktree path containing the task name
+    builder = builders.find((b) => b.worktree.endsWith(`/${taskName}`) || b.worktree.endsWith(`/${taskName}/`));
+  }
+
+  return builder;
+}
+
+/**
+ * Re-implement the --project lookup for task IDs.
+ * Mirrors the project lookup in cleanup.ts.
+ */
+function findByProject(builders: Builder[], projectId: string): Builder | undefined {
+  // Direct ID match
+  let builder = builders.find((b) => b.id === projectId);
+
+  if (!builder && projectId.startsWith('task-')) {
+    // Normalized task ID
+    const shortId = projectId.slice(5);
+    const normalizedId = `builder-task-${shortId.toLowerCase()}`;
+    builder = builders.find((b) => b.id === normalizedId);
+  }
+
+  if (!builder) {
+    // Name pattern match
+    builder = builders.find((b) => b.name.includes(projectId));
+  }
+
+  return builder;
+}
+
+// Helper to create a minimal Builder for testing
+function makeBuilder(overrides: Partial<Builder>): Builder {
+  return {
+    id: 'test-builder',
+    name: 'Test Builder',
+    status: 'implementing',
+    phase: 'init',
+    worktree: '/workspace/.builders/test',
+    branch: 'builder/test',
+    type: 'task',
+    ...overrides,
+  };
+}
+
+describe('Cleanup — Task builder lookup (Bugfix #347)', () => {
+  const taskBuilder = makeBuilder({
+    id: 'builder-task-bepd',
+    name: 'Task: Quick fix for auth',
+    worktree: '/workspace/.builders/task-bEPd',
+    branch: 'builder/task-bEPd',
+    type: 'task',
+  });
+
+  const bugfixBuilder = makeBuilder({
+    id: 'bugfix-42',
+    name: 'Bugfix: Login fails',
+    worktree: '/workspace/.builders/bugfix-42-login-fails',
+    branch: 'builder/bugfix-42-login-fails',
+    type: 'bugfix',
+    issueNumber: 42,
+  });
+
+  const builders = [taskBuilder, bugfixBuilder];
+
+  describe('findTaskBuilder (--task option)', () => {
+    it('finds task builder by worktree name with correct casing', () => {
+      const found = findTaskBuilder(builders, 'task-bEPd');
+      expect(found).toBe(taskBuilder);
+    });
+
+    it('finds task builder by worktree name with different casing', () => {
+      const found = findTaskBuilder(builders, 'task-BEPD');
+      expect(found).toBe(taskBuilder);
+    });
+
+    it('finds task builder by short ID alone', () => {
+      const found = findTaskBuilder(builders, 'bEPd');
+      expect(found).toBe(taskBuilder);
+    });
+
+    it('returns undefined for non-existent task', () => {
+      const found = findTaskBuilder(builders, 'task-XyZw');
+      expect(found).toBeUndefined();
+    });
+
+    it('does not find bugfix builders', () => {
+      const found = findTaskBuilder(builders, 'bugfix-42');
+      expect(found).toBeUndefined();
+    });
+
+    it('finds by worktree path fallback', () => {
+      // Builder ID doesn't match but worktree path does
+      const oddBuilder = makeBuilder({
+        id: 'weird-id',
+        worktree: '/workspace/.builders/task-AbCd',
+      });
+      const found = findTaskBuilder([oddBuilder], 'task-AbCd');
+      expect(found).toBe(oddBuilder);
+    });
+  });
+
+  describe('findByProject — handles task-* project IDs', () => {
+    it('finds task builder via --project task-bEPd', () => {
+      const found = findByProject(builders, 'task-bEPd');
+      expect(found).toBe(taskBuilder);
+    });
+
+    it('finds bugfix builder via --project bugfix-42', () => {
+      const found = findByProject(builders, 'bugfix-42');
+      expect(found).toBe(bugfixBuilder);
+    });
+
+    it('finds builder by direct ID match', () => {
+      const found = findByProject(builders, 'builder-task-bepd');
+      expect(found).toBe(taskBuilder);
+    });
+
+    it('returns undefined for non-existent project', () => {
+      const found = findByProject(builders, 'task-ZZZZ');
+      expect(found).toBeUndefined();
+    });
+  });
+
+  describe('cleanup behavior — ephemeral builders', () => {
+    it('task builders should be treated as ephemeral (like bugfix)', () => {
+      // This documents the expected behavior: task builders get full cleanup
+      // (worktree removal + branch deletion) just like bugfix builders
+      const isEphemeral = taskBuilder.type === 'bugfix' || taskBuilder.type === 'task';
+      expect(isEphemeral).toBe(true);
+    });
+
+    it('bugfix builders are ephemeral', () => {
+      const isEphemeral = bugfixBuilder.type === 'bugfix' || bugfixBuilder.type === 'task';
+      expect(isEphemeral).toBe(true);
+    });
+
+    it('spec builders are NOT ephemeral', () => {
+      const specBuilder = makeBuilder({ type: 'spec' });
+      const isEphemeral = specBuilder.type === 'bugfix' || specBuilder.type === 'task';
+      expect(isEphemeral).toBe(false);
+    });
+  });
+});

--- a/packages/codev/src/agent-farm/__tests__/spawn.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/spawn.test.ts
@@ -40,8 +40,12 @@ function validateSpawnOptions(options: SpawnOptions): string | null {
     return '--files requires --task';
   }
 
-  if ((options.noComment || options.force) && !options.issueNumber) {
-    return '--no-comment and --force require an issue number';
+  if (options.noComment && !options.issueNumber) {
+    return '--no-comment requires an issue number';
+  }
+
+  if (options.force && !options.issueNumber && !options.task) {
+    return '--force requires an issue number (not needed for --task)';
   }
 
   // --protocol cannot be used with --shell or --worktree
@@ -159,6 +163,11 @@ describe('Spawn Command', () => {
         expect(validateSpawnOptions(options)).toBeNull();
       });
 
+      it('should accept --task with --force (Bugfix #347: task builders skip dirty worktree)', () => {
+        const options: SpawnOptions = { task: 'Quick fix', force: true };
+        expect(validateSpawnOptions(options)).toBeNull();
+      });
+
       it('should accept --protocol alone', () => {
         const options: SpawnOptions = { protocol: 'maintain' };
         expect(validateSpawnOptions(options)).toBeNull();
@@ -227,13 +236,13 @@ describe('Spawn Command', () => {
       it('should reject --no-comment without issue number', () => {
         const options: SpawnOptions = { task: 'Fix bug', noComment: true };
         const error = validateSpawnOptions(options);
-        expect(error).toContain('--no-comment and --force require an issue number');
+        expect(error).toContain('--no-comment requires an issue number');
       });
 
-      it('should reject --force without issue number', () => {
-        const options: SpawnOptions = { task: 'Fix bug', force: true };
+      it('should reject --force without issue number or task', () => {
+        const options: SpawnOptions = { protocol: 'maintain', force: true };
         const error = validateSpawnOptions(options);
-        expect(error).toContain('--no-comment and --force require an issue number');
+        expect(error).toContain('--force requires an issue number');
       });
 
       it('should reject --files without --task', () => {

--- a/packages/codev/src/agent-farm/cli.ts
+++ b/packages/codev/src/agent-farm/cli.ts
@@ -281,20 +281,22 @@ export async function runAgentFarm(args: string[]): Promise<void> {
     .description('Clean up a builder worktree and branch')
     .option('-p, --project <id>', 'Builder ID to clean up')
     .option('-i, --issue <number>', 'Cleanup bugfix builder for a GitHub issue')
+    .option('-t, --task <id>', 'Cleanup task builder (e.g., task-bEPd)')
     .option('-f, --force', 'Force cleanup even if branch not merged')
     .action(async (options) => {
       const { cleanup } = await import('./commands/cleanup.js');
       try {
         const issue = options.issue ? parseInt(options.issue, 10) : undefined;
-        if (!options.project && !issue) {
-          logger.error('Must specify either --project (-p) or --issue (-i)');
+        const specifiedCount = [options.project, issue, options.task].filter(Boolean).length;
+        if (specifiedCount === 0) {
+          logger.error('Must specify one of --project (-p), --issue (-i), or --task (-t)');
           process.exit(1);
         }
-        if (options.project && issue) {
-          logger.error('--project and --issue are mutually exclusive');
+        if (specifiedCount > 1) {
+          logger.error('--project, --issue, and --task are mutually exclusive');
           process.exit(1);
         }
-        await cleanup({ project: options.project, issue, force: options.force });
+        await cleanup({ project: options.project, issue, task: options.task, force: options.force });
       } catch (error) {
         logger.error(error instanceof Error ? error.message : String(error));
         process.exit(1);


### PR DESCRIPTION
## Summary
Fixes #347

Task builders (`af spawn --task`) were second-class citizens in the af CLI:

1. **`af cleanup` couldn't find task builders** — Added `--task` option and normalized task-XXX lookups to builder-task-xxx IDs. Task builders now get full ephemeral cleanup (worktree + branch removal) same as bugfix builders.

2. **`af spawn --task` blocked by dirty worktree** — Task builders now skip the dirty worktree check entirely since they're ephemeral and don't depend on committed specs/plans. `--force` also works with `--task` now.

3. **`af status` / dashboard visibility** — Verified already working: `discoverBuilders()` and `worktreeNameToRoleId()` correctly handle `task-*` patterns. No code changes needed.

## Root Cause
- Cleanup: ID lookup didn't normalize `task-bEPd` → `builder-task-bepd`, and `cleanupBuilder` only fully removed bugfix worktrees
- Spawn: Validation coupled `--force` to `--no-comment` requiring issue number; dirty worktree check had no task exemption

## Fix
- `cleanup.ts`: Add `--task` option, normalize task ID lookups, treat task type as ephemeral (full cleanup)
- `spawn.ts`: Split `--force`/`--no-comment` validation, skip dirty worktree check for `--task`
- `cli.ts`: Add `-t, --task` option to cleanup command

## Test Plan
- [x] Added 13 regression tests in `cleanup-task-builders.test.ts`
- [x] Updated 3 existing spawn validation tests for new behavior
- [x] Added 1 new spawn test for `--task` + `--force`
- [x] All 1514 unit tests pass
- [x] Build succeeds with no type errors