### PR TITLE
[Bugfix #405] Show both wall clock and agent time in builder elapsed display

### DIFF
--- a/packages/codev/dashboard/src/components/BuilderCard.tsx
+++ b/packages/codev/dashboard/src/components/BuilderCard.tsx
@@ -16,9 +16,7 @@ function stateLabel(builder: OverviewBuilder): string {
   return `${builder.phase} (${idx + 1}/${phases.length})`;
 }
 
-function elapsed(startedAt: string | null): string {
-  if (!startedAt) return '-';
-  const ms = Date.now() - new Date(startedAt).getTime();
+function formatMs(ms: number): string {
   if (ms < 0) return '-';
   const mins = Math.floor(ms / 60_000);
   if (mins < 60) return `${mins}m`;
@@ -27,6 +25,15 @@ function elapsed(startedAt: string | null): string {
   if (hours < 24) return `${hours}h ${rem}m`;
   const days = Math.floor(hours / 24);
   return `${days}d ${hours % 24}h`;
+}
+
+function elapsed(startedAt: string | null, idleMs: number): string {
+  if (!startedAt) return '-';
+  const wallMs = Date.now() - new Date(startedAt).getTime();
+  if (wallMs < 0) return '-';
+  const agentMs = Math.max(0, wallMs - idleMs);
+  if (idleMs === 0) return formatMs(wallMs);
+  return `${formatMs(wallMs)} wc / ${formatMs(agentMs)} ag`;
 }
 
 export function BuilderCard({ builder, onOpen }: BuilderCardProps) {
@@ -53,7 +60,7 @@ export function BuilderCard({ builder, onOpen }: BuilderCardProps) {
         </div>
         <span className="progress-pct">{pct}%</span>
       </td>
-      <td className="builder-col-elapsed">{elapsed(builder.startedAt)}</td>
+      <td className="builder-col-elapsed">{elapsed(builder.startedAt, builder.idleMs ?? 0)}</td>
       <td className="builder-col-actions">
         {onOpen && (
           <button className="builder-row-open" onClick={() => onOpen(builder)}>

--- a/packages/codev/dashboard/src/lib/api.ts
+++ b/packages/codev/dashboard/src/lib/api.ts
@@ -89,6 +89,7 @@ export interface OverviewBuilder {
   progress: number;
   blocked: string | null;
   startedAt: string | null;
+  idleMs: number;
 }
 
 export interface OverviewPR {


### PR DESCRIPTION
Fixes #405

## Root Cause

The dashboard's `BuilderCard` shows only wall clock time (`Date.now() - startedAt`). Gate timestamps (`requested_at`, `approved_at`) already exist in `status.yaml` but aren't surfaced to compute agent time (time spent actively working, excluding gate wait periods).

## Fix

- **`overview.ts`**: Parse `approved_at` from gate data in `status.yaml`. Add `computeIdleMs()` that sums gate wait intervals (`requested_at` → `approved_at` for completed gates, `requested_at` → now for pending gates). Expose `idleMs` on `BuilderOverview`.
- **`api.ts`**: Add `idleMs: number` to dashboard `OverviewBuilder` type.
- **`BuilderCard.tsx`**: Update `elapsed()` to display both values when idle time exists: `2h 15m wc / 45m ag`. Falls back to wall-clock-only display when no gate waits have occurred.

## Test Plan

- [x] Added 8 regression tests covering `approved_at` parsing, `computeIdleMs` (completed gates, multiple gates, pending gates, pre-approved gates), and `idleMs` in `discoverBuilders`
- [x] All 107 overview tests pass
- [x] Build passes
- [x] Existing tests pass (1 pre-existing flaky test tracked in #411)

## CMAP Review

Skipped per architect instruction — proceeding directly to PR due to pre-existing flaky test (#411) blocking porch checks.