### PR TITLE
[Air #641] test: verify SPIR solo mode emits single consultation task

### DIFF
--- a/packages/codev/src/commands/porch/__tests__/next.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/next.test.ts
@@ -13,12 +13,17 @@ import type { ProjectState, Protocol, PorchNextResponse } from '../types.js';
 // Mock loadConfig to return defaults, preventing workspace/global config from leaking in.
 // Without this, loadConfig reads ~/.codev/config.json and framework cache, which can
 // override consultation models (e.g., "parent") and break tests expecting 3-model defaults.
+// Use vi.hoisted mutable ref so individual tests can override consultation models.
+const { configRef } = vi.hoisted(() => ({
+  configRef: { models: ['gemini', 'codex', 'claude'] as string | string[] },
+}));
+
 vi.mock('../../../lib/config.js', async (importOriginal) => {
   const original = await importOriginal<typeof import('../../../lib/config.js')>();
   return {
     ...original,
     loadConfig: (_workspaceRoot: string) => ({
-      porch: { consultation: { models: ['gemini', 'codex', 'claude'] } },
+      porch: { consultation: { models: configRef.models } },
     }),
   };
 });
@@ -149,6 +154,7 @@ describe('porch next', () => {
 
   afterEach(() => {
     fs.rmSync(testDir, { recursive: true, force: true });
+    configRef.models = ['gemini', 'codex', 'claude'];
   });
 
   // --------------------------------------------------------------------------
@@ -830,5 +836,43 @@ describe('porch next', () => {
     expect(desc).toContain('claude');
     // Must NOT indicate parent/none delegation
     expect(desc).not.toContain('parent');
+  });
+
+  // --------------------------------------------------------------------------
+  // Solo mode — single consultation model (#641, #592, #618)
+  // --------------------------------------------------------------------------
+
+  it('emits single VERIFY task when only one model is configured (solo mode)', async () => {
+    configRef.models = ['claude'];
+    setupState(testDir, makeState({ build_complete: true }));
+
+    const result = await next(testDir, '0001');
+
+    expect(result.status).toBe('tasks');
+    expect(result.tasks).toBeDefined();
+    expect(result.tasks!.length).toBe(1);
+    expect(result.tasks![0].subject).toContain('1-way consultation');
+    expect(result.tasks![0].description).toContain('claude');
+    expect(result.tasks![0].description).not.toContain('gemini');
+    expect(result.tasks![0].description).not.toContain('codex');
+  });
+
+  // --------------------------------------------------------------------------
+  // None mode — consultation disabled (#641, #592)
+  // --------------------------------------------------------------------------
+
+  it('skips consultation when mode is "none"', async () => {
+    configRef.models = 'none';
+    setupState(testDir, makeState({ build_complete: true }));
+
+    const result = await next(testDir, '0001');
+
+    expect(result.status).toBe('tasks');
+    expect(result.tasks).toBeDefined();
+    expect(result.tasks!.length).toBe(1);
+    expect(result.tasks![0].subject).toContain('Consultation skipped');
+    expect(result.tasks![0].description).toContain('none');
+    // Must NOT contain consult commands
+    expect(result.tasks![0].description).not.toContain('consult -m');
   });
 });


### PR DESCRIPTION
## Summary

Adds missing test coverage verifying that `porch next` respects consultation model configuration — specifically solo mode (single model) and none mode (consultation disabled).

Implements #641

## What Changed

Two new tests in `next.test.ts`:

1. **Solo mode test**: Mocks `loadConfig` to return `models: ['claude']`, asserts `porch next` emits exactly 1 consultation task containing only `claude` (not `gemini` or `codex`)
2. **None mode test**: Mocks `loadConfig` to return `models: 'none'`, asserts `porch next` emits a "Consultation skipped" task with no `consult -m` commands

Also refactored the `loadConfig` mock to use `vi.hoisted` with a mutable ref (`configRef`), allowing per-test overrides while keeping the default 3-model behavior for all existing tests. The `afterEach` resets `configRef.models` to the default.

## Key Decisions

- Used `vi.hoisted` mutable ref pattern instead of `vi.fn().mockReturnValueOnce()` because vitest's async mock factories don't properly propagate `mockReturnValueOnce` overrides to the imported module reference.
- Kept assertions aligned with actual source behavior: solo mode checks `N-way consultation` subject, none mode checks `Consultation skipped` subject.

## Test Plan

- [x] 2 new unit tests added (solo mode + none mode)
- [x] Build passes (`tsc --noEmit`)
- [x] All 26 tests in `next.test.ts` pass
- [x] Full test suite: 2301 passed, 13 skipped, 23 pre-existing failures (unrelated: adopt, consult, update, session-manager)

## Review Notes

Net diff is ~45 lines. The `configRef` approach is minimal and isolated — existing tests are unaffected since `afterEach` resets to defaults.