### PR TITLE
[Bugfix #365] Fix doubled project ID in plan/review filenames

### DIFF
--- a/codev-skeleton/protocols/spir/prompts/plan.md
+++ b/codev-skeleton/protocols/spir/prompts/plan.md
@@ -11,8 +11,8 @@ Transform the approved specification into an executable implementation plan with
 - **Project ID**: {{project_id}}
 - **Project Title**: {{title}}
 - **Current State**: {{current_state}}
-- **Spec File**: `codev/specs/{{project_id}}-{{title}}.md`
-- **Plan File**: `codev/plans/{{project_id}}-{{title}}.md`
+- **Spec File**: `codev/specs/{{artifact_name}}.md`
+- **Plan File**: `codev/plans/{{artifact_name}}.md`
 
 ## Prerequisites
 
@@ -74,7 +74,7 @@ After completing the plan draft, signal completion. Porch will run 3-way consult
 
 ## Output
 
-Create the plan file at `codev/plans/{{project_id}}-{{title}}.md`.
+Create the plan file at `codev/plans/{{artifact_name}}.md`.
 
 Use the plan template from `codev/protocols/spir/templates/plan.md` if available.
 
@@ -129,7 +129,7 @@ Make commits at these milestones:
 
 **CRITICAL**: Never use `git add .` or `git add -A`. Always stage specific files:
 ```bash
-git add codev/plans/{{project_id}}-{{title}}.md
+git add codev/plans/{{artifact_name}}.md
 ```
 
 ## Important Notes

--- a/codev-skeleton/protocols/spir/prompts/review.md
+++ b/codev-skeleton/protocols/spir/prompts/review.md
@@ -11,9 +11,9 @@ Perform a comprehensive review, document lessons learned, and prepare for PR sub
 - **Project ID**: {{project_id}}
 - **Project Title**: {{title}}
 - **Current State**: {{current_state}}
-- **Spec File**: `codev/specs/{{project_id}}-{{title}}.md`
-- **Plan File**: `codev/plans/{{project_id}}-{{title}}.md`
-- **Review File**: `codev/reviews/{{project_id}}-{{title}}.md`
+- **Spec File**: `codev/specs/{{artifact_name}}.md`
+- **Plan File**: `codev/plans/{{artifact_name}}.md`
+- **Review File**: `codev/reviews/{{artifact_name}}.md`
 
 ## Prerequisites
 
@@ -57,7 +57,7 @@ Compare final implementation to original specification:
 
 ### 3. Create Review Document
 
-Create `codev/reviews/{{project_id}}-{{title}}.md`:
+Create `codev/reviews/{{artifact_name}}.md`:
 
 ```markdown
 # Review: {{title}}
@@ -135,10 +135,10 @@ gh pr create --title "[Spec {{project_id}}] {{title}}" --body "$(cat <<'EOF'
 - Manual testing completed for [Y]
 
 ## Spec
-Link: codev/specs/{{project_id}}-{{title}}.md
+Link: codev/specs/{{artifact_name}}.md
 
 ## Review
-Link: codev/reviews/{{project_id}}-{{title}}.md
+Link: codev/reviews/{{artifact_name}}.md
 EOF
 )"
 ```
@@ -151,7 +151,7 @@ changes, you'll be respawned with their feedback.
 
 ## Output
 
-- Review document at `codev/reviews/{{project_id}}-{{title}}.md`
+- Review document at `codev/reviews/{{artifact_name}}.md`
 - Updated documentation (if needed)
 - Pull request created and ready for review
 

--- a/codev-skeleton/protocols/spir/prompts/specify.md
+++ b/codev-skeleton/protocols/spir/prompts/specify.md
@@ -11,7 +11,7 @@ Create a comprehensive specification document that thoroughly explores the probl
 - **Project ID**: {{project_id}}
 - **Project Title**: {{title}}
 - **Current State**: {{current_state}}
-- **Spec File**: `codev/specs/{{project_id}}-{{title}}.md`
+- **Spec File**: `codev/specs/{{artifact_name}}.md`
 
 ## Process
 
@@ -82,12 +82,12 @@ After completing the spec draft, signal completion. Porch will run 3-way consult
 
 ## Output
 
-Create or update the specification file at `codev/specs/{{project_id}}-{{title}}.md`.
+Create or update the specification file at `codev/specs/{{artifact_name}}.md`.
 
 **IMPORTANT**: Keep spec/plan/review filenames in sync:
-- Spec: `codev/specs/{{project_id}}-{{title}}.md`
-- Plan: `codev/plans/{{project_id}}-{{title}}.md`
-- Review: `codev/reviews/{{project_id}}-{{title}}.md`
+- Spec: `codev/specs/{{artifact_name}}.md`
+- Plan: `codev/plans/{{artifact_name}}.md`
+- Review: `codev/reviews/{{artifact_name}}.md`
 
 ## Signals
 
@@ -121,7 +121,7 @@ Make commits at these milestones:
 
 **CRITICAL**: Never use `git add .` or `git add -A`. Always stage specific files:
 ```bash
-git add codev/specs/{{project_id}}-{{title}}.md
+git add codev/specs/{{artifact_name}}.md
 ```
 
 ## Important Notes

--- a/packages/codev/src/commands/porch/index.ts
+++ b/packages/codev/src/commands/porch/index.ts
@@ -19,6 +19,7 @@ import {
   getStatusPath,
   detectProjectId,
   resolveProjectId,
+  resolveArtifactBaseName,
 } from './state.js';
 import {
   loadProtocol,
@@ -180,7 +181,7 @@ export async function check(workspaceRoot: string, projectId: string): Promise<v
     return;
   }
 
-  const checkEnv: CheckEnv = { PROJECT_ID: state.id, PROJECT_TITLE: state.title };
+  const checkEnv: CheckEnv = { PROJECT_ID: state.id, PROJECT_TITLE: resolveArtifactBaseName(workspaceRoot, state.id, state.title) };
 
   console.log('');
   console.log(chalk.bold('RUNNING CHECKS...'));
@@ -216,7 +217,7 @@ export async function done(workspaceRoot: string, projectId: string): Promise<vo
 
   // Run checks first
   if (Object.keys(checks).length > 0) {
-    const checkEnv: CheckEnv = { PROJECT_ID: state.id, PROJECT_TITLE: state.title };
+    const checkEnv: CheckEnv = { PROJECT_ID: state.id, PROJECT_TITLE: resolveArtifactBaseName(workspaceRoot, state.id, state.title) };
 
     console.log('');
     console.log(chalk.bold('RUNNING CHECKS...'));
@@ -465,7 +466,7 @@ export async function approve(
   const checks = getPhaseChecks(protocol, state.phase);
 
   if (Object.keys(checks).length > 0) {
-    const checkEnv: CheckEnv = { PROJECT_ID: state.id, PROJECT_TITLE: state.title };
+    const checkEnv: CheckEnv = { PROJECT_ID: state.id, PROJECT_TITLE: resolveArtifactBaseName(workspaceRoot, state.id, state.title) };
 
     console.log('');
     console.log(chalk.bold('RUNNING CHECKS...'));
@@ -590,14 +591,15 @@ function getNextAction(state: ProjectState, protocol: Protocol): string {
   return `Complete the phase work, then run: porch done ${state.id}`;
 }
 
-function getArtifactForPhase(_workspaceRoot: string, state: ProjectState): string | null {
+function getArtifactForPhase(workspaceRoot: string, state: ProjectState): string | null {
+  const baseName = resolveArtifactBaseName(workspaceRoot, state.id, state.title);
   switch (state.phase) {
     case 'specify':
-      return `codev/specs/${state.id}-${state.title}.md`;
+      return `codev/specs/${baseName}.md`;
     case 'plan':
-      return `codev/plans/${state.id}-${state.title}.md`;
+      return `codev/plans/${baseName}.md`;
     case 'review':
-      return `codev/reviews/${state.id}-${state.title}.md`;
+      return `codev/reviews/${baseName}.md`;
     default:
       return null;
   }

--- a/packages/codev/src/commands/porch/next.ts
+++ b/packages/codev/src/commands/porch/next.ts
@@ -12,7 +12,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { globSync } from 'glob';
-import { readState, writeState, findStatusPath, getProjectDir } from './state.js';
+import { readState, writeState, findStatusPath, getProjectDir, resolveArtifactBaseName } from './state.js';
 import {
   loadProtocol,
   getPhaseConfig,
@@ -254,7 +254,10 @@ export async function next(workspaceRoot: string, projectId: string): Promise<Po
   if (isBuildVerify(protocol, state.phase) && !state.build_complete && state.iteration === 1) {
     const buildConfig = getBuildConfig(protocol, state.phase);
     if (buildConfig?.artifact) {
-      const artifactGlob = buildConfig.artifact.replace('${PROJECT_ID}', state.id);
+      const artifactBaseName = resolveArtifactBaseName(workspaceRoot, state.id, state.title);
+      const artifactGlob = buildConfig.artifact
+        .replace('${PROJECT_ID}', state.id)
+        .replace('${PROJECT_TITLE}', artifactBaseName);
       if (isArtifactPreApproved(workspaceRoot, artifactGlob)) {
         // Auto-approve gate and advance
         const gateName = getPhaseGate(protocol, state.phase);


### PR DESCRIPTION
## Summary

Fixes #365. Porch was creating artifact filenames with doubled project IDs (e.g. `364-0364-terminal-refresh-button.md` instead of `0364-terminal-refresh-button.md`).

**Root cause:** `getArtifactForPhase()` constructed paths as `${state.id}-${state.title}`, but `state.title` could already contain the ID prefix (from spawn's title normalization). Combined with the protocol.json change (commit d472386c) that switched to `${PROJECT_TITLE}` patterns, this caused doubling.

**Fix:**
- New `resolveArtifactBaseName()` utility looks up the actual spec file on disk to derive the canonical artifact name, preserving zero-padded IDs
- New `stripIdPrefix()` utility safely removes ID prefixes from title strings
- Fixed `getArtifactForPhase()`, all `checkEnv` assignments, artifact glob substitution in `next.ts`, `findPlanFile()` normalized matching, and prompt templates

## Changes
- `packages/codev/src/commands/porch/state.ts` — Added `stripIdPrefix()`, `resolveArtifactBaseName()`, fixed `getProjectDir()`
- `packages/codev/src/commands/porch/index.ts` — Fixed `getArtifactForPhase()` and 3 `checkEnv` lines
- `packages/codev/src/commands/porch/next.ts` — Fixed artifact glob `${PROJECT_TITLE}` substitution
- `packages/codev/src/commands/porch/prompts.ts` — Added `artifact_name` template variable
- `packages/codev/src/commands/porch/plan.ts` — Fixed `findPlanFile()` normalized ID matching
- `codev-skeleton/protocols/spir/prompts/{specify,plan,review}.md` — Use `{{artifact_name}}` instead of `{{project_id}}-{{title}}`
- `packages/codev/src/commands/porch/__tests__/state.test.ts` — Regression tests

## Testing
- All porch state tests pass (49 tests including 10 new regression tests)
- Full test suite: 1509 passed, pre-existing failures in unrelated session-manager/update tests
- TypeScript compiles cleanly