### PR TITLE
[Bugfix #143] Verify scroll-to-bottom fix and add regression test

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/bugfix-143-preview-scroll.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-143-preview-scroll.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression test for bugfix #143: Can't scroll to bottom with markdown preview
+ *
+ * The bug: open.html's preview container used `height: calc(100vh - 80px)` which
+ * hardcoded the header height. When the actual header was taller than 80px, the
+ * container extended beyond the viewport, creating a confusing double-scroll
+ * (page scroll + container scroll) that prevented reaching the bottom content.
+ *
+ * The fix: Replace the hardcoded height with a flex layout. body.preview-active
+ * uses `display: flex; flex-direction: column; overflow: hidden` to constrain to
+ * viewport. The preview container uses `flex: 1; min-height: 0` to fill remaining
+ * space, with `overflow: auto` for scrolling. This creates a single scroll context.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('Bugfix #143: Preview scroll-to-bottom', () => {
+  const templatePath = resolve(
+    import.meta.dirname,
+    '../../../templates/open.html',
+  );
+  const html = readFileSync(templatePath, 'utf-8');
+
+  describe('CSS layout prevents double-scroll', () => {
+    it('body.preview-active should use flex column layout with overflow hidden', () => {
+      // body.preview-active must be a flex column to distribute height correctly
+      expect(html).toMatch(/body\.preview-active\s*\{[^}]*display:\s*flex/);
+      expect(html).toMatch(/body\.preview-active\s*\{[^}]*flex-direction:\s*column/);
+      // overflow: hidden prevents page-level scroll (only container scrolls)
+      expect(html).toMatch(/body\.preview-active\s*\{[^}]*overflow:\s*hidden/);
+    });
+
+    it('header should not shrink in flex layout', () => {
+      // Header must have flex-shrink: 0 so it keeps its natural height
+      expect(html).toMatch(/\.header\s*\{[^}]*flex-shrink:\s*0/);
+    });
+
+    it('preview container should use flex: 1 with min-height: 0', () => {
+      // flex: 1 fills remaining space after header
+      expect(html).toMatch(/#preview-container\s*\{[^}]*flex:\s*1/);
+      // min-height: 0 allows shrinking below content size (required for overflow to work)
+      expect(html).toMatch(/#preview-container\s*\{[^}]*min-height:\s*0/);
+    });
+
+    it('preview container inline style should NOT use hardcoded height: calc(...)', () => {
+      // The old broken approach: height: calc(100vh - 80px) assumed header = 80px
+      // Extract the inline style of the preview-container element
+      const match = html.match(/id="preview-container"\s+style="([^"]*)"/);
+      expect(match).toBeTruthy();
+      const inlineStyle = match![1];
+      expect(inlineStyle).not.toMatch(/height:\s*calc\(/);
+    });
+
+    it('preview container inline style should have overflow: auto', () => {
+      // The inline style on the preview container element must include overflow: auto
+      expect(html).toMatch(/id="preview-container"[^>]*overflow:\s*auto/);
+    });
+  });
+
+  describe('toggle function preserves scroll context', () => {
+    it('should add preview-active class to body when entering preview mode', () => {
+      // The toggle function must add the class that activates the flex layout
+      expect(html).toContain("document.body.classList.add('preview-active')");
+    });
+
+    it('should remove preview-active class when leaving preview mode', () => {
+      expect(html).toContain("document.body.classList.remove('preview-active')");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #143

## Root Cause
The original `open.html` preview container used `height: calc(100vh - 80px)` which hardcoded the header height as 80px. When the actual header was taller (~108px due to actions row), the container extended beyond the viewport, creating a double-scroll problem: both the page and the container were scrollable. Users couldn't reliably scroll to the bottom because they had to navigate two scroll contexts.

## Fix
The fix was already applied in commit aaa3124c3 (2026-01-11) which:
- Added `display: flex; flex-direction: column; overflow: hidden` to `body.preview-active` — constrains body to viewport height with a single scroll context
- Added `flex-shrink: 0` to `.header` — header keeps its natural height regardless of content
- Replaced `height: calc(100vh - 80px)` with `flex: 1; min-height: 0` on `#preview-container` — container fills remaining space dynamically
- Keeps `overflow: auto` on the container for scrolling

This PR verifies the fix works correctly through Playwright testing (programmatic scroll, wheel scroll, iframe context matching the dashboard layout) and adds a regression test.

## Test Plan
- [x] Added regression test (7 assertions verifying CSS layout properties)
- [x] Verified fix with Playwright in standalone mode
- [x] Verified fix with Playwright in iframe context (matching actual dashboard layout)
- [x] Verified wheel scroll reaches bottom
- [x] All existing tests pass (86 files, 1712 tests)
- [x] Build succeeds

## CMAP Review
To be added after review