### PR TITLE
Add nharward to team — Forge subsystem developer

### DIFF
--- a/codev/team/messages.md
+++ b/codev/team/messages.md
@@ -1,0 +1,4 @@
+
+---
+**waleedkadous** | 2026-03-10 00:35:25 UTC
+Great work on Forge, @nharward!

--- a/codev/team/people/nharward.md
+++ b/codev/team/people/nharward.md
@@ -1,0 +1,10 @@
+---
+name: Nathaniel Harward
+github: nharward
+role: Developer — Forge Subsystem
+---
+
+Nat is working on the forge concept command abstraction layer (#589), which
+decouples codev from direct GitHub CLI calls and enables support for GitLab,
+Gitea, and other software forges. This includes provider presets, the forge
+skill, and documentation.


### PR DESCRIPTION
## Summary

- Add Nathaniel Harward (@nharward) as team member
- Role: Developer working on the forge concept command abstraction (#589)
- Welcome message from @waleedkadous

This is the second team member, which enables the Team tab in Tower.