### PR TITLE
[Bugfix #451] Replace intrusive reconnect overlay with status dot + fix premature give-up

### DIFF
--- a/packages/codev/dashboard/src/index.css
+++ b/packages/codev/dashboard/src/index.css
@@ -327,34 +327,28 @@ body {
   opacity: 1.0;
 }
 
-/* Reconnection overlay (Bugfix #442) */
-.terminal-reconnecting-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 30;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 4px 12px;
-  background-color: #3a2a00;
-  color: #ffcc00;
-  font-size: 12px;
-}
-
-.terminal-reconnecting-spinner {
+/* Connection status dot (Bugfix #451 — replaces intrusive overlay from #442) */
+.terminal-status-dot {
   display: inline-block;
-  width: 12px;
-  height: 12px;
-  border: 2px solid #ffcc0040;
-  border-top-color: #ffcc00;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
-  animation: terminal-spin 0.8s linear infinite;
+  flex-shrink: 0;
+  align-self: center;
 }
 
-@keyframes terminal-spin {
-  to { transform: rotate(360deg); }
+.terminal-status-reconnecting {
+  background-color: #ffcc00;
+  animation: terminal-pulse 1.2s ease-in-out infinite;
+}
+
+.terminal-status-disconnected {
+  background-color: #ff4444;
+}
+
+@keyframes terminal-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
 }
 
 /* Mobile layout */


### PR DESCRIPTION
## Summary

Fixes two issues with the terminal reconnect feature (PR #445):
1. **UX**: Replaced the yellow "Reconnecting..." overlay (which covered terminal content) with a small status dot indicator in the terminal controls area
2. **Bug**: Fixed premature reconnect give-up caused by a flawed rapid failure detection mechanism

Fixes #451

## Root Cause

**UX issue**: The `terminal-reconnecting-overlay` div was positioned absolutely over the terminal content, obscuring output during reconnection attempts.

**Premature give-up**: The `rapidFailures` counter counted WebSocket connections that closed within 2 seconds of creation. When the server was temporarily unreachable, each failed connection attempt (which fails in <2s by definition) was counted as a "rapid failure" — regardless of the backoff delay between attempts. After just 5 such failures (~15 seconds), the reconnect permanently gave up, even though the session was still alive on the server (page reload would succeed).

## Fix

1. **Status dot**: Added a small colored dot to the `TerminalControls` component:
   - No dot when connected (clean state)
   - Yellow pulsing dot when reconnecting
   - Red dot when disconnected
   
2. **Reconnect logic**: Removed the flawed `rapidFailures` mechanism entirely. Increased `MAX_ATTEMPTS` from 15 to 50 (with 30s backoff cap, gives ~20 minutes of retry). Exponential backoff alone is sufficient for graceful degradation.

## Test Plan

- [x] Regression test added (verifies 10+ rapid failures don't cause premature give-up)
- [x] Status dot tests (reconnecting dot shown/hidden, disconnected dot after max attempts)
- [x] Build passes
- [x] All reconnect tests pass (11/11)
- [x] All backend tests pass (1798/1798)
- [x] Pre-existing failures in fit-scroll and ime-dedup tests confirmed on main