### PR TITLE
[Bugfix #411] Move send-integration test to e2e suite

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/send-integration.e2e.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/send-integration.e2e.test.ts
@@ -20,7 +20,8 @@ import net from 'node:net';
 import WebSocket from 'ws';
 
 // Use a unique port to avoid conflicts with other e2e test suites
-const TEST_TOWER_PORT = 14500;
+// Port 14500 is used by cli-tower-mode.e2e.test.ts — use 14600 here
+const TEST_TOWER_PORT = 14600;
 const STARTUP_TIMEOUT = 15_000;
 
 const TOWER_SERVER_PATH = resolve(


### PR DESCRIPTION
## Summary
Fixes #411

## Root Cause
`send-integration.test.ts` spawns a real Tower server (e2e behavior) but was named as a regular unit test, so it ran in the default `npm test` suite. It also used hardcoded port 14500, which collides with `cli-tower-mode.e2e.test.ts`.

When the full suite runs, the port collision causes intermittent failures — blocking builders from passing `porch done` checks.

## Fix
- Renamed `send-integration.test.ts` → `send-integration.e2e.test.ts` (excluded from default suite by vitest config's `**/*.e2e.test.ts` pattern)
- Changed port from 14500 → 14600 (unique, avoids collision with cli-tower-mode.e2e.test.ts)

## Test Plan
- [x] Full test suite passes (`npm test` — 81 files, 1680 tests)
- [x] Renamed e2e test passes in isolation (`vitest run --config vitest.e2e.config.ts` — 5/5 tests pass)
- [x] `send-integration` no longer appears in default suite run
- [x] Build succeeds