### PR TITLE
[Bugfix #531] Fix: Restructure dashboard analytics sections, keep GitHub data source

### DIFF
--- a/packages/codev/dashboard/__tests__/analytics.test.tsx
+++ b/packages/codev/dashboard/__tests__/analytics.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for the Analytics tab (Spec 456, Phase 3).
+ * Tests for the Analytics tab (Bugfix #531).
  *
  * Tests: useAnalytics hook behavior, AnalyticsView rendering,
  * null value formatting, error states, and range switching.
@@ -25,18 +25,16 @@ vi.mock('../src/lib/api.js', () => ({
 function makeStats(overrides: Partial<AnalyticsResponse> = {}): AnalyticsResponse {
   return {
     timeRange: '7d',
-    github: {
+    activity: {
       prsMerged: 12,
       avgTimeToMergeHours: 3.5,
-      bugBacklog: 4,
-      nonBugBacklog: 8,
       issuesClosed: 6,
       avgTimeToCloseBugsHours: 1.2,
-    },
-    builders: {
       projectsCompleted: 5,
+      bugsFixed: 3,
       throughputPerWeek: 2.5,
       activeBuilders: 2,
+      projectsByProtocol: { spir: 3, bugfix: 2, aspir: 1 },
     },
     consultation: {
       totalCount: 20,
@@ -50,10 +48,6 @@ function makeStats(overrides: Partial<AnalyticsResponse> = {}): AnalyticsRespons
       ],
       byReviewType: { spec: 5, plan: 5, pr: 10 },
       byProtocol: { spir: 15, tick: 5 },
-      costByProject: [
-        { projectId: '456', totalCost: 0.75 },
-        { projectId: '123', totalCost: 0.48 },
-      ],
     },
     ...overrides,
   };
@@ -84,7 +78,7 @@ describe('useAnalytics', () => {
     });
 
     expect(mockFetchAnalytics).toHaveBeenCalledWith('7', false);
-    expect(result.current.data?.github.prsMerged).toBe(12);
+    expect(result.current.data?.activity.prsMerged).toBe(12);
     expect(result.current.loading).toBe(false);
   });
 
@@ -180,21 +174,22 @@ describe('AnalyticsView', () => {
     expect(screen.getByText('Loading analytics...')).toBeInTheDocument();
   });
 
-  it('renders all three section headers', async () => {
+  it('renders Activity and Consultation section headers (not GitHub/Builders)', async () => {
     mockFetchAnalytics.mockResolvedValue(makeStats());
 
     const { AnalyticsView } = await import('../src/components/AnalyticsView.js');
     render(<AnalyticsView isActive={true} />);
 
     await waitFor(() => {
-      expect(screen.getByText('GitHub')).toBeInTheDocument();
+      expect(screen.getByText('Activity')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('Builders')).toBeInTheDocument();
     expect(screen.getByText('Consultation')).toBeInTheDocument();
+    expect(screen.queryByText('GitHub')).not.toBeInTheDocument();
+    expect(screen.queryByText('Builders')).not.toBeInTheDocument();
   });
 
-  it('renders GitHub metric values', async () => {
+  it('renders Activity metric values', async () => {
     mockFetchAnalytics.mockResolvedValue(makeStats());
 
     const { AnalyticsView } = await import('../src/components/AnalyticsView.js');
@@ -206,6 +201,23 @@ describe('AnalyticsView', () => {
 
     expect(screen.getByText('12')).toBeInTheDocument();
     expect(screen.getByText('3.5h')).toBeInTheDocument();
+    expect(screen.getByText('Projects Completed')).toBeInTheDocument();
+    expect(screen.getByText('Bugs Fixed')).toBeInTheDocument();
+  });
+
+  it('renders protocol breakdown metrics', async () => {
+    mockFetchAnalytics.mockResolvedValue(makeStats());
+
+    const { AnalyticsView } = await import('../src/components/AnalyticsView.js');
+    render(<AnalyticsView isActive={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Projects by Protocol')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('SPIR')).toBeInTheDocument();
+    expect(screen.getByText('BUGFIX')).toBeInTheDocument();
+    expect(screen.getByText('ASPIR')).toBeInTheDocument();
   });
 
   it('renders consultation total cost', async () => {
@@ -223,13 +235,16 @@ describe('AnalyticsView', () => {
 
   it('displays null values as em-dash', async () => {
     const stats = makeStats({
-      github: {
+      activity: {
         prsMerged: 3,
         avgTimeToMergeHours: null,
-        bugBacklog: 0,
-        nonBugBacklog: 0,
         issuesClosed: 0,
         avgTimeToCloseBugsHours: null,
+        projectsCompleted: 0,
+        bugsFixed: 0,
+        throughputPerWeek: 0,
+        activeBuilders: 0,
+        projectsByProtocol: {},
       },
     });
     mockFetchAnalytics.mockResolvedValue(stats);
@@ -238,7 +253,7 @@ describe('AnalyticsView', () => {
     render(<AnalyticsView isActive={true} />);
 
     await waitFor(() => {
-      expect(screen.getByText('GitHub')).toBeInTheDocument();
+      expect(screen.getByText('Activity')).toBeInTheDocument();
     });
 
     const dashes = screen.getAllByText('\u2014');
@@ -273,19 +288,30 @@ describe('AnalyticsView', () => {
     expect(screen.getByText('gpt-5.2-codex')).toBeInTheDocument();
   });
 
-  it('renders cost per project section', async () => {
+  it('does not render Cost per Project section', async () => {
     mockFetchAnalytics.mockResolvedValue(makeStats());
 
     const { AnalyticsView } = await import('../src/components/AnalyticsView.js');
     render(<AnalyticsView isActive={true} />);
 
     await waitFor(() => {
-      expect(screen.getByText('Cost per Project')).toBeInTheDocument();
+      expect(screen.getByText('Activity')).toBeInTheDocument();
     });
 
-    // Chart internals (#456, $0.75) render as SVG via Recharts and are
-    // not visible in jsdom's 0-width ResponsiveContainer.  Verifying the
-    // section heading confirms the data path is wired correctly.
+    expect(screen.queryByText('Cost per Project')).not.toBeInTheDocument();
+  });
+
+  it('does not render Open Issue Backlog', async () => {
+    mockFetchAnalytics.mockResolvedValue(makeStats());
+
+    const { AnalyticsView } = await import('../src/components/AnalyticsView.js');
+    render(<AnalyticsView isActive={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Activity')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Open Issue Backlog')).not.toBeInTheDocument();
   });
 
   it('calls fetchAnalytics with new range when range button is clicked', async () => {
@@ -295,7 +321,7 @@ describe('AnalyticsView', () => {
     render(<AnalyticsView isActive={true} />);
 
     await waitFor(() => {
-      expect(screen.getByText('GitHub')).toBeInTheDocument();
+      expect(screen.getByText('Activity')).toBeInTheDocument();
     });
 
     mockFetchAnalytics.mockResolvedValue(makeStats({ timeRange: '30d' }));
@@ -313,7 +339,7 @@ describe('AnalyticsView', () => {
     render(<AnalyticsView isActive={true} />);
 
     await waitFor(() => {
-      expect(screen.getByText('GitHub')).toBeInTheDocument();
+      expect(screen.getByText('Activity')).toBeInTheDocument();
     });
 
     const refreshBtn = screen.getByRole('button', { name: /Refresh/ });

--- a/packages/codev/dashboard/src/components/AnalyticsView.tsx
+++ b/packages/codev/dashboard/src/components/AnalyticsView.tsx
@@ -3,7 +3,6 @@ import { useAnalytics } from '../hooks/useAnalytics.js';
 import type { AnalyticsResponse } from '../lib/api.js';
 import {
   BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell,
-  PieChart, Pie,
 } from 'recharts';
 
 interface AnalyticsViewProps {
@@ -99,72 +98,33 @@ function MiniBarChart({ data, dataKey, nameKey, color, formatter }: {
   );
 }
 
-function MiniPieChart({ data, dataKey, nameKey }: {
-  data: Array<Record<string, unknown>>;
-  dataKey: string;
-  nameKey: string;
-}) {
-  if (data.length === 0) return null;
-  return (
-    <ResponsiveContainer width="100%" height={160}>
-      <PieChart>
-        <Pie
-          data={data}
-          dataKey={dataKey}
-          nameKey={nameKey}
-          cx="50%"
-          cy="50%"
-          outerRadius={55}
-          innerRadius={30}
-          label={({ name, percent }) => `${name} ${((percent ?? 0) * 100).toFixed(0)}%`}
-          labelLine={false}
-          style={{ fontSize: 10 }}
-        >
-          {data.map((_entry, idx) => (
-            <Cell key={idx} fill={CHART_COLORS[idx % CHART_COLORS.length]} />
-          ))}
-        </Pie>
-        <Tooltip
-          contentStyle={{ background: 'var(--bg-primary)', border: '1px solid var(--border-color)', fontSize: 11, borderRadius: 4 }}
-          labelStyle={{ color: 'var(--text-primary)' }}
-          itemStyle={{ color: 'var(--text-secondary)' }}
-        />
-      </PieChart>
-    </ResponsiveContainer>
-  );
-}
-
-function GitHubSection({ github, errors }: { github: AnalyticsResponse['github']; errors?: AnalyticsResponse['errors'] }) {
-  const backlogData = [
-    { name: 'Bug', value: github.bugBacklog },
-    { name: 'Non-Bug', value: github.nonBugBacklog },
-  ].filter(d => d.value > 0);
+function ActivitySection({ activity, errors }: { activity: AnalyticsResponse['activity']; errors?: AnalyticsResponse['errors'] }) {
+  const protocolData = Object.entries(activity.projectsByProtocol)
+    .map(([proto, count]) => ({ name: proto.toUpperCase(), value: count }))
+    .sort((a, b) => b.value - a.value);
 
   return (
-    <Section title="GitHub" error={errors?.github}>
-      <MetricGrid>
-        <Metric label="PRs Merged" value={String(github.prsMerged)} />
-        <Metric label="Avg Time to Merge" value={fmt(github.avgTimeToMergeHours, 1, 'h')} />
-        <Metric label="Issues Closed" value={String(github.issuesClosed)} />
-        <Metric label="Avg Time to Close Bugs" value={fmt(github.avgTimeToCloseBugsHours, 1, 'h')} />
-      </MetricGrid>
-      {backlogData.length > 0 && (
+    <Section title="Activity" error={errors?.github}>
+      {protocolData.length > 0 && (
         <div className="analytics-sub-section">
-          <h4 className="analytics-sub-title">Open Issue Backlog</h4>
-          <MiniBarChart data={backlogData} dataKey="value" nameKey="name" />
+          <h4 className="analytics-sub-title">Projects by Protocol</h4>
+          <MetricGrid>
+            {protocolData.map(d => (
+              <Metric key={d.name} label={d.name} value={String(d.value)} />
+            ))}
+          </MetricGrid>
+          <MiniBarChart data={protocolData} dataKey="value" nameKey="name" />
         </div>
       )}
-    </Section>
-  );
-}
-
-function BuildersSection({ builders }: { builders: AnalyticsResponse['builders'] }) {
-  return (
-    <Section title="Builders">
       <MetricGrid>
-        <Metric label="Projects Completed" value={String(builders.projectsCompleted)} />
-        <Metric label="Throughput / Week" value={fmt(builders.throughputPerWeek)} />
-        <Metric label="Active Builders" value={String(builders.activeBuilders)} />
+        <Metric label="Projects Completed" value={String(activity.projectsCompleted)} />
+        <Metric label="Bugs Fixed" value={String(activity.bugsFixed)} />
+        <Metric label="PRs Merged" value={String(activity.prsMerged)} />
+        <Metric label="Issues Closed" value={String(activity.issuesClosed)} />
+        <Metric label="Avg Time to Merge" value={fmt(activity.avgTimeToMergeHours, 1, 'h')} />
+        <Metric label="Avg Time to Close Bugs" value={fmt(activity.avgTimeToCloseBugsHours, 1, 'h')} />
+        <Metric label="Throughput / Week" value={fmt(activity.throughputPerWeek)} />
+        <Metric label="Active Builders" value={String(activity.activeBuilders)} />
       </MetricGrid>
     </Section>
   );
@@ -187,11 +147,6 @@ function ConsultationSection({ consultation, errors }: { consultation: Analytics
   const protocolData = Object.entries(consultation.byProtocol).map(([proto, count]) => ({
     name: proto,
     value: count,
-  }));
-
-  const projectData = consultation.costByProject.map(p => ({
-    name: `#${p.projectId}`,
-    cost: p.totalCost,
   }));
 
   return (
@@ -248,27 +203,15 @@ function ConsultationSection({ consultation, errors }: { consultation: Analytics
           {reviewTypeData.length > 0 && (
             <div className="analytics-sub-section analytics-chart-half">
               <h4 className="analytics-sub-title">By Review Type</h4>
-              <MiniPieChart data={reviewTypeData} dataKey="value" nameKey="name" />
+              <MiniBarChart data={reviewTypeData} dataKey="value" nameKey="name" />
             </div>
           )}
           {protocolData.length > 0 && (
             <div className="analytics-sub-section analytics-chart-half">
               <h4 className="analytics-sub-title">By Protocol</h4>
-              <MiniPieChart data={protocolData} dataKey="value" nameKey="name" />
+              <MiniBarChart data={protocolData} dataKey="value" nameKey="name" />
             </div>
           )}
-        </div>
-      )}
-
-      {projectData.length > 0 && (
-        <div className="analytics-sub-section">
-          <h4 className="analytics-sub-title">Cost per Project</h4>
-          <MiniBarChart
-            data={projectData}
-            dataKey="cost"
-            nameKey="name"
-            formatter={(v) => `$${v.toFixed(2)}`}
-          />
         </div>
       )}
     </Section>
@@ -312,8 +255,7 @@ export function AnalyticsView({ isActive }: AnalyticsViewProps) {
 
         {data && (
           <>
-            <GitHubSection github={data.github} errors={data.errors} />
-            <BuildersSection builders={data.builders} />
+            <ActivitySection activity={data.activity} errors={data.errors} />
             <ConsultationSection consultation={data.consultation} errors={data.errors} />
           </>
         )}

--- a/packages/codev/dashboard/src/lib/api.ts
+++ b/packages/codev/dashboard/src/lib/api.ts
@@ -145,18 +145,16 @@ export interface OverviewData {
 
 export interface AnalyticsResponse {
   timeRange: '24h' | '7d' | '30d' | 'all';
-  github: {
+  activity: {
     prsMerged: number;
     avgTimeToMergeHours: number | null;
-    bugBacklog: number;
-    nonBugBacklog: number;
     issuesClosed: number;
     avgTimeToCloseBugsHours: number | null;
-  };
-  builders: {
     projectsCompleted: number;
+    bugsFixed: number;
     throughputPerWeek: number;
     activeBuilders: number;
+    projectsByProtocol: Record<string, number>;
   };
   consultation: {
     totalCount: number;
@@ -173,10 +171,6 @@ export interface AnalyticsResponse {
     }>;
     byReviewType: Record<string, number>;
     byProtocol: Record<string, number>;
-    costByProject: Array<{
-      projectId: string;
-      totalCost: number;
-    }>;
   };
   errors?: {
     github?: string;

--- a/packages/codev/src/agent-farm/__tests__/tower-routes.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tower-routes.test.ts
@@ -1017,9 +1017,8 @@ describe('tower-routes', () => {
   describe('GET /api/analytics', () => {
     const fakeStats = {
       timeRange: '7d',
-      github: { prsMerged: 5, avgTimeToMergeHours: 2.5, bugBacklog: 3, nonBugBacklog: 7, issuesClosed: 4, avgTimeToCloseBugsHours: 1.2 },
-      builders: { projectsCompleted: 3, throughputPerWeek: 3, activeBuilders: 1 },
-      consultation: { totalCount: 10, totalCostUsd: 0.5, costByModel: {}, avgLatencySeconds: 12, successRate: 90, byModel: [], byReviewType: {}, byProtocol: {}, costByProject: [] },
+      activity: { prsMerged: 5, avgTimeToMergeHours: 2.5, issuesClosed: 4, avgTimeToCloseBugsHours: 1.2, projectsCompleted: 3, bugsFixed: 1, throughputPerWeek: 3, activeBuilders: 1, projectsByProtocol: { spir: 2, bugfix: 1 } },
+      consultation: { totalCount: 10, totalCostUsd: 0.5, costByModel: {}, avgLatencySeconds: 12, successRate: 90, byModel: [], byReviewType: {}, byProtocol: {} },
     };
 
     beforeEach(() => {
@@ -1034,7 +1033,7 @@ describe('tower-routes', () => {
 
       expect(statusCode()).toBe(200);
       const parsed = JSON.parse(body());
-      expect(parsed.github.prsMerged).toBe(5);
+      expect(parsed.activity.prsMerged).toBe(5);
       expect(mockComputeAnalytics).toHaveBeenCalledWith('/tmp/workspace', '7', 0, false);
     });
 
@@ -1074,8 +1073,8 @@ describe('tower-routes', () => {
       expect(statusCode()).toBe(200);
       const parsed = JSON.parse(body());
       expect(parsed.timeRange).toBe('30d');
-      expect(parsed.github.prsMerged).toBe(0);
-      expect(parsed.builders.activeBuilders).toBe(0);
+      expect(parsed.activity.prsMerged).toBe(0);
+      expect(parsed.activity.activeBuilders).toBe(0);
       expect(mockComputeAnalytics).not.toHaveBeenCalled();
     });
 

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -719,7 +719,7 @@ async function handleAnalytics(res: http.ServerResponse, url: URL, workspaceOver
 
   if (!workspaceRoot) {
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ timeRange: rangeLabel, github: { prsMerged: 0, avgTimeToMergeHours: null, bugBacklog: 0, nonBugBacklog: 0, issuesClosed: 0, avgTimeToCloseBugsHours: null }, builders: { projectsCompleted: 0, throughputPerWeek: 0, activeBuilders: 0 }, consultation: { totalCount: 0, totalCostUsd: null, costByModel: {}, avgLatencySeconds: null, successRate: null, byModel: [], byReviewType: {}, byProtocol: {}, costByProject: [] } }));
+    res.end(JSON.stringify({ timeRange: rangeLabel, activity: { prsMerged: 0, avgTimeToMergeHours: null, issuesClosed: 0, avgTimeToCloseBugsHours: null, projectsCompleted: 0, bugsFixed: 0, throughputPerWeek: 0, activeBuilders: 0, projectsByProtocol: {} }, consultation: { totalCount: 0, totalCostUsd: null, costByModel: {}, avgLatencySeconds: null, successRate: null, byModel: [], byReviewType: {}, byProtocol: {} } }));
     return;
   }
   const range = rangeParam as '1' | '7' | '30' | 'all';


### PR DESCRIPTION
## Summary

Restructures the dashboard Analytics tab per issue requirements: merges GitHub + Builders sections into a unified Activity section, adds protocol breakdown from status.yaml, adds Bugs Fixed metric, replaces pie charts with bar charts, and removes cost-per-project — all while keeping GitHub API as the primary data source.

Fixes #531

## Root Cause

The analytics tab had separate GitHub and Builders sections that should be unified. The previous attempt (#529/#530) was reverted because it replaced GitHub API data with local artifact scanning, breaking completion counts.

## Fix

**Backend (`analytics.ts`)**:
- Merged `github` + `builders` response keys into single `activity` section
- Added `bugsFixed` count (closed issues with bug label)
- Added `projectsByProtocol` from `codev/projects/*/status.yaml` (supplementary source)
- Removed `bugBacklog`, `nonBugBacklog` (open issues backlog)
- Removed `costByProject` from consultation section
- Kept all GitHub API calls unchanged (`fetchMergedPRs`, `fetchClosedIssues`)
- Normalizes legacy `spider` protocol to `spir`

**Frontend (`AnalyticsView.tsx`)**:
- Merged `GitHubSection` + `BuildersSection` into `ActivitySection`
- Protocol breakdown displayed prominently at top with per-protocol counts + bar chart
- Replaced `MiniPieChart` with `MiniBarChart` for consultation review type and protocol
- Removed `MiniPieChart` component and `PieChart`/`Pie` imports
- Removed Cost per Project sub-section
- Removed Open Issue Backlog chart

**API types (`api.ts`)**: Updated `AnalyticsResponse` interface to match new shape.
**Tower routes**: Updated fallback empty response for new structure.

## Test Plan

- [x] Regression tests updated (backend: 33 tests, frontend: 17 tests, tower-routes: 59 tests)
- [x] Build passes (`tsc --noEmit`)
- [x] All tests pass
- [x] Tests verify: no `github`/`builders` top-level keys, no `costByProject`, Activity section renders, protocol breakdown works, spider→spir normalization, bugsFixed count, no Open Issue Backlog, no Cost per Project

## CMAP Review

_Pending_