### PR TITLE
Fix: Isolate porch tests from workspace config (#639)

### DIFF
--- a/packages/codev/src/commands/porch/__tests__/done-verification.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/done-verification.test.ts
@@ -12,6 +12,19 @@ import { done } from '../index.js';
 import { writeState, getProjectDir, getStatusPath } from '../state.js';
 import type { ProjectState } from '../types.js';
 
+// Mock loadConfig to return defaults, preventing workspace/global config from leaking in.
+// Without this, loadConfig reads ~/.codev/config.json and framework cache, which can
+// override consultation models (e.g., "parent") and break tests expecting 3-model defaults.
+vi.mock('../../../lib/config.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../../lib/config.js')>();
+  return {
+    ...original,
+    loadConfig: (_workspaceRoot: string) => ({
+      porch: { consultation: { models: ['gemini', 'codex', 'claude'] } },
+    }),
+  };
+});
+
 // ============================================================================
 // Test Fixtures
 // ============================================================================

--- a/packages/codev/src/commands/porch/__tests__/next.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/next.test.ts
@@ -2,13 +2,26 @@
  * Tests for porch next command
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { tmpdir } from 'node:os';
 import { next } from '../next.js';
 import { writeState, getProjectDir, getStatusPath, PROJECTS_DIR } from '../state.js';
 import type { ProjectState, Protocol, PorchNextResponse } from '../types.js';
+
+// Mock loadConfig to return defaults, preventing workspace/global config from leaking in.
+// Without this, loadConfig reads ~/.codev/config.json and framework cache, which can
+// override consultation models (e.g., "parent") and break tests expecting 3-model defaults.
+vi.mock('../../../lib/config.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../../lib/config.js')>();
+  return {
+    ...original,
+    loadConfig: (_workspaceRoot: string) => ({
+      porch: { consultation: { models: ['gemini', 'codex', 'claude'] } },
+    }),
+  };
+});
 
 // ============================================================================
 // Test Fixtures
@@ -795,5 +808,27 @@ describe('porch next', () => {
     // Second task: merge PR
     expect(result.tasks![1].subject).toContain('Merge');
     expect(result.tasks![1].description).toContain('pr-merge');
+  });
+
+  // --------------------------------------------------------------------------
+  // Regression: config isolation (#639)
+  // --------------------------------------------------------------------------
+
+  it('verify tasks use default 3-model consultation regardless of workspace config', async () => {
+    // This test ensures the loadConfig mock is active: even if the real workspace
+    // has consultation.models set to "parent" or "none", tests always get defaults.
+    setupState(testDir, makeState({ build_complete: true }));
+
+    const result = await next(testDir, '0001');
+
+    expect(result.status).toBe('tasks');
+    expect(result.tasks!.length).toBe(1);
+    const desc = result.tasks![0].description!;
+    // All 3 default models must appear in the consultation command
+    expect(desc).toContain('gemini');
+    expect(desc).toContain('codex');
+    expect(desc).toContain('claude');
+    // Must NOT indicate parent/none delegation
+    expect(desc).not.toContain('parent');
   });
 });


### PR DESCRIPTION
## Summary

- Mock `loadConfig()` in `next.test.ts` and `done-verification.test.ts` to return default config, preventing workspace/global `.codev/config.json` from leaking into tests
- Add regression test verifying 3-model consultation defaults are used regardless of environment config

## Root Cause

`resolveConsultationModels()` in `next.ts` and verification logic in `index.ts` call `loadConfig(workspaceRoot)` which reads global config (`~/.codev/config.json`) and framework cache config in addition to the project config. Tests create temp directories for project state but cannot isolate these external config sources. When they contain `porch.consultation.models: "parent"`, 12 tests fail expecting default 3-model behavior.

## Fix

Added `vi.mock('../../../lib/config.js', ...)` in both test files to return deterministic defaults (the standard `['gemini', 'codex', 'claude']` model list), ensuring tests are fully isolated from the host environment.

## Test plan

- [x] All 225 porch tests pass (including new regression test)
- [x] `porch check` passes (build + full test suite)
- [x] New regression test explicitly verifies consultation task contains all 3 default models

Fixes #639