### PR TITLE
[Bugfix #563] Fix shell buttons broken by stale scrollState in safeFit()

### DIFF
--- a/packages/codev/dashboard/src/components/Terminal.tsx
+++ b/packages/codev/dashboard/src/components/Terminal.tsx
@@ -386,7 +386,7 @@ export function Terminal({ wsPath, onFileOpen, persistent, toolbarExtra }: Termi
       if (!rect || rect.width === 0 || rect.height === 0) return;
 
       const baseY = term.buffer?.active?.baseY;
-      if (!baseY && !scrollState.baseY) {
+      if (!baseY) {
         fitAddon.fit();
         return;
       }


### PR DESCRIPTION
## Summary

- Reverts `safeFit()` condition from `if (!baseY && !scrollState.baseY)` back to `if (!baseY)` — `baseY` from `term.buffer.active` is not affected by `display:none` toggling, so `scrollState.baseY` is unnecessary and can become stale
- Keeps `scrollState.wasAtBottom` and `scrollState.viewportY` usage (the core Issue #560 fix for viewport position preservation)
- Adds regression test for the stale `scrollState.baseY` scenario

## Root Cause

PR #561 added `!scrollState.baseY` to the `safeFit()` early-return condition. When `scrollState.baseY` retained a stale positive value (e.g., after buffer clear or terminal reset), `safeFit()` would take the scroll-preserving path even when the buffer had no scrollback (`baseY=0`). This caused incorrect scroll restoration with stale position values, interfering with terminal rendering and button interaction.

## Test Plan

- [x] All 176 dashboard unit tests pass (175 existing + 1 new regression test)
- [x] Dashboard builds successfully (`npx vite build`)
- [x] New regression test covers the stale `scrollState.baseY` scenario
- [ ] Manual verification: shell buttons (+ Shell, shell tabs) work after fix

Fixes #563