### PR TITLE
[SMOKE TEST - DO NOT MERGE] ci channel alert test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Run unit tests with coverage
         working-directory: packages/codev
         run: |
+          # Enable pipefail so a vitest failure is not masked by tee's exit code.
+          # (GitHub Actions' default Linux shell is `bash -e {0}` without pipefail.)
+          set -o pipefail
           # Vitest forks pool has a known issue where the worker process crashes
           # during cleanup after all tests pass (native module teardown).
           # Capture the output and check if all test files passed.

--- a/packages/codev/src/__tests__/ci-channel-smoke.test.ts
+++ b/packages/codev/src/__tests__/ci-channel-smoke.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+
+// Intentional failure for CI channel smoke test (throwaway branch test/ci-channel-smoke).
+// This file should never reach main — the branch is deleted after verifying the alert.
+describe('ci-channel smoke', () => {
+  it('intentionally fails to trigger a CI alert', () => {
+    expect(1).toBe(2);
+  });
+});


### PR DESCRIPTION
## Purpose

Smoke test for the newly-installed ci channel MCP server. Contains an intentional test failure so CI will fail and (hopefully) deliver an alert event through the ci channel.

**Do not merge.** Branch + PR will be deleted once the alert is confirmed.