### PR TITLE
[Bugfix #535] Fix: af open cross-workspace file resolution

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/bugfix-500-af-open-any-dir.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-500-af-open-any-dir.test.ts
@@ -6,8 +6,9 @@
  * (or in a different subdirectory), the wrong workspace path is sent to
  * the Tower API, causing the open to fail.
  *
- * Fix: Derive workspace root from the FILE's directory (via findWorkspaceRoot)
- * instead of CWD. The file itself determines which workspace it belongs to.
+ * Fix (updated by bugfix #535): Prefer CWD-based workspace detection (for
+ * cross-workspace opens), but fall back to file-based detection when CWD
+ * isn't in a recognizable workspace.
  */
 import { describe, it, expect } from 'vitest';
 import { resolve } from 'node:path';
@@ -19,10 +20,11 @@ describe('Bugfix #500: af open works from any directory', () => {
     'utf-8',
   );
 
-  it('should use findWorkspaceRoot from file directory, not getConfig', () => {
-    // The fix: workspace root is derived from the file's location
+  it('should fall back to findWorkspaceRoot from file directory when CWD is not in a workspace', () => {
+    // Bugfix #535 changed to CWD-first with file-based fallback.
+    // The file-based fallback must still exist for when CWD is outside any workspace.
     expect(openSrc).toContain('findWorkspaceRoot(dirname(filePath))');
-    // Should NOT use getConfig() — that uses CWD which is the wrong approach
+    // Should NOT use getConfig() — that doesn't support file-based fallback
     expect(openSrc).not.toContain('getConfig()');
   });
 

--- a/packages/codev/src/agent-farm/__tests__/bugfix-535-af-open-cross-workspace.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-535-af-open-cross-workspace.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Regression test for bugfix #535: af open does not reliably work on files
+ * outside the current directory
+ *
+ * Root cause: `open.ts` derived the workspace from the FILE's location
+ * (via findWorkspaceRoot(dirname(filePath))). When running `af open` from
+ * workspace A but targeting a file in workspace B, the file opened in B's
+ * annotation viewer instead of A's.
+ *
+ * Fix: Prefer CWD-based workspace detection (findWorkspaceRoot(process.cwd()))
+ * so the file opens in the user's current workspace. Fall back to file-based
+ * detection only when CWD isn't in a recognizable workspace.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+describe('Bugfix #535: af open cross-workspace file resolution', () => {
+  const openSrc = readFileSync(
+    resolve(import.meta.dirname, '../commands/open.ts'),
+    'utf-8',
+  );
+
+  it('should prefer CWD-based workspace detection over file-based', () => {
+    // The fix: determine workspace from CWD first
+    expect(openSrc).toContain('findWorkspaceRoot(process.cwd())');
+  });
+
+  it('should check whether CWD resolves to a real workspace', () => {
+    // Must verify CWD is in a workspace (has codev/ or .git) before using it
+    expect(openSrc).toContain('cwdIsWorkspace');
+    expect(openSrc).toMatch(/existsSync.*codev/);
+    expect(openSrc).toMatch(/existsSync.*\.git/);
+  });
+
+  it('should fall back to file-based detection when CWD is not a workspace', () => {
+    // When CWD is outside any workspace (e.g., /tmp), fall back to file location
+    expect(openSrc).toContain('findWorkspaceRoot(dirname(filePath))');
+  });
+
+  it('should still support worktree fallback to main repo', () => {
+    // Bugfix #427's worktree fallback must be preserved
+    expect(openSrc).toContain('getMainRepoFromWorktree(workspacePath)');
+  });
+
+  it('should not use getConfig for workspace detection', () => {
+    // getConfig() uses CWD internally but doesn't support the fallback pattern
+    expect(openSrc).not.toContain('getConfig()');
+  });
+});


### PR DESCRIPTION
## Summary

`af open` derived workspace from the file's location instead of the user's CWD. When opening a file from workspace A that physically resides in workspace B, it opened in B's annotation viewer instead of A's.

Fixes #535

## Root Cause

`open.ts` used `findWorkspaceRoot(dirname(filePath))` to determine which workspace to target. This meant the workspace was always derived from where the file lives, not where the user is working. For cross-workspace file opens (e.g., opening a codev source file from the marketmaker workspace), the file tab was created in the wrong workspace's viewer.

## Fix

Prefer CWD-based workspace detection (`findWorkspaceRoot(process.cwd())`), which correctly identifies the user's active workspace. Fall back to file-based detection only when CWD isn't in a recognizable workspace (no `codev/` or `.git/` directory).

## Test Plan

- [x] Regression test added (`bugfix-535-af-open-cross-workspace.test.ts`)
- [x] Updated bugfix-500 test to reflect CWD-first with file fallback approach
- [x] Build passes
- [x] All existing af open tests pass (bugfix-427, bugfix-500, bugfix-502)