### PR TITLE
[Bugfix #622] Search builder worktrees for project status from repo root

### DIFF
--- a/packages/codev/src/commands/porch/__tests__/state.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/state.test.ts
@@ -278,6 +278,82 @@ updated_at: "${state.updated_at}"
       const result = findStatusPath(emptyDir, '0074');
       expect(result).toBeNull();
     });
+
+    // ========================================================================
+    // Bugfix #622: find projects in builder worktrees from repo root
+    // ========================================================================
+
+    it('should find project in .builders worktree when not in local codev/projects (bugfix #622)', () => {
+      // Simulate a builder worktree with a project
+      const worktreeProjectsDir = path.join(testDir, '.builders', 'bugfix-622-fix-porch', PROJECTS_DIR);
+      const worktreeProjectDir = path.join(worktreeProjectsDir, 'bugfix-622-bug-porch-status');
+      fs.mkdirSync(worktreeProjectDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(worktreeProjectDir, 'status.yaml'),
+        'id: "bugfix-622"\nprotocol: bugfix\nphase: investigate\n',
+      );
+
+      const result = findStatusPath(testDir, 'bugfix-622');
+
+      expect(result).not.toBeNull();
+      expect(result).toContain('.builders/bugfix-622-fix-porch');
+      expect(result).toContain('bugfix-622-bug-porch-status/status.yaml');
+    });
+
+    it('should find numeric project in .builders worktree (bugfix #622)', () => {
+      const worktreeProjectsDir = path.join(testDir, '.builders', 'spir-0042-feature', PROJECTS_DIR);
+      const worktreeProjectDir = path.join(worktreeProjectsDir, '0042-some-feature');
+      fs.mkdirSync(worktreeProjectDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(worktreeProjectDir, 'status.yaml'),
+        'id: "0042"\nprotocol: spir\nphase: specify\n',
+      );
+
+      const result = findStatusPath(testDir, '0042');
+
+      expect(result).not.toBeNull();
+      expect(result).toContain('.builders/spir-0042-feature');
+      expect(result).toContain('0042-some-feature/status.yaml');
+    });
+
+    it('should prefer local codev/projects over .builders worktrees (bugfix #622)', () => {
+      // Create project in both local and worktree
+      const localProjectDir = path.join(projectsDir, '0074-test-feature');
+      fs.mkdirSync(localProjectDir, { recursive: true });
+      fs.writeFileSync(path.join(localProjectDir, 'status.yaml'), 'id: "0074"\nprotocol: spir\nphase: specify\n');
+
+      const worktreeProjectsDir = path.join(testDir, '.builders', 'spir-0074-test', PROJECTS_DIR);
+      const worktreeProjectDir = path.join(worktreeProjectsDir, '0074-test-feature');
+      fs.mkdirSync(worktreeProjectDir, { recursive: true });
+      fs.writeFileSync(path.join(worktreeProjectDir, 'status.yaml'), 'id: "0074"\nprotocol: spir\nphase: implement\n');
+
+      const result = findStatusPath(testDir, '0074');
+
+      expect(result).not.toBeNull();
+      // Should find the local one, not the worktree one
+      expect(result).not.toContain('.builders');
+      expect(result).toContain('0074-test-feature');
+    });
+
+    it('should return null when project not in local or any worktree (bugfix #622)', () => {
+      // Create .builders dir with an unrelated worktree
+      const worktreeProjectsDir = path.join(testDir, '.builders', 'bugfix-100-other', PROJECTS_DIR);
+      const worktreeProjectDir = path.join(worktreeProjectsDir, 'bugfix-100-other-fix');
+      fs.mkdirSync(worktreeProjectDir, { recursive: true });
+      fs.writeFileSync(path.join(worktreeProjectDir, 'status.yaml'), 'id: "bugfix-100"\nprotocol: bugfix\nphase: investigate\n');
+
+      const result = findStatusPath(testDir, 'bugfix-999');
+      expect(result).toBeNull();
+    });
+
+    it('should skip non-directory entries in .builders (bugfix #622)', () => {
+      // Create a file (not directory) in .builders
+      fs.mkdirSync(path.join(testDir, '.builders'), { recursive: true });
+      fs.writeFileSync(path.join(testDir, '.builders', 'some-file.txt'), 'not a worktree');
+
+      const result = findStatusPath(testDir, 'bugfix-622');
+      expect(result).toBeNull();
+    });
   });
 
   describe('detectProjectId (filesystem scan)', () => {

--- a/packages/codev/src/commands/porch/state.ts
+++ b/packages/codev/src/commands/porch/state.ts
@@ -180,14 +180,10 @@ export function createInitialState(
 // ============================================================================
 
 /**
- * Find status.yaml by project ID (searches for NNNN-* directories)
+ * Search a single codev/projects/ directory for a matching project.
  */
-export function findStatusPath(workspaceRoot: string, projectId: string): string | null {
-  const projectsDir = path.join(workspaceRoot, PROJECTS_DIR);
-
-  if (!fs.existsSync(projectsDir)) {
-    return null;
-  }
+function findProjectInDir(projectsDir: string, projectId: string): string | null {
+  if (!fs.existsSync(projectsDir)) return null;
 
   const entries = fs.readdirSync(projectsDir, { withFileTypes: true });
 
@@ -197,6 +193,30 @@ export function findStatusPath(workspaceRoot: string, projectId: string): string
       if (fs.existsSync(statusPath)) {
         return statusPath;
       }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Find status.yaml by project ID.
+ * Searches local codev/projects/ first, then falls back to
+ * .builders/* /codev/projects/ worktrees (enables porch status from repo root).
+ */
+export function findStatusPath(workspaceRoot: string, projectId: string): string | null {
+  // 1. Search local codev/projects/
+  const localResult = findProjectInDir(path.join(workspaceRoot, PROJECTS_DIR), projectId);
+  if (localResult) return localResult;
+
+  // 2. Search builder worktrees (.builders/*/codev/projects/)
+  const buildersDir = path.join(workspaceRoot, '.builders');
+  if (fs.existsSync(buildersDir)) {
+    const worktrees = fs.readdirSync(buildersDir, { withFileTypes: true });
+    for (const wt of worktrees) {
+      if (!wt.isDirectory()) continue;
+      const result = findProjectInDir(path.join(buildersDir, wt.name, PROJECTS_DIR), projectId);
+      if (result) return result;
     }
   }
 


### PR DESCRIPTION
Fixes #622

## Root Cause

`findStatusPath()` in `state.ts` only searched `{workspaceRoot}/codev/projects/` for project state. When `porch status <id>` is run from the main repo root, builder projects (created via `porch init` inside worktrees) live under `.builders/*/codev/projects/` and were invisible.

## Fix

Modified `findStatusPath()` to search `.builders/*/codev/projects/` as a fallback when the project isn't found in the local `codev/projects/` directory. Local projects still take priority over worktree projects.

Extracted the directory scanning logic into a `findProjectInDir()` helper to avoid duplication between the local and worktree search paths.

## Test Plan

- [x] Added 5 regression tests covering:
  - Finding bugfix project in .builders worktree
  - Finding numeric (SPIR) project in .builders worktree
  - Local codev/projects/ takes priority over .builders
  - Returns null when project not in local or any worktree
  - Skips non-directory entries in .builders
- [x] All 230 porch tests pass
- [x] Build succeeds
- [x] Porch checks pass