### PR TITLE
[Bugfix #517] Fix mobile duplicate letters and extra periods

### DIFF
--- a/packages/codev/dashboard/__tests__/Terminal.ime-dedup.test.tsx
+++ b/packages/codev/dashboard/__tests__/Terminal.ime-dedup.test.tsx
@@ -115,6 +115,7 @@ function fireComposition(type: 'compositionstart' | 'compositionend', data?: str
 }
 
 /** Mock matchMedia to simulate touch device (pointer: coarse). */
+const originalMatchMedia = window.matchMedia;
 function mockTouchDevice(isTouch: boolean) {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
@@ -131,6 +132,13 @@ function mockTouchDevice(isTouch: boolean) {
     })),
   });
 }
+function restoreMatchMedia() {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: originalMatchMedia,
+  });
+}
 
 describe('Terminal IME deduplication (Issue #253, #517)', () => {
   beforeEach(() => {
@@ -143,6 +151,7 @@ describe('Terminal IME deduplication (Issue #253, #517)', () => {
 
   afterEach(() => {
     cleanup();
+    restoreMatchMedia();
     vi.useRealTimers();
   });
 
@@ -243,6 +252,7 @@ describe('Terminal touch device dedup — iPad fix (Issue #517)', () => {
 
   afterEach(() => {
     cleanup();
+    restoreMatchMedia();
     vi.useRealTimers();
   });
 

--- a/packages/codev/dashboard/src/components/Terminal.tsx
+++ b/packages/codev/dashboard/src/components/Terminal.tsx
@@ -520,6 +520,8 @@ export function Terminal({ wsPath, onFileOpen, persistent }: TerminalProps) {
     //    where delayed duplicates can arrive outside the composition window
     //    (e.g. near line wraps). Uses pointer:coarse media query instead of
     //    UA string to correctly detect iPads (iPadOS sends desktop UA).
+    //    Tradeoff: iPad + external keyboard would still get dedup, but
+    //    default keyboard repeat rates (>250ms) are above the 150ms window.
     const isTouchDevice = window.matchMedia?.('(pointer: coarse)')?.matches ?? false;
     const textarea = term.textarea;
     let isComposing = false;


### PR DESCRIPTION
## Summary
Fixes #517

## Root Cause
The previous mobile input deduplication used a User Agent regex (`/Android|iPhone|iPad|iPod/i`) to detect mobile devices. This had two problems:

1. **iPads not detected**: iPadOS 13+ sends a desktop User Agent (`Macintosh; Intel Mac OS X`), so the regex never matched. The dedup was **never activated on iPads**.
2. **No composition awareness**: The dedup was always-on for matched devices but off for everything else, with no knowledge of when IME composition was actually happening.

## Fix
Replaced the UA-based approach with two complementary dedup triggers:

1. **Composition event tracking** — Listens for `compositionstart`/`compositionend` on xterm's textarea. Deduplicates during and within 150ms after IME composition. Works on ALL platforms (catches mobile + desktop CJK input).
2. **`pointer:coarse` media query** — Always-on dedup for touch/soft-keyboard devices. Catches delayed duplicates that arrive outside the composition window (e.g. near line wraps). Correctly detects iPads, Android tablets, and any touch device.

**Key design choice**: Using `(pointer: coarse)` instead of UA sniffing correctly identifies soft-keyboard devices without false-positives on touch-screen laptops (which report `pointer: fine` since mouse/trackpad is the primary pointer).

## Test Plan
- [x] Added 4 new regression tests for touch device dedup (iPad scenario)
- [x] Updated 5 existing IME composition dedup tests
- [x] Verified desktop key repeat is not affected (no composition → no dedup)
- [x] All 31 terminal-related tests pass (9 IME dedup + 8 input filter + 14 virtual keyboard)
- [x] TypeScript compiles clean
- [ ] CMAP review

## CMAP Review
<To be added after review>