### PR TITLE
[Bugfix #562] Require --amends for --protocol tick

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/spawn.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/spawn.test.ts
@@ -58,6 +58,11 @@ function validateSpawnOptions(options: SpawnOptions): string | null {
     return '--amends requires --protocol tick';
   }
 
+  // --protocol tick requires --amends
+  if (options.protocol === 'tick' && !options.amends) {
+    return '--protocol tick requires --amends <spec-number> to identify the spec being amended';
+  }
+
   // --strict and --soft are mutually exclusive
   if (options.strict && options.soft) {
     return '--strict and --soft are mutually exclusive';
@@ -267,6 +272,12 @@ describe('Spawn Command', () => {
         expect(error).toContain('--amends requires --protocol tick');
       });
 
+      it('should reject --protocol tick without --amends (issue #562)', () => {
+        const options: SpawnOptions = { issueNumber: 5, protocol: 'tick' };
+        const error = validateSpawnOptions(options);
+        expect(error).toContain('--protocol tick requires --amends');
+      });
+
       it('should reject --strict with --soft', () => {
         const options: SpawnOptions = { issueNumber: 315, protocol: 'spir', strict: true, soft: true };
         const error = validateSpawnOptions(options);
@@ -468,6 +479,12 @@ describe('Spawn Command', () => {
       const options: SpawnOptions = { issueNumber: 320, protocol: 'spir', amends: 315 };
       const error = validateSpawnOptions(options);
       expect(error).toContain('--amends requires --protocol tick');
+    });
+
+    it('rejects --protocol tick without --amends (issue #562)', () => {
+      const options: SpawnOptions = { issueNumber: 5, protocol: 'tick' };
+      const error = validateSpawnOptions(options);
+      expect(error).toContain('--protocol tick requires --amends');
     });
   });
 

--- a/packages/codev/src/agent-farm/commands/spawn.ts
+++ b/packages/codev/src/agent-farm/commands/spawn.ts
@@ -89,6 +89,7 @@ function generateShortId(): string {
  * - --protocol is required when issueNumber is present (unless --resume or --soft)
  * - --protocol alone (no issueNumber) is valid as a protocol-only run
  * - --amends requires --protocol tick
+ * - --protocol tick requires --amends
  */
 function validateSpawnOptions(options: SpawnOptions): void {
   // Count primary input modes
@@ -152,6 +153,11 @@ function validateSpawnOptions(options: SpawnOptions): void {
   // --amends requires --protocol tick
   if (options.amends && options.protocol !== 'tick') {
     fatal('--amends requires --protocol tick');
+  }
+
+  // --protocol tick requires --amends
+  if (options.protocol === 'tick' && !options.amends) {
+    fatal('--protocol tick requires --amends <spec-number> to identify the spec being amended');
   }
 
   // --strict and --soft are mutually exclusive


### PR DESCRIPTION
## Summary
Fixes #562

When `af spawn 5 --protocol tick` is run without `--amends`, the `specLookupId` falls back to the issue number instead of the spec being amended. This causes the builder to read the wrong spec file.

## Root Cause
In `spawn.ts`, the spec lookup logic uses a conditional:
```typescript
const specLookupId = (protocol === 'tick' && options.amends)
  ? String(options.amends)
  : projectId;
```
When `--amends` is omitted, `specLookupId` defaults to `projectId` (the issue number), which resolves a different spec than intended. There was no validation requiring `--amends` for TICK protocol.

## Fix
Added validation in `validateSpawnOptions()` that `--protocol tick` requires `--amends <spec-number>`. This is the minimal Option A from the issue — fail fast with a clear error message rather than silently resolving the wrong spec.

## Test Plan
- [x] Added regression test: `--protocol tick` without `--amends` returns error
- [x] All 106 existing spawn tests pass
- [x] Verified fix locally