### PR TITLE
[Bugfix #577] Fix: Parse architect command flags via shell execution

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/af-architect.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/af-architect.test.ts
@@ -58,7 +58,7 @@ describe('af architect command', () => {
     expect(mockSpawn).toHaveBeenCalledWith(
       'claude',
       ['--append-system-prompt', '# Architect Role\n\nYou are an architect.'],
-      { stdio: 'inherit', cwd: '/test/workspace' }
+      { stdio: 'inherit', cwd: '/test/workspace', shell: true }
     );
   });
 
@@ -80,7 +80,7 @@ describe('af architect command', () => {
     expect(mockSpawn).toHaveBeenCalledWith(
       'claude',
       ['--resume', '--append-system-prompt', '# Architect Role\n\nYou are an architect.'],
-      { stdio: 'inherit', cwd: '/test/workspace' }
+      { stdio: 'inherit', cwd: '/test/workspace', shell: true }
     );
   });
 

--- a/packages/codev/src/agent-farm/commands/architect.ts
+++ b/packages/codev/src/agent-farm/commands/architect.ts
@@ -35,6 +35,7 @@ export async function architect(options: ArchitectOptions = {}): Promise<void> {
     const child = spawn(cmd, args, {
       stdio: 'inherit',
       cwd: config.workspaceRoot,
+      shell: true,
     });
 
     child.on('error', (err) => {


### PR DESCRIPTION
## Summary

- `af architect` fails with ENOENT when `af-config.json` contains command flags (e.g., `"claude --dangerously-skip-permissions"`)
- Node's `spawn()` without `shell: true` treats the full string as a literal binary name
- Added `shell: true` to spawn options so the command is parsed by `/bin/sh`
- Updated test assertions to match

Fixes #577