### PR TITLE
[Bugfix #605] Fix porch auto-detection for protocol-prefixed worktrees

### DIFF
--- a/packages/codev/src/commands/porch/__tests__/state.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/state.test.ts
@@ -313,6 +313,30 @@ updated_at: "${state.updated_at}"
       expect(detectProjectIdFromCwd('/repo/.builders/bugfix-332-fix-login-bug/src/commands/')).toBe('bugfix-332');
     });
 
+    it('should detect numeric ID from aspir worktree', () => {
+      expect(detectProjectIdFromCwd('/repo/.builders/aspir-221-rename-cli-tools')).toBe('221');
+    });
+
+    it('should detect numeric ID from spir worktree', () => {
+      expect(detectProjectIdFromCwd('/repo/.builders/spir-042-feature-name')).toBe('042');
+    });
+
+    it('should detect numeric ID from air worktree', () => {
+      expect(detectProjectIdFromCwd('/repo/.builders/air-100-small-feature')).toBe('100');
+    });
+
+    it('should detect numeric ID from tick worktree', () => {
+      expect(detectProjectIdFromCwd('/repo/.builders/tick-050-amendment')).toBe('050');
+    });
+
+    it('should detect protocol worktree ID from subdirectory', () => {
+      expect(detectProjectIdFromCwd('/repo/.builders/aspir-221-rename-cli-tools/src/commands/')).toBe('221');
+    });
+
+    it('should detect protocol worktree without slug', () => {
+      expect(detectProjectIdFromCwd('/repo/.builders/spir-042')).toBe('042');
+    });
+
     it('should return null for task worktrees', () => {
       expect(detectProjectIdFromCwd('/repo/.builders/task-aB2C')).toBeNull();
     });
@@ -321,7 +345,7 @@ updated_at: "${state.updated_at}"
       expect(detectProjectIdFromCwd('/repo/.builders/maintain-xY9z')).toBeNull();
     });
 
-    it('should return null for protocol worktrees', () => {
+    it('should return null for protocol worktrees with non-numeric IDs', () => {
       expect(detectProjectIdFromCwd('/repo/.builders/spir-aB2C')).toBeNull();
     });
 

--- a/packages/codev/src/commands/porch/state.ts
+++ b/packages/codev/src/commands/porch/state.ts
@@ -211,13 +211,18 @@ export function findStatusPath(workspaceRoot: string, projectId: string): string
 export function detectProjectIdFromCwd(cwd: string): string | null {
   const normalized = path.resolve(cwd).split(path.sep).join('/');
   // Bugfix worktrees: .builders/bugfix-{N}-{slug} (slug is optional for legacy paths)
+  // Protocol worktrees: .builders/{protocol}-{N}-{slug} (aspir, spir, air, tick)
   // Spec worktrees (legacy): .builders/{NNNN} (bare 4-digit ID, no slug)
-  const match = normalized.match(/\/\.builders\/(bugfix-(\d+)(?:-[^/]*)?|(\d{4}))(\/|$)/);
+  const match = normalized.match(
+    /\/\.builders\/(bugfix-(\d+)(?:-[^/]*)?|(?:aspir|spir|air|tick)-(\d+)(?:-[^/]*)?|(\d{4}))(\/|$)/,
+  );
   if (!match) return null;
   // Bugfix worktrees use "bugfix-N" as the porch project ID
   if (match[2]) return `bugfix-${match[2]}`;
+  // Protocol worktrees (aspir, spir, air, tick) use the bare numeric ID
+  if (match[3]) return match[3];
   // Spec worktrees use zero-padded numeric IDs
-  return match[3];
+  return match[4];
 }
 
 export type ResolvedProjectId = { id: string; source: 'explicit' | 'cwd' | 'filesystem' };


### PR DESCRIPTION
## Summary
Fixes #605

## Root Cause
`detectProjectIdFromCwd()` in `src/commands/porch/state.ts` only matched two worktree patterns:
1. `bugfix-{N}` (with optional slug)
2. `{NNNN}` (bare 4-digit ID)

It did NOT match protocol-prefixed worktrees like `aspir-221-rename-cli-tools`, `spir-042-feature-name`, `air-100-small-feature`, or `tick-050-amendment`.

This caused `porch status` (without args) to fall through to the filesystem scan, which could pick up an unrelated project.

## Fix
Extended the regex in `detectProjectIdFromCwd()` to also match `aspir-{N}`, `spir-{N}`, `air-{N}`, and `tick-{N}` prefixed worktree patterns, extracting the bare numeric ID as the project ID.

## Test Plan
- [x] Added 6 regression tests for protocol-prefixed worktrees (aspir, spir, air, tick, subdirectory, no-slug)
- [x] Updated existing test description for clarity
- [x] All 55 state tests pass
- [x] Full build succeeds
- [x] Full test suite passes

## CMAP Review
- **Codex**: APPROVE (HIGH confidence) — no issues found
- **Claude**: APPROVE (HIGH confidence) — no issues found
- **Gemini**: Timed out (sandbox path error)