### PR TITLE
[Bugfix #502] Fix: af open allows files outside workspace

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/bugfix-427-af-open-worktree.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-427-af-open-worktree.test.ts
@@ -84,23 +84,20 @@ describe('Bugfix #427: getMainRepoFromWorktree export', () => {
 // Test 3: Consistent containment checks in tower-routes.ts
 // ============================================================================
 
-describe('Bugfix #427: Consistent containment checks', () => {
-  it('GET /file route should use symlink-aware containment check', async () => {
+describe('Bugfix #427: GET /file route exists', () => {
+  it('GET /file route handler is present', async () => {
     const { readFileSync } = await import('node:fs');
     const routesSrc = readFileSync(
       resolve(import.meta.dirname, '../servers/tower-routes.ts'),
       'utf-8',
     );
 
-    // Find the GET /file handler section
+    // GET /file handler should still exist
     const getFileIdx = routesSrc.indexOf("subPath === 'file'");
     expect(getFileIdx).toBeGreaterThan(-1);
 
-    // Extract the section around the GET /file handler (next ~30 lines)
+    // Containment check removed in bugfix #502 to allow files outside workspace
     const section = routesSrc.slice(getFileIdx, getFileIdx + 800);
-
-    // Should use fs.realpathSync for symlink-aware containment,
-    // not just path.resolve
-    expect(section).toContain('realpathSync');
+    expect(section).not.toContain('Forbidden');
   });
 });

--- a/packages/codev/src/agent-farm/__tests__/bugfix-502-af-open-outside-workspace.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-502-af-open-outside-workspace.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regression test for bugfix #502: af open blocks files outside workspace directory
+ *
+ * Root cause: The POST /api/tabs/file handler in tower-routes.ts had a workspace
+ * containment check that rejected any file path not under the workspace root with
+ * HTTP 403 "Path outside workspace". The GET /file handler had a similar check.
+ *
+ * Fix: Removed the workspace containment checks from both handlers. Tower runs
+ * on localhost only — there's no security reason to restrict file access to the
+ * workspace. Users need to open files from anywhere (e.g., files in other repos,
+ * system configs for reference, etc.).
+ */
+import { describe, it, expect } from 'vitest';
+import { resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+describe('Bugfix #502: af open allows files outside workspace', () => {
+  const routesSrc = readFileSync(
+    resolve(import.meta.dirname, '../servers/tower-routes.ts'),
+    'utf-8',
+  );
+
+  describe('POST /api/tabs/file handler', () => {
+    // Find the function definition (async function handleWorkspaceFileTabCreate)
+    const fnDefIdx = routesSrc.indexOf('async function handleWorkspaceFileTabCreate');
+
+    it('should NOT have workspace containment check', () => {
+      expect(fnDefIdx).toBeGreaterThan(-1);
+
+      // Extract the function body (up to ~2000 chars covers it)
+      const fnSection = routesSrc.slice(fnDefIdx, fnDefIdx + 2000);
+
+      // Must not reject with "Path outside workspace"
+      expect(fnSection).not.toContain("'Path outside workspace'");
+      expect(fnSection).not.toContain('isWithinWorkspace');
+    });
+
+    it('should still resolve symlinks for canonical paths', () => {
+      expect(fnDefIdx).toBeGreaterThan(-1);
+      const fnSection = routesSrc.slice(fnDefIdx, fnDefIdx + 2000);
+
+      // Symlink resolution should still be present
+      expect(fnSection).toContain('realpathSync');
+    });
+  });
+
+  describe('GET /file handler', () => {
+    it('should NOT have workspace containment check', () => {
+      // Find the GET /file handler
+      const getFileIdx = routesSrc.indexOf("subPath === 'file'");
+      expect(getFileIdx).toBeGreaterThan(-1);
+
+      const section = routesSrc.slice(getFileIdx, getFileIdx + 500);
+
+      // Must not have the old containment rejection
+      expect(section).not.toContain('Forbidden');
+      expect(section).not.toContain('403');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`af open` was rejecting files outside the workspace directory with HTTP 403 "Path outside workspace". Removed the workspace containment checks from Tower's file tab creation and file serving handlers, since Tower is a localhost-only server and users need to open files from anywhere.

Fixes #502

## Root Cause

Both the `POST /api/tabs/file` handler (used by `af open` to create file tabs) and the `GET /file` handler (used by the dashboard to read file content) had workspace containment checks that rejected any file path not under the workspace root directory.

These checks were originally added as defense-in-depth security measures (spec 0092), but they're overly restrictive for a local development tool. Issue #500 fixed workspace root derivation from CWD, but left these path restrictions in place.

## Fix

- Removed the workspace containment check from `handleWorkspaceFileTabCreate()` in `tower-routes.ts` (POST /api/tabs/file)
- Removed the workspace containment check from the GET /file handler in `tower-routes.ts`
- Kept symlink resolution for canonical path normalization in the tab creation handler
- Updated existing tests (`file-path-resolution.test.ts`, `bugfix-427-af-open-worktree.test.ts`) to reflect the new behavior
- Added regression test (`bugfix-502-af-open-outside-workspace.test.ts`)

## Test Plan

- [x] Regression test added (bugfix-502-af-open-outside-workspace.test.ts)
- [x] Existing tests updated (file-path-resolution.test.ts, bugfix-427-af-open-worktree.test.ts)
- [x] Build passes
- [x] All related tests pass (16/16)