### PR TITLE
Fix #540: Replace duplicate analytics counts with per-protocol avg wall clock times

### DIFF
--- a/packages/codev/dashboard/__tests__/analytics.test.tsx
+++ b/packages/codev/dashboard/__tests__/analytics.test.tsx
@@ -30,11 +30,12 @@ function makeStats(overrides: Partial<AnalyticsResponse> = {}): AnalyticsRespons
       avgTimeToMergeHours: 3.5,
       issuesClosed: 6,
       avgTimeToCloseBugsHours: 1.2,
-      projectsCompleted: 5,
-      bugsFixed: 3,
-      throughputPerWeek: 2.5,
       activeBuilders: 2,
-      projectsByProtocol: { spir: 3, bugfix: 2, aspir: 1 },
+      projectsByProtocol: {
+        spir: { count: 3, avgWallClockHours: 48.2 },
+        bugfix: { count: 2, avgWallClockHours: 1.5 },
+        aspir: { count: 1, avgWallClockHours: 24.0 },
+      },
     },
     consultation: {
       totalCount: 20,
@@ -201,8 +202,10 @@ describe('AnalyticsView', () => {
 
     expect(screen.getByText('12')).toBeInTheDocument();
     expect(screen.getByText('3.5h')).toBeInTheDocument();
-    expect(screen.getByText('Projects Completed')).toBeInTheDocument();
-    expect(screen.getByText('Bugs Fixed')).toBeInTheDocument();
+    // Removed redundant metrics
+    expect(screen.queryByText('Projects Completed')).not.toBeInTheDocument();
+    expect(screen.queryByText('Bugs Fixed')).not.toBeInTheDocument();
+    expect(screen.queryByText('Throughput / Week')).not.toBeInTheDocument();
   });
 
   it('renders protocol breakdown metrics', async () => {
@@ -240,9 +243,6 @@ describe('AnalyticsView', () => {
         avgTimeToMergeHours: null,
         issuesClosed: 0,
         avgTimeToCloseBugsHours: null,
-        projectsCompleted: 0,
-        bugsFixed: 0,
-        throughputPerWeek: 0,
         activeBuilders: 0,
         projectsByProtocol: {},
       },

--- a/packages/codev/dashboard/src/components/AnalyticsView.tsx
+++ b/packages/codev/dashboard/src/components/AnalyticsView.tsx
@@ -98,10 +98,20 @@ function MiniBarChart({ data, dataKey, nameKey, color, formatter }: {
   );
 }
 
+function fmtWallClock(hours: number | null): string {
+  if (hours === null) return '\u2014';
+  if (hours < 1) return `${Math.round(hours * 60)}m`;
+  return `${Number(hours.toFixed(1))}h`;
+}
+
 function ActivitySection({ activity, errors }: { activity: AnalyticsResponse['activity']; errors?: AnalyticsResponse['errors'] }) {
   const protocolData = Object.entries(activity.projectsByProtocol)
-    .map(([proto, count]) => ({ name: proto.toUpperCase(), value: count }))
-    .sort((a, b) => b.value - a.value);
+    .map(([proto, stats]) => ({
+      name: proto.toUpperCase(),
+      count: stats.count,
+      avgWallClock: stats.avgWallClockHours,
+    }))
+    .sort((a, b) => b.count - a.count);
 
   return (
     <Section title="Activity" error={errors?.github}>
@@ -110,20 +120,17 @@ function ActivitySection({ activity, errors }: { activity: AnalyticsResponse['ac
           <h4 className="analytics-sub-title">Projects by Protocol</h4>
           <MetricGrid>
             {protocolData.map(d => (
-              <Metric key={d.name} label={d.name} value={String(d.value)} />
+              <Metric key={d.name} label={d.name} value={`${d.count} (avg ${fmtWallClock(d.avgWallClock)})`} />
             ))}
           </MetricGrid>
-          <MiniBarChart data={protocolData} dataKey="value" nameKey="name" />
+          <MiniBarChart data={protocolData} dataKey="count" nameKey="name" />
         </div>
       )}
       <MetricGrid>
-        <Metric label="Projects Completed" value={String(activity.projectsCompleted)} />
-        <Metric label="Bugs Fixed" value={String(activity.bugsFixed)} />
         <Metric label="PRs Merged" value={String(activity.prsMerged)} />
         <Metric label="Issues Closed" value={String(activity.issuesClosed)} />
         <Metric label="Avg Time to Merge" value={fmt(activity.avgTimeToMergeHours, 1, 'h')} />
         <Metric label="Avg Time to Close Bugs" value={fmt(activity.avgTimeToCloseBugsHours, 1, 'h')} />
-        <Metric label="Throughput / Week" value={fmt(activity.throughputPerWeek)} />
         <Metric label="Active Builders" value={String(activity.activeBuilders)} />
       </MetricGrid>
     </Section>

--- a/packages/codev/dashboard/src/lib/api.ts
+++ b/packages/codev/dashboard/src/lib/api.ts
@@ -143,6 +143,11 @@ export interface OverviewData {
 
 // Spec 456: Analytics tab types and fetcher
 
+export interface ProtocolStats {
+  count: number;
+  avgWallClockHours: number | null;
+}
+
 export interface AnalyticsResponse {
   timeRange: '24h' | '7d' | '30d' | 'all';
   activity: {
@@ -150,11 +155,8 @@ export interface AnalyticsResponse {
     avgTimeToMergeHours: number | null;
     issuesClosed: number;
     avgTimeToCloseBugsHours: number | null;
-    projectsCompleted: number;
-    bugsFixed: number;
-    throughputPerWeek: number;
     activeBuilders: number;
-    projectsByProtocol: Record<string, number>;
+    projectsByProtocol: Record<string, ProtocolStats>;
   };
   consultation: {
     totalCount: number;

--- a/packages/codev/src/agent-farm/__tests__/tower-routes.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tower-routes.test.ts
@@ -1017,7 +1017,7 @@ describe('tower-routes', () => {
   describe('GET /api/analytics', () => {
     const fakeStats = {
       timeRange: '7d',
-      activity: { prsMerged: 5, avgTimeToMergeHours: 2.5, issuesClosed: 4, avgTimeToCloseBugsHours: 1.2, projectsCompleted: 3, bugsFixed: 1, throughputPerWeek: 3, activeBuilders: 1, projectsByProtocol: { spir: 2, bugfix: 1 } },
+      activity: { prsMerged: 5, avgTimeToMergeHours: 2.5, issuesClosed: 4, avgTimeToCloseBugsHours: 1.2, activeBuilders: 1, projectsByProtocol: { spir: { count: 2, avgWallClockHours: 36 }, bugfix: { count: 1, avgWallClockHours: 2.5 } } },
       consultation: { totalCount: 10, totalCostUsd: 0.5, costByModel: {}, avgLatencySeconds: 12, successRate: 90, byModel: [], byReviewType: {}, byProtocol: {} },
     };
 

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -719,7 +719,7 @@ async function handleAnalytics(res: http.ServerResponse, url: URL, workspaceOver
 
   if (!workspaceRoot) {
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ timeRange: rangeLabel, activity: { prsMerged: 0, avgTimeToMergeHours: null, issuesClosed: 0, avgTimeToCloseBugsHours: null, projectsCompleted: 0, bugsFixed: 0, throughputPerWeek: 0, activeBuilders: 0, projectsByProtocol: {} }, consultation: { totalCount: 0, totalCostUsd: null, costByModel: {}, avgLatencySeconds: null, successRate: null, byModel: [], byReviewType: {}, byProtocol: {} } }));
+    res.end(JSON.stringify({ timeRange: rangeLabel, activity: { prsMerged: 0, avgTimeToMergeHours: null, issuesClosed: 0, avgTimeToCloseBugsHours: null, activeBuilders: 0, projectsByProtocol: {} }, consultation: { totalCount: 0, totalCostUsd: null, costByModel: {}, avgLatencySeconds: null, successRate: null, byModel: [], byReviewType: {}, byProtocol: {} } }));
     return;
   }
   const range = rangeParam as '1' | '7' | '30' | 'all';


### PR DESCRIPTION
## Summary

Replaces redundant Activity section metrics (Projects Completed, Bugs Fixed, Throughput/Week) with per-protocol average wall clock times, making the protocol breakdown the single source for project counts and adding useful timing data.

Fixes #540

## Root Cause

The Activity section had overlapping metrics: "Projects Completed" and "Bugs Fixed" were redundant with the protocol breakdown counts (bugfix + spir + aspir + air + tick), and there were no timing metrics for understanding productivity.

## Fix

- **Removed** `projectsCompleted`, `bugsFixed`, `throughputPerWeek` from `AnalyticsResponse.activity`
- **Changed** `projectsByProtocol` from `Record<string, number>` to `Record<string, ProtocolStats>` where `ProtocolStats = { count: number; avgWallClockHours: number | null }`
- **Added** `fetchOnItTimestamps()` in `github.ts` to fetch the "On it!" comment timestamp from issues (posted by `af spawn`) as the start time for wall clock calculation
- **Wall clock formula**: `PR mergedAt - "On it!" comment createdAt` (fallback: `PR createdAt`)
- **Updated** `AnalyticsView.tsx` to show count + avg wall clock per protocol (e.g., "3 (avg 48.2h)")
- **Updated** all affected tests across backend and frontend

## Test Plan

- [x] Regression tests added (on-it timestamp usage, fallback behavior, new response shape)
- [x] Build passes (tsc --noEmit clean)
- [x] All backend tests pass (42 analytics + 59 tower-routes = 101 tests)
- [x] Frontend component tests have pre-existing vitest 4 + jest-dom matcher issue (unrelated to this change)

## CMAP Review

To be added after review.