### PR TITLE
[Bugfix #511] Fix STL viewer model floating above grid

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/bugfix-511-stl-viewer-origin.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-511-stl-viewer-origin.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Regression test for #511: STL viewer model origin doesn't match file
+ *
+ * Bug: Three.js BufferGeometry.translate() auto-updates the bounding box,
+ * but the code subtracted center.z from the already-updated min.z, causing
+ * a double offset that made models float above the grid plane.
+ *
+ * Fix: Center only in XY (not Z), then use boundingBox.min.z directly
+ * to sit the model on the Z=0 plane.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('STL viewer model origin (#511)', () => {
+  const templatePath = resolve(
+    import.meta.dirname,
+    '../../../templates/3d-viewer.html',
+  );
+  const html = readFileSync(templatePath, 'utf-8');
+
+  describe('STL geometry centering fixes', () => {
+    it('should center only in XY, not Z', () => {
+      // The translate call should only move X and Y, leaving Z at 0
+      expect(html).toContain('geometry.translate(-center.x, -center.y, 0)');
+      // Must NOT center all three axes (the old buggy pattern)
+      expect(html).not.toContain(
+        'geometry.translate(-center.x, -center.y, -center.z)',
+      );
+    });
+
+    it('should use boundingBox.min.z directly to sit on grid', () => {
+      // After translate() auto-updates the bbox, min.z is already correct
+      expect(html).toContain(
+        'geometry.translate(0, 0, -geometry.boundingBox.min.z)',
+      );
+      // Must NOT subtract center.z from min.z (the old double-offset bug)
+      expect(html).not.toContain('geometry.boundingBox.min.z - center.z');
+    });
+  });
+
+  describe('Phong shading', () => {
+    it('should compute vertex normals for smooth shading', () => {
+      expect(html).toContain('geometry.computeVertexNormals()');
+    });
+  });
+
+  describe('background color', () => {
+    it('should use 30% gray background', () => {
+      expect(html).toContain('new THREE.Color(0x4D4D4D)');
+      expect(html).toContain('background: #4D4D4D');
+    });
+  });
+});

--- a/packages/codev/templates/3d-viewer.html
+++ b/packages/codev/templates/3d-viewer.html
@@ -12,7 +12,7 @@
     }
 
     body {
-      background: #000000;
+      background: #4D4D4D;
       color: #e0e0e0;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       overflow: hidden;
@@ -276,7 +276,7 @@
     function init() {
       // Scene
       scene = new THREE.Scene();
-      scene.background = new THREE.Color(0x000000);
+      scene.background = new THREE.Color(0x4D4D4D);
 
       // Cameras (Z-up coordinate system)
       const aspect = container.clientWidth / container.clientHeight;
@@ -378,21 +378,20 @@
           geometry.computeBoundingBox();
           const center = new THREE.Vector3();
           geometry.boundingBox.getCenter(center);
-          geometry.translate(-center.x, -center.y, -center.z);
+          // Only center in XY; Three.js translate() auto-updates boundingBox
+          geometry.translate(-center.x, -center.y, 0);
 
           // Move to sit on grid (Z=0 plane)
-          const minZ = geometry.boundingBox.min.z - center.z;
-          geometry.translate(0, 0, -minZ);
+          geometry.translate(0, 0, -geometry.boundingBox.min.z);
 
-          // Recalculate bounding box after translation
-          geometry.computeBoundingBox();
+          // Compute vertex normals for smooth Phong shading
+          geometry.computeVertexNormals();
 
           // Material
           const material = new THREE.MeshPhongMaterial({
             color: 0x3b82f6,
-            specular: 0x111111,
-            shininess: 30,
-            flatShading: false
+            specular: 0x222222,
+            shininess: 60
           });
 
           model = new THREE.Mesh(geometry, material);
@@ -775,21 +774,20 @@
         geometry.computeBoundingBox();
         const center = new THREE.Vector3();
         geometry.boundingBox.getCenter(center);
-        geometry.translate(-center.x, -center.y, -center.z);
+        // Only center in XY; Three.js translate() auto-updates boundingBox
+        geometry.translate(-center.x, -center.y, 0);
 
         // Move to sit on grid (Z=0 plane)
-        const minZ = geometry.boundingBox.min.z - center.z;
-        geometry.translate(0, 0, -minZ);
+        geometry.translate(0, 0, -geometry.boundingBox.min.z);
 
-        // Recalculate bounding box after translation
-        geometry.computeBoundingBox();
+        // Compute vertex normals for smooth Phong shading
+        geometry.computeVertexNormals();
 
         // Create new material
         const material = new THREE.MeshPhongMaterial({
           color: 0x3b82f6,
-          specular: 0x111111,
-          shininess: 30,
-          flatShading: false
+          specular: 0x222222,
+          shininess: 60
         });
 
         model = new THREE.Mesh(geometry, material);


### PR DESCRIPTION
## Summary
Fixes #511

## Root Cause
Three.js `BufferGeometry.translate()` automatically recomputes the bounding box (via `applyMatrix4`), but the STL loading code assumed the bounding box was still stale after the centering translation. The line:

```javascript
const minZ = geometry.boundingBox.min.z - center.z;
```

subtracted `center.z` from an already-updated `min.z`, causing a double offset that made models float above the Z=0 grid plane by exactly `center.z` units.

## Fix
1. **Center only in XY** — changed `translate(-center.x, -center.y, -center.z)` to `translate(-center.x, -center.y, 0)` so Z coordinates are preserved from the file
2. **Use boundingBox.min.z directly** — since `translate()` auto-updates the bounding box, `geometry.boundingBox.min.z` is already the correct post-translation value
3. **Background color** — changed from black (#000000) to 30% gray (#4D4D4D) per architect request
4. **Phong shading** — added `computeVertexNormals()` for smooth shading on STL models (STL files only store face normals), increased specular/shininess

Applied to both `loadSTL()` and `reloadSTL()` code paths.

## Test Plan
- [x] Added regression test (`bugfix-511-stl-viewer-origin.test.ts`) — verifies template doesn't contain buggy patterns
- [x] All existing tests pass
- [x] Build succeeds
- [x] Net diff: 88 LOC (well under 300 LOC threshold)

## CMAP Review
_Pending_