### PR TITLE
[Bugfix #545] Fix: Scope consultation metrics to workspace

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/analytics.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/analytics.test.ts
@@ -517,6 +517,43 @@ describe('computeAnalytics', () => {
     expect(mockSummary).toHaveBeenCalledTimes(2);
   });
 
+  // --- Workspace scoping (#545) ---
+
+  it('passes workspace filter to MetricsDB.summary()', async () => {
+    mockGhOutput({ mergedPRs: '[]', closedIssues: '[]' });
+
+    await computeAnalytics('/tmp/my-workspace', '7', 0);
+
+    expect(mockSummary).toHaveBeenCalledWith(
+      expect.objectContaining({ workspace: '/tmp/my-workspace' }),
+    );
+  });
+
+  it('passes workspace filter for all time ranges', async () => {
+    mockGhOutput({ mergedPRs: '[]', closedIssues: '[]' });
+
+    await computeAnalytics('/tmp/workspace-a', 'all', 0);
+
+    expect(mockSummary).toHaveBeenCalledWith(
+      expect.objectContaining({ workspace: '/tmp/workspace-a' }),
+    );
+  });
+
+  it('different workspaces get different cache entries', async () => {
+    mockGhOutput({ mergedPRs: '[]', closedIssues: '[]' });
+
+    await computeAnalytics('/tmp/workspace-a', '7', 0);
+    await computeAnalytics('/tmp/workspace-b', '7', 0);
+
+    expect(mockSummary).toHaveBeenCalledTimes(2);
+    expect(mockSummary).toHaveBeenCalledWith(
+      expect.objectContaining({ workspace: '/tmp/workspace-a' }),
+    );
+    expect(mockSummary).toHaveBeenCalledWith(
+      expect.objectContaining({ workspace: '/tmp/workspace-b' }),
+    );
+  });
+
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/codev/src/agent-farm/servers/analytics.ts
+++ b/packages/codev/src/agent-farm/servers/analytics.ts
@@ -189,10 +189,11 @@ interface ConsultationMetrics {
   byProtocol: Record<string, number>;
 }
 
-function computeConsultationMetrics(days: number | undefined): ConsultationMetrics {
+function computeConsultationMetrics(days: number | undefined, workspacePath: string): ConsultationMetrics {
   const db = new MetricsDB();
   try {
-    const filters = days ? { days } : {};
+    const filters: { days?: number; workspace: string } = { workspace: workspacePath };
+    if (days) filters.days = days;
     const summary = db.summary(filters);
 
     // Derive costByModel from summary.byModel
@@ -378,7 +379,7 @@ export async function computeAnalytics(
   // Consultation metrics
   let consultMetrics: ConsultationMetrics;
   try {
-    consultMetrics = computeConsultationMetrics(days);
+    consultMetrics = computeConsultationMetrics(days, workspaceRoot);
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     errors.consultation = msg;

--- a/packages/codev/src/commands/consult/metrics.ts
+++ b/packages/codev/src/commands/consult/metrics.ts
@@ -67,6 +67,7 @@ export interface StatsFilters {
   type?: string;
   protocol?: string;
   project?: string;
+  workspace?: string;
   last?: number;
 }
 
@@ -147,6 +148,10 @@ function buildWhereClause(filters: StatsFilters): { where: string; params: Recor
   if (filters.project) {
     conditions.push('project_id = @filterProject');
     params.filterProject = filters.project;
+  }
+  if (filters.workspace) {
+    conditions.push('workspace_path = @filterWorkspace');
+    params.filterWorkspace = filters.workspace;
   }
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';


### PR DESCRIPTION
## Summary

Consultation metrics in the analytics dashboard were showing global totals from all workspaces instead of being scoped to the current workspace. A small project displayed the same $428 cost and 5893 consultations as the main codev workspace.

Fixes #545

## Root Cause

`computeConsultationMetrics()` in `analytics.ts` called `MetricsDB.summary()` with only a `days` filter, never passing the workspace path. The `StatsFilters` interface lacked a `workspace` field entirely, so there was no way to filter by `workspace_path` even though the column existed in the database schema.

## Fix

1. Added `workspace?: string` to the `StatsFilters` interface in `metrics.ts`
2. Added `workspace_path` filtering in `buildWhereClause()`
3. Updated `computeConsultationMetrics()` to accept and pass `workspacePath`
4. Updated `computeAnalytics()` to pass `workspaceRoot` through to the consultation metrics query

4 files changed, 94 insertions, 3 deletions.

## Test Plan

- [x] Regression test: MetricsDB `query()` filters by workspace
- [x] Regression test: MetricsDB `summary()` scoped to workspace
- [x] Regression test: MetricsDB `summary()` without workspace returns all
- [x] Regression test: MetricsDB `costByProject()` scoped to workspace
- [x] Regression test: `computeAnalytics` passes workspace to `MetricsDB.summary()`
- [x] Regression test: different workspaces use different time ranges
- [x] Regression test: different workspaces get different cache entries
- [x] Build passes
- [x] All existing tests pass (93 tests in affected files)