### PR TITLE
[Bugfix #500] Fix: af open works from any directory

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/bugfix-427-af-open-worktree.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-427-af-open-worktree.test.ts
@@ -39,7 +39,9 @@ describe('Bugfix #427: af open worktree fallback', () => {
       );
 
       // The fix: detect worktree and fall back to main repo
-      expect(openSrc).toContain('getMainRepoFromWorktree(config.workspaceRoot)');
+      // (Bugfix #500 changed from config.workspaceRoot to workspacePath
+      //  derived from file location via findWorkspaceRoot)
+      expect(openSrc).toContain('getMainRepoFromWorktree(workspacePath)');
       // Should use the resolved workspace path (not config.workspaceRoot directly)
       // for the Tower API call
       expect(openSrc).toMatch(/tryTowerApi\(client,\s*workspacePath/);

--- a/packages/codev/src/agent-farm/__tests__/bugfix-500-af-open-any-dir.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-500-af-open-any-dir.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Regression test for bugfix #500: af open should work from any directory
+ *
+ * Root cause: `open.ts` used `getConfig().workspaceRoot` which derives the
+ * workspace root from `process.cwd()`. When CWD is outside the workspace
+ * (or in a different subdirectory), the wrong workspace path is sent to
+ * the Tower API, causing the open to fail.
+ *
+ * Fix: Derive workspace root from the FILE's directory (via findWorkspaceRoot)
+ * instead of CWD. The file itself determines which workspace it belongs to.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+describe('Bugfix #500: af open works from any directory', () => {
+  const openSrc = readFileSync(
+    resolve(import.meta.dirname, '../commands/open.ts'),
+    'utf-8',
+  );
+
+  it('should use findWorkspaceRoot from file directory, not getConfig', () => {
+    // The fix: workspace root is derived from the file's location
+    expect(openSrc).toContain('findWorkspaceRoot(dirname(filePath))');
+    // Should NOT use getConfig() — that uses CWD which is the wrong approach
+    expect(openSrc).not.toContain('getConfig()');
+  });
+
+  it('should import findWorkspaceRoot and dirname', () => {
+    expect(openSrc).toContain('findWorkspaceRoot');
+    expect(openSrc).toContain('dirname');
+  });
+
+  it('should still support worktree fallback to main repo', () => {
+    // Bugfix #427's worktree fallback must be preserved
+    expect(openSrc).toContain('getMainRepoFromWorktree(workspacePath)');
+  });
+});
+
+describe('Bugfix #500: findWorkspaceRoot is properly exported', () => {
+  it('should be exported from config.ts', () => {
+    const configSrc = readFileSync(
+      resolve(import.meta.dirname, '../utils/config.ts'),
+      'utf-8',
+    );
+
+    // Must be exported (not just a local function or test-only export)
+    expect(configSrc).toMatch(/export\s*\{[^}]*findWorkspaceRoot[^}]*\}/);
+  });
+});

--- a/packages/codev/src/agent-farm/utils/config.ts
+++ b/packages/codev/src/agent-farm/utils/config.ts
@@ -271,5 +271,5 @@ export async function ensureDirectories(config: Config): Promise<void> {
   }
 }
 
-// Exported for testing
-export { findWorkspaceRoot as _findWorkspaceRoot };
+// Exported for testing and for commands that need to resolve workspace from a path
+export { findWorkspaceRoot, findWorkspaceRoot as _findWorkspaceRoot };


### PR DESCRIPTION
## Summary
Fixes #500

## Root Cause
`af open` derived the workspace root from `process.cwd()` via `getConfig()`. When the user's CWD was outside the workspace root (e.g., in a subdirectory, worktree, or different directory entirely), the wrong workspace path was sent to the Tower API, causing the open to fail with a 404 or containment error.

## Fix
Changed `open.ts` to derive the workspace root from the **file's directory** (via `findWorkspaceRoot(dirname(filePath))`) instead of CWD. The file itself now determines which workspace it belongs to, so `af open` works regardless of where the command is run from.

Changes:
- `open.ts`: Replaced `getConfig().workspaceRoot` with `findWorkspaceRoot(dirname(filePath))`
- `config.ts`: Exported `findWorkspaceRoot` (previously only exported as `_findWorkspaceRoot` for testing)
- Updated bugfix-427 regression test to match new code pattern
- Added bugfix-500 regression test

## Test Plan
- [x] Added regression test (bugfix-500-af-open-any-dir.test.ts)
- [x] Updated bugfix-427 test to match new code
- [x] All relevant tests pass (23/23)
- [x] TypeScript compiles cleanly
- [x] Existing tests unaffected (pre-existing failures are unrelated)

## CMAP Review
_To be added after review_