### PR TITLE
Add HTML preview support in af open viewer

### DIFF
--- a/codev/projects/536-add-html-preview-support-in-af/status.yaml
+++ b/codev/projects/536-add-html-preview-support-in-af/status.yaml
@@ -1,0 +1,14 @@
+id: '536'
+title: add-html-preview-support-in-af
+protocol: air
+phase: pr
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-02-23T19:29:32.300Z'
+updated_at: '2026-02-23T19:38:19.216Z'

--- a/codev/protocols/air/protocol.json
+++ b/codev/protocols/air/protocol.json
@@ -30,11 +30,13 @@
       "checks": {
         "build": {
           "command": "npm run build",
+          "cwd": "packages/codev",
           "on_fail": "retry",
           "max_retries": 2
         },
         "tests": {
           "command": "npm test -- --exclude='**/e2e/**'",
+          "cwd": "packages/codev",
           "description": "Unit tests only - e2e tests run in PR phase",
           "on_fail": "retry",
           "max_retries": 2
@@ -70,6 +72,7 @@
         },
         "e2e_tests": {
           "command": "npm run test:e2e 2>&1 || echo 'e2e tests skipped (not configured)'",
+          "cwd": "packages/codev",
           "description": "Full e2e test suite",
           "optional": true
         }

--- a/packages/codev/src/agent-farm/__tests__/html-preview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/html-preview.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for HTML preview support in the annotation viewer (#536)
+ *
+ * When opening an HTML file with `af open`, the viewer should:
+ * 1. Detect HTML files via IS_HTML template variable
+ * 2. Show a sandboxed iframe preview by default
+ * 3. Allow toggling between preview and annotated code view
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('HTML preview support (#536)', () => {
+  const templatePath = resolve(
+    import.meta.dirname,
+    '../../../templates/open.html',
+  );
+  const routesPath = resolve(
+    import.meta.dirname,
+    '../servers/tower-routes.ts',
+  );
+
+  describe('template contains HTML preview elements', () => {
+    it('should have IS_HTML template placeholder', () => {
+      const html = readFileSync(templatePath, 'utf-8');
+      expect(html).toContain('{{IS_HTML}}');
+    });
+
+    it('should declare isHtmlFile state variable', () => {
+      const html = readFileSync(templatePath, 'utf-8');
+      expect(html).toContain('const isHtmlFile = {{IS_HTML}}');
+    });
+
+    it('should have a sandboxed iframe for HTML preview', () => {
+      const html = readFileSync(templatePath, 'utf-8');
+      expect(html).toContain('id="html-preview-container"');
+      expect(html).toContain('sandbox="allow-scripts"');
+    });
+
+    it('should have renderHtmlPreview function that sets srcdoc', () => {
+      const html = readFileSync(templatePath, 'utf-8');
+      expect(html).toContain('function renderHtmlPreview()');
+      expect(html).toContain('iframe.srcdoc = currentContent');
+    });
+
+    it('should auto-show preview for HTML files on init', () => {
+      const html = readFileSync(templatePath, 'utf-8');
+      // After init() sets up the file, it should auto-toggle preview for HTML
+      expect(html).toContain('if (isHtmlFile)');
+      // The togglePreviewMode call must appear inside init()
+      const initFn = html.slice(
+        html.indexOf('function init(content)'),
+        html.indexOf('function initPreviewToggle()'),
+      );
+      expect(initFn).toContain('togglePreviewMode()');
+    });
+
+    it('should enable preview toggle for HTML files', () => {
+      const html = readFileSync(templatePath, 'utf-8');
+      // initPreviewToggle should check for isHtmlFile
+      const initToggleFn = html.slice(
+        html.indexOf('function initPreviewToggle()'),
+        html.indexOf('function initImage('),
+      );
+      expect(initToggleFn).toContain('isHtmlFile');
+    });
+
+    it('should support Cmd+Shift+P shortcut for HTML files', () => {
+      const html = readFileSync(templatePath, 'utf-8');
+      // The keyboard shortcut handler should include isHtmlFile
+      expect(html).toContain('isMarkdownFile || isHtmlFile');
+    });
+  });
+
+  describe('tower-routes detects HTML files', () => {
+    it('should detect html and htm extensions', () => {
+      const src = readFileSync(routesPath, 'utf-8');
+      // Should have isHtml detection for both .html and .htm
+      expect(src).toContain("const isHtml = ['html', 'htm'].includes(ext)");
+    });
+
+    it('should inject IS_HTML template variable', () => {
+      const src = readFileSync(routesPath, 'utf-8');
+      expect(src).toContain("html.replace(/\\{\\{IS_HTML\\}\\}/g, String(isHtml))");
+    });
+  });
+});

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -1971,6 +1971,7 @@ function handleWorkspaceAnnotate(
   const is3D = ['stl', '3mf'].includes(ext);
   const isPdf = ext === 'pdf';
   const isMarkdown = ext === 'md';
+  const isHtml = ['html', 'htm'].includes(ext);
 
   // Sub-route: GET /file — re-read file content from disk
   if (req.method === 'GET' && subRoute === 'file') {
@@ -2090,6 +2091,7 @@ function handleWorkspaceAnnotate(
         html = html.replace(/\{\{IS_IMAGE\}\}/g, String(isImage));
         html = html.replace(/\{\{IS_VIDEO\}\}/g, String(isVideo));
         html = html.replace(/\{\{IS_PDF\}\}/g, String(isPdf));
+        html = html.replace(/\{\{IS_HTML\}\}/g, String(isHtml));
         html = html.replace(/\{\{FILE_SIZE\}\}/g, String(fileSize));
 
         // Inject initialization script (template loads content via fetch)

--- a/packages/codev/templates/open.html
+++ b/packages/codev/templates/open.html
@@ -188,6 +188,13 @@
       color: #888;
     }
 
+    /* HTML Preview Container (iframe) */
+    #html-preview-container {
+      flex: 1;
+      min-height: 0;
+      background: #fff;
+    }
+
     /* Editor container with line numbers */
     #editor-container {
       display: none;
@@ -476,6 +483,9 @@
   <!-- Markdown preview mode -->
   <div id="preview-container" style="display: none; padding: 20px; overflow: auto;"></div>
 
+  <!-- HTML preview mode (sandboxed iframe) -->
+  <iframe id="html-preview-container" sandbox="allow-scripts" style="display: none; width: 100%; border: none;" title="HTML preview"></iframe>
+
   <!-- Image viewer mode -->
   <div id="image-viewer">
     <div class="image-controls">
@@ -585,6 +595,9 @@
     // Video viewer state
     const isVideoFile = {{IS_VIDEO}};
 
+    // HTML preview state
+    const isHtmlFile = {{IS_HTML}};
+
     // Comment patterns by file extension
     const COMMENT_PATTERNS = {
       js: { prefix: '// REVIEW', regex: /^(\s*)\/\/\s*REVIEW(\(@\w+\))?:\s*(.*)$/ },
@@ -616,12 +629,16 @@
       renderFile();
       updateAnnotationsList();
       initPreviewToggle();
+      // Auto-show preview for HTML files
+      if (isHtmlFile) {
+        togglePreviewMode();
+      }
     }
 
     // Initialize preview toggle for markdown files
     function initPreviewToggle() {
       const togglePreviewBtn = document.getElementById('togglePreviewBtn');
-      if (isMarkdownFile && togglePreviewBtn) {
+      if ((isMarkdownFile || isHtmlFile) && togglePreviewBtn) {
         togglePreviewBtn.style.display = 'inline-block';
         togglePreviewBtn.addEventListener('click', togglePreviewMode);
       }
@@ -844,16 +861,25 @@
 
       if (isPreviewMode) {
         // Switch to Preview mode: hide viewMode, show preview
-        renderPreview();
         viewMode.style.display = 'none';
-        previewContainer.style.display = 'block';
+        if (isHtmlFile) {
+          renderHtmlPreview();
+          document.getElementById('html-preview-container').style.display = 'block';
+        } else {
+          renderPreview();
+          previewContainer.style.display = 'block';
+        }
         document.body.classList.add('preview-active');
         toggleIcon.textContent = '📝';
         toggleText.textContent = 'Annotate';
       } else {
         // Switch back to annotated view
         viewMode.style.display = 'grid';
-        previewContainer.style.display = 'none';
+        if (isHtmlFile) {
+          document.getElementById('html-preview-container').style.display = 'none';
+        } else {
+          previewContainer.style.display = 'none';
+        }
         document.body.classList.remove('preview-active');
         toggleIcon.textContent = '👁';
         toggleText.textContent = 'Preview';
@@ -909,6 +935,12 @@
         }
         Prism.highlightElement(block);
       });
+    }
+
+    // Render HTML preview in sandboxed iframe
+    function renderHtmlPreview() {
+      const iframe = document.getElementById('html-preview-container');
+      iframe.srcdoc = currentContent;
     }
 
     function renderFile() {
@@ -1516,7 +1548,7 @@
 
       // Cmd/Ctrl+Shift+P to toggle preview (markdown files only)
       if ((e.ctrlKey || e.metaKey) && e.shiftKey && (e.key === 'p' || e.key === 'P')) {
-        if (isMarkdownFile) {
+        if (isMarkdownFile || isHtmlFile) {
           e.preventDefault();
           togglePreviewMode();
         }
@@ -1790,7 +1822,9 @@
           fileLines = content.split('\n');
 
           // Re-render based on current mode
-          if (isPreviewMode) {
+          if (isPreviewMode && isHtmlFile) {
+            renderHtmlPreview();
+          } else if (isPreviewMode) {
             renderPreview();
           } else {
             renderFile();


### PR DESCRIPTION
Closes #536

## Summary

- Adds HTML preview support to the `af open` annotation viewer
- When opening `.html`/`.htm` files, the viewer now renders a live preview in a sandboxed iframe (using `srcdoc` with `sandbox="allow-scripts"`) instead of showing raw markup
- Users can toggle between preview and annotated code view with Cmd+Shift+P
- HTML files auto-open in preview mode; code view remains available for editing/annotations

## Changes

**`packages/codev/src/agent-farm/servers/tower-routes.ts`** (+3 lines)
- Added `isHtml` detection for `.html`/`.htm` extensions
- Injected `{{IS_HTML}}` template variable into the annotation template

**`packages/codev/templates/open.html`** (+30 lines)
- Added `isHtmlFile` state variable
- Added sandboxed `<iframe>` element for HTML preview
- Added `renderHtmlPreview()` function using `srcdoc`
- Extended `initPreviewToggle()` and `togglePreviewMode()` for HTML files
- Extended Cmd+Shift+P shortcut to work with HTML files
- Auto-toggle to preview mode on init for HTML files
- Handle auto-reload in HTML preview mode

**`packages/codev/src/agent-farm/__tests__/html-preview.test.ts`** (new, 9 tests)
- Template verification: IS_HTML placeholder, iframe element, sandbox attribute
- Function verification: renderHtmlPreview, auto-preview on init
- Route verification: HTML extension detection, template variable injection

**`codev/protocols/air/protocol.json`** (fix)
- Added `cwd: "packages/codev"` to check definitions (monorepo fix matching bugfix protocol pattern)

## Design Decisions

- **Sandboxed iframe with `srcdoc`**: Natural isolation for HTML content. `sandbox="allow-scripts"` allows JS execution while preventing access to the parent page. No `allow-same-origin` to maintain security boundary.
- **Preview as default view**: The issue says "render a preview rather than just showing raw markup", so HTML files auto-toggle to preview. Users can switch back to code view for annotations/editing.
- **Follows markdown preview pattern**: Reuses the existing toggle infrastructure (Cmd+Shift+P, toggle button) for consistency.
- **No DOMPurify needed**: The iframe sandbox provides sufficient isolation without HTML sanitization.

## Limitations

- Relative resource references (CSS, images) in the HTML won't resolve since `srcdoc` uses `about:srcdoc` as base URL. External absolute URLs work fine. This could be enhanced in a future PR by serving HTML through a dedicated sub-route.

## Test Plan

- [x] Build passes (`npm run build` from `packages/codev/`)
- [x] All 1982 unit tests pass (+ 9 new)
- [x] 13 pre-existing skipped tests unchanged
- [ ] Manual: `af open test.html` shows rendered preview
- [ ] Manual: Toggle button switches between preview and code view
- [ ] Manual: Cmd+Shift+P shortcut works for HTML files
- [ ] Manual: Editing HTML and switching back to preview shows updated content