### PR TITLE
[Spec 178] Support OpenCode as an alternative agent shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,9 +353,43 @@ Agent Farm is an optional companion tool for Codev that provides a web-based das
 - **Automatic prompting** - builders start with instructions to implement their assigned spec
 
 **Current limitations:**
-- Currently optimized for **Claude Code** (uses `--append-system-prompt`, `--dangerously-skip-permissions`, etc.)
 - Uses **shellper processes** for persistent terminal sessions (node-pty handles terminal I/O)
 - macOS-focused (should work on Linux but less tested)
+
+### Alternative Agent Shells
+
+Agent Farm supports multiple AI coding agents as shells. Configure in `.codev/config.json`:
+
+**Claude Code** (default):
+```json
+{
+  "shell": {
+    "architect": "claude --dangerously-skip-permissions",
+    "builder": "claude --dangerously-skip-permissions"
+  }
+}
+```
+
+**OpenCode** (builder only):
+```json
+{
+  "shell": {
+    "architect": "claude --dangerously-skip-permissions",
+    "builder": "opencode run"
+  }
+}
+```
+
+OpenCode supports 75+ LLM providers (OpenAI, Anthropic, Google, Ollama, etc.). When using OpenCode as a builder:
+- Include `run` in the command (plain `opencode` launches the TUI, which hangs in a PTY session)
+- Configure tool permissions for unattended execution in `~/.config/opencode/opencode.json` or your project's `opencode.json`:
+  ```json
+  { "permissions": { "edit": "allow", "bash": "allow" } }
+  ```
+- OpenCode reads `AGENTS.md` for project instructions (already present in Codev projects)
+- OpenCode is only supported as a **builder** shell, not as an architect shell
+
+Other shells (Codex, Gemini) are also supported via the harness system. See `packages/codev/src/agent-farm/utils/harness.ts` for details, or define a custom harness in `.codev/config.json`.
 
 ## Architect-Builder Pattern
 

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ OpenCode supports 75+ LLM providers (OpenAI, Anthropic, Google, Ollama, etc.). W
 - Include `run` in the command (plain `opencode` launches the TUI, which hangs in a PTY session)
 - Configure tool permissions for unattended execution in `~/.config/opencode/opencode.json` or your project's `opencode.json`:
   ```json
-  { "permissions": { "edit": "allow", "bash": "allow" } }
+  { "permission": { "edit": "allow", "bash": "allow" } }
   ```
 - OpenCode reads `AGENTS.md` for project instructions (already present in Codev projects)
 - OpenCode is only supported as a **builder** shell, not as an architect shell

--- a/codev/plans/178-support-opencode-as-an-alterna.md
+++ b/codev/plans/178-support-opencode-as-an-alterna.md
@@ -1,0 +1,315 @@
+# Plan: Support OpenCode as an Alternative Agent Shell
+
+## Metadata
+- **ID**: plan-2026-04-12-support-opencode
+- **Status**: draft
+- **Specification**: codev/specs/178-support-opencode-as-an-alterna.md
+- **Created**: 2026-04-12
+
+## Executive Summary
+
+Implement first-class OpenCode support by extending the harness abstraction layer with a new built-in `OPENCODE_HARNESS` provider, adding auto-detection, extending the `HarnessProvider` interface with an optional `getWorktreeFiles()` method for file-based role injection, updating `codev doctor` to check for the `opencode` binary, and documenting the configuration.
+
+This is a low-risk, narrowly scoped change (~100-150 LOC across 4-5 files) that follows established patterns from the Claude, Codex, and Gemini harness implementations.
+
+## Success Metrics
+- [ ] All spec success criteria met
+- [ ] All existing harness tests pass (no regressions)
+- [ ] New unit tests for OpenCode harness, auto-detection, and worktree files
+- [ ] `npm run build` succeeds
+- [ ] `npm test` passes
+
+## Phases (Machine Readable)
+
+```json
+{
+  "phases": [
+    {"id": "harness_provider", "title": "Harness Provider and Auto-Detection"},
+    {"id": "spawn_integration", "title": "Spawn Worktree Integration"},
+    {"id": "doctor_and_docs", "title": "Doctor Validation and Documentation"}
+  ]
+}
+```
+
+## Phase Breakdown
+
+### Phase 1: Harness Provider and Auto-Detection
+**Dependencies**: None
+
+#### Objectives
+- Add `OPENCODE_HARNESS` as a built-in provider with empty args/env (role injection handled via worktree files)
+- Add `getWorktreeFiles?()` optional method to `HarnessProvider` interface
+- Implement `getWorktreeFiles()` on `OPENCODE_HARNESS` to return `opencode.json` with `instructions: [".builder-role.md"]`
+- Add `opencode` to `detectHarnessFromCommand()` auto-detection
+- Add `opencode` to `BUILTIN_HARNESSES` map
+- Write comprehensive unit tests
+
+#### Deliverables
+- [ ] `HarnessProvider` interface extended with optional `getWorktreeFiles?()` method
+- [ ] `OPENCODE_HARNESS` constant exported from `harness.ts`
+- [ ] `opencode` added to `BUILTIN_HARNESSES`
+- [ ] `detectHarnessFromCommand()` recognizes `opencode` basename
+- [ ] Unit tests for all new functionality
+
+#### Implementation Details
+
+**File: `packages/codev/src/agent-farm/utils/harness.ts`**
+
+1. Add optional method to `HarnessProvider` interface:
+```typescript
+export interface HarnessProvider {
+  buildRoleInjection(roleContent: string, roleFilePath: string): {
+    args: string[];
+    env: Record<string, string>;
+  };
+  buildScriptRoleInjection(roleContent: string, roleFilePath: string): {
+    fragment: string;
+    env: Record<string, string>;
+  };
+  /** Optional: files to write in the worktree before launching the agent */
+  getWorktreeFiles?(roleContent: string, roleFilePath: string): Array<{
+    relativePath: string;
+    content: string;
+  }>;
+}
+```
+
+2. Add `OPENCODE_HARNESS`:
+```typescript
+export const OPENCODE_HARNESS: HarnessProvider = {
+  buildRoleInjection: () => ({ args: [], env: {} }),
+  buildScriptRoleInjection: () => ({ fragment: '', env: {} }),
+  getWorktreeFiles: () => ([{
+    relativePath: 'opencode.json',
+    content: JSON.stringify({ instructions: ['.builder-role.md'] }, null, 2) + '\n',
+  }]),
+};
+```
+
+3. Add to `BUILTIN_HARNESSES`:
+```typescript
+const BUILTIN_HARNESSES: Record<string, HarnessProvider> = {
+  claude: CLAUDE_HARNESS,
+  codex: CODEX_HARNESS,
+  gemini: GEMINI_HARNESS,
+  opencode: OPENCODE_HARNESS,
+};
+```
+
+4. Add to `detectHarnessFromCommand()`:
+```typescript
+if (basename.includes('opencode')) return 'opencode';
+```
+
+**File: `packages/codev/src/agent-farm/__tests__/harness.test.ts`**
+
+Add tests mirroring the existing Claude/Codex/Gemini test structure:
+- `OPENCODE_HARNESS.buildRoleInjection()` returns `{ args: [], env: {} }`
+- `OPENCODE_HARNESS.buildScriptRoleInjection()` returns `{ fragment: '', env: {} }`
+- `OPENCODE_HARNESS.getWorktreeFiles()` returns array with `opencode.json` entry
+- `detectHarnessFromCommand('opencode run')` returns `'opencode'`
+- `detectHarnessFromCommand('/usr/local/bin/opencode')` returns `'opencode'`
+- `resolveHarness('opencode')` returns `OPENCODE_HARNESS`
+- Auto-detect from command `'opencode run --model anthropic/claude-sonnet'` returns `'opencode'`
+- Existing harnesses don't have `getWorktreeFiles` (verify backward compat)
+
+#### Acceptance Criteria
+- [ ] `npm run build` succeeds
+- [ ] All existing harness tests pass
+- [ ] All new OpenCode harness tests pass
+- [ ] `resolveHarness()` with no args still defaults to claude
+
+#### Test Plan
+- **Unit Tests**: Direct tests of `OPENCODE_HARNESS` methods, auto-detection, resolution
+- **Regression**: Run full existing harness test suite
+
+#### Rollback Strategy
+Revert the single commit — no data migrations or external state changes.
+
+#### Risks
+- **Risk**: Adding optional method to interface breaks existing custom harnesses
+  - **Mitigation**: Method is optional (`?`), so TypeScript won't require existing implementations to add it
+
+---
+
+### Phase 2: Spawn Worktree Integration
+**Dependencies**: Phase 1
+
+#### Objectives
+- Update `spawn-worktree.ts` to call `getWorktreeFiles()` after writing `.builder-role.md` and write any returned files to the worktree
+- Verify the generated `.builder-start.sh` produces the correct command shape for `opencode run`
+
+#### Deliverables
+- [ ] `spawn-worktree.ts` calls `getWorktreeFiles()` when available
+- [ ] Generated files are written to correct paths in worktree
+- [ ] Startup script works with `opencode run` as the base command
+
+#### Implementation Details
+
+**File: `packages/codev/src/agent-farm/commands/spawn-worktree.ts`**
+
+In `startBuilderSession()`, after writing `.builder-role.md` (around line 594), add:
+
+```typescript
+// Write any harness-specific worktree files (e.g., opencode.json)
+if (harness.getWorktreeFiles) {
+  const worktreeFiles = harness.getWorktreeFiles(roleWithPort, roleFile);
+  for (const file of worktreeFiles) {
+    writeFileSync(resolve(worktreePath, file.relativePath), file.content);
+  }
+}
+```
+
+This is ~5 lines of code. The harness is already resolved at this point (`getBuilderHarness(config.workspaceRoot)` on line 598).
+
+Also do the same in the `buildBuilderStartScript()` function (around line 673) which is the alternate code path for script generation.
+
+**Verification**: With `shell.builder: "opencode run"`, the generated script should be:
+```bash
+#!/bin/bash
+cd "/path/to/worktree"
+while true; do
+  opencode run  "$(cat '/path/to/worktree/.builder-prompt.txt')"
+  echo ""
+  echo "Agent exited. Restarting in 2 seconds... (Ctrl+C to quit)"
+  sleep 2
+done
+```
+
+The empty space between `opencode run` and `"$(cat...)"` is correct (empty fragment, harmless in bash).
+
+#### Acceptance Criteria
+- [ ] `npm run build` succeeds
+- [ ] `npm test` passes
+- [ ] When harness has `getWorktreeFiles()`, files are written to worktree
+- [ ] When harness doesn't have `getWorktreeFiles()`, no change in behavior (Claude/Codex/Gemini unaffected)
+
+#### Test Plan
+- **Unit Tests**: Test that `startBuilderSession` calls `getWorktreeFiles` when present and writes files
+- **Regression**: Existing spawn tests pass unchanged
+
+#### Rollback Strategy
+Revert the commit — spawn-worktree falls back to not calling `getWorktreeFiles()`.
+
+#### Risks
+- **Risk**: Writing `opencode.json` conflicts with an existing user `opencode.json` in the repo
+  - **Mitigation**: Builder worktrees are isolated copies. The generated file only affects the builder session, not the main repo. If the repo already has an `opencode.json`, the generated one overwrites it in the worktree — this is acceptable because builder worktrees are ephemeral and the `instructions` field merges with other config sources.
+
+---
+
+### Phase 3: Doctor Validation and Documentation
+**Dependencies**: Phase 1, Phase 2
+
+#### Objectives
+- Add `opencode` to `codev doctor`'s `AI_DEPENDENCIES` list (binary existence check only)
+- Document OpenCode configuration in README or relevant docs
+- Document required `opencode.json` permission configuration for unattended builders
+- Document known differences vs Claude Code
+
+#### Deliverables
+- [ ] `opencode` entry in `AI_DEPENDENCIES` array in `doctor.ts`
+- [ ] Configuration documentation with examples
+- [ ] Permission setup documentation
+- [ ] Known differences/limitations documentation
+
+#### Implementation Details
+
+**File: `packages/codev/src/commands/doctor.ts`**
+
+Add to `AI_DEPENDENCIES` array (after the Gemini entry):
+```typescript
+{
+  name: 'OpenCode',
+  command: 'opencode',
+  versionArg: '--version',
+  versionExtract: () => 'working',
+  required: false,
+  installHint: {
+    macos: 'npm install -g opencode',
+    linux: 'npm install -g opencode',
+  },
+},
+```
+
+No `VERIFY_CONFIGS` entry — OpenCode is multi-provider, so auth verification depends on the user's chosen provider. Binary existence is sufficient.
+
+**File: `README.md` (or relevant docs section)**
+
+Add an "Alternative Agent Shells" section covering:
+
+1. Configuration example:
+```json
+{
+  "shell": {
+    "builder": "opencode run",
+    "architect": "claude --dangerously-skip-permissions"
+  }
+}
+```
+
+2. Required `opencode.json` for unattended execution:
+```json
+{
+  "permissions": {
+    "edit": "allow",
+    "bash": "allow"
+  }
+}
+```
+
+3. Known differences:
+- OpenCode reads `AGENTS.md` for project instructions (already present in Codev repos)
+- Must include `run` subcommand in `shell.builder` (plain `opencode` launches TUI)
+- No `--dangerously-skip-permissions` — must configure permissions in `opencode.json`
+- Multi-provider: uses whatever LLM backend the user has configured in their OpenCode setup
+
+#### Acceptance Criteria
+- [ ] `codev doctor` shows OpenCode status when the binary is installed
+- [ ] Documentation is clear and has working configuration examples
+- [ ] `npm run build` succeeds
+- [ ] `npm test` passes
+
+#### Test Plan
+- **Manual Testing**: Run `codev doctor` and verify OpenCode appears in output
+- **Regression**: Existing doctor tests pass
+
+#### Rollback Strategy
+Revert the commit — doctor falls back to not checking OpenCode.
+
+#### Risks
+- **Risk**: OpenCode installation method changes
+  - **Mitigation**: Install hint is informational only; doesn't affect functionality
+
+## Dependency Map
+```
+Phase 1 (Harness) ──→ Phase 2 (Spawn) ──→ Phase 3 (Doctor & Docs)
+```
+
+## Integration Points
+
+### Internal Systems
+- **harness.ts**: New provider + interface extension (Phase 1)
+- **spawn-worktree.ts**: Calls `getWorktreeFiles()` (Phase 2)
+- **doctor.ts**: New dependency entry (Phase 3)
+
+### External Systems
+- **OpenCode CLI**: Must be installed by user; no runtime dependency from Codev
+
+## Risk Analysis
+
+### Technical Risks
+| Risk | Probability | Impact | Mitigation |
+|------|------------|--------|------------|
+| Optional interface method breaks existing TS consumers | Low | Medium | Method is optional (`?`), fully backward compatible |
+| Generated `opencode.json` overwrites user file in worktree | Low | Low | Worktrees are ephemeral; instructions merge with other config |
+| OpenCode changes `instructions` field behavior | Low | Medium | Pin to documented behavior; custom harness as fallback |
+
+## Validation Checkpoints
+1. **After Phase 1**: All harness tests pass, `resolveHarness('opencode')` works
+2. **After Phase 2**: Build succeeds, spawn integration works end-to-end
+3. **After Phase 3**: Doctor shows OpenCode, documentation is complete
+
+## Documentation Updates Required
+- [ ] README section on alternative agent shells
+- [ ] OpenCode permission configuration guide
+- [ ] Known differences/limitations

--- a/codev/plans/178-support-opencode-as-an-alterna.md
+++ b/codev/plans/178-support-opencode-as-an-alterna.md
@@ -294,7 +294,7 @@ Add to `README.md` under a new "Alternative Agent Shells" section:
 2. **Required permissions for unattended execution** (in global `~/.config/opencode/opencode.json` OR project-level `opencode.json`):
 ```json
 {
-  "permissions": {
+  "permission": {
     "edit": "allow",
     "bash": "allow"
   }

--- a/codev/plans/178-support-opencode-as-an-alterna.md
+++ b/codev/plans/178-support-opencode-as-an-alterna.md
@@ -37,9 +37,10 @@ This is a low-risk, narrowly scoped change (~100-150 LOC across 4-5 files) that 
 **Dependencies**: None
 
 #### Objectives
-- Add `OPENCODE_HARNESS` as a built-in provider with empty args/env (role injection handled via worktree files)
+- Add `OPENCODE_HARNESS` as a built-in provider
 - Add `getWorktreeFiles?()` optional method to `HarnessProvider` interface
 - Implement `getWorktreeFiles()` on `OPENCODE_HARNESS` to return `opencode.json` with `instructions: [".builder-role.md"]`
+- Make `buildRoleInjection()` throw for OpenCode (architect use is unsupported -- see rationale below)
 - Add `opencode` to `detectHarnessFromCommand()` auto-detection
 - Add `opencode` to `BUILTIN_HARNESSES` map
 - Write comprehensive unit tests
@@ -77,7 +78,14 @@ export interface HarnessProvider {
 2. Add `OPENCODE_HARNESS`:
 ```typescript
 export const OPENCODE_HARNESS: HarnessProvider = {
-  buildRoleInjection: () => ({ args: [], env: {} }),
+  buildRoleInjection: () => {
+    throw new Error(
+      'OpenCode is only supported as a builder shell, not as an architect shell. ' +
+      'OpenCode uses file-based role injection (opencode.json instructions field) ' +
+      'which requires an ephemeral worktree. Configure a different shell for ' +
+      'the architect (e.g., "claude --dangerously-skip-permissions").',
+    );
+  },
   buildScriptRoleInjection: () => ({ fragment: '', env: {} }),
   getWorktreeFiles: () => ([{
     relativePath: 'opencode.json',
@@ -85,6 +93,10 @@ export const OPENCODE_HARNESS: HarnessProvider = {
   }]),
 };
 ```
+
+**Rationale for throwing in `buildRoleInjection()`**: This method is called only for architect sessions (in `tower-utils.ts:buildArchitectArgs()`). OpenCode has no CLI flag for system prompt injection, and writing `opencode.json` to the main workspace root (non-ephemeral) is unsafe -- it could overwrite user config and persist after the session. Throwing early with a clear error message prevents a silent failure where the architect launches without its role instructions.
+
+Builders use `buildScriptRoleInjection()` (called in `spawn-worktree.ts`), which returns empty fragment/env since role injection happens via `getWorktreeFiles()`.
 
 3. Add to `BUILTIN_HARNESSES`:
 ```typescript
@@ -104,14 +116,15 @@ if (basename.includes('opencode')) return 'opencode';
 **File: `packages/codev/src/agent-farm/__tests__/harness.test.ts`**
 
 Add tests mirroring the existing Claude/Codex/Gemini test structure:
-- `OPENCODE_HARNESS.buildRoleInjection()` returns `{ args: [], env: {} }`
+- `OPENCODE_HARNESS.buildRoleInjection()` throws with descriptive error message
 - `OPENCODE_HARNESS.buildScriptRoleInjection()` returns `{ fragment: '', env: {} }`
-- `OPENCODE_HARNESS.getWorktreeFiles()` returns array with `opencode.json` entry
+- `OPENCODE_HARNESS.getWorktreeFiles()` returns array with `opencode.json` entry containing valid JSON
 - `detectHarnessFromCommand('opencode run')` returns `'opencode'`
 - `detectHarnessFromCommand('/usr/local/bin/opencode')` returns `'opencode'`
+- `detectHarnessFromCommand('opencode run --model anthropic/claude-sonnet')` returns `'opencode'`
 - `resolveHarness('opencode')` returns `OPENCODE_HARNESS`
-- Auto-detect from command `'opencode run --model anthropic/claude-sonnet'` returns `'opencode'`
-- Existing harnesses don't have `getWorktreeFiles` (verify backward compat)
+- Auto-detect from command `'opencode run'` resolves to `OPENCODE_HARNESS`
+- Existing harnesses (`CLAUDE_HARNESS`, `CODEX_HARNESS`, `GEMINI_HARNESS`) don't have `getWorktreeFiles` (verify backward compat)
 
 #### Acceptance Criteria
 - [ ] `npm run build` succeeds
@@ -124,7 +137,7 @@ Add tests mirroring the existing Claude/Codex/Gemini test structure:
 - **Regression**: Run full existing harness test suite
 
 #### Rollback Strategy
-Revert the single commit — no data migrations or external state changes.
+Revert the single commit -- no data migrations or external state changes.
 
 #### Risks
 - **Risk**: Adding optional method to interface breaks existing custom harnesses
@@ -136,33 +149,47 @@ Revert the single commit — no data migrations or external state changes.
 **Dependencies**: Phase 1
 
 #### Objectives
-- Update `spawn-worktree.ts` to call `getWorktreeFiles()` after writing `.builder-role.md` and write any returned files to the worktree
-- Verify the generated `.builder-start.sh` produces the correct command shape for `opencode run`
+- Update `spawn-worktree.ts` to call `getWorktreeFiles()` and write returned files to the worktree, with merge support for existing files
+- Verify the generated startup script produces the correct command shape for `opencode run`
 
 #### Deliverables
-- [ ] `spawn-worktree.ts` calls `getWorktreeFiles()` when available
-- [ ] Generated files are written to correct paths in worktree
+- [ ] `startBuilderSession()` calls `getWorktreeFiles()` when available
+- [ ] `buildWorktreeLaunchScript()` calls `getWorktreeFiles()` when available
+- [ ] Generated files merge with existing worktree files (read/merge/write for JSON files)
 - [ ] Startup script works with `opencode run` as the base command
 
 #### Implementation Details
 
 **File: `packages/codev/src/agent-farm/commands/spawn-worktree.ts`**
 
-In `startBuilderSession()`, after writing `.builder-role.md` (around line 594), add:
+In `startBuilderSession()` (line 570), AFTER the harness is resolved (line 598: `const harness = getBuilderHarness(config.workspaceRoot)`), add the `getWorktreeFiles()` call:
 
 ```typescript
-// Write any harness-specific worktree files (e.g., opencode.json)
+// Write any harness-specific worktree files (e.g., opencode.json for OpenCode)
 if (harness.getWorktreeFiles) {
   const worktreeFiles = harness.getWorktreeFiles(roleWithPort, roleFile);
   for (const file of worktreeFiles) {
-    writeFileSync(resolve(worktreePath, file.relativePath), file.content);
+    const targetPath = resolve(worktreePath, file.relativePath);
+    // Merge with existing file if it's JSON and already exists
+    if (file.relativePath.endsWith('.json') && existsSync(targetPath)) {
+      const existing = JSON.parse(readFileSync(targetPath, 'utf-8'));
+      const incoming = JSON.parse(file.content);
+      // Shallow merge: incoming properties override, arrays are concatenated for 'instructions'
+      const merged = { ...existing, ...incoming };
+      if (Array.isArray(existing.instructions) && Array.isArray(incoming.instructions)) {
+        merged.instructions = [...new Set([...existing.instructions, ...incoming.instructions])];
+      }
+      writeFileSync(targetPath, JSON.stringify(merged, null, 2) + '\n');
+    } else {
+      writeFileSync(targetPath, file.content);
+    }
   }
 }
 ```
 
-This is ~5 lines of code. The harness is already resolved at this point (`getBuilderHarness(config.workspaceRoot)` on line 598).
+Also apply the same logic in `buildWorktreeLaunchScript()` (line 666), after the harness is resolved (line 679: `const harness = getBuilderHarness(workspaceRoot)`).
 
-Also do the same in the `buildBuilderStartScript()` function (around line 673) which is the alternate code path for script generation.
+**Why merge**: If the repo has a project-level `opencode.json` with `permissions: { "edit": "allow", "bash": "allow" }`, a naive overwrite would destroy those permissions, causing the builder to hang on permission prompts. The merge strategy preserves existing keys while adding/deduplicating the `instructions` array.
 
 **Verification**: With `shell.builder: "opencode run"`, the generated script should be:
 ```bash
@@ -181,19 +208,21 @@ The empty space between `opencode run` and `"$(cat...)"` is correct (empty fragm
 #### Acceptance Criteria
 - [ ] `npm run build` succeeds
 - [ ] `npm test` passes
-- [ ] When harness has `getWorktreeFiles()`, files are written to worktree
+- [ ] When harness has `getWorktreeFiles()`, files are written/merged in worktree
 - [ ] When harness doesn't have `getWorktreeFiles()`, no change in behavior (Claude/Codex/Gemini unaffected)
+- [ ] Existing `opencode.json` permissions are preserved after merge
 
 #### Test Plan
-- **Unit Tests**: Test that `startBuilderSession` calls `getWorktreeFiles` when present and writes files
+- **Unit Tests**: Test merge logic (new file, merge with existing JSON, non-JSON file)
+- **Integration**: Verify `buildWorktreeLaunchScript()` with OpenCode harness produces correct script shape
 - **Regression**: Existing spawn tests pass unchanged
 
 #### Rollback Strategy
-Revert the commit — spawn-worktree falls back to not calling `getWorktreeFiles()`.
+Revert the commit -- spawn-worktree falls back to not calling `getWorktreeFiles()`.
 
 #### Risks
-- **Risk**: Writing `opencode.json` conflicts with an existing user `opencode.json` in the repo
-  - **Mitigation**: Builder worktrees are isolated copies. The generated file only affects the builder session, not the main repo. If the repo already has an `opencode.json`, the generated one overwrites it in the worktree — this is acceptable because builder worktrees are ephemeral and the `instructions` field merges with other config sources.
+- **Risk**: JSON merge has unexpected behavior for edge-case configs
+  - **Mitigation**: Merge is shallow and only special-cases `instructions` array. All other fields use standard object spread.
 
 ---
 
@@ -201,13 +230,15 @@ Revert the commit — spawn-worktree falls back to not calling `getWorktreeFiles
 **Dependencies**: Phase 1, Phase 2
 
 #### Objectives
-- Add `opencode` to `codev doctor`'s `AI_DEPENDENCIES` list (binary existence check only)
-- Document OpenCode configuration in README or relevant docs
-- Document required `opencode.json` permission configuration for unattended builders
-- Document known differences vs Claude Code
+- Add `opencode` to `codev doctor`'s `AI_DEPENDENCIES` list
+- Add minimal `VERIFY_CONFIGS` entry to avoid misleading "unknown model" skip output
+- Add doctor warning if OpenCode is configured as architect shell
+- Document OpenCode configuration, permissions, and known differences
 
 #### Deliverables
 - [ ] `opencode` entry in `AI_DEPENDENCIES` array in `doctor.ts`
+- [ ] `VERIFY_CONFIGS` entry for OpenCode (`opencode --version`, exit 0 = OK)
+- [ ] Doctor warning for OpenCode-as-architect misconfiguration
 - [ ] Configuration documentation with examples
 - [ ] Permission setup documentation
 - [ ] Known differences/limitations documentation
@@ -216,7 +247,7 @@ Revert the commit — spawn-worktree falls back to not calling `getWorktreeFiles
 
 **File: `packages/codev/src/commands/doctor.ts`**
 
-Add to `AI_DEPENDENCIES` array (after the Gemini entry):
+1. Add to `AI_DEPENDENCIES` array:
 ```typescript
 {
   name: 'OpenCode',
@@ -231,13 +262,26 @@ Add to `AI_DEPENDENCIES` array (after the Gemini entry):
 },
 ```
 
-No `VERIFY_CONFIGS` entry — OpenCode is multi-provider, so auth verification depends on the user's chosen provider. Binary existence is sufficient.
+2. Add to `VERIFY_CONFIGS`:
+```typescript
+'OpenCode': {
+  command: 'opencode',
+  args: ['--version'],
+  timeout: 10000,
+  successCheck: (r) => r.status === 0,
+  authHint: 'Run "opencode --version" to verify installation',
+},
+```
 
-**File: `README.md` (or relevant docs section)**
+This ensures `codev doctor` shows `[OK] OpenCode - operational` instead of `[SKIP] OpenCode - unknown model`.
 
-Add an "Alternative Agent Shells" section covering:
+3. Add architect-shell warning: After the AI dependency checks, if OpenCode is installed and configured as the architect shell (via `getResolvedCommands().architect` containing `opencode`), emit a warning that OpenCode is only supported as a builder shell.
 
-1. Configuration example:
+**File: Documentation**
+
+Add to `README.md` under a new "Alternative Agent Shells" section:
+
+1. **Configuration example**:
 ```json
 {
   "shell": {
@@ -247,7 +291,7 @@ Add an "Alternative Agent Shells" section covering:
 }
 ```
 
-2. Required `opencode.json` for unattended execution:
+2. **Required permissions for unattended execution** (in global `~/.config/opencode/opencode.json` OR project-level `opencode.json`):
 ```json
 {
   "permissions": {
@@ -257,28 +301,30 @@ Add an "Alternative Agent Shells" section covering:
 }
 ```
 
-3. Known differences:
+3. **Known differences**:
 - OpenCode reads `AGENTS.md` for project instructions (already present in Codev repos)
 - Must include `run` subcommand in `shell.builder` (plain `opencode` launches TUI)
-- No `--dangerously-skip-permissions` — must configure permissions in `opencode.json`
-- Multi-provider: uses whatever LLM backend the user has configured in their OpenCode setup
+- No `--dangerously-skip-permissions` -- must configure permissions in `opencode.json`
+- Multi-provider: uses whatever LLM backend the user has configured
+- **Only supported as builder shell** -- architect sessions require a different shell (e.g., Claude, Codex)
 
 #### Acceptance Criteria
-- [ ] `codev doctor` shows OpenCode status when the binary is installed
+- [ ] `codev doctor` shows OpenCode as `[OK]` when binary exists (not `[SKIP]`)
+- [ ] `codev doctor` warns if OpenCode is configured as architect shell
 - [ ] Documentation is clear and has working configuration examples
 - [ ] `npm run build` succeeds
 - [ ] `npm test` passes
 
 #### Test Plan
-- **Manual Testing**: Run `codev doctor` and verify OpenCode appears in output
+- **Manual Testing**: Run `codev doctor` and verify OpenCode appears correctly
 - **Regression**: Existing doctor tests pass
 
 #### Rollback Strategy
-Revert the commit — doctor falls back to not checking OpenCode.
+Revert the commit -- doctor falls back to not checking OpenCode.
 
 #### Risks
-- **Risk**: OpenCode installation method changes
-  - **Mitigation**: Install hint is informational only; doesn't affect functionality
+- **Risk**: OpenCode install method or `--version` flag changes
+  - **Mitigation**: Version check is best-effort; binary existence is the primary check
 
 ## Dependency Map
 ```
@@ -289,8 +335,9 @@ Phase 1 (Harness) ──→ Phase 2 (Spawn) ──→ Phase 3 (Doctor & Docs)
 
 ### Internal Systems
 - **harness.ts**: New provider + interface extension (Phase 1)
-- **spawn-worktree.ts**: Calls `getWorktreeFiles()` (Phase 2)
-- **doctor.ts**: New dependency entry (Phase 3)
+- **spawn-worktree.ts**: Calls `getWorktreeFiles()` with merge logic (Phase 2)
+- **doctor.ts**: New dependency + verification entry (Phase 3)
+- **tower-utils.ts**: `buildArchitectArgs()` will throw if OpenCode harness detected for architect (Phase 1, no code change needed -- the throw is in the harness itself)
 
 ### External Systems
 - **OpenCode CLI**: Must be installed by user; no runtime dependency from Codev
@@ -301,15 +348,30 @@ Phase 1 (Harness) ──→ Phase 2 (Spawn) ──→ Phase 3 (Doctor & Docs)
 | Risk | Probability | Impact | Mitigation |
 |------|------------|--------|------------|
 | Optional interface method breaks existing TS consumers | Low | Medium | Method is optional (`?`), fully backward compatible |
-| Generated `opencode.json` overwrites user file in worktree | Low | Low | Worktrees are ephemeral; instructions merge with other config |
+| Generated `opencode.json` conflicts with user config | Medium | Medium | JSON merge strategy preserves existing config while adding instructions |
+| User configures OpenCode as architect shell | Medium | Low | `buildRoleInjection()` throws clear error; doctor emits warning |
 | OpenCode changes `instructions` field behavior | Low | Medium | Pin to documented behavior; custom harness as fallback |
 
 ## Validation Checkpoints
-1. **After Phase 1**: All harness tests pass, `resolveHarness('opencode')` works
-2. **After Phase 2**: Build succeeds, spawn integration works end-to-end
-3. **After Phase 3**: Doctor shows OpenCode, documentation is complete
+1. **After Phase 1**: All harness tests pass, `resolveHarness('opencode')` works, throw on architect use
+2. **After Phase 2**: Build succeeds, spawn integration writes/merges files correctly
+3. **After Phase 3**: Doctor shows OpenCode correctly, documentation complete
 
 ## Documentation Updates Required
 - [ ] README section on alternative agent shells
 - [ ] OpenCode permission configuration guide
-- [ ] Known differences/limitations
+- [ ] Known differences/limitations (including builder-only support)
+
+## Expert Review
+
+### Consultation 1 (2026-04-12)
+**Models Consulted**: Gemini, Codex, Claude
+
+**Key Feedback Addressed**:
+- **opencode.json overwrite** (all three): Changed from naive overwrite to read/merge/write strategy that preserves existing config (esp. permissions) while adding instructions.
+- **Wrong function name** (Codex, Claude): Corrected `buildBuilderStartScript()` to `buildWorktreeLaunchScript()` (actual name at line 666 of spawn-worktree.ts).
+- **Architect silent failure** (Gemini): `buildRoleInjection()` now throws with clear error explaining OpenCode is builder-only.
+- **Doctor verification output** (Codex, Gemini): Added `VERIFY_CONFIGS` entry so doctor shows `[OK]` not `[SKIP] unknown model`.
+- **Doctor architect warning** (Gemini): Added warning if OpenCode configured as architect shell.
+- **Snippet placement** (Codex): Clarified that `getWorktreeFiles()` call goes AFTER harness is resolved, not before.
+- **More integration tests** (Codex): Added tests for script shape generation and merge behavior.

--- a/codev/reviews/178-support-opencode-as-an-alterna.md
+++ b/codev/reviews/178-support-opencode-as-an-alterna.md
@@ -1,0 +1,129 @@
+# Review: Support OpenCode as an Alternative Agent Shell
+
+## Summary
+
+Added first-class OpenCode support as an alternative agent shell in Codev's agent farm. OpenCode (140K+ GitHub stars) supports 75+ LLM providers, giving users flexibility beyond Claude Code. The implementation extends the existing harness abstraction layer with a new built-in `OPENCODE_HARNESS` provider, auto-detection, JSON-merge-based role injection via `opencode.json`, `codev doctor` validation, and documentation.
+
+**Files changed**: 4 source files, 2 test files, 1 documentation file
+**Net LOC**: ~150 lines of production code, ~100 lines of tests
+
+## Spec Compliance
+
+- [x] `opencode` auto-detected by `detectHarnessFromCommand()` when command basename contains "opencode"
+- [x] Built-in `OPENCODE_HARNESS` registered in `BUILTIN_HARNESSES`
+- [x] Role injection via `opencode.json` `instructions` field referencing `.builder-role.md`
+- [x] `codev doctor` checks for `opencode` binary with `VERIFY_CONFIGS` entry
+- [x] Configuration example documented with correct `shell.builder` format
+- [x] Documentation covers required `opencode.json` tool permissions for unattended execution
+- [x] Known capability differences documented (builder-only, permission model, `run` subcommand)
+- [x] All existing tests pass (2331 tests, 0 failures)
+- [x] Unit tests cover harness provider, auto-detection, worktree file writing/merging
+
+## Deviations from Plan
+
+- **Phase 1**: `buildRoleInjection()` throws for architect use (as planned). No deviation.
+- **Phase 2**: Extracted `writeWorktreeFiles()` as a helper function rather than inlining (minor improvement over plan).
+- **Phase 3**: Used dynamic import for `loadConfig` in doctor.ts architect warning to handle non-project contexts gracefully. Type casting is heavier than ideal but functional inside try/catch.
+
+## Lessons Learned
+
+### What Went Well
+- The harness abstraction was perfectly suited for this extension -- adding a new provider followed an established, well-tested pattern
+- The 3-way consultation process caught real design issues early (opencode.json overwrite, architect silent failure, wrong function name)
+- The spec phase correctly identified that OpenCode lacks `--system-prompt` CLI flag, which shaped the entire design
+
+### Challenges Encountered
+- **Gemini consultation failures**: Gemini repeatedly failed to produce review output during Phase 2 consultation (3 attempts). Eventually resolved on 4th attempt. Root cause unclear -- likely a transient Gemini service issue.
+- **OpenCode lacks CLI-based role injection**: Unlike Claude (`--append-system-prompt`), Codex (`-c model_instructions_file=`), and Gemini (`GEMINI_SYSTEM_MD`), OpenCode has no CLI flag or env var for system prompt injection. Required introducing `getWorktreeFiles?()` interface extension.
+
+### What Would Be Done Differently
+- Would verify OpenCode's exact CLI capabilities earlier in the spec phase rather than leaving it as a "Critical" open question that had to be resolved mid-spec
+
+### Methodology Improvements
+- The SPIR consultation process is highly effective for catching design issues before implementation. All three reviewers consistently identified the same core issues (opencode.json overwrite, architect failure) independently.
+
+## Technical Debt
+- The type casting in doctor.ts architect warning (lines 599-601) could be cleaner if `loadConfig()` returned a fully typed config interface. Minor -- safe inside try/catch.
+- No automated tests for doctor OpenCode output (plan specified manual testing for Phase 3).
+
+## Consultation Feedback
+
+### Specify Phase (Round 1)
+
+#### Gemini (REQUEST_CHANGES)
+- **Concern**: Role injection mechanism is an unresolved critical blocker
+  - **Addressed**: Resolved by using `opencode.json` `instructions` field
+- **Concern**: Interface constraint violation if AGENTS.md append is needed
+  - **Addressed**: Dropped "no interface changes" constraint; added optional `getWorktreeFiles?()` method
+- **Concern**: Config contradiction (`opencode` vs `opencode run`)
+  - **Addressed**: Standardized on `"builder": "opencode run"`
+- **Concern**: Doctor.ts architecture mismatch (static vs config-aware)
+  - **Addressed**: Added to static list + VERIFY_CONFIGS entry
+
+#### Codex (REQUEST_CHANGES)
+- **Concern**: Role injection underspecified, suggests config-based approach
+  - **Addressed**: Chose `opencode.json` instructions field approach
+- **Concern**: Config examples use wrong format
+  - **Addressed**: Fixed all examples to use `shell.builder` nested format
+
+#### Claude (COMMENT)
+- **Concern**: Role injection unresolved, suggests `preRun` hook
+  - **Addressed**: Used `getWorktreeFiles?()` optional method instead
+- **Concern**: Unattended execution needs to be a requirement
+  - **Addressed**: Elevated to documented requirement with configuration examples
+
+### Plan Phase (Round 1)
+
+#### Gemini (REQUEST_CHANGES)
+- **Concern**: Architect role silent failure
+  - **Addressed**: `buildRoleInjection()` throws with clear error message
+- **Concern**: Missing doctor warning for opencode-as-architect
+  - **Addressed**: Added architect-shell warning in doctor
+- **Concern**: Doctor verification shows misleading "unknown model" skip
+  - **Addressed**: Added `VERIFY_CONFIGS` entry
+
+#### Codex (REQUEST_CHANGES)
+- **Concern**: opencode.json overwrite risk destroys user permissions
+  - **Addressed**: Implemented JSON read/merge/write strategy
+- **Concern**: Wrong function name (`buildBuilderStartScript`)
+  - **Addressed**: Corrected to `buildWorktreeLaunchScript()`
+- **Concern**: Need more integration tests
+  - **Addressed**: Added tests for script shape and merge behavior
+
+#### Claude (COMMENT)
+- **Concern**: opencode.json overwrite can blow away user permissions
+  - **Addressed**: Same merge strategy as Codex concern
+- **Concern**: Wrong function name
+  - **Addressed**: Same correction as Codex concern
+
+### Implementation Phase 1 — harness_provider (Round 1)
+- **Gemini**: APPROVE — no concerns
+- **Codex**: APPROVE — no concerns
+- **Claude**: APPROVE — no concerns
+
+### Implementation Phase 2 — spawn_integration (Round 1)
+- **Gemini**: APPROVE (on retry — first attempt produced empty output)
+- **Codex**: APPROVE — no concerns
+- **Claude**: APPROVE — minor suggestion to add `logger.warn()` in JSON parse catch block (non-blocking)
+
+### Implementation Phase 3 — doctor_and_docs (Round 1)
+- **Gemini**: APPROVE — no concerns
+- **Codex**: COMMENT — minor note about type casting and missing doctor-specific tests (non-blocking)
+- **Claude**: APPROVE — minor note about type casting in architect warning code (non-blocking)
+
+## Architecture Updates
+
+No architecture updates needed. This feature extends the existing harness abstraction layer (`packages/codev/src/agent-farm/utils/harness.ts`) with one new built-in provider following the established Claude/Codex/Gemini pattern. The new optional `getWorktreeFiles?()` method on `HarnessProvider` is a backward-compatible extension to the existing interface, not a new subsystem.
+
+## Lessons Learned Updates
+
+No lessons learned updates needed. The implementation was straightforward, following established patterns. The key insight (OpenCode's file-based config vs CLI-based role injection) is specific to this feature and documented in the spec.
+
+## Flaky Tests
+
+No flaky tests encountered.
+
+## Follow-up Items
+- Consider adding `logger.warn()` to the JSON parse catch block in `writeWorktreeFiles()` for better diagnostics
+- Could improve type safety in doctor.ts architect warning by using a typed config interface
+- Future: investigate OpenCode's ACP (Agent Client Protocol) mode for potentially better integration than PTY-based approach

--- a/codev/specs/178-support-opencode-as-an-alterna.md
+++ b/codev/specs/178-support-opencode-as-an-alterna.md
@@ -1,0 +1,190 @@
+# Specification: Support OpenCode as an Alternative Agent Shell
+
+## Metadata
+- **ID**: spec-2026-04-11-support-opencode
+- **Status**: draft
+- **Created**: 2026-04-11
+- **Issue**: #178
+
+## Problem Statement
+
+Codev's agent farm currently supports Claude Code, Codex, and Gemini CLI as agent shells via the harness abstraction layer. OpenCode (https://github.com/opencode-ai/opencode) is a popular open-source terminal-based AI coding agent with 140,000+ GitHub stars that supports 75+ LLM providers. Users who prefer OpenCode or need alternative LLM backends (local models, OpenRouter, etc.) cannot use it as a drop-in agent shell without manually configuring a custom harness in `.codev/config.json`.
+
+Adding first-class OpenCode support would reduce configuration friction and signal that Codev is genuinely provider-agnostic.
+
+## Current State
+
+The harness system (`packages/codev/src/agent-farm/utils/harness.ts`) already provides a clean abstraction for agent shell integration:
+
+- **Three built-in harnesses**: `claude` (uses `--append-system-prompt`), `codex` (uses `-c model_instructions_file=`), `gemini` (uses `GEMINI_SYSTEM_MD` env var)
+- **Auto-detection**: `detectHarnessFromCommand()` matches command basenames against known CLI names
+- **Custom harness support**: Users can define arbitrary harnesses in `.codev/config.json` under the `harness` key with `roleArgs`, `roleEnv`, `roleScriptFragment`, `roleScriptEnv`
+- **Configuration hierarchy**: CLI overrides > config.json > defaults (all defaulting to `claude`)
+
+Users *can* configure OpenCode today via a custom harness, but they must know the exact config format and OpenCode's CLI flags. There's no auto-detection, no built-in harness, and no documentation.
+
+## Desired State
+
+OpenCode works as a first-class agent shell alongside Claude, Codex, and Gemini:
+
+1. Setting `"builder": "opencode"` in `.codev/config.json` just works -- the harness auto-detects and injects roles correctly
+2. `codev doctor` validates the OpenCode installation
+3. Documentation covers configuration and known differences
+4. The existing AGENTS.md file (already present in the repo) provides instructions to OpenCode automatically
+
+## Stakeholders
+- **Primary Users**: Codev users who prefer OpenCode or alternative LLM providers
+- **Secondary Users**: Contributors to Codev who want to test with different agent shells
+- **Technical Team**: Codev maintainers
+- **Business Owners**: Codev project leads
+
+## Success Criteria
+- [ ] `opencode` auto-detected by `detectHarnessFromCommand()` when command basename contains "opencode"
+- [ ] Built-in `OPENCODE_HARNESS` provider correctly injects role content via OpenCode's CLI mechanism
+- [ ] `codev doctor` checks for `opencode` binary when configured as architect or builder shell
+- [ ] Configuration example documented showing how to switch to OpenCode
+- [ ] Known capability differences documented (what works, what doesn't)
+- [ ] All existing tests pass (no regressions)
+- [ ] Unit tests cover the new harness provider and auto-detection
+
+## Constraints
+
+### Technical Constraints
+- OpenCode uses `AGENTS.md` for project-level instructions (the repo already has one, identical to `CLAUDE.md`)
+- OpenCode's non-interactive mode is `opencode run "prompt"` -- the startup script must use this subcommand
+- OpenCode does not have a direct `--append-system-prompt` equivalent for runtime injection; it reads `AGENTS.md` from the project root automatically
+- The harness must work within the existing `HarnessProvider` interface (no interface changes)
+- The existing auto-restart loop in `.builder-start.sh` must work with OpenCode's CLI
+
+### Business Constraints
+- This is a community-requested feature (#178)
+- Should not break any existing Claude/Codex/Gemini workflows
+
+## Assumptions
+- OpenCode is installed and available on the user's PATH when configured
+- OpenCode supports `opencode run "prompt"` for non-interactive execution (confirmed in research)
+- OpenCode reads `AGENTS.md` from the working directory automatically (confirmed)
+- The `.builder-role.md` file written by spawn-worktree can be injected via an environment variable or CLI flag that OpenCode supports for additional system instructions
+
+## Solution Approaches
+
+### Approach 1: Built-in Harness with AGENTS.md Reliance (Recommended)
+
+Add `OPENCODE_HARNESS` as a built-in provider. OpenCode automatically reads `AGENTS.md` from the project root for its instructions (the repo already maintains `AGENTS.md` identical to `CLAUDE.md`). The harness injects the builder role via a mechanism that appends it to OpenCode's system context.
+
+**Role injection strategy**: Write the role content to `.builder-role.md` (already done by spawn-worktree) and set an environment variable like `OPENCODE_SYSTEM_PROMPT_FILE` pointing to it, or use a CLI flag if available. If OpenCode supports `--system-prompt` or similar, use that. If not, append the role content to a local `AGENTS.md` copy in the worktree.
+
+**Startup command**: The `.builder-start.sh` script needs to use `opencode run "$(cat .builder-prompt.txt)"` instead of `opencode "$(cat .builder-prompt.txt)"`, since OpenCode requires the `run` subcommand for non-interactive execution.
+
+**Pros**:
+- Minimal code changes (add harness + auto-detection, ~30 lines)
+- Follows established patterns for claude/codex/gemini
+- OpenCode gets project context automatically via AGENTS.md
+- No changes to spawn-worktree or session management
+
+**Cons**:
+- Role injection mechanism depends on OpenCode's specific CLI flags (needs verification)
+- If OpenCode changes its CLI interface, the harness breaks
+
+**Estimated Complexity**: Low
+**Risk Level**: Low
+
+### Approach 2: Custom Harness Documentation Only
+
+Don't add a built-in harness. Instead, document how to configure OpenCode via the existing custom harness mechanism in `.codev/config.json`.
+
+**Pros**:
+- Zero code changes
+- Users have full control over the configuration
+
+**Cons**:
+- Higher friction for users (must know exact config format)
+- No auto-detection
+- No `codev doctor` validation
+- Doesn't signal first-class support
+
+**Estimated Complexity**: Very Low
+**Risk Level**: Very Low
+
+### Approach 3: Startup Script Adaptation
+
+In addition to the built-in harness (Approach 1), modify the startup script generation in `spawn-worktree.ts` to detect OpenCode and use `opencode run` instead of passing the prompt as a bare argument.
+
+**Pros**:
+- Handles the `run` subcommand requirement cleanly
+- More robust than relying on users to include `run` in their config command
+
+**Cons**:
+- Adds shell-specific logic to spawn-worktree (currently shell-agnostic)
+- Could be handled by having users set `"builder": "opencode run"` in config
+
+**Estimated Complexity**: Medium
+**Risk Level**: Medium
+
+## Recommended Approach
+
+**Approach 1** (Built-in Harness) is recommended. The startup script issue (Approach 3) can be handled by documenting that users should configure `"builder": "opencode run"` to include the `run` subcommand, keeping spawn-worktree shell-agnostic.
+
+## Open Questions
+
+### Critical (Blocks Progress)
+- [x] Does OpenCode support a CLI flag or env var for injecting additional system prompt content beyond AGENTS.md? **Research indicates**: OpenCode reads AGENTS.md automatically from the project root. For additional runtime instructions, we need to verify if there's a `--system-prompt` flag or if appending to the worktree's AGENTS.md is the cleanest approach.
+
+### Important (Affects Design)
+- [ ] Should the harness append role content to the worktree's AGENTS.md rather than using a separate mechanism? This would be the most natural integration since OpenCode already reads AGENTS.md.
+- [ ] Does `opencode run` support reading the prompt from stdin or only as a CLI argument? (Affects how long prompts are passed)
+
+### Nice-to-Know (Optimization)
+- [ ] What is the exact set of OpenCode tools available, and do any conflict with porch signal expectations?
+- [ ] Does OpenCode's `acp` (Agent Client Protocol) mode offer better integration than the PTY-based approach?
+
+## Performance Requirements
+- **Startup Time**: OpenCode session should start within the same timeframe as Claude Code sessions (< 10s)
+- **Resource Usage**: No additional resource overhead beyond the OpenCode process itself
+
+## Security Considerations
+- OpenCode may connect to third-party LLM providers (user's choice) -- this is expected and acceptable
+- API keys for providers are managed by the user's OpenCode configuration, not by Codev
+- The `--dangerously-skip-permissions` pattern used with Claude Code has no OpenCode equivalent; OpenCode's permission model is different (configurable per-tool allow/deny/ask)
+
+## Test Scenarios
+
+### Functional Tests
+1. `detectHarnessFromCommand('opencode run')` returns `'opencode'`
+2. `detectHarnessFromCommand('/usr/local/bin/opencode')` returns `'opencode'`
+3. `resolveHarness('opencode')` returns the `OPENCODE_HARNESS` provider
+4. `OPENCODE_HARNESS.buildRoleInjection()` returns correct args/env
+5. `OPENCODE_HARNESS.buildScriptRoleInjection()` returns correct fragment/env
+6. Configuring `"builder": "opencode run"` in config.json resolves correctly via `getResolvedCommands()`
+
+### Non-Functional Tests
+1. Existing Claude/Codex/Gemini harness tests continue to pass (no regressions)
+2. `resolveHarness()` with no args still defaults to claude (backward compatibility)
+
+## Dependencies
+- **External**: OpenCode CLI must be installed by the user
+- **Internal**: Depends on the existing harness system (`harness.ts`, `config.ts`)
+- **Libraries**: No new dependencies required
+
+## Risks and Mitigation
+| Risk | Probability | Impact | Mitigation Strategy |
+|------|------------|--------|-------------------|
+| OpenCode CLI interface changes break harness | Low | Medium | Pin to known-working behavior; custom harness as fallback |
+| Role injection doesn't work as expected | Medium | High | Verify during implementation; fall back to AGENTS.md append approach |
+| OpenCode lacks features porch expects (signal handling) | Low | Low | Document limitations; porch signals are text-based and shell-agnostic |
+| Users expect full feature parity with Claude Code | Medium | Low | Document known differences clearly |
+
+## Notes
+
+### OpenCode Key Facts (from research)
+- **Version**: 1.4.2 (April 2026), very active development
+- **Stars**: 140,000+ on GitHub
+- **Providers**: 75+ LLM providers including OpenAI, Anthropic, Google, Ollama, LM Studio
+- **CLI modes**: `opencode` (TUI), `opencode run "prompt"` (non-interactive), `opencode serve` (API server)
+- **Instructions**: Reads `AGENTS.md` from project root automatically
+- **Tools**: 13 built-in tools (read, edit, write, grep, glob, bash, etc.)
+- **Config**: `opencode.json` in project root or `~/.config/opencode/`
+
+### Why This Is Low-Risk
+
+The harness abstraction was designed exactly for this use case. Adding a new built-in harness is a well-trodden path (Claude, Codex, Gemini all follow the same pattern). The main risk is getting the role injection mechanism right for OpenCode's specific CLI, which can be validated during implementation and falls back to the custom harness mechanism if needed.

--- a/codev/specs/178-support-opencode-as-an-alterna.md
+++ b/codev/specs/178-support-opencode-as-an-alterna.md
@@ -20,6 +20,7 @@ The harness system (`packages/codev/src/agent-farm/utils/harness.ts`) already pr
 - **Auto-detection**: `detectHarnessFromCommand()` matches command basenames against known CLI names
 - **Custom harness support**: Users can define arbitrary harnesses in `.codev/config.json` under the `harness` key with `roleArgs`, `roleEnv`, `roleScriptFragment`, `roleScriptEnv`
 - **Configuration hierarchy**: CLI overrides > config.json > defaults (all defaulting to `claude`)
+- **Doctor validation**: `codev doctor` checks a static `AI_DEPENDENCIES` array for known CLI tools (claude, codex, gemini) regardless of which shell is configured
 
 Users *can* configure OpenCode today via a custom harness, but they must know the exact config format and OpenCode's CLI flags. There's no auto-detection, no built-in harness, and no documentation.
 
@@ -27,10 +28,11 @@ Users *can* configure OpenCode today via a custom harness, but they must know th
 
 OpenCode works as a first-class agent shell alongside Claude, Codex, and Gemini:
 
-1. Setting `"builder": "opencode"` in `.codev/config.json` just works -- the harness auto-detects and injects roles correctly
-2. `codev doctor` validates the OpenCode installation
-3. Documentation covers configuration and known differences
-4. The existing AGENTS.md file (already present in the repo) provides instructions to OpenCode automatically
+1. Setting `"shell": { "builder": "opencode run" }` in `.codev/config.json` auto-detects the `opencode` harness and injects roles correctly
+2. `codev doctor` validates the OpenCode installation (binary existence check)
+3. Documentation covers configuration, required `opencode.json` permissions setup, and known differences
+4. The existing AGENTS.md file (already present in the repo) provides project instructions to OpenCode automatically
+5. The builder role (`.builder-role.md`) is injected via `opencode.json`'s `instructions` field
 
 ## Stakeholders
 - **Primary Users**: Codev users who prefer OpenCode or alternative LLM providers
@@ -40,21 +42,26 @@ OpenCode works as a first-class agent shell alongside Claude, Codex, and Gemini:
 
 ## Success Criteria
 - [ ] `opencode` auto-detected by `detectHarnessFromCommand()` when command basename contains "opencode"
-- [ ] Built-in `OPENCODE_HARNESS` provider correctly injects role content via OpenCode's CLI mechanism
-- [ ] `codev doctor` checks for `opencode` binary when configured as architect or builder shell
-- [ ] Configuration example documented showing how to switch to OpenCode
-- [ ] Known capability differences documented (what works, what doesn't)
+- [ ] Built-in `OPENCODE_HARNESS` provider registers in `BUILTIN_HARNESSES`
+- [ ] Role injection works via `opencode.json` `instructions` field referencing `.builder-role.md`
+- [ ] `codev doctor` checks for `opencode` binary (added to static `AI_DEPENDENCIES` list, binary existence only -- no auth check since OpenCode is multi-provider)
+- [ ] Configuration example in documentation uses correct `shell.builder` format: `{ "shell": { "builder": "opencode run" } }`
+- [ ] Documentation covers required `opencode.json` tool permissions for unattended builder execution
+- [ ] Known capability differences documented (what works, what doesn't, permission model)
 - [ ] All existing tests pass (no regressions)
-- [ ] Unit tests cover the new harness provider and auto-detection
+- [ ] Unit tests cover: new harness provider, auto-detection, and generated startup script shape
 
 ## Constraints
 
 ### Technical Constraints
 - OpenCode uses `AGENTS.md` for project-level instructions (the repo already has one, identical to `CLAUDE.md`)
-- OpenCode's non-interactive mode is `opencode run "prompt"` -- the startup script must use this subcommand
-- OpenCode does not have a direct `--append-system-prompt` equivalent for runtime injection; it reads `AGENTS.md` from the project root automatically
-- The harness must work within the existing `HarnessProvider` interface (no interface changes)
+- OpenCode's non-interactive mode is `opencode run "prompt"` -- users must include `run` in their `shell.builder` config value
+- **OpenCode has no `--system-prompt` or `--append-system-prompt` CLI flag** -- role injection must use `opencode.json`'s `instructions` field (confirmed via OpenCode docs)
+- **OpenCode has no `--dangerously-skip-permissions` equivalent** -- unattended execution requires pre-configuring tool permissions in `opencode.json`
 - The existing auto-restart loop in `.builder-start.sh` must work with OpenCode's CLI
+
+### Interface Impact
+- The `HarnessProvider` interface will be extended with one optional method: `getWorktreeFiles?()` -- this returns files to write in the worktree before launch (e.g., `opencode.json` with `instructions: [".builder-role.md"]`). This is backward-compatible: existing harnesses don't implement it, and `spawn-worktree.ts` calls it conditionally.
 
 ### Business Constraints
 - This is a community-requested feature (#178)
@@ -62,81 +69,97 @@ OpenCode works as a first-class agent shell alongside Claude, Codex, and Gemini:
 
 ## Assumptions
 - OpenCode is installed and available on the user's PATH when configured
-- OpenCode supports `opencode run "prompt"` for non-interactive execution (confirmed in research)
+- OpenCode supports `opencode run "prompt"` for non-interactive execution (confirmed)
 - OpenCode reads `AGENTS.md` from the working directory automatically (confirmed)
-- The `.builder-role.md` file written by spawn-worktree can be injected via an environment variable or CLI flag that OpenCode supports for additional system instructions
+- OpenCode's `opencode.json` `instructions` field accepts file paths and merges them with AGENTS.md content (confirmed)
+- Users configure `"builder": "opencode run"` (including the `run` subcommand) in `.codev/config.json`
 
-## Solution Approaches
+## Solution Design
 
-### Approach 1: Built-in Harness with AGENTS.md Reliance (Recommended)
+### Role Injection: `opencode.json` Instructions Field
 
-Add `OPENCODE_HARNESS` as a built-in provider. OpenCode automatically reads `AGENTS.md` from the project root for its instructions (the repo already maintains `AGENTS.md` identical to `CLAUDE.md`). The harness injects the builder role via a mechanism that appends it to OpenCode's system context.
+**Problem**: OpenCode has no CLI flag or env var for injecting additional system prompt content. Unlike Claude (`--append-system-prompt`), Codex (`-c model_instructions_file=`), or Gemini (`GEMINI_SYSTEM_MD` env var), OpenCode reads instructions only from AGENTS.md files and the `instructions` field in `opencode.json`.
 
-**Role injection strategy**: Write the role content to `.builder-role.md` (already done by spawn-worktree) and set an environment variable like `OPENCODE_SYSTEM_PROMPT_FILE` pointing to it, or use a CLI flag if available. If OpenCode supports `--system-prompt` or similar, use that. If not, append the role content to a local `AGENTS.md` copy in the worktree.
+**Solution**: Extend the `HarnessProvider` interface with one optional method:
 
-**Startup command**: The `.builder-start.sh` script needs to use `opencode run "$(cat .builder-prompt.txt)"` instead of `opencode "$(cat .builder-prompt.txt)"`, since OpenCode requires the `run` subcommand for non-interactive execution.
+```typescript
+/** Optional: files to write in the worktree before launching the agent */
+getWorktreeFiles?(roleContent: string, roleFilePath: string): Array<{
+  relativePath: string;
+  content: string;
+}>;
+```
 
-**Pros**:
-- Minimal code changes (add harness + auto-detection, ~30 lines)
-- Follows established patterns for claude/codex/gemini
-- OpenCode gets project context automatically via AGENTS.md
-- No changes to spawn-worktree or session management
+The `OPENCODE_HARNESS` implements this method to write a minimal `opencode.json` in the worktree:
 
-**Cons**:
-- Role injection mechanism depends on OpenCode's specific CLI flags (needs verification)
-- If OpenCode changes its CLI interface, the harness breaks
+```json
+{
+  "instructions": [".builder-role.md"]
+}
+```
 
-**Estimated Complexity**: Low
-**Risk Level**: Low
+This causes OpenCode to load:
+1. Project instructions from `AGENTS.md` (automatic, always loaded)
+2. Builder role from `.builder-role.md` (via `opencode.json` instructions field)
 
-### Approach 2: Custom Harness Documentation Only
+The harness's `buildRoleInjection` and `buildScriptRoleInjection` return empty args/env/fragment since role injection happens via file, not CLI flags.
 
-Don't add a built-in harness. Instead, document how to configure OpenCode via the existing custom harness mechanism in `.codev/config.json`.
+`spawn-worktree.ts` gains a small change: after writing `.builder-role.md`, check if the harness implements `getWorktreeFiles()` and write any returned files. This is ~5 lines of code.
 
-**Pros**:
-- Zero code changes
-- Users have full control over the configuration
+**Why this approach**:
+- Backward-compatible: existing harnesses don't implement `getWorktreeFiles()` and are unaffected
+- Clean abstraction: spawn-worktree doesn't need to know about OpenCode specifically
+- Follows OpenCode's documented configuration pattern
+- The generated `opencode.json` merges with any user-level OpenCode config (instructions arrays are concatenated and deduplicated)
 
-**Cons**:
-- Higher friction for users (must know exact config format)
-- No auto-detection
-- No `codev doctor` validation
-- Doesn't signal first-class support
+### Configuration
 
-**Estimated Complexity**: Very Low
-**Risk Level**: Very Low
+Users configure OpenCode in `.codev/config.json`:
 
-### Approach 3: Startup Script Adaptation
+```json
+{
+  "shell": {
+    "builder": "opencode run"
+  }
+}
+```
 
-In addition to the built-in harness (Approach 1), modify the startup script generation in `spawn-worktree.ts` to detect OpenCode and use `opencode run` instead of passing the prompt as a bare argument.
+Key details:
+- The `run` subcommand MUST be included because `opencode` without `run` launches the TUI, which hangs in a PTY builder session
+- Auto-detection extracts `opencode` from the command basename and resolves to the `OPENCODE_HARNESS`
+- The harness returns empty `fragment` and `env`, so the startup script becomes: `opencode run "$(cat '.builder-prompt.txt')"`
 
-**Pros**:
-- Handles the `run` subcommand requirement cleanly
-- More robust than relying on users to include `run` in their config command
+### Doctor Validation
 
-**Cons**:
-- Adds shell-specific logic to spawn-worktree (currently shell-agnostic)
-- Could be handled by having users set `"builder": "opencode run"` in config
+Add `opencode` to the static `AI_DEPENDENCIES` array in `doctor.ts`, following the same pattern as `gemini` and `codex`:
+- Check binary existence only (`which opencode`)
+- No auth/provider verification (OpenCode supports 75+ providers; auth depends on user's chosen provider)
+- No config validation (user's OpenCode config is their responsibility)
 
-**Estimated Complexity**: Medium
-**Risk Level**: Medium
+This is the simple, consistent approach that matches how Gemini and Codex are currently handled.
 
-## Recommended Approach
+### Unattended Builder Execution
 
-**Approach 1** (Built-in Harness) is recommended. The startup script issue (Approach 3) can be handled by documenting that users should configure `"builder": "opencode run"` to include the `run` subcommand, keeping spawn-worktree shell-agnostic.
+**Requirement**: Documentation must cover how to configure OpenCode for unattended builder execution.
+
+OpenCode's permission model uses per-tool `allow`/`deny`/`ask` settings in `opencode.json`. Without pre-configuration, OpenCode will prompt for permission on tool use, hanging the builder indefinitely.
+
+Required documentation content:
+- Example `opencode.json` with all tools set to `allow` for builder use
+- Warning about security implications (similar to Claude's `--dangerously-skip-permissions`)
+- Note that the generated `opencode.json` in the worktree only adds `instructions` -- users must configure permissions separately (in their global `~/.config/opencode/opencode.json` or project-level config)
 
 ## Open Questions
 
 ### Critical (Blocks Progress)
-- [x] Does OpenCode support a CLI flag or env var for injecting additional system prompt content beyond AGENTS.md? **Research indicates**: OpenCode reads AGENTS.md automatically from the project root. For additional runtime instructions, we need to verify if there's a `--system-prompt` flag or if appending to the worktree's AGENTS.md is the cleanest approach.
+- [x] Does OpenCode support a CLI flag or env var for system prompt injection? **RESOLVED: No.** OpenCode has no `--system-prompt` flag or equivalent env var. Role injection uses `opencode.json`'s `instructions` field referencing `.builder-role.md`.
 
 ### Important (Affects Design)
-- [ ] Should the harness append role content to the worktree's AGENTS.md rather than using a separate mechanism? This would be the most natural integration since OpenCode already reads AGENTS.md.
-- [ ] Does `opencode run` support reading the prompt from stdin or only as a CLI argument? (Affects how long prompts are passed)
+- [x] Should the harness append role content to the worktree's AGENTS.md rather than using a separate mechanism? **RESOLVED: No.** Use `opencode.json` `instructions` field instead. This avoids modifying AGENTS.md (which is a tracked file) and uses OpenCode's documented configuration mechanism.
+- [ ] Does `opencode run` support reading the prompt from stdin or only as a CLI argument? This matters for very long prompts that might hit shell argument length limits. Not blocking -- the current approach (command-line arg) works for typical prompt sizes.
 
 ### Nice-to-Know (Optimization)
-- [ ] What is the exact set of OpenCode tools available, and do any conflict with porch signal expectations?
-- [ ] Does OpenCode's `acp` (Agent Client Protocol) mode offer better integration than the PTY-based approach?
+- [ ] Does OpenCode's `acp` (Agent Client Protocol) mode offer better integration than the PTY-based approach? (Future enhancement, not in scope)
 
 ## Performance Requirements
 - **Startup Time**: OpenCode session should start within the same timeframe as Claude Code sessions (< 10s)
@@ -145,33 +168,37 @@ In addition to the built-in harness (Approach 1), modify the startup script gene
 ## Security Considerations
 - OpenCode may connect to third-party LLM providers (user's choice) -- this is expected and acceptable
 - API keys for providers are managed by the user's OpenCode configuration, not by Codev
-- The `--dangerously-skip-permissions` pattern used with Claude Code has no OpenCode equivalent; OpenCode's permission model is different (configurable per-tool allow/deny/ask)
+- **Unattended execution**: OpenCode has no `--dangerously-skip-permissions` flag. Users MUST pre-configure tool permissions in `opencode.json` to avoid interactive prompts that would hang builder sessions. Documentation must cover this as a setup requirement.
+- The generated `opencode.json` in the worktree contains only `instructions` (no permission changes) -- users are responsible for their own permission configuration
 
 ## Test Scenarios
 
 ### Functional Tests
-1. `detectHarnessFromCommand('opencode run')` returns `'opencode'`
+1. `detectHarnessFromCommand('opencode run')` returns `'opencode'` (first token `opencode`, basename `opencode`)
 2. `detectHarnessFromCommand('/usr/local/bin/opencode')` returns `'opencode'`
 3. `resolveHarness('opencode')` returns the `OPENCODE_HARNESS` provider
-4. `OPENCODE_HARNESS.buildRoleInjection()` returns correct args/env
-5. `OPENCODE_HARNESS.buildScriptRoleInjection()` returns correct fragment/env
-6. Configuring `"builder": "opencode run"` in config.json resolves correctly via `getResolvedCommands()`
+4. `OPENCODE_HARNESS.buildRoleInjection()` returns `{ args: [], env: {} }`
+5. `OPENCODE_HARNESS.buildScriptRoleInjection()` returns `{ fragment: '', env: {} }`
+6. `OPENCODE_HARNESS.getWorktreeFiles()` returns `[{ relativePath: 'opencode.json', content: '{"instructions":[".builder-role.md"]}' }]`
+7. Configuring `{ "shell": { "builder": "opencode run" } }` in config.json resolves correctly via `getResolvedCommands()`
+8. Generated `.builder-start.sh` with opencode produces: `opencode run "$(cat '...')"` (no harness fragment between command and prompt)
 
 ### Non-Functional Tests
 1. Existing Claude/Codex/Gemini harness tests continue to pass (no regressions)
 2. `resolveHarness()` with no args still defaults to claude (backward compatibility)
+3. Harnesses without `getWorktreeFiles()` method continue to work (optional method, no errors)
 
 ## Dependencies
 - **External**: OpenCode CLI must be installed by the user
-- **Internal**: Depends on the existing harness system (`harness.ts`, `config.ts`)
+- **Internal**: Depends on the existing harness system (`harness.ts`, `config.ts`, `spawn-worktree.ts`)
 - **Libraries**: No new dependencies required
 
 ## Risks and Mitigation
 | Risk | Probability | Impact | Mitigation Strategy |
 |------|------------|--------|-------------------|
-| OpenCode CLI interface changes break harness | Low | Medium | Pin to known-working behavior; custom harness as fallback |
-| Role injection doesn't work as expected | Medium | High | Verify during implementation; fall back to AGENTS.md append approach |
-| OpenCode lacks features porch expects (signal handling) | Low | Low | Document limitations; porch signals are text-based and shell-agnostic |
+| OpenCode CLI interface changes break harness | Low | Medium | Pin to known-working behavior; custom harness config as fallback |
+| `opencode.json` instructions merge conflicts with user config | Low | Medium | Generated config only contains `instructions` field; OpenCode concatenates instruction arrays |
+| Users forget to configure tool permissions, builders hang | High | Medium | Clear documentation with example `opencode.json`; warn during `codev doctor` if opencode is configured but no `opencode.json` exists |
 | Users expect full feature parity with Claude Code | Medium | Low | Document known differences clearly |
 
 ## Notes
@@ -181,10 +208,25 @@ In addition to the built-in harness (Approach 1), modify the startup script gene
 - **Stars**: 140,000+ on GitHub
 - **Providers**: 75+ LLM providers including OpenAI, Anthropic, Google, Ollama, LM Studio
 - **CLI modes**: `opencode` (TUI), `opencode run "prompt"` (non-interactive), `opencode serve` (API server)
-- **Instructions**: Reads `AGENTS.md` from project root automatically
+- **Instructions**: Reads `AGENTS.md` from project root automatically; also reads `instructions` from `opencode.json`
 - **Tools**: 13 built-in tools (read, edit, write, grep, glob, bash, etc.)
 - **Config**: `opencode.json` in project root or `~/.config/opencode/`
+- **Permissions**: Per-tool `allow`/`deny`/`ask` in `opencode.json` -- no global skip-permissions flag
 
 ### Why This Is Low-Risk
 
-The harness abstraction was designed exactly for this use case. Adding a new built-in harness is a well-trodden path (Claude, Codex, Gemini all follow the same pattern). The main risk is getting the role injection mechanism right for OpenCode's specific CLI, which can be validated during implementation and falls back to the custom harness mechanism if needed.
+The harness abstraction was designed for this kind of extension. The main complexity is that OpenCode uses file-based config (`opencode.json`) rather than CLI flags for instruction loading, which requires a small backward-compatible interface extension (`getWorktreeFiles?()`). The custom harness mechanism always exists as a fallback if the built-in harness doesn't work for a user's specific setup.
+
+## Expert Consultation
+
+### Consultation 1 (2026-04-11)
+**Models Consulted**: Gemini, Codex, Claude
+
+**Key Feedback Addressed**:
+- **Role injection mechanism** (all three): Resolved. OpenCode has no `--system-prompt` flag. Solution uses `opencode.json` `instructions` field via new optional `getWorktreeFiles()` method on `HarnessProvider`.
+- **Config contradiction** (Gemini, Codex): Fixed. Config requires `"builder": "opencode run"` (with `run` subcommand). Updated all examples and desired state.
+- **HarnessProvider interface** (Gemini, Claude): Acknowledged. Dropped the "no interface changes" constraint. Added one optional backward-compatible method (`getWorktreeFiles?()`) to support file-based config injection.
+- **Doctor validation** (all three): Specified. Add to static `AI_DEPENDENCIES` list, binary existence check only (no auth verification for multi-provider tool).
+- **Unattended execution** (Claude, Codex): Elevated from informational to requirement. Documentation must cover `opencode.json` tool permission configuration.
+- **Config format** (Codex): Fixed all examples to use correct nested `shell.builder` format.
+- **Test coverage** (Codex): Added test scenario for generated startup script shape and `getWorktreeFiles()` behavior.

--- a/codev/specs/178-support-opencode-as-an-alterna.md
+++ b/codev/specs/178-support-opencode-as-an-alterna.md
@@ -157,6 +157,7 @@ Required documentation content:
 ### Important (Affects Design)
 - [x] Should the harness append role content to the worktree's AGENTS.md rather than using a separate mechanism? **RESOLVED: No.** Use `opencode.json` `instructions` field instead. This avoids modifying AGENTS.md (which is a tracked file) and uses OpenCode's documented configuration mechanism.
 - [ ] Does `opencode run` support reading the prompt from stdin or only as a CLI argument? This matters for very long prompts that might hit shell argument length limits. Not blocking -- the current approach (command-line arg) works for typical prompt sizes.
+<!-- REVIEW(@architect): Not much of an issue. We can always put the prompt in a file and then tell opencode to read from the file. -->
 
 ### Nice-to-Know (Optimization)
 - [ ] Does OpenCode's `acp` (Agent Client Protocol) mode offer better integration than the PTY-based approach? (Future enhancement, not in scope)

--- a/packages/codev/src/agent-farm/__tests__/harness.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/harness.test.ts
@@ -3,6 +3,7 @@ import {
   CLAUDE_HARNESS,
   CODEX_HARNESS,
   GEMINI_HARNESS,
+  OPENCODE_HARNESS,
   buildCustomHarnessProvider,
   validateCustomHarnessConfig,
   resolveHarness,
@@ -59,6 +60,41 @@ describe('harness', () => {
       const result = GEMINI_HARNESS.buildScriptRoleInjection(ROLE_CONTENT, ROLE_FILE);
       expect(result.fragment).toBe('');
       expect(result.env).toEqual({ GEMINI_SYSTEM_MD: ROLE_FILE });
+    });
+  });
+
+  describe('OPENCODE_HARNESS', () => {
+    it('buildRoleInjection throws (architect use unsupported)', () => {
+      expect(() => OPENCODE_HARNESS.buildRoleInjection(ROLE_CONTENT, ROLE_FILE))
+        .toThrow('OpenCode is only supported as a builder shell');
+    });
+
+    it('buildScriptRoleInjection returns empty fragment and env', () => {
+      const result = OPENCODE_HARNESS.buildScriptRoleInjection(ROLE_CONTENT, ROLE_FILE);
+      expect(result.fragment).toBe('');
+      expect(result.env).toEqual({});
+    });
+
+    it('getWorktreeFiles returns opencode.json with instructions', () => {
+      const files = OPENCODE_HARNESS.getWorktreeFiles!(ROLE_CONTENT, ROLE_FILE);
+      expect(files).toHaveLength(1);
+      expect(files[0].relativePath).toBe('opencode.json');
+      const parsed = JSON.parse(files[0].content);
+      expect(parsed).toEqual({ instructions: ['.builder-role.md'] });
+    });
+  });
+
+  describe('getWorktreeFiles backward compatibility', () => {
+    it('CLAUDE_HARNESS does not have getWorktreeFiles', () => {
+      expect(CLAUDE_HARNESS.getWorktreeFiles).toBeUndefined();
+    });
+
+    it('CODEX_HARNESS does not have getWorktreeFiles', () => {
+      expect(CODEX_HARNESS.getWorktreeFiles).toBeUndefined();
+    });
+
+    it('GEMINI_HARNESS does not have getWorktreeFiles', () => {
+      expect(GEMINI_HARNESS.getWorktreeFiles).toBeUndefined();
     });
   });
 
@@ -216,6 +252,11 @@ describe('harness', () => {
       expect(provider).toBe(GEMINI_HARNESS);
     });
 
+    it('resolves built-in opencode', () => {
+      const provider = resolveHarness('opencode');
+      expect(provider).toBe(OPENCODE_HARNESS);
+    });
+
     it('resolves custom harness from config', () => {
       const customHarnesses: Record<string, CustomHarnessConfig> = {
         'my-agent': {
@@ -257,6 +298,11 @@ describe('harness', () => {
       expect(provider).toBe(CLAUDE_HARNESS);
     });
 
+    it('auto-detects opencode from command', () => {
+      const provider = resolveHarness(undefined, undefined, 'opencode run');
+      expect(provider).toBe(OPENCODE_HARNESS);
+    });
+
     it('explicit harnessName takes priority over auto-detection', () => {
       const provider = resolveHarness('gemini', undefined, 'codex');
       expect(provider).toBe(GEMINI_HARNESS);
@@ -283,6 +329,22 @@ describe('harness', () => {
 
     it('detects gemini', () => {
       expect(detectHarnessFromCommand('gemini')).toBe('gemini');
+    });
+
+    it('detects opencode', () => {
+      expect(detectHarnessFromCommand('opencode')).toBe('opencode');
+    });
+
+    it('detects opencode with run subcommand', () => {
+      expect(detectHarnessFromCommand('opencode run')).toBe('opencode');
+    });
+
+    it('detects opencode from full path', () => {
+      expect(detectHarnessFromCommand('/usr/local/bin/opencode')).toBe('opencode');
+    });
+
+    it('detects opencode with model flags', () => {
+      expect(detectHarnessFromCommand('opencode run --model anthropic/claude-sonnet')).toBe('opencode');
     });
 
     it('detects from full path', () => {

--- a/packages/codev/src/agent-farm/__tests__/spawn-worktree.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/spawn-worktree.test.ts
@@ -32,6 +32,14 @@ vi.mock('node:fs', async (importOriginal) => {
   };
 });
 
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execSync: vi.fn(),
+  };
+});
+
 vi.mock('../utils/logger.js', () => ({
   logger: {
     info: vi.fn(),
@@ -213,17 +221,17 @@ describe('spawn-worktree', () => {
       expect(content.instructions).toContain('.builder-role.md');
     });
 
-    it('merges with existing opencode.json preserving permissions', async () => {
+    it('merges with existing opencode.json preserving permission config', async () => {
       getBuilderHarnessMock.mockReturnValueOnce(OPENCODE_HARNESS);
       const { existsSync, writeFileSync } = await import('node:fs');
       const { readFileSync } = await import('node:fs');
-      // Mock: opencode.json already exists with permissions
+      // Mock: opencode.json already exists with permission (singular, per OpenCode docs)
       vi.mocked(existsSync).mockImplementation((p) => {
         if (typeof p === 'string' && p.endsWith('opencode.json')) return true;
         return false;
       });
       vi.mocked(readFileSync).mockReturnValueOnce(JSON.stringify({
-        permissions: { edit: 'allow', bash: 'allow' },
+        permission: { edit: 'allow', bash: 'allow' },
         instructions: ['existing.md'],
       }));
       const role = { content: 'You are a builder', source: 'codev' };
@@ -234,9 +242,31 @@ describe('spawn-worktree', () => {
       );
       expect(opencodeCall).toBeDefined();
       const merged = JSON.parse(opencodeCall![1] as string);
-      expect(merged.permissions).toEqual({ edit: 'allow', bash: 'allow' });
+      expect(merged.permission).toEqual({ edit: 'allow', bash: 'allow' });
       expect(merged.instructions).toContain('existing.md');
       expect(merged.instructions).toContain('.builder-role.md');
+    });
+
+    it('warns and skips when existing opencode.json is JSONC (not valid JSON)', async () => {
+      getBuilderHarnessMock.mockReturnValueOnce(OPENCODE_HARNESS);
+      const { existsSync, writeFileSync } = await import('node:fs');
+      const { readFileSync } = await import('node:fs');
+      vi.mocked(existsSync).mockImplementation((p) => {
+        if (typeof p === 'string' && p.endsWith('opencode.json')) return true;
+        return false;
+      });
+      // JSONC with comments — JSON.parse will fail
+      vi.mocked(readFileSync).mockReturnValueOnce('{ // this is a comment\n  "permission": { "bash": "allow" }\n}');
+      const role = { content: 'You are a builder', source: 'codev' };
+      buildWorktreeLaunchScript('/tmp/worktree', 'opencode run', role);
+      const { logger } = await import('../utils/logger.js');
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Cannot merge opencode.json'));
+      // Should NOT have written opencode.json (skipped to preserve user config)
+      const writeCalls = vi.mocked(writeFileSync).mock.calls;
+      const opencodeCall = writeCalls.find(
+        call => typeof call[0] === 'string' && call[0].endsWith('opencode.json'),
+      );
+      expect(opencodeCall).toBeUndefined();
     });
 
     it('does not write worktree files for claude harness', async () => {

--- a/packages/codev/src/agent-farm/__tests__/spawn-worktree.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/spawn-worktree.test.ts
@@ -23,6 +23,7 @@ vi.mock('node:fs', async (importOriginal) => {
   return {
     ...actual,
     existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(() => '{}'),
     writeFileSync: vi.fn(),
     chmodSync: vi.fn(),
     symlinkSync: vi.fn(),
@@ -51,9 +52,10 @@ vi.mock('../../lib/forge.js', () => ({
 }));
 
 // Mock the harness resolution to return claude harness by default
-import { CLAUDE_HARNESS } from '../utils/harness.js';
+import { CLAUDE_HARNESS, OPENCODE_HARNESS } from '../utils/harness.js';
+const getBuilderHarnessMock = vi.fn(() => CLAUDE_HARNESS);
 vi.mock('../utils/config.js', () => ({
-  getBuilderHarness: () => CLAUDE_HARNESS,
+  getBuilderHarness: (...args: unknown[]) => getBuilderHarnessMock(...args),
 }));
 
 describe('spawn-worktree', () => {
@@ -179,6 +181,74 @@ describe('spawn-worktree', () => {
       expect(script).toContain('while true');
       expect(script).toContain('Agent exited');
       expect(script).toContain('Restarting in 2 seconds');
+    });
+  });
+
+  // =========================================================================
+  // buildWorktreeLaunchScript — OpenCode harness (Spec 178)
+  // =========================================================================
+
+  describe('buildWorktreeLaunchScript (opencode harness)', () => {
+    it('generates script with empty fragment for opencode', () => {
+      getBuilderHarnessMock.mockReturnValueOnce(OPENCODE_HARNESS);
+      const role = { content: 'You are a builder', source: 'codev' };
+      const script = buildWorktreeLaunchScript('/tmp/worktree', 'opencode run', role);
+      expect(script).toContain('opencode run');
+      expect(script).not.toContain('--append-system-prompt');
+      expect(script).toContain('while true');
+    });
+
+    it('writes opencode.json via getWorktreeFiles', async () => {
+      getBuilderHarnessMock.mockReturnValueOnce(OPENCODE_HARNESS);
+      const { writeFileSync } = await import('node:fs');
+      const role = { content: 'You are a builder', source: 'codev' };
+      buildWorktreeLaunchScript('/tmp/worktree', 'opencode run', role);
+      // Should write .builder-role.md and opencode.json
+      const writeCalls = vi.mocked(writeFileSync).mock.calls;
+      const opencodeCall = writeCalls.find(
+        call => typeof call[0] === 'string' && call[0].endsWith('opencode.json'),
+      );
+      expect(opencodeCall).toBeDefined();
+      const content = JSON.parse(opencodeCall![1] as string);
+      expect(content.instructions).toContain('.builder-role.md');
+    });
+
+    it('merges with existing opencode.json preserving permissions', async () => {
+      getBuilderHarnessMock.mockReturnValueOnce(OPENCODE_HARNESS);
+      const { existsSync, writeFileSync } = await import('node:fs');
+      const { readFileSync } = await import('node:fs');
+      // Mock: opencode.json already exists with permissions
+      vi.mocked(existsSync).mockImplementation((p) => {
+        if (typeof p === 'string' && p.endsWith('opencode.json')) return true;
+        return false;
+      });
+      vi.mocked(readFileSync).mockReturnValueOnce(JSON.stringify({
+        permissions: { edit: 'allow', bash: 'allow' },
+        instructions: ['existing.md'],
+      }));
+      const role = { content: 'You are a builder', source: 'codev' };
+      buildWorktreeLaunchScript('/tmp/worktree', 'opencode run', role);
+      const writeCalls = vi.mocked(writeFileSync).mock.calls;
+      const opencodeCall = writeCalls.find(
+        call => typeof call[0] === 'string' && call[0].endsWith('opencode.json'),
+      );
+      expect(opencodeCall).toBeDefined();
+      const merged = JSON.parse(opencodeCall![1] as string);
+      expect(merged.permissions).toEqual({ edit: 'allow', bash: 'allow' });
+      expect(merged.instructions).toContain('existing.md');
+      expect(merged.instructions).toContain('.builder-role.md');
+    });
+
+    it('does not write worktree files for claude harness', async () => {
+      getBuilderHarnessMock.mockReturnValueOnce(CLAUDE_HARNESS);
+      const { writeFileSync } = await import('node:fs');
+      const role = { content: 'You are a builder', source: 'codev' };
+      buildWorktreeLaunchScript('/tmp/worktree', 'claude', role);
+      const writeCalls = vi.mocked(writeFileSync).mock.calls;
+      const opencodeCall = writeCalls.find(
+        call => typeof call[0] === 'string' && call[0].endsWith('opencode.json'),
+      );
+      expect(opencodeCall).toBeUndefined();
     });
   });
 

--- a/packages/codev/src/agent-farm/commands/spawn-worktree.ts
+++ b/packages/codev/src/agent-farm/commands/spawn-worktree.ts
@@ -8,6 +8,7 @@
  */
 
 import { resolve } from 'node:path';
+import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync, chmodSync, symlinkSync, readdirSync, mkdirSync } from 'node:fs';
 import type { Config, ProtocolDefinition } from '../types.js';
 import { logger, fatal } from '../utils/logger.js';
@@ -567,7 +568,9 @@ export async function createPtySession(
 /**
  * Write harness-provided files to the worktree, merging with existing JSON files.
  * For JSON files: reads existing file, shallow-merges properties, and deduplicates
- * the 'instructions' array. For non-JSON files: writes directly.
+ * the 'instructions' array. If existing JSON can't be parsed (e.g., JSONC with
+ * comments), warns and skips to avoid destroying user config.
+ * After writing, marks files with git skip-worktree to prevent accidental commits.
  */
 function writeWorktreeFiles(
   files: Array<{ relativePath: string; content: string }>,
@@ -585,10 +588,22 @@ function writeWorktreeFiles(
         }
         writeFileSync(targetPath, JSON.stringify(merged, null, 2) + '\n');
       } catch {
-        writeFileSync(targetPath, file.content);
+        // Existing file is not valid JSON (likely JSONC with comments/trailing commas).
+        // Do NOT overwrite — that would destroy user config. Warn and skip.
+        logger.warn(`Cannot merge ${file.relativePath}: existing file is not valid JSON. Skipping to preserve user config.`);
+        continue;
       }
     } else {
       writeFileSync(targetPath, file.content);
+    }
+    // Prevent generated files from being accidentally committed back to the repo
+    try {
+      execSync(`git update-index --skip-worktree "${file.relativePath}"`, {
+        cwd: worktreePath,
+        stdio: 'pipe',
+      });
+    } catch {
+      // Non-fatal: file may not be tracked by git yet (new file in worktree)
     }
   }
 }

--- a/packages/codev/src/agent-farm/commands/spawn-worktree.ts
+++ b/packages/codev/src/agent-farm/commands/spawn-worktree.ts
@@ -8,7 +8,7 @@
  */
 
 import { resolve } from 'node:path';
-import { existsSync, writeFileSync, chmodSync, symlinkSync, readdirSync, mkdirSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, chmodSync, symlinkSync, readdirSync, mkdirSync } from 'node:fs';
 import type { Config, ProtocolDefinition } from '../types.js';
 import { logger, fatal } from '../utils/logger.js';
 import { getBuilderHarness } from '../utils/config.js';
@@ -565,6 +565,35 @@ export async function createPtySession(
 }
 
 /**
+ * Write harness-provided files to the worktree, merging with existing JSON files.
+ * For JSON files: reads existing file, shallow-merges properties, and deduplicates
+ * the 'instructions' array. For non-JSON files: writes directly.
+ */
+function writeWorktreeFiles(
+  files: Array<{ relativePath: string; content: string }>,
+  worktreePath: string,
+): void {
+  for (const file of files) {
+    const targetPath = resolve(worktreePath, file.relativePath);
+    if (file.relativePath.endsWith('.json') && existsSync(targetPath)) {
+      try {
+        const existing = JSON.parse(readFileSync(targetPath, 'utf-8'));
+        const incoming = JSON.parse(file.content);
+        const merged = { ...existing, ...incoming };
+        if (Array.isArray(existing.instructions) && Array.isArray(incoming.instructions)) {
+          merged.instructions = [...new Set([...existing.instructions, ...incoming.instructions])];
+        }
+        writeFileSync(targetPath, JSON.stringify(merged, null, 2) + '\n');
+      } catch {
+        writeFileSync(targetPath, file.content);
+      }
+    } else {
+      writeFileSync(targetPath, file.content);
+    }
+  }
+}
+
+/**
  * Start a terminal session for a builder
  */
 export async function startBuilderSession(
@@ -601,6 +630,11 @@ export async function startBuilderSession(
       .map(([k, v]) => `export ${k}='${shellEscapeSingleQuote(v)}'`)
       .join('\n');
     const envBlock = envExports ? `${envExports}\n` : '';
+
+    // Write any harness-specific worktree files (e.g., opencode.json for OpenCode)
+    if (harness.getWorktreeFiles) {
+      writeWorktreeFiles(harness.getWorktreeFiles(roleWithPort, roleFile), worktreePath);
+    }
 
     scriptContent = `#!/bin/bash
 cd "${worktreePath}"
@@ -682,6 +716,11 @@ export function buildWorktreeLaunchScript(
       .map(([k, v]) => `export ${k}='${shellEscapeSingleQuote(v)}'`)
       .join('\n');
     const envBlock = envExports ? `${envExports}\n` : '';
+
+    // Write any harness-specific worktree files (e.g., opencode.json for OpenCode)
+    if (harness.getWorktreeFiles) {
+      writeWorktreeFiles(harness.getWorktreeFiles(roleWithPort, roleFile), worktreePath);
+    }
 
     return `#!/bin/bash
 cd "${worktreePath}"

--- a/packages/codev/src/agent-farm/utils/harness.ts
+++ b/packages/codev/src/agent-farm/utils/harness.ts
@@ -35,6 +35,16 @@ export interface HarnessProvider {
     fragment: string;
     env: Record<string, string>;
   };
+
+  /**
+   * Optional: files to write in the worktree before launching the agent.
+   * Used by harnesses that rely on file-based configuration (e.g., OpenCode
+   * uses opencode.json's instructions field for role injection).
+   */
+  getWorktreeFiles?(roleContent: string, roleFilePath: string): Array<{
+    relativePath: string;
+    content: string;
+  }>;
 }
 
 /** Custom harness definition from .codev/config.json */
@@ -82,10 +92,27 @@ export const GEMINI_HARNESS: HarnessProvider = {
   }),
 };
 
+export const OPENCODE_HARNESS: HarnessProvider = {
+  buildRoleInjection: () => {
+    throw new Error(
+      'OpenCode is only supported as a builder shell, not as an architect shell. ' +
+      'OpenCode uses file-based role injection (opencode.json instructions field) ' +
+      'which requires an ephemeral worktree. Configure a different shell for ' +
+      'the architect (e.g., "claude --dangerously-skip-permissions").',
+    );
+  },
+  buildScriptRoleInjection: () => ({ fragment: '', env: {} }),
+  getWorktreeFiles: () => ([{
+    relativePath: 'opencode.json',
+    content: JSON.stringify({ instructions: ['.builder-role.md'] }, null, 2) + '\n',
+  }]),
+};
+
 const BUILTIN_HARNESSES: Record<string, HarnessProvider> = {
   claude: CLAUDE_HARNESS,
   codex: CODEX_HARNESS,
   gemini: GEMINI_HARNESS,
+  opencode: OPENCODE_HARNESS,
 };
 
 // =============================================================================
@@ -211,6 +238,7 @@ export function detectHarnessFromCommand(command: string): string | undefined {
   if (basename.includes('claude')) return 'claude';
   if (basename.includes('codex')) return 'codex';
   if (basename.includes('gemini')) return 'gemini';
+  if (basename.includes('opencode')) return 'opencode';
 
   return undefined;
 }

--- a/packages/codev/src/commands/doctor.ts
+++ b/packages/codev/src/commands/doctor.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
 import { query as claudeQuery } from '@anthropic-ai/claude-agent-sdk';
 import { executeForgeCommandSync, loadForgeConfig, validateForgeConfig, resolveAllConcepts, type ConceptResolution } from '../lib/forge.js';
+import { detectHarnessFromCommand } from '../agent-farm/utils/harness.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -170,6 +171,17 @@ const AI_DEPENDENCIES: Dependency[] = [
       linux: 'npm i -g @openai/codex',
     },
   },
+  {
+    name: 'OpenCode',
+    command: 'opencode',
+    versionArg: '--version',
+    versionExtract: () => 'working',
+    required: false,
+    installHint: {
+      macos: 'npm install -g opencode',
+      linux: 'npm install -g opencode',
+    },
+  },
 ];
 
 /**
@@ -240,6 +252,14 @@ const VERIFY_CONFIGS: Record<string, VerifyConfig> = {
     timeout: 10000,
     successCheck: (r) => r.status === 0,
     authHint: 'Run "codex login status" in this directory and confirm it works without codev first',
+  },
+  // OpenCode: multi-provider, so we just verify the CLI works (no auth check)
+  'OpenCode': {
+    command: 'opencode',
+    args: ['--version'],
+    timeout: 10000,
+    successCheck: (r) => r.status === 0,
+    authHint: 'Run "opencode --version" to verify installation',
   },
   // Claude is verified via Agent SDK — see verifyClaudeViaSDK() below
   'Gemini': {
@@ -568,6 +588,32 @@ export async function doctor(): Promise<number> {
     console.log('');
     console.log(chalk.red('  ✗') + ' No AI model operational! Check API keys and authentication.');
     errors++;
+  }
+
+  // Warn if OpenCode is configured as architect shell (unsupported)
+  try {
+    const { loadConfig } = await import('../lib/config.js');
+    const root = findWorkspaceRoot();
+    if (root) {
+      const config = loadConfig(root);
+      const architectCmd = (config as Record<string, unknown>)?.shell
+        ? ((config as Record<string, Record<string, string>>).shell?.architect ?? '')
+        : '';
+      if (architectCmd && detectHarnessFromCommand(architectCmd) === 'opencode') {
+        console.log('');
+        console.log(chalk.yellow('  ⚠') + ' OpenCode is configured as architect shell — this is unsupported.');
+        console.log(chalk.yellow('    ') + 'OpenCode uses file-based role injection that requires an ephemeral worktree.');
+        console.log(chalk.yellow('    ') + 'Use a different shell for the architect (e.g., "claude --dangerously-skip-permissions").');
+        warnings++;
+        warningDetails.push({
+          name: 'Shell config',
+          issue: 'OpenCode configured as architect shell (unsupported)',
+          recommendation: 'Set shell.architect to "claude --dangerously-skip-permissions" in .codev/config.json',
+        });
+      }
+    }
+  } catch {
+    // Config loading may fail in non-project contexts — skip warning
   }
 
   console.log('');

--- a/packages/codev/src/commands/doctor.ts
+++ b/packages/codev/src/commands/doctor.ts
@@ -178,8 +178,8 @@ const AI_DEPENDENCIES: Dependency[] = [
     versionExtract: () => 'working',
     required: false,
     installHint: {
-      macos: 'npm install -g opencode',
-      linux: 'npm install -g opencode',
+      macos: 'npm install -g opencode-ai',
+      linux: 'npm install -g opencode-ai',
     },
   },
 ];
@@ -595,11 +595,16 @@ export async function doctor(): Promise<number> {
     const { loadConfig } = await import('../lib/config.js');
     const root = findWorkspaceRoot();
     if (root) {
-      const config = loadConfig(root);
-      const architectCmd = (config as Record<string, unknown>)?.shell
-        ? ((config as Record<string, Record<string, string>>).shell?.architect ?? '')
-        : '';
-      if (architectCmd && detectHarnessFromCommand(architectCmd) === 'opencode') {
+      const config = loadConfig(root) as Record<string, unknown>;
+      const shell = config?.shell as Record<string, unknown> | undefined;
+      // Check explicit architectHarness or auto-detect from architect command
+      const architectHarness = shell?.architectHarness as string | undefined;
+      const architectCmd = Array.isArray(shell?.architect)
+        ? (shell.architect as string[]).join(' ')
+        : (shell?.architect as string ?? '');
+      const isOpencode = architectHarness === 'opencode' ||
+        (architectCmd && detectHarnessFromCommand(architectCmd) === 'opencode');
+      if (isOpencode) {
         console.log('');
         console.log(chalk.yellow('  ⚠') + ' OpenCode is configured as architect shell — this is unsupported.');
         console.log(chalk.yellow('    ') + 'OpenCode uses file-based role injection that requires an ephemeral worktree.');


### PR DESCRIPTION
## Summary

Add first-class OpenCode support as an alternative agent shell in Codev's agent farm. OpenCode supports 75+ LLM providers, giving users flexibility beyond Claude Code.

## Changes

- **Harness provider** (`harness.ts`): New `OPENCODE_HARNESS` built-in provider with `getWorktreeFiles()` for file-based role injection via `opencode.json`. `buildRoleInjection()` throws for architect use (builder-only). Auto-detection recognizes `opencode` basename. Optional `getWorktreeFiles?()` method added to `HarnessProvider` interface (backward-compatible).
- **Spawn integration** (`spawn-worktree.ts`): Both `startBuilderSession()` and `buildWorktreeLaunchScript()` call `getWorktreeFiles()` when available. JSON merge strategy preserves existing `opencode.json` config (e.g., permissions) while adding instructions.
- **Doctor validation** (`doctor.ts`): OpenCode added to `AI_DEPENDENCIES` and `VERIFY_CONFIGS`. Warns if OpenCode configured as architect shell.
- **Documentation** (`README.md`): New "Alternative Agent Shells" section with configuration examples, permission setup, and known differences.

## Testing

- 51 harness unit tests (12 new for OpenCode)
- 64 spawn-worktree unit tests (4 new for OpenCode merge/script behavior)
- All 2331 tests passing, 0 regressions
- 3-way consultation (Gemini, Codex, Claude) approved all 3 phases

## Spec

Link: codev/specs/178-support-opencode-as-an-alterna.md

## Review

Link: codev/reviews/178-support-opencode-as-an-alterna.md