### PR TITLE
[Bugfix #463] Add spike label support to dashboard Work view

### DIFF
--- a/packages/codev/dashboard/src/components/BacklogList.tsx
+++ b/packages/codev/dashboard/src/components/BacklogList.tsx
@@ -25,6 +25,7 @@ const PRIORITY_CLASS: Record<string, string> = {
 const TYPE_CLASS: Record<string, string> = {
   bug: 'type-tag--bug',
   project: 'type-tag--project',
+  spike: 'type-tag--spike',
 };
 
 function ArtifactLink({ label, filePath, onRefresh }: { label: string; filePath: string; onRefresh?: () => void }) {

--- a/packages/codev/dashboard/src/components/RecentlyClosedList.tsx
+++ b/packages/codev/dashboard/src/components/RecentlyClosedList.tsx
@@ -17,6 +17,7 @@ function timeAgo(dateStr: string): string {
 const TYPE_CLASS: Record<string, string> = {
   bug: 'type-tag--bug',
   project: 'type-tag--project',
+  spike: 'type-tag--spike',
 };
 
 export function RecentlyClosedList({ items }: RecentlyClosedListProps) {

--- a/packages/codev/dashboard/src/components/WorkView.tsx
+++ b/packages/codev/dashboard/src/components/WorkView.tsx
@@ -112,7 +112,7 @@ export function WorkView({ state, onRefresh, onSelectTab }: WorkViewProps) {
 
         {/* Backlog & Bugs */}
         <section className="work-section">
-          <h3 className="work-section-title">Projects and Bugs</h3>
+          <h3 className="work-section-title">Backlog</h3>
           {overview?.errors?.issues ? (
             <p className="work-unavailable">{overview.errors.issues}</p>
           ) : (

--- a/packages/codev/dashboard/src/index.css
+++ b/packages/codev/dashboard/src/index.css
@@ -1314,6 +1314,11 @@ a.attention-row {
   color: #a855f7;
 }
 
+.type-tag--spike {
+  background: rgba(14, 165, 233, 0.12);
+  color: #0ea5e9;
+}
+
 .backlog-row-title {
   flex: 1;
   font-size: 16px;

--- a/packages/codev/src/__tests__/github.test.ts
+++ b/packages/codev/src/__tests__/github.test.ts
@@ -142,6 +142,13 @@ describe('parseLabelDefaults', () => {
     });
   });
 
+  it('matches bare "spike" label when no type: prefix exists', () => {
+    expect(parseLabelDefaults([{ name: 'spike' }])).toEqual({
+      type: 'spike',
+      priority: 'medium',
+    });
+  });
+
   it('prefers type: prefixed label over bare label', () => {
     expect(parseLabelDefaults([
       { name: 'bug' },

--- a/packages/codev/src/lib/github.ts
+++ b/packages/codev/src/lib/github.ts
@@ -201,7 +201,7 @@ export function parseLinkedIssue(prBody: string, prTitle: string): number | null
  * - Multiple labels of same kind → first alphabetical
  */
 /** Labels that map directly to a type without the `type:` prefix. */
-const BARE_TYPE_LABELS = new Set(['bug', 'project']);
+const BARE_TYPE_LABELS = new Set(['bug', 'project', 'spike']);
 
 /** Title keywords that suggest a bug report. Trailing \b omitted to match plurals/verb forms. */
 const BUG_TITLE_PATTERNS = /\b(fix|bug|broken|error|crash|fail|wrong|regression|not working)/i;


### PR DESCRIPTION
## Summary
Fixes #463

## Root Cause
The dashboard Work view's issue categorization logic only recognized `bug` and `project` as bare label types. The `spike` label was not in the `BARE_TYPE_LABELS` set, so spike-labeled issues fell through to the title-based heuristic and were miscategorized as "project".

## Fix
- Added `'spike'` to `BARE_TYPE_LABELS` in `github.ts`
- Added `spike` CSS class mapping in `BacklogList.tsx` and `RecentlyClosedList.tsx`
- Added `.type-tag--spike` styling in `index.css` (sky blue color scheme)
- Updated section title from "Projects and Bugs" to "Backlog" (more inclusive)

## Test Plan
- [x] Added regression test for bare "spike" label recognition
- [x] All 1815 existing tests pass
- [x] Build succeeds
- [x] Verified `parseLabelDefaults([{ name: 'spike' }])` returns `{ type: 'spike', priority: 'medium' }`

## CMAP Review
_To be added after review_