### PR TITLE
[Air #551] feat: Add newsletter subscribe link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Codev is an operating system for structured human-AI collaboration. You write sp
 
 **Quick Links**: [FAQ](docs/faq.md) | [Tips](docs/tips.md) | [Cheatsheet](codev/resources/cheatsheet.md) | [CLI Reference](codev/resources/commands/overview.md) | [Why Codev?](docs/why.md) | [Discord](https://discord.gg/mJ92DhDa6n)
 
+📬 **Stay updated** — [Subscribe to the Codev newsletter](https://marketmaker.cluesmith.com/subscribe/codev) for release notes, tips, and community updates.
+
 ## Table of Contents
 
 - [Quick Start](#quick-start)


### PR DESCRIPTION
## Summary

Adds a newsletter subscribe link near the top of README.md with a short call-to-action.

Implements #551

## What Changed

Added a single line below the Quick Links section linking to `marketmaker.cluesmith.com/subscribe/codev` with a brief CTA: "Stay updated — Subscribe to the Codev newsletter for release notes, tips, and community updates."

## Key Decisions

None — straightforward implementation. Placed the link directly below Quick Links for visibility without disrupting the existing structure.

## Test Plan

- [x] Build passes
- [x] All tests pass (17 pre-existing failures in adopt/update/consult tests unrelated to this change — "Skeleton directory not found")
- [x] Link is correctly formatted and points to the right URL

## Review Notes

Standard implementation — no special concerns. Single-line markdown addition.