### PR TITLE
[Bugfix #389] Fix: Kill shellper processes during af cleanup

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/cleanup-shellper-kill.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/cleanup-shellper-kill.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for cleanup command — shellper process kill (Bugfix #389)
+ *
+ * When `af cleanup` runs, it must kill shellper processes associated with the
+ * builder's worktree. Previously, cleanup relied solely on the Tower API which
+ * silently fails when Tower is not running or the terminal was already removed.
+ *
+ * The fix adds a direct `ps`-based search for shellper-main.js processes whose
+ * JSON config contains the worktree path, killing them via process group signal.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { killShellperProcesses } from '../commands/cleanup.js';
+import { execFile } from 'node:child_process';
+
+// Mock execFile to simulate ps output
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    execFile: vi.fn(),
+  };
+});
+
+const mockExecFile = vi.mocked(execFile);
+
+// Mock process.kill to track kill signals
+const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('killShellperProcesses (Bugfix #389)', () => {
+  const worktree = '/workspace/.builders/bugfix-42-login-fails';
+
+  function simulatePsOutput(stdout: string): void {
+    mockExecFile.mockImplementation((_cmd, _args, callback) => {
+      (callback as (err: Error | null, stdout: string) => void)(null, stdout);
+      return {} as ReturnType<typeof execFile>;
+    });
+  }
+
+  function simulatePsError(): void {
+    mockExecFile.mockImplementation((_cmd, _args, callback) => {
+      (callback as (err: Error | null, stdout: string) => void)(new Error('ps failed'), '');
+      return {} as ReturnType<typeof execFile>;
+    });
+  }
+
+  it('kills shellper processes matching the worktree cwd', async () => {
+    simulatePsOutput(
+      `  PID ARGS\n` +
+      `12345 node /path/to/shellper-main.js {"command":"/bin/bash","args":[],"cwd":"${worktree}","socketPath":"/tmp/shellper-abc.sock"}\n` +
+      `99999 node /usr/bin/some-other-process\n`
+    );
+
+    const killed = await killShellperProcesses(worktree);
+
+    expect(killed).toBe(1);
+    // Should attempt process group kill first (-pid)
+    expect(killSpy).toHaveBeenCalledWith(-12345, 'SIGTERM');
+  });
+
+  it('does not kill shellper processes for different worktrees', async () => {
+    simulatePsOutput(
+      `  PID ARGS\n` +
+      `12345 node /path/to/shellper-main.js {"command":"/bin/bash","args":[],"cwd":"/workspace/.builders/bugfix-99-other","socketPath":"/tmp/shellper-abc.sock"}\n`
+    );
+
+    const killed = await killShellperProcesses(worktree);
+
+    expect(killed).toBe(0);
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not match partial worktree path prefixes', async () => {
+    // bugfix-42 should NOT match bugfix-42-login-fails-continued
+    const shortWorktree = '/workspace/.builders/bugfix-42';
+    simulatePsOutput(
+      `  PID ARGS\n` +
+      `12345 node /path/to/shellper-main.js {"command":"/bin/bash","args":[],"cwd":"${shortWorktree}-login-fails-continued","socketPath":"/tmp/shellper-abc.sock"}\n`
+    );
+
+    const killed = await killShellperProcesses(shortWorktree);
+
+    expect(killed).toBe(0);
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it('kills multiple shellper processes for the same worktree', async () => {
+    simulatePsOutput(
+      `  PID ARGS\n` +
+      `12345 node /path/to/shellper-main.js {"command":"/bin/bash","args":[],"cwd":"${worktree}","socketPath":"/tmp/shellper-abc.sock"}\n` +
+      `12346 node /path/to/shellper-main.js {"command":"/bin/bash","args":[],"cwd":"${worktree}","socketPath":"/tmp/shellper-def.sock"}\n`
+    );
+
+    const killed = await killShellperProcesses(worktree);
+
+    expect(killed).toBe(2);
+    expect(killSpy).toHaveBeenCalledWith(-12345, 'SIGTERM');
+    expect(killSpy).toHaveBeenCalledWith(-12346, 'SIGTERM');
+  });
+
+  it('falls back to individual PID kill when process group kill fails', async () => {
+    simulatePsOutput(
+      `  PID ARGS\n` +
+      `12345 node /path/to/shellper-main.js {"command":"/bin/bash","args":[],"cwd":"${worktree}","socketPath":"/tmp/shellper-abc.sock"}\n`
+    );
+
+    // First call (-pid group kill) fails, second call (individual pid) succeeds
+    killSpy
+      .mockImplementationOnce(() => { throw new Error('ESRCH'); })
+      .mockImplementationOnce(() => true);
+
+    const killed = await killShellperProcesses(worktree);
+
+    expect(killed).toBe(1);
+    expect(killSpy).toHaveBeenCalledWith(-12345, 'SIGTERM');
+    expect(killSpy).toHaveBeenCalledWith(12345, 'SIGTERM');
+  });
+
+  it('returns 0 when no shellper processes found', async () => {
+    simulatePsOutput(
+      `  PID ARGS\n` +
+      `99999 node /usr/bin/some-other-process\n`
+    );
+
+    const killed = await killShellperProcesses(worktree);
+
+    expect(killed).toBe(0);
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 gracefully when ps fails', async () => {
+    simulatePsError();
+
+    const killed = await killShellperProcesses(worktree);
+
+    expect(killed).toBe(0);
+  });
+
+  it('skips non-shellper processes even if they mention the worktree', async () => {
+    simulatePsOutput(
+      `  PID ARGS\n` +
+      `12345 claude --cwd ${worktree}\n`
+    );
+
+    const killed = await killShellperProcesses(worktree);
+
+    expect(killed).toBe(0);
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not kill its own process', async () => {
+    simulatePsOutput(
+      `  PID ARGS\n` +
+      `${process.pid} node /path/to/shellper-main.js {"command":"/bin/bash","args":[],"cwd":"${worktree}","socketPath":"/tmp/shellper-abc.sock"}\n`
+    );
+
+    const killed = await killShellperProcesses(worktree);
+
+    expect(killed).toBe(0);
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #389

## Root Cause

`af cleanup` relied exclusively on the Tower REST API (`TowerClient.killTerminal()`) to kill shellper processes. This silently fails when:
- Tower is not running (exception caught and swallowed)
- The terminal was already removed from Tower's registry (e.g., process exited naturally)
- Tower was restarted and lost the shellper session mapping

In all these cases, the shellper process and its PTY children (Claude, bash) are left running as orphans.

## Fix

Added `killShellperProcesses(worktreePath)` in `cleanup.ts` that:
1. Searches `ps -ww -eo pid,args` output for `shellper-main.js` processes
2. Matches by exact worktree path in the JSON config `cwd` field (prevents false positives from partial path prefixes)
3. Kills via process group signal (`SIGTERM` to `-pid`) to also terminate PTY children
4. Falls back to individual PID kill if process group kill fails
5. Runs after the Tower API kill attempt as a reliable fallback for all non-shell builders
6. Non-fatal: silently handles cases where `ps` isn't available or no processes are found

## Test Plan

- [x] Added regression test (`cleanup-shellper-kill.test.ts`, 9 tests)
- [x] Tests cover: exact cwd matching, no false positives on different/partial paths, multiple kills, process group fallback, ps failure handling, self-process exclusion
- [x] Existing cleanup tests pass (`cleanup-task-builders.test.ts`, 13 tests)
- [x] TypeScript type-check passes
- [x] Build passes