### PR TITLE
[Air #633] feat: Update Codex consultation model to gpt-5.4-codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,7 @@ Use sequential numbering with descriptive names (no leading zeros):
 
 **DEFAULT BEHAVIOR**: Consultation is ENABLED by default with:
 - **Gemini 3 Pro** (gemini-3-pro-preview) for deep analysis
-- **GPT-5.2 Codex** (gpt-5.2-codex) for coding and architecture perspective
+- **GPT-5.4 Codex** (gpt-5.4-codex) for coding and architecture perspective
 
 To disable: User must explicitly say "without multi-agent consultation"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,7 +238,7 @@ Use sequential numbering with descriptive names (no leading zeros):
 
 **DEFAULT BEHAVIOR**: Consultation is ENABLED by default with:
 - **Gemini 3 Pro** (gemini-3-pro-preview) for deep analysis
-- **GPT-5.2 Codex** (gpt-5.2-codex) for coding and architecture perspective
+- **GPT-5.4 Codex** (gpt-5.4-codex) for coding and architecture perspective
 
 To disable: User must explicitly say "without multi-agent consultation"
 

--- a/packages/codev/src/commands/consult/__tests__/codex-sdk.test.ts
+++ b/packages/codev/src/commands/consult/__tests__/codex-sdk.test.ts
@@ -265,7 +265,7 @@ describe('runCodexConsultation() with mocked SDK', () => {
     // Verify startThread receives model, sandboxMode, and workingDirectory
     expect(mockStartThreadArgs).toBeDefined();
     const threadArgs = mockStartThreadArgs as Record<string, unknown>;
-    expect(threadArgs.model).toBe('gpt-5.2-codex');
+    expect(threadArgs.model).toBe('gpt-5.4-codex');
     expect(threadArgs.sandboxMode).toBe('read-only');
     expect(threadArgs.workingDirectory).toBe(tmpDir);
   });

--- a/packages/codev/src/commands/consult/index.ts
+++ b/packages/codev/src/commands/consult/index.ts
@@ -402,7 +402,7 @@ export async function runCodexConsultation(
     });
 
     const thread = codex.startThread({
-      model: 'gpt-5.2-codex',
+      model: 'gpt-5.4-codex',
       sandboxMode: 'read-only',
       modelReasoningEffort: 'medium',
       workingDirectory: workspaceRoot,


### PR DESCRIPTION
## Summary

Updates the Codex consultation model from `gpt-5.2-codex` to `gpt-5.4-codex` across the codebase.

Closes #633

## What Changed

- **`packages/codev/src/commands/consult/index.ts`** — Model string updated from `gpt-5.2-codex` to `gpt-5.4-codex` in `startThread()` call
- **`packages/codev/src/commands/consult/__tests__/codex-sdk.test.ts`** — Test assertion updated to expect `gpt-5.4-codex`
- **`CLAUDE.md` / `AGENTS.md`** — Documentation references updated from GPT-5.2 Codex to GPT-5.4 Codex

## Key Decisions

- **Pricing unchanged**: `CODEX_PRICING` constants kept at the same values (`inputPer1M: 2.00`, `cachedInputPer1M: 1.00`, `outputPer1M: 8.00`). If OpenAI changes pricing for gpt-5.4-codex, this should be updated separately once confirmed.
- **SDK version unchanged**: `@openai/codex-sdk` at `^0.101.0` — semver range should cover the new model without a version bump.
- **Analytics test fixtures untouched**: The dashboard analytics tests use `gpt-5.2-codex` in mock data representing historical consultation records. These are valid historical data points, not model configuration.

## Test Plan

- [x] Unit tests pass (2270 passed, 13 skipped)
- [x] Build succeeds
- [x] Model string assertion in `codex-sdk.test.ts` updated and passing
- [x] No CMAP — straightforward config change across 4 files

## Review Notes

Standard model version bump — no special concerns. The only thing to verify externally is whether gpt-5.4-codex pricing has changed from gpt-5.2-codex rates.