### PR TITLE
[Bugfix #538] Derive protocol breakdown from PR branch names

### DIFF
--- a/packages/codev/src/lib/github.ts
+++ b/packages/codev/src/lib/github.ts
@@ -174,6 +174,7 @@ export interface MergedPR {
   createdAt: string;
   mergedAt: string;
   body: string;
+  headRefName: string;
 }
 
 export interface ClosedIssue {
@@ -194,7 +195,7 @@ export async function fetchMergedPRs(since: string | null, cwd?: string): Promis
     const args = [
       'pr', 'list',
       '--state', 'merged',
-      '--json', 'number,title,createdAt,mergedAt,body',
+      '--json', 'number,title,createdAt,mergedAt,body,headRefName',
       '--limit', '1000',
     ];
     if (since) {


### PR DESCRIPTION
## Summary

The protocol breakdown in the analytics tab was sourced from `codev/projects/*/status.yaml`, which only captured ~20 projects (strict-mode porch builders only). This fix derives protocol from PR branch names via the GitHub API, covering all 110+ completed projects.

Fixes #538

## Root Cause

`computeProjectsByProtocol` read `status.yaml` files from the local filesystem. Two problems:
1. `af cleanup` deleted these files before #532's fix, losing historical data
2. Only strict-mode porch builders create `status.yaml` — soft-mode, ad-hoc, and pre-porch projects had none
3. The function ignored the time range selector, counting all projects regardless of selected range

## Fix

- Replaced `computeProjectsByProtocol` to derive protocol from `headRefName` (PR branch name) using pattern matching (`builder/bugfix-*` → bugfix, `builder/spir-*` → spir, etc.)
- Added `headRefName` to the `fetchMergedPRs` GitHub API query
- Protocol breakdown now uses the same date-filtered merged PR list as other metrics, respecting time range
- Removed unused `fs`, `path`, `yaml` imports from analytics.ts

## Test Plan

- [x] Regression test: `protocolFromBranch` unit tests cover all protocol patterns
- [x] Integration tests: `computeAnalytics` verifies protocol counts from branch names
- [x] Edge cases: unrecognized branches ignored, GitHub failure returns empty breakdown
- [x] `fetchMergedPRs` test verifies `headRefName` is requested
- [x] Build passes
- [x] All 46 analytics tests pass