### PR TITLE
[Bugfix #465] Add clickable artifact links to Recently Closed items

### DIFF
--- a/packages/codev/dashboard/src/components/WorkView.tsx
+++ b/packages/codev/dashboard/src/components/WorkView.tsx
@@ -124,7 +124,7 @@ export function WorkView({ state, onRefresh, onSelectTab }: WorkViewProps) {
         {overview?.recentlyClosed && overview.recentlyClosed.length > 0 && (
           <section className="work-section">
             <h3 className="work-section-title">Recently Closed</h3>
-            <RecentlyClosedList items={overview.recentlyClosed} />
+            <RecentlyClosedList items={overview.recentlyClosed} onRefresh={onRefresh} />
           </section>
         )}
       </div>

--- a/packages/codev/dashboard/src/index.css
+++ b/packages/codev/dashboard/src/index.css
@@ -1339,17 +1339,25 @@ a.attention-row {
 .recently-closed-row {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 6px;
   padding: 4px 14px;
   border-radius: 6px;
-  text-decoration: none;
-  color: inherit;
   opacity: 0.7;
 }
 
 .recently-closed-row:hover {
   background: var(--bg-secondary);
   opacity: 1;
+}
+
+.recently-closed-row-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+  text-decoration: none;
+  color: inherit;
 }
 
 .recently-closed-check {

--- a/packages/codev/dashboard/src/lib/api.ts
+++ b/packages/codev/dashboard/src/lib/api.ts
@@ -126,6 +126,10 @@ export interface OverviewRecentlyClosed {
   url: string;
   type: string;
   closedAt: string;
+  prUrl?: string;
+  specPath?: string;
+  planPath?: string;
+  reviewPath?: string;
 }
 
 export interface OverviewData {


### PR DESCRIPTION
## Summary

The "Recently Closed" section in the dashboard showed plain text items with no links to their associated artifacts (PR, spec, plan, review). Now each item displays clickable links to its artifacts.

Fixes #465

## Root Cause

`RecentlyClosedItem` type only had basic fields (`number`, `title`, `url`, `type`, `closedAt`) with no artifact paths or PR URLs. The `RecentlyClosedList.tsx` component rendered items as plain rows linking only to the GitHub issue URL.

## Fix

- Added `fetchMergedPRs()` to `github.ts` to fetch recently merged PRs for cross-referencing with closed issues via `parseLinkedIssue()`
- Enriched `RecentlyClosedItem` in `overview.ts` with optional `prUrl`, `specPath`, `planPath`, `reviewPath` fields using existing `scanArtifactDir()` pattern
- Updated `RecentlyClosedList.tsx` to render artifact links (spec/plan/review open in annotation viewer; PR opens in browser tab)
- Added merged PR cache to `OverviewCache` with same TTL and parallel fetch pattern

## Test Plan

- [x] Regression test: PR URL enrichment from merged PRs
- [x] Regression test: spec/plan/review path enrichment from artifact directories
- [x] Regression test: graceful handling when merged PRs fetch returns null
- [x] Build passes
- [x] All 1817 tests pass (90 test files)
- [x] Net diff: 242 LOC (under 300 LOC BUGFIX threshold)