### PR TITLE
[Bugfix #397] Fix stale consult tests breaking all CI builds

### DIFF
--- a/packages/codev/src/__tests__/cli/consult.e2e.test.ts
+++ b/packages/codev/src/__tests__/cli/consult.e2e.test.ts
@@ -82,37 +82,30 @@ describe('consult command (CLI)', () => {
     expect(result.status).not.toBe(0);
   });
 
-  // === Custom Role Support ===
+  // === Protocol Options ===
 
-  it('--help shows --role option', () => {
+  it('--help shows --protocol option', () => {
     const result = runConsult(['--help'], env.dir, env.env);
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('--role');
+    expect(result.stdout).toContain('--protocol');
   });
 
-  it('--role blocks directory traversal', () => {
-    const result = runConsult(
-      ['--model', 'gemini', '--role', '../../../etc/passwd', 'general', 'test', '--dry-run'],
-      env.dir, env.env
-    );
-    expect(result.status).not.toBe(0);
-    const output = result.stdout + result.stderr;
-    expect(output).toContain('Invalid role name');
-  });
-
-  it('--role blocks path separators', () => {
-    const result = runConsult(
-      ['--model', 'gemini', '--role', 'foo/bar', 'general', 'test', '--dry-run'],
-      env.dir, env.env
-    );
-    expect(result.status).not.toBe(0);
-    const output = result.stdout + result.stderr;
-    expect(output).toContain('Invalid role name');
-  });
-
-  it('supports --dry-run flag', () => {
+  it('--help shows --type option', () => {
     const result = runConsult(['--help'], env.dir, env.env);
-    expect(result.stdout).toContain('dry');
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('--type');
+  });
+
+  it('--help shows --prompt option', () => {
+    const result = runConsult(['--help'], env.dir, env.env);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('--prompt');
+  });
+
+  it('--help shows stats subcommand', () => {
+    const result = runConsult(['--help'], env.dir, env.env);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('stats');
   });
 
   // === Model Options ===
@@ -132,25 +125,17 @@ describe('consult command (CLI)', () => {
     expect(result.status).toBe(0);
   });
 
-  // === Role Validation ===
+  // === Input Validation ===
 
-  it('--role accepts hyphens and underscores in names', () => {
-    const result = runConsult(
-      ['--model', 'gemini', '--role', 'my-custom_role123', 'general', 'test', '--dry-run'],
-      env.dir, env.env
-    );
-    const output = result.stdout + result.stderr;
-    // Should fail because the role doesn't exist, NOT because the name is invalid
-    expect(output).not.toContain('Invalid role name');
+  it('--type without --model fails', () => {
+    const result = runConsult(['--type', 'spec'], env.dir, env.env);
+    expect(result.status).not.toBe(0);
   });
 
-  it('--role with nonexistent role shows helpful error', () => {
-    const result = runConsult(
-      ['--model', 'gemini', '--role', 'nonexistent-role-xyz', 'general', 'test', '--dry-run'],
-      env.dir, env.env
-    );
+  it('unknown subcommand shows helpful error', () => {
+    const result = runConsult(['nonexistent-cmd'], env.dir, env.env);
     expect(result.status).not.toBe(0);
     const output = result.stdout + result.stderr;
-    expect(output).toMatch(/Available roles|No custom roles found|not found|does not exist/i);
+    expect(output).toContain('Unknown subcommand');
   });
 });

--- a/packages/codev/src/__tests__/consult.test.ts
+++ b/packages/codev/src/__tests__/consult.test.ts
@@ -672,9 +672,9 @@ describe('consult command', () => {
       expect(args).not.toContain('--yolo');
     });
 
-    it('protocol mode should pass --yolo to Gemini CLI', async () => {
-      // Protocol mode (--type) uses structured reviews where --yolo is needed
-      // for file access during code review.
+    it('protocol mode should NOT pass --yolo to Gemini CLI', async () => {
+      // After Bugfix #370 fix (commit 2ea868d0), --yolo is never passed to
+      // Gemini in any mode — consultations must be read-only.
       vi.resetModules();
 
       // Clear spawn mock calls from previous tests
@@ -715,12 +715,12 @@ describe('consult command', () => {
       // --issue required from architect context
       await consult({ model: 'gemini', type: 'spec', issue: '1' });
 
-      // Verify spawn was called WITH --yolo
+      // Verify spawn was called WITHOUT --yolo (never used in any mode)
       const spawnCalls = vi.mocked(spawn).mock.calls;
       const geminiCall = spawnCalls.find(call => call[0] === 'gemini');
       expect(geminiCall).toBeDefined();
       const args = geminiCall![1] as string[];
-      expect(args).toContain('--yolo');
+      expect(args).not.toContain('--yolo');
     });
   });
 


### PR DESCRIPTION
## Summary
Fixes #397

## Root Cause
`consult.e2e.test.ts` had 5 tests referencing `--role` and `--dry-run` CLI options that were removed in PR #367 (consult rework). Additionally, `consult.test.ts` had a unit test expecting `--yolo` to be passed in protocol mode, but commit 2ea868d0 removed `--yolo` from all Gemini consult modes.

## Fix
- **consult.e2e.test.ts**: Replaced 5 stale tests (`--role` option, `--dry-run` flag, `Invalid role name` errors) with 6 tests for the current CLI interface (`--protocol`, `--type`, `--prompt`, `stats` subcommand, input validation)
- **consult.test.ts**: Updated the `--yolo` protocol mode test to verify `--yolo` is NOT passed (matching current behavior after Bugfix #370)

## Test Plan
- [x] All 72 CLI integration tests pass (`vitest.cli.config.ts`)
- [x] All 1566 unit tests pass (`vitest.config.ts`)
- [x] No stale references in other test files (overview, session-manager, send-integration all clean)