### PR TITLE
[Bugfix #409] Replace Pull Requests with Needs Attention section

### DIFF
--- a/packages/codev/dashboard/src/components/NeedsAttentionList.tsx
+++ b/packages/codev/dashboard/src/components/NeedsAttentionList.tsx
@@ -1,0 +1,105 @@
+import type { OverviewPR, OverviewBuilder } from '../lib/api.js';
+
+interface NeedsAttentionListProps {
+  prs: OverviewPR[];
+  builders: OverviewBuilder[];
+}
+
+interface AttentionItem {
+  key: string;
+  issueOrPR: string;
+  title: string;
+  kind: string;
+  kindClass: string;
+  waitingSince: string;
+  url?: string;
+}
+
+function timeAgo(dateStr: string): string {
+  const ms = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(ms / 60000);
+  if (mins < 60) return `${Math.max(1, mins)}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+function buildItems(prs: OverviewPR[], builders: OverviewBuilder[]): AttentionItem[] {
+  const items: AttentionItem[] = [];
+
+  // PRs needing review
+  for (const pr of prs) {
+    items.push({
+      key: `pr-${pr.number}`,
+      issueOrPR: `#${pr.number}`,
+      title: pr.title,
+      kind: 'PR review',
+      kindClass: 'attention-kind--pr',
+      waitingSince: pr.createdAt,
+      url: pr.url,
+    });
+  }
+
+  // Builders blocked on gate approvals
+  for (const b of builders) {
+    if (!b.blocked || !b.blockedSince) continue;
+    // Skip "PR review" — those are already covered by the PRs list
+    if (b.blocked === 'PR review') continue;
+    const label = b.issueNumber ? `#${b.issueNumber}` : b.id;
+    items.push({
+      key: `gate-${b.id}`,
+      issueOrPR: label,
+      title: b.issueTitle || b.id,
+      kind: b.blocked,
+      kindClass: b.blocked === 'spec review'
+        ? 'attention-kind--spec'
+        : 'attention-kind--plan',
+      waitingSince: b.blockedSince,
+    });
+  }
+
+  // Sort by waiting time (oldest first)
+  items.sort((a, b) =>
+    new Date(a.waitingSince).getTime() - new Date(b.waitingSince).getTime()
+  );
+
+  return items;
+}
+
+export function NeedsAttentionList({ prs, builders }: NeedsAttentionListProps) {
+  const items = buildItems(prs, builders);
+
+  if (items.length === 0) {
+    return <p className="work-empty">Nothing needs attention</p>;
+  }
+
+  return (
+    <div className="attention-rows">
+      {items.map(item => {
+        const inner = (
+          <>
+            <span className="attention-row-id">{item.issueOrPR}</span>
+            <span className="attention-row-title">{item.title}</span>
+            <span className={`attention-row-kind ${item.kindClass}`}>{item.kind}</span>
+            <span className="attention-row-age">{timeAgo(item.waitingSince)}</span>
+          </>
+        );
+
+        if (item.url) {
+          return (
+            <a key={item.key} className="attention-row" href={item.url} target="_blank" rel="noopener noreferrer">
+              {inner}
+            </a>
+          );
+        }
+
+        return (
+          <div key={item.key} className="attention-row">
+            {inner}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/codev/dashboard/src/components/WorkView.tsx
+++ b/packages/codev/dashboard/src/components/WorkView.tsx
@@ -3,7 +3,7 @@ import { useOverview } from '../hooks/useOverview.js';
 import { createShellTab } from '../lib/api.js';
 import type { OverviewBuilder, DashboardState } from '../lib/api.js';
 import { BuilderCard } from './BuilderCard.js';
-import { PRList } from './PRList.js';
+import { NeedsAttentionList } from './NeedsAttentionList.js';
 import { BacklogList } from './BacklogList.js';
 import { RecentlyClosedList } from './RecentlyClosedList.js';
 import { FileTree } from './FileTree.js';
@@ -97,13 +97,16 @@ export function WorkView({ state, onRefresh, onSelectTab }: WorkViewProps) {
           )}
         </section>
 
-        {/* Pull Requests */}
+        {/* Needs Attention */}
         <section className="work-section">
-          <h3 className="work-section-title">Pull Requests</h3>
+          <h3 className="work-section-title">Needs Attention</h3>
           {overview?.errors?.prs ? (
             <p className="work-unavailable">{overview.errors.prs}</p>
           ) : (
-            <PRList prs={overview?.pendingPRs ?? []} />
+            <NeedsAttentionList
+              prs={overview?.pendingPRs ?? []}
+              builders={overview?.builders ?? []}
+            />
           )}
         </section>
 

--- a/packages/codev/dashboard/src/index.css
+++ b/packages/codev/dashboard/src/index.css
@@ -1129,6 +1129,72 @@ a.pr-row {
   white-space: nowrap;
 }
 
+/* Needs Attention rows */
+.attention-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+a.attention-row {
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+.attention-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 10px 14px;
+}
+
+.attention-row:hover {
+  border-color: var(--accent);
+}
+
+.attention-row-id {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+.attention-row-title {
+  flex: 1;
+  font-size: 13px;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.attention-row-kind {
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.attention-kind--pr {
+  color: var(--status-waiting);
+}
+
+.attention-kind--spec {
+  color: var(--status-error);
+}
+
+.attention-kind--plan {
+  color: var(--status-error);
+}
+
+.attention-row-age {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
 /* Backlog rows */
 .backlog-rows {
   display: flex;
@@ -1355,6 +1421,10 @@ a.pr-row {
     flex-wrap: wrap;
   }
 
+  .attention-row {
+    flex-wrap: wrap;
+  }
+
   .builder-table {
     font-size: 12px;
   }
@@ -1365,6 +1435,7 @@ a.pr-row {
   }
 
   .pr-row-title,
+  .attention-row-title,
   .backlog-row-title {
     min-width: 60%;
   }

--- a/packages/codev/dashboard/src/lib/api.ts
+++ b/packages/codev/dashboard/src/lib/api.ts
@@ -88,6 +88,7 @@ export interface OverviewBuilder {
   planPhases: Array<{ id: string; title: string; status: string }>;
   progress: number;
   blocked: string | null;
+  blockedSince: string | null;
   startedAt: string | null;
   idleMs: number;
 }

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -41,6 +41,7 @@ export interface BuilderOverview {
   planPhases: PlanPhase[];
   progress: number;
   blocked: string | null;
+  blockedSince: string | null;
   startedAt: string | null;
   idleMs: number;
 }
@@ -335,6 +336,20 @@ export function detectBlocked(parsed: ParsedStatus): string | null {
 }
 
 /**
+ * Detect when the current blocked gate was first requested.
+ * Returns the ISO timestamp string or null if not blocked.
+ */
+export function detectBlockedSince(parsed: ParsedStatus): string | null {
+  const gateNames = ['spec-approval', 'plan-approval', 'pr'];
+  for (const gate of gateNames) {
+    if (parsed.gates[gate] === 'pending' && parsed.gateRequestedAt[gate]) {
+      return parsed.gateRequestedAt[gate];
+    }
+  }
+  return null;
+}
+
+/**
  * Compute total idle time (ms) from gate wait periods.
  * Includes completed gate waits (requested_at → approved_at) and
  * any currently-pending gate wait (requested_at → now).
@@ -479,6 +494,7 @@ export function discoverBuilders(workspaceRoot: string): BuilderOverview[] {
         planPhases: [],
         progress: 0,
         blocked: null,
+        blockedSince: null,
         startedAt: null,
         idleMs: 0,
       });
@@ -529,6 +545,7 @@ export function discoverBuilders(workspaceRoot: string): BuilderOverview[] {
             planPhases: parsed.planPhases,
             progress: calculateProgress(parsed, workspaceRoot),
             blocked: detectBlocked(parsed),
+            blockedSince: detectBlockedSince(parsed),
             startedAt: parsed.startedAt || null,
             idleMs: computeIdleMs(parsed),
           });
@@ -556,6 +573,7 @@ export function discoverBuilders(workspaceRoot: string): BuilderOverview[] {
         planPhases: [],
         progress: 0,
         blocked: null,
+        blockedSince: null,
         startedAt: null,
         idleMs: 0,
       });


### PR DESCRIPTION
## Summary
Fixes #409

Replaces the dashboard Work view's "Pull Requests" section with a unified **"Needs Attention"** section that surfaces all items requiring architect action:
- **Pull Requests** — open PRs from builders (existing)
- **Spec Approvals** — builders waiting at `spec-approval` gate
- **Plan Approvals** — builders waiting at `plan-approval` gate

## Root Cause
The dashboard only displayed PRs needing review, but spec-approval and plan-approval gates were invisible — architects only learned about them via `af send` messages or `porch pending`.

## Fix
- Added `detectBlockedSince()` function to `overview.ts` to extract the ISO timestamp of when a gate was first requested
- Added `blockedSince` field to `BuilderOverview` interface (backend + frontend)
- Created `NeedsAttentionList.tsx` component that merges PRs and blocked-gate builders into a single sorted list
- Replaced "Pull Requests" section in `WorkView.tsx` with "Needs Attention" using the new component
- Added CSS styles matching the existing PR row pattern
- Added regression tests for `detectBlockedSince`

Each item shows: issue/PR number, title, what it needs (PR review / spec review / plan review), and how long it's been waiting.

## Test Plan
- [x] Added 6 regression tests for `detectBlockedSince()`
- [x] All 113 overview unit tests pass
- [x] TypeScript compiles cleanly
- [x] Build succeeds