### PR TITLE
Fix #492: Remove composing flag from send deferral logic

### DIFF
--- a/packages/codev/src/agent-farm/servers/send-buffer.ts
+++ b/packages/codev/src/agent-farm/servers/send-buffer.ts
@@ -94,10 +94,11 @@ export class SendBuffer {
       const now = Date.now();
       const maxAgeExceeded = messages.some(m => now - m.timestamp >= this.maxBufferAgeMs);
       const isIdle = session.isUserIdle(this.idleThresholdMs);
-      const isComposing = session.composing;
 
-      // Deliver when: forced, idle AND not composing, or max age exceeded (Bugfix #450)
-      if (forceAll || (!isComposing && isIdle) || maxAgeExceeded) {
+      // Deliver when: forced, user idle, or max age exceeded.
+      // Bugfix #492: removed composing check — it gets stuck true after non-Enter
+      // keystrokes (Ctrl+C, arrows, Tab), causing messages to wait 60s max age.
+      if (forceAll || isIdle || maxAgeExceeded) {
         // Deliver all messages in order
         for (const msg of messages) {
           this.deliver(session, msg);

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -895,8 +895,10 @@ async function handleSend(
   }
 
   // Check if user is idle — deliver immediately or buffer (Spec 403, Bugfix #450)
-  // Defer when composing (typed but not submitted) OR recently typed (idle threshold)
-  const shouldDefer = !interrupt && (session.composing || !session.isUserIdle(sendBuffer.idleThresholdMs));
+  // Defer only when user has typed recently (within idle threshold).
+  // Bugfix #492: removed session.composing check — composing gets stuck true
+  // after non-Enter keystrokes (Ctrl+C, arrows, Tab), causing 60s delays.
+  const shouldDefer = !interrupt && !session.isUserIdle(sendBuffer.idleThresholdMs);
 
   if (shouldDefer) {
     // User is actively typing — buffer for deferred delivery


### PR DESCRIPTION
## Summary

The typing awareness composing flag (Bugfix #450) gets stuck `true` after non-Enter keystrokes (Ctrl+C, arrows, Tab), causing nearly all `af send` messages to wait the full 60s max buffer age instead of delivering promptly.

Fixes #492

## Root Cause

The `composing` flag in `PtySession` is set to `true` on ANY non-Enter keystroke and only cleared when Enter (`\r`/`\n`) is detected. Normal terminal interactions (Ctrl+C, Tab, arrow keys, scrolling) all set `composing=true` without a subsequent Enter. The flush condition required `!isComposing && isIdle`, so even when the user had been idle for seconds, the stuck `composing=true` blocked delivery until the 60s max age timeout.

## Fix

Removed the `composing` flag from both deferral conditions:
- `tower-routes.ts`: `shouldDefer` now checks idle threshold only
- `send-buffer.ts`: flush condition now checks idle threshold only

The idle threshold (3s of no input) is sufficient — if the user hasn't typed for 3 seconds, they're not composing regardless of whether Enter was pressed. The composing tracking code remains in PtySession (harmless) but is no longer used for deferral decisions.

## Test Plan

- [x] Regression test updated: verifies delivery when idle + composing=true
- [x] Build passes
- [x] All related tests pass (71 tests in send-buffer + tower-routes)
- [x] TypeScript type-check passes