### PR TITLE
Fix #667: Update E2E test for dashboard-dist path after monorepo restructure

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/e2e/dashboard-terminals.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/dashboard-terminals.test.ts
@@ -153,13 +153,13 @@ test.describe('Dashboard Terminals E2E', () => {
     await request.delete(`${BASE_URL}/api/tabs/${body.id}`);
   });
 
-  test('npm pack includes dashboard/dist', async () => {
+  test('npm pack includes dashboard-dist', async () => {
     const { execSync } = await import('node:child_process');
     const output = execSync('npm pack --dry-run 2>&1', {
       cwd: resolve(WORKSPACE_PATH, 'packages/codev'),
       encoding: 'utf-8',
     });
-    expect(output).toContain('dashboard/dist/index.html');
-    expect(output).toContain('dashboard/dist/assets/');
+    expect(output).toContain('dashboard-dist/index.html');
+    expect(output).toContain('dashboard-dist/assets/');
   });
 });


### PR DESCRIPTION
## Summary

The dashboard E2E test (`dashboard-terminals.test.ts`) was checking that `npm pack` includes `dashboard/dist/index.html`, but PR #666 moved the dashboard to `packages/dashboard/` and changed the build output to `dashboard-dist/`. The test assertion was not updated to match.

Fixes #667

## Root Cause

PR #666 (VS Code extension monorepo restructure) changed:
- `build:dashboard` script from `cd dashboard && npm install && npm run build` to `cd ../dashboard && npm run build && cp -r dist ../../packages/codev/dashboard-dist`
- `files` field from `dashboard/dist` to `dashboard-dist`

The E2E test was not updated to match the new path.

## Fix

Updated the test assertions from `dashboard/dist/index.html` → `dashboard-dist/index.html` and `dashboard/dist/assets/` → `dashboard-dist/assets/`.

## Test Plan

- [x] Regression test updated (the fix IS the test update)
- [x] Build passes
- [x] All 2442 unit tests pass
- [x] `npm pack --dry-run` confirms `dashboard-dist/index.html` is in the tarball