### PR TITLE
[Bugfix #677] Allow --force with --protocol alone

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/spawn.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/spawn.test.ts
@@ -44,8 +44,8 @@ function validateSpawnOptions(options: SpawnOptions): string | null {
     return '--no-comment requires an issue number';
   }
 
-  if (options.force && !options.issueNumber && !options.task) {
-    return '--force requires an issue number (not needed for --task)';
+  if (options.force && !options.issueNumber && !options.task && !options.protocol) {
+    return '--force requires an issue number, --task, or --protocol';
   }
 
   // --protocol cannot be used with --shell or --worktree
@@ -194,6 +194,11 @@ describe('Spawn Command', () => {
         expect(validateSpawnOptions(options)).toBeNull();
       });
 
+      it('should accept --protocol with --force (Bugfix #677: protocol-only spawns skip dirty worktree)', () => {
+        const options: SpawnOptions = { protocol: 'maintain', force: true };
+        expect(validateSpawnOptions(options)).toBeNull();
+      });
+
       it('should accept --shell alone', () => {
         const options: SpawnOptions = { shell: true };
         expect(validateSpawnOptions(options)).toBeNull();
@@ -260,8 +265,8 @@ describe('Spawn Command', () => {
         expect(error).toContain('--no-comment requires an issue number');
       });
 
-      it('should reject --force without issue number or task', () => {
-        const options: SpawnOptions = { protocol: 'maintain', force: true };
+      it('should reject --force without issue number, task, or protocol', () => {
+        const options: SpawnOptions = { shell: true, force: true };
         const error = validateSpawnOptions(options);
         expect(error).toContain('--force requires an issue number');
       });

--- a/packages/codev/src/agent-farm/commands/spawn.ts
+++ b/packages/codev/src/agent-farm/commands/spawn.ts
@@ -142,8 +142,8 @@ function validateSpawnOptions(options: SpawnOptions): void {
     fatal('--no-comment requires an issue number');
   }
 
-  if (options.force && !options.issueNumber && !options.task) {
-    fatal('--force requires an issue number (not needed for --task)');
+  if (options.force && !options.issueNumber && !options.task && !options.protocol) {
+    fatal('--force requires an issue number, --task, or --protocol');
   }
 
   // --protocol cannot be used with --shell or --worktree


### PR DESCRIPTION
## Summary
Fixes #677

`afx spawn --protocol maintain --force` now works without an issue number. Maintenance runs are operational and don't naturally have GitHub issues.

## Root Cause
`validateSpawnOptions` in `spawn.ts` rejected `--force` unless `--issue` or `--task` was present. When the main worktree had uncommitted local state and a user tried `afx spawn --protocol maintain --force` to bypass the dirty check, validation failed with `--force requires an issue number (not needed for --task)`.

## Fix
Relaxed the `--force` validation to also allow `--protocol`:

```ts
if (options.force && !options.issueNumber && !options.task && !options.protocol) {
  fatal('--force requires an issue number, --task, or --protocol');
}
```

The existing dirty-worktree check at `spawn()` already honors `--force` correctly, so no further changes were needed.

## Test Plan
- [x] Added regression test: `--protocol maintain + --force` is accepted
- [x] Updated the opposing test to target a still-invalid combo (`--shell + --force`)
- [x] Full `agent-farm` suite passes (1434 passing, 13 pre-existing skipped)

## CMAP Review
Not run — this is a 2-line validation change with a clear regression test.