### PR TITLE
Show Tower version in dashboard header

### DIFF
--- a/packages/codev/dashboard/src/components/App.tsx
+++ b/packages/codev/dashboard/src/components/App.tsx
@@ -169,6 +169,7 @@ export function App() {
         <h1 className="app-title">
           {state?.workspaceName ? `${state.workspaceName} dashboard` : 'dashboard'}
         </h1>
+        {state?.version && <span className="header-version">v{state.version}</span>}
       </header>
       <div className="app-body">
         <SplitPane

--- a/packages/codev/dashboard/src/index.css
+++ b/packages/codev/dashboard/src/index.css
@@ -73,6 +73,12 @@ body {
   color: var(--text-primary);
 }
 
+.header-version {
+  font-size: 11px;
+  color: var(--text-secondary);
+  font-weight: 400;
+}
+
 .app-body {
   flex: 1;
   overflow: hidden;

--- a/packages/codev/dashboard/src/lib/api.ts
+++ b/packages/codev/dashboard/src/lib/api.ts
@@ -45,6 +45,7 @@ export interface DashboardState {
   utils: UtilTerminal[];
   annotations: Annotation[];
   workspaceName?: string;
+  version?: string;
 }
 
 export interface FileEntry {

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -21,6 +21,7 @@ import { promisify } from 'node:util';
 import { homedir, tmpdir } from 'node:os';
 import { encodeWorkspacePath, decodeWorkspacePath } from '../lib/tower-client.js';
 import { fileURLToPath } from 'node:url';
+import { version } from '../../version.js';
 
 const execAsync = promisify(exec);
 import type { SessionManager } from '../../terminal/session-manager.js';
@@ -1253,12 +1254,14 @@ async function handleWorkspaceState(
     utils: Array<{ id: string; name: string; port: number; pid: number; terminalId?: string; persistent?: boolean }>;
     annotations: Array<{ id: string; file: string; port: number; pid: number }>;
     workspaceName?: string;
+    version?: string;
   } = {
     architect: null,
     builders: [],
     utils: [],
     annotations: [],
     workspaceName: path.basename(workspacePath),
+    version,
   };
 
   // Add architect if exists


### PR DESCRIPTION
## Summary
- Adds Tower version number (e.g. `v2.0.10`) to the far right of the dashboard header bar
- Version is sourced from `package.json` via the existing `state` API endpoint
- Displayed as subtle, small secondary text (11px, `--text-secondary` color)

## Changes
- **tower-routes.ts**: Import `version` from `src/version.ts`, include in state response
- **api.ts**: Add `version?: string` to `DashboardState` interface
- **App.tsx**: Render `<span className="header-version">v{version}</span>` in header
- **index.css**: Add `.header-version` styling (11px, secondary color, normal weight)

## Test plan
- [x] All 1705 unit tests pass
- [x] Build succeeds
- [ ] Verify version appears in header bar via Playwright or manual testing