### PR TITLE
Fix annotator resolving builder paths against main workspace

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/bugfix-506-annotator-worktree-cwd.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-506-annotator-worktree-cwd.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Regression test for bugfix #506: af open / annotator resolves builder file
+ * paths against main workspace instead of worktree.
+ *
+ * Root cause: The terminal_sessions table did not store the session's cwd.
+ * After Tower restart, reconciliation recreated PtySession objects using
+ * workspace_path (main repo root) instead of the original cwd (worktree path
+ * for builders). File links clicked in a builder terminal resolved relative
+ * paths against the wrong root, producing ENOENT.
+ *
+ * Fix: Add a `cwd` column to terminal_sessions. Persist the actual working
+ * directory when saving sessions. Use it during reconciliation and on-the-fly
+ * reconnection, falling back to workspace_path for pre-migration rows.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+// ============================================================================
+// Test 1: Schema includes cwd column
+// ============================================================================
+
+describe('Bugfix #506: cwd column in terminal_sessions', () => {
+  it('schema.ts should define cwd column on terminal_sessions', () => {
+    const schemaSrc = readFileSync(
+      resolve(import.meta.dirname, '../db/schema.ts'),
+      'utf-8',
+    );
+    // The cwd column must exist in the CREATE TABLE terminal_sessions block
+    const terminalSessionsBlock = schemaSrc.slice(
+      schemaSrc.indexOf('CREATE TABLE IF NOT EXISTS terminal_sessions'),
+      schemaSrc.indexOf(');', schemaSrc.indexOf('CREATE TABLE IF NOT EXISTS terminal_sessions')),
+    );
+    expect(terminalSessionsBlock).toContain('cwd TEXT');
+  });
+
+  it('migration v12 should add cwd column', () => {
+    const dbSrc = readFileSync(
+      resolve(import.meta.dirname, '../db/index.ts'),
+      'utf-8',
+    );
+    expect(dbSrc).toContain('Migration v12');
+    expect(dbSrc).toContain('ALTER TABLE terminal_sessions ADD COLUMN cwd TEXT');
+  });
+});
+
+// ============================================================================
+// Test 2: DbTerminalSession type includes cwd
+// ============================================================================
+
+describe('Bugfix #506: DbTerminalSession.cwd', () => {
+  it('tower-types.ts should include cwd field in DbTerminalSession', () => {
+    const typesSrc = readFileSync(
+      resolve(import.meta.dirname, '../servers/tower-types.ts'),
+      'utf-8',
+    );
+    const dbTermBlock = typesSrc.slice(
+      typesSrc.indexOf('interface DbTerminalSession'),
+      typesSrc.indexOf('}', typesSrc.indexOf('interface DbTerminalSession')),
+    );
+    expect(dbTermBlock).toContain('cwd:');
+  });
+});
+
+// ============================================================================
+// Test 3: saveTerminalSession persists cwd
+// ============================================================================
+
+describe('Bugfix #506: saveTerminalSession stores cwd', () => {
+  it('INSERT statement should include cwd column', () => {
+    const src = readFileSync(
+      resolve(import.meta.dirname, '../servers/tower-terminals.ts'),
+      'utf-8',
+    );
+    // Find the INSERT in saveTerminalSession
+    const fnStart = src.indexOf('export function saveTerminalSession');
+    const fnEnd = src.indexOf('\n}', fnStart);
+    const fnBody = src.slice(fnStart, fnEnd);
+    expect(fnBody).toContain('cwd');
+    // The VALUES placeholder count should include cwd (10 params)
+    expect(fnBody).toMatch(/VALUES\s*\(\?\s*(?:,\s*\?){9}\)/);
+  });
+});
+
+// ============================================================================
+// Test 4: Reconciliation uses stored cwd, not workspace_path
+// ============================================================================
+
+describe('Bugfix #506: reconciliation uses dbSession.cwd', () => {
+  it('reconcileTerminalSessions should use dbSession.cwd for createSessionRaw', () => {
+    const src = readFileSync(
+      resolve(import.meta.dirname, '../servers/tower-terminals.ts'),
+      'utf-8',
+    );
+    // The reconciliation code should use dbSession.cwd with fallback
+    expect(src).toContain('dbSession.cwd ?? workspacePath');
+  });
+
+  it('on-the-fly reconnection should use dbSession.cwd for createSessionRaw', () => {
+    const src = readFileSync(
+      resolve(import.meta.dirname, '../servers/tower-terminals.ts'),
+      'utf-8',
+    );
+    // The on-the-fly reconnection code should use dbSession.cwd with fallback
+    expect(src).toContain('dbSession.cwd ?? dbSession.workspace_path');
+  });
+});
+
+// ============================================================================
+// Test 5: Terminal creation passes cwd to saveTerminalSession
+// ============================================================================
+
+describe('Bugfix #506: terminal creation passes cwd', () => {
+  it('handleTerminalCreate should pass cwd to saveTerminalSession', () => {
+    const src = readFileSync(
+      resolve(import.meta.dirname, '../servers/tower-routes.ts'),
+      'utf-8',
+    );
+    // Find the handleTerminalCreate function
+    const fnStart = src.indexOf('async function handleTerminalCreate');
+    const fnEnd = src.indexOf('\nasync function', fnStart + 1);
+    const fnBody = src.slice(fnStart, fnEnd);
+    // Both shellper and fallback paths should pass cwd
+    const saveCalls = fnBody.match(/saveTerminalSession\([^)]+\)/g) ?? [];
+    expect(saveCalls.length).toBeGreaterThanOrEqual(2);
+    for (const call of saveCalls) {
+      expect(call).toContain('cwd');
+    }
+  });
+});

--- a/packages/codev/src/agent-farm/db/index.ts
+++ b/packages/codev/src/agent-farm/db/index.ts
@@ -645,6 +645,18 @@ function ensureGlobalDatabase(): Database.Database {
     console.log('[info] Added label column to terminal_sessions (Spec 468)');
   }
 
+  // Migration v12: Add cwd column to terminal_sessions (Bugfix #506)
+  const v12 = db.prepare('SELECT version FROM _migrations WHERE version = 12').get();
+  if (!v12) {
+    try {
+      db.exec(`ALTER TABLE terminal_sessions ADD COLUMN cwd TEXT`);
+    } catch {
+      // Column may already exist from a fresh install
+    }
+    db.prepare('INSERT INTO _migrations (version) VALUES (12)').run();
+    console.log('[info] Added cwd column to terminal_sessions (Bugfix #506)');
+  }
+
   return db;
 }
 

--- a/packages/codev/src/agent-farm/db/schema.ts
+++ b/packages/codev/src/agent-farm/db/schema.ts
@@ -104,6 +104,7 @@ CREATE TABLE IF NOT EXISTS terminal_sessions (
   shellper_pid INTEGER,                   -- shellper process PID
   shellper_start_time INTEGER,            -- shellper process start time (epoch ms)
   label TEXT,                             -- custom display label (Spec 468)
+  cwd TEXT,                               -- working directory of the terminal (Bugfix #506)
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 

--- a/packages/codev/src/agent-farm/servers/tower-instances.ts
+++ b/packages/codev/src/agent-farm/servers/tower-instances.ts
@@ -44,6 +44,7 @@ export interface InstanceDeps {
     id: string, workspacePath: string, type: 'architect' | 'builder' | 'shell',
     roleId: string | null, pid: number | null,
     shellperSocket?: string | null, shellperPid?: number | null, shellperStartTime?: number | null,
+    label?: string | null, cwd?: string | null,
   ) => void;
   /** Delete a terminal session row from SQLite */
   deleteTerminalSession: (id: string) => void;
@@ -405,7 +406,7 @@ export async function launchInstance(workspacePath: string): Promise<{ success: 
 
             entry.architect = session.id;
             _deps.saveTerminalSession(session.id, resolvedPath, 'architect', null, shellperInfo.pid,
-              shellperInfo.socketPath, shellperInfo.pid, shellperInfo.startTime);
+              shellperInfo.socketPath, shellperInfo.pid, shellperInfo.startTime, null, workspacePath);
 
             // Clean up cache/SQLite when the shellper session permanently exits
             // (e.g., max restarts exceeded or killed). With restartOnExit, this
@@ -440,7 +441,7 @@ export async function launchInstance(workspacePath: string): Promise<{ success: 
           });
 
           entry.architect = session.id;
-          _deps.saveTerminalSession(session.id, resolvedPath, 'architect', null, session.pid);
+          _deps.saveTerminalSession(session.id, resolvedPath, 'architect', null, session.pid, null, null, null, null, workspacePath);
 
           const ptySession = manager.getSession(session.id);
           if (ptySession) {

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -426,7 +426,7 @@ async function handleTerminalCreate(
             entry.shells.set(roleId, session.id);
           }
           saveTerminalSession(session.id, workspacePath, termType, roleId, shellperInfo.pid,
-            shellperInfo.socketPath, shellperInfo.pid, shellperInfo.startTime);
+            shellperInfo.socketPath, shellperInfo.pid, shellperInfo.startTime, label ?? null, cwd ?? null);
           ctx.log('INFO', `Registered shellper terminal ${session.id} as ${termType} "${roleId}" for workspace ${workspacePath}`);
         }
       } catch (shellperErr) {
@@ -447,7 +447,7 @@ async function handleTerminalCreate(
         } else {
           entry.shells.set(roleId, info.id);
         }
-        saveTerminalSession(info.id, workspacePath, termType, roleId, info.pid);
+        saveTerminalSession(info.id, workspacePath, termType, roleId, info.pid, null, null, null, null, cwd ?? null);
         ctx.log('WARN', `Terminal ${info.id} for ${workspacePath} is non-persistent (shellper unavailable)`);
       }
     }
@@ -1508,7 +1508,7 @@ async function handleWorkspaceShellCreate(
         const entry = getWorkspaceTerminalsEntry(workspacePath);
         entry.shells.set(shellId, session.id);
         saveTerminalSession(session.id, workspacePath, 'shell', shellId, shellperInfo.pid,
-          shellperInfo.socketPath, shellperInfo.pid, shellperInfo.startTime, session.label);
+          shellperInfo.socketPath, shellperInfo.pid, shellperInfo.startTime, session.label, workspacePath);
 
         shellCreated = true;
         res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -1539,7 +1539,7 @@ async function handleWorkspaceShellCreate(
 
       const entry = getWorkspaceTerminalsEntry(workspacePath);
       entry.shells.set(shellId, session.id);
-      saveTerminalSession(session.id, workspacePath, 'shell', shellId, session.pid, null, null, null, session.label);
+      saveTerminalSession(session.id, workspacePath, 'shell', shellId, session.pid, null, null, null, session.label, workspacePath);
       ctx.log('WARN', `Shell ${shellId} for ${workspacePath} is non-persistent (shellper unavailable)`);
 
       res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/packages/codev/src/agent-farm/servers/tower-types.ts
+++ b/packages/codev/src/agent-farm/servers/tower-types.ts
@@ -80,5 +80,6 @@ export interface DbTerminalSession {
   shellper_pid: number | null;
   shellper_start_time: number | null;
   label: string | null;
+  cwd: string | null;
   created_at: string;
 }


### PR DESCRIPTION
## Summary

Fixes #506

After Tower restart, the annotator resolved builder file paths against the main workspace root instead of the builder's worktree. This caused ENOENT errors when clicking file links in builder terminals.

**Root cause:** The `terminal_sessions` SQLite table stored `workspace_path` (main repo root) but not the terminal's actual working directory. During reconciliation, `createSessionRaw` used `workspace_path` as the `cwd`, which for builder terminals should be the worktree path.

**Fix:** 
- Added `cwd` column to `terminal_sessions` table (schema + migration v12)
- Updated `saveTerminalSession()` to persist `cwd`
- Updated all callers to pass the actual working directory
- Updated reconciliation and on-the-fly reconnection to use stored `cwd` with fallback to `workspace_path` for pre-migration rows

## Changes

| File | Change |
|------|--------|
| `db/schema.ts` | Added `cwd TEXT` column to `terminal_sessions` |
| `db/index.ts` | Added migration v12 for `cwd` column |
| `tower-types.ts` | Added `cwd` to `DbTerminalSession` interface |
| `tower-terminals.ts` | Updated `saveTerminalSession` signature, reconciliation, and reconnection to use `cwd` |
| `tower-routes.ts` | Pass `cwd` in all `saveTerminalSession` calls |
| `tower-instances.ts` | Pass `cwd` in architect session creation |
| `bugfix-506-*.test.ts` | 7 regression tests |

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] 7 new regression tests pass
- [x] 42 existing tower-terminals tests pass
- [x] 5 predecessor bugfix-427 tests pass
- [ ] Manual: restart Tower with builder running, click file link in builder terminal — should resolve to worktree path