### PR TITLE
[Bugfix #664] Read issue number from DB, not builder name

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -27,12 +27,13 @@ import {
 // Mocks
 // ============================================================================
 
-const { mockFetchPRList, mockFetchIssueList, mockFetchRecentlyClosed, mockFetchMergedPRs, mockLoadProtocol } = vi.hoisted(() => ({
+const { mockFetchPRList, mockFetchIssueList, mockFetchRecentlyClosed, mockFetchMergedPRs, mockLoadProtocol, mockDbPrepare } = vi.hoisted(() => ({
   mockFetchPRList: vi.fn(),
   mockFetchIssueList: vi.fn(),
   mockFetchRecentlyClosed: vi.fn(),
   mockFetchMergedPRs: vi.fn(),
   mockLoadProtocol: vi.fn(),
+  mockDbPrepare: vi.fn(),
 }));
 
 vi.mock('../../lib/github.js', async (importOriginal) => {
@@ -48,6 +49,10 @@ vi.mock('../../lib/github.js', async (importOriginal) => {
 
 vi.mock('../../commands/porch/protocol.js', () => ({
   loadProtocol: mockLoadProtocol,
+}));
+
+vi.mock('../db/index.js', () => ({
+  getDb: () => ({ prepare: mockDbPrepare }),
 }));
 
 // ============================================================================
@@ -112,6 +117,7 @@ describe('overview', () => {
     mockFetchIssueList.mockResolvedValue([]);
     mockFetchRecentlyClosed.mockResolvedValue([]);
     mockFetchMergedPRs.mockResolvedValue([]);
+    mockDbPrepare.mockReturnValue({ all: () => [] });
   });
 
   afterEach(() => {
@@ -1723,6 +1729,63 @@ describe('overview', () => {
 
       expect(data.recentlyClosed).toHaveLength(1);
       expect(data.recentlyClosed[0].prUrl).toBeUndefined();
+    });
+
+    it('enriches issueId from DB issue_number for unknown protocols (#664)', async () => {
+      // research-533 doesn't match any protocol regex → soft mode, issueId null
+      const worktreePath = createBuilderWorktree(tmpDir, 'research-533-context-window');
+
+      // Mock DB to return issue_number for this worktree
+      mockDbPrepare.mockReturnValue({
+        all: () => [{ worktree: worktreePath, issue_number: 533 }],
+      });
+
+      const cache = new OverviewCache();
+      const data = await cache.getOverview(tmpDir);
+
+      expect(data.builders).toHaveLength(1);
+      expect(data.builders[0].issueId).toBe('533');
+    });
+
+    it('DB issue_number overrides regex-parsed issueId (#664)', async () => {
+      // spir-42 matches the regex → issueId '42' from regex
+      // DB also has issue_number 42 → should still be '42'
+      const worktreePath = createBuilderWorktree(tmpDir, 'spir-42-feature', [
+        "id: '0042'",
+        'title: feature',
+        'protocol: spir',
+        'phase: implement',
+        'gates:',
+      ].join('\n'), '0042-feature');
+
+      mockDbPrepare.mockReturnValue({
+        all: () => [{ worktree: worktreePath, issue_number: 42 }],
+      });
+
+      const cache = new OverviewCache();
+      const data = await cache.getOverview(tmpDir);
+
+      expect(data.builders).toHaveLength(1);
+      expect(data.builders[0].issueId).toBe('42');
+    });
+
+    it('falls back to regex-parsed issueId when DB has no issue_number (#664)', async () => {
+      createBuilderWorktree(tmpDir, 'spir-42-feature', [
+        "id: '0042'",
+        'title: feature',
+        'protocol: spir',
+        'phase: implement',
+        'gates:',
+      ].join('\n'), '0042-feature');
+
+      // DB returns no rows → regex-parsed issueId preserved
+      mockDbPrepare.mockReturnValue({ all: () => [] });
+
+      const cache = new OverviewCache();
+      const data = await cache.getOverview(tmpDir);
+
+      expect(data.builders).toHaveLength(1);
+      expect(data.builders[0].issueId).toBe('42');
     });
   });
 });

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import Database from 'better-sqlite3';
 import {
   OverviewCache,
   parseStatusYaml,
@@ -27,13 +28,12 @@ import {
 // Mocks
 // ============================================================================
 
-const { mockFetchPRList, mockFetchIssueList, mockFetchRecentlyClosed, mockFetchMergedPRs, mockLoadProtocol, mockDbPrepare } = vi.hoisted(() => ({
+const { mockFetchPRList, mockFetchIssueList, mockFetchRecentlyClosed, mockFetchMergedPRs, mockLoadProtocol } = vi.hoisted(() => ({
   mockFetchPRList: vi.fn(),
   mockFetchIssueList: vi.fn(),
   mockFetchRecentlyClosed: vi.fn(),
   mockFetchMergedPRs: vi.fn(),
   mockLoadProtocol: vi.fn(),
-  mockDbPrepare: vi.fn(),
 }));
 
 vi.mock('../../lib/github.js', async (importOriginal) => {
@@ -49,10 +49,6 @@ vi.mock('../../lib/github.js', async (importOriginal) => {
 
 vi.mock('../../commands/porch/protocol.js', () => ({
   loadProtocol: mockLoadProtocol,
-}));
-
-vi.mock('../db/index.js', () => ({
-  getDb: () => ({ prepare: mockDbPrepare }),
 }));
 
 // ============================================================================
@@ -105,6 +101,19 @@ function issueItem(number: number, title: string, labels: Array<{ name: string }
   return { number, title, url: `https://github.com/org/repo/issues/${number}`, labels, createdAt: '2026-01-01T00:00:00Z' };
 }
 
+/** Create a state.db in the workspace's .agent-farm/ with builder issue_number rows. */
+function createStateDb(root: string, rows: Array<{ worktree: string; issue_number: number }>): void {
+  const agentFarmDir = path.join(root, '.agent-farm');
+  fs.mkdirSync(agentFarmDir, { recursive: true });
+  const db = new Database(path.join(agentFarmDir, 'state.db'));
+  db.exec('CREATE TABLE IF NOT EXISTS builders (worktree TEXT, issue_number INTEGER)');
+  const insert = db.prepare('INSERT INTO builders (worktree, issue_number) VALUES (?, ?)');
+  for (const row of rows) {
+    insert.run(row.worktree, row.issue_number);
+  }
+  db.close();
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -117,7 +126,6 @@ describe('overview', () => {
     mockFetchIssueList.mockResolvedValue([]);
     mockFetchRecentlyClosed.mockResolvedValue([]);
     mockFetchMergedPRs.mockResolvedValue([]);
-    mockDbPrepare.mockReturnValue({ all: () => [] });
   });
 
   afterEach(() => {
@@ -1735,10 +1743,8 @@ describe('overview', () => {
       // research-533 doesn't match any protocol regex → soft mode, issueId null
       const worktreePath = createBuilderWorktree(tmpDir, 'research-533-context-window');
 
-      // Mock DB to return issue_number for this worktree
-      mockDbPrepare.mockReturnValue({
-        all: () => [{ worktree: worktreePath, issue_number: 533 }],
-      });
+      // Create a real DB with issue_number for this worktree
+      createStateDb(tmpDir, [{ worktree: worktreePath, issue_number: 533 }]);
 
       const cache = new OverviewCache();
       const data = await cache.getOverview(tmpDir);
@@ -1758,9 +1764,7 @@ describe('overview', () => {
         'gates:',
       ].join('\n'), '0042-feature');
 
-      mockDbPrepare.mockReturnValue({
-        all: () => [{ worktree: worktreePath, issue_number: 42 }],
-      });
+      createStateDb(tmpDir, [{ worktree: worktreePath, issue_number: 42 }]);
 
       const cache = new OverviewCache();
       const data = await cache.getOverview(tmpDir);
@@ -1778,9 +1782,7 @@ describe('overview', () => {
         'gates:',
       ].join('\n'), '0042-feature');
 
-      // DB returns no rows → regex-parsed issueId preserved
-      mockDbPrepare.mockReturnValue({ all: () => [] });
-
+      // No state.db → regex-parsed issueId preserved
       const cache = new OverviewCache();
       const data = await cache.getOverview(tmpDir);
 

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -19,6 +19,7 @@ import {
 } from '../../lib/github.js';
 import type { ForgePR, ForgeIssueListItem } from '../../lib/github.js';
 import { loadProtocol } from '../../commands/porch/protocol.js';
+import { getDb } from '../db/index.js';
 
 // =============================================================================
 // Types
@@ -692,6 +693,23 @@ export class OverviewCache {
         return roleId !== null && activeBuilderRoleIds.has(roleId);
       });
     }
+
+    // Enrich issueId from DB issue_number — protocol-agnostic (fixes #664)
+    try {
+      const db = getDb();
+      const rows = db.prepare(
+        'SELECT worktree, issue_number FROM builders WHERE issue_number IS NOT NULL',
+      ).all() as Array<{ worktree: string; issue_number: number }>;
+      for (const row of rows) {
+        const builder = builders.find(b => b.worktreePath === row.worktree);
+        if (builder) {
+          builder.issueId = String(row.issue_number);
+        }
+      }
+    } catch {
+      // DB not available (e.g., no Tower running) — keep regex-parsed issueId
+    }
+
     const activeBuilderIssues = new Set(
       builders
         .map(b => b.issueId)

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -19,7 +19,7 @@ import {
 } from '../../lib/github.js';
 import type { ForgePR, ForgeIssueListItem } from '../../lib/github.js';
 import { loadProtocol } from '../../commands/porch/protocol.js';
-import { getDb } from '../db/index.js';
+import Database from 'better-sqlite3';
 
 // =============================================================================
 // Types
@@ -695,19 +695,28 @@ export class OverviewCache {
     }
 
     // Enrich issueId from DB issue_number — protocol-agnostic (fixes #664)
+    // Open DB directly using workspaceRoot to avoid singleton path issues
+    // when Tower serves multiple workspaces.
     try {
-      const db = getDb();
-      const rows = db.prepare(
-        'SELECT worktree, issue_number FROM builders WHERE issue_number IS NOT NULL',
-      ).all() as Array<{ worktree: string; issue_number: number }>;
-      for (const row of rows) {
-        const builder = builders.find(b => b.worktreePath === row.worktree);
-        if (builder) {
-          builder.issueId = String(row.issue_number);
+      const dbPath = path.join(workspaceRoot, '.agent-farm', 'state.db');
+      if (fs.existsSync(dbPath)) {
+        const db = new Database(dbPath, { readonly: true });
+        try {
+          const rows = db.prepare(
+            'SELECT worktree, issue_number FROM builders WHERE issue_number IS NOT NULL',
+          ).all() as Array<{ worktree: string; issue_number: number }>;
+          for (const row of rows) {
+            const builder = builders.find(b => b.worktreePath === row.worktree);
+            if (builder) {
+              builder.issueId = String(row.issue_number);
+            }
+          }
+        } finally {
+          db.close();
         }
       }
     } catch {
-      // DB not available (e.g., no Tower running) — keep regex-parsed issueId
+      // DB not available — keep regex-parsed issueId
     }
 
     const activeBuilderIssues = new Set(


### PR DESCRIPTION
Fixes #664

## Root Cause

The dashboard's Issue column extracted issue numbers by regex-matching builder names against known protocol prefixes (`spir-NNN`, `aspir-NNN`, `bugfix-NNN`, etc.). Unknown protocols like `research` didn't match, so their issue number showed as the full builder name.

## Fix

In `getOverview()`, after discovering builders from the filesystem, enrich `issueId` from the DB's `issue_number` column. The `builders` table already stores this value at spawn time. This is protocol-agnostic — works for any current or future protocol without regex updates.

Falls back gracefully to the regex-parsed value when the DB is unavailable (e.g., no Tower running).

## Test Plan

- [x] Added regression test: unknown protocol (`research-533-*`) gets correct `issueId` from DB
- [x] Added test: DB value overrides regex-parsed value for known protocols
- [x] Added test: falls back to regex when DB has no `issue_number`
- [x] All 129 existing overview tests pass
- [x] Full build succeeds
- [x] Full test suite passes (excluding known flaky E2E tests)