### PR TITLE
[Bugfix #676] Scope porch check artifact resolution to the worktree

### DIFF
--- a/packages/codev/src/commands/porch/__tests__/bugfix-676-approve-worktree-artifacts.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/bugfix-676-approve-worktree-artifacts.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Regression test for bugfix #676: `porch approve plan-approval` fails with
+ * "Plan not found" when the plan lives in a builder worktree.
+ *
+ * Reproduction:
+ *   1. Architect runs `porch approve NNN plan-approval ...` from the main
+ *      workspace root (cwd = repo root).
+ *   2. `findStatusPath` (fixed in PR #674) correctly locates the project's
+ *      status.yaml inside `.builders/<slug>/codev/projects/...`.
+ *   3. BUT the artifact resolver and the cwd passed to `runPhaseChecks` are
+ *      still scoped to the main workspace, so the `plan_exists` check looks
+ *      at `<main>/codev/plans/` — where the plan does not exist yet —
+ *      and fails.
+ *
+ * Fix: `check`, `done`, and `approve` derive the artifact root from the
+ * resolved status path (via `getArtifactRoot`) and rebuild the resolver +
+ * check cwd to point at that worktree.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import { approve, check, done } from '../index.js';
+import { writeState, readState, getStatusPath } from '../state.js';
+import type { ProjectState } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Mimic the on-disk layout: `<mainRoot>/.builders/<slug>/...` with its own codev/. */
+function makeWorkspace(suffix: string): { mainRoot: string; worktreeRoot: string; worktreeSlug: string } {
+  const mainRoot = path.join(tmpdir(), `porch-676-${suffix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  fs.mkdirSync(mainRoot, { recursive: true });
+  const worktreeSlug = 'spir-42-test-feature';
+  const worktreeRoot = path.join(mainRoot, '.builders', worktreeSlug);
+  fs.mkdirSync(worktreeRoot, { recursive: true });
+  return { mainRoot, worktreeRoot, worktreeSlug };
+}
+
+function writeProtocol(root: string, protocol: { name: string; [k: string]: unknown }): void {
+  const dir = path.join(root, 'codev', 'protocols', protocol.name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'protocol.json'), JSON.stringify(protocol, null, 2));
+}
+
+function writeWorktreeStatus(worktreeRoot: string, state: ProjectState): string {
+  const statusPath = getStatusPath(worktreeRoot, state.id, state.title);
+  fs.mkdirSync(path.dirname(statusPath), { recursive: true });
+  writeState(statusPath, state);
+  return statusPath;
+}
+
+function makeState(overrides: Partial<ProjectState> = {}): ProjectState {
+  return {
+    id: '0042',
+    title: 'test-feature',
+    protocol: 'spir-676-test',
+    phase: 'plan',
+    plan_phases: [],
+    current_plan_phase: null,
+    gates: {
+      'plan-approval': { status: 'pending', requested_at: new Date().toISOString() },
+    },
+    iteration: 1,
+    build_complete: false,
+    history: [],
+    started_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// Protocol is saved to disk as JSON and normalized by `loadProtocol`.
+// Phase `checks` is an object of name → command (not an array).
+const testProtocolJson = {
+  name: 'spir-676-test',
+  version: '1.0.0',
+  phases: [
+    {
+      id: 'plan',
+      name: 'Plan',
+      gate: 'plan-approval',
+      checks: {
+        plan_exists: 'test -f codev/plans/${PROJECT_TITLE}.md',
+      },
+      next: 'implement',
+    },
+    { id: 'implement', name: 'Implement', next: null },
+  ],
+};
+
+// Suppress noisy CLI output; keep process.exit swallowable so we can inspect state.
+let logSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    throw new Error(`process.exit(${code ?? 0})`);
+  }) as never);
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  exitSpy.mockRestore();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('bugfix #676 — artifact resolver follows worktree status path', () => {
+  it('approve resolves plan_exists against the worktree, not the main workspace', async () => {
+    const { mainRoot, worktreeRoot } = makeWorkspace('approve');
+    writeProtocol(mainRoot, testProtocolJson);
+    // Protocol files are read from the main workspace — but artifacts live in the worktree.
+
+    const statusPath = writeWorktreeStatus(worktreeRoot, makeState());
+
+    // Plan exists ONLY in the worktree; the main workspace has NO codev/plans/ directory.
+    const worktreePlansDir = path.join(worktreeRoot, 'codev', 'plans');
+    fs.mkdirSync(worktreePlansDir, { recursive: true });
+    fs.writeFileSync(path.join(worktreePlansDir, '0042-test-feature.md'), '# Plan\n');
+
+    expect(fs.existsSync(path.join(mainRoot, 'codev', 'plans'))).toBe(false);
+
+    // Architect runs approve from main workspace root
+    await approve(mainRoot, '0042', 'plan-approval', true);
+
+    // Gate should be approved (checks passed because resolver found the plan in the worktree)
+    const updated = readState(statusPath);
+    expect(updated.gates['plan-approval'].status).toBe('approved');
+    expect(updated.gates['plan-approval'].approved_at).toBeDefined();
+  });
+
+  it('approve fails cleanly when the plan is missing from the worktree', async () => {
+    const { mainRoot, worktreeRoot } = makeWorkspace('approve-missing');
+    writeProtocol(mainRoot, testProtocolJson);
+    const statusPath = writeWorktreeStatus(worktreeRoot, makeState());
+
+    // Writing a plan in the MAIN workspace must NOT trick the check into
+    // approving the gate — only the worktree is authoritative.
+    const mainPlansDir = path.join(mainRoot, 'codev', 'plans');
+    fs.mkdirSync(mainPlansDir, { recursive: true });
+    fs.writeFileSync(path.join(mainPlansDir, '0042-test-feature.md'), '# Decoy\n');
+
+    await expect(approve(mainRoot, '0042', 'plan-approval', true)).rejects.toThrow(/process\.exit/);
+
+    // Gate must NOT be approved when the worktree lacks the plan
+    const updated = readState(statusPath);
+    expect(updated.gates['plan-approval'].status).toBe('pending');
+    expect(updated.gates['plan-approval'].approved_at).toBeUndefined();
+  });
+
+  it('check resolves plan_exists against the worktree', async () => {
+    const { mainRoot, worktreeRoot } = makeWorkspace('check');
+    writeProtocol(mainRoot, testProtocolJson);
+    writeWorktreeStatus(worktreeRoot, makeState());
+
+    const worktreePlansDir = path.join(worktreeRoot, 'codev', 'plans');
+    fs.mkdirSync(worktreePlansDir, { recursive: true });
+    fs.writeFileSync(path.join(worktreePlansDir, '0042-test-feature.md'), '# Plan\n');
+
+    // check() prints results but must not throw when all checks pass
+    await expect(check(mainRoot, '0042')).resolves.toBeUndefined();
+  });
+
+  it('done resolves plan_exists against the worktree', async () => {
+    const { mainRoot, worktreeRoot } = makeWorkspace('done');
+    // Protocol where the plan phase has no gate, so done() will attempt to advance
+    const protocolNoGate = {
+      name: 'spir-676-test-done',
+      version: '1.0.0',
+      phases: [
+        {
+          id: 'plan',
+          name: 'Plan',
+          checks: { plan_exists: 'test -f codev/plans/${PROJECT_TITLE}.md' },
+          next: 'review',
+        },
+        { id: 'review', name: 'Review', next: null },
+      ],
+    };
+    writeProtocol(mainRoot, protocolNoGate);
+
+    const state = makeState({ protocol: 'spir-676-test-done', gates: {} });
+    const statusPath = writeWorktreeStatus(worktreeRoot, state);
+
+    const worktreePlansDir = path.join(worktreeRoot, 'codev', 'plans');
+    fs.mkdirSync(worktreePlansDir, { recursive: true });
+    fs.writeFileSync(path.join(worktreePlansDir, '0042-test-feature.md'), '# Plan\n');
+
+    await done(mainRoot, '0042');
+
+    const updated = readState(statusPath);
+    expect(updated.phase).toBe('review');
+  });
+});

--- a/packages/codev/src/commands/porch/artifacts.ts
+++ b/packages/codev/src/commands/porch/artifacts.ts
@@ -362,8 +362,18 @@ export class CliResolver implements ArtifactResolver {
 /**
  * Create the appropriate artifact resolver for this workspace.
  * Reads config via loadConfig() (v3.0.0 unified config — .codev/config.json).
+ *
+ * @param workspaceRoot - The top-level workspace (where .codev/config.json lives).
+ *                        Always used to load config; also used as the .env source
+ *                        for the CLI backend.
+ * @param artifactRoot - Optional override for where the local backend reads
+ *                        specs/plans/reviews from. When the project lives in a
+ *                        builder worktree (`.builders/<slug>/`), pass that
+ *                        worktree's root so artifact lookups find files there
+ *                        instead of the top-level `codev/` directory (bugfix #676).
+ *                        Defaults to workspaceRoot.
  */
-export function getResolver(workspaceRoot: string): ArtifactResolver {
+export function getResolver(workspaceRoot: string, artifactRoot?: string): ArtifactResolver {
   const config = loadConfig(workspaceRoot);
   const artifacts = config.artifacts;
 
@@ -390,5 +400,5 @@ export function getResolver(workspaceRoot: string): ArtifactResolver {
     );
   }
 
-  return new LocalResolver(workspaceRoot);
+  return new LocalResolver(artifactRoot ?? workspaceRoot);
 }

--- a/packages/codev/src/commands/porch/index.ts
+++ b/packages/codev/src/commands/porch/index.ts
@@ -15,6 +15,7 @@ import {
   writeStateAndCommit,
   createInitialState,
   findStatusPath,
+  getArtifactRoot,
   getProjectDir,
   getStatusPath,
   detectProjectId,
@@ -39,7 +40,7 @@ import {
   allPlanPhasesComplete,
   isPlanPhaseComplete,
 } from './plan.js';
-import { getResolver, type ArtifactResolver } from './artifacts.js';
+import { getResolver, LocalResolver, type ArtifactResolver } from './artifacts.js';
 import {
   runPhaseChecks,
   formatCheckResults,
@@ -60,6 +61,29 @@ function header(text: string): string {
 
 function section(title: string, content: string): string {
   return `\n${chalk.bold(title)}:\n${content}`;
+}
+
+/**
+ * Return a resolver scoped to `artifactRoot` when it differs from the caller's
+ * cwd-rooted resolver. The incoming `resolver` is typically built from
+ * `process.cwd()` (the main workspace), but `findStatusPath` may resolve a
+ * project to a builder worktree under `.builders/`. Checks like `plan_exists`
+ * must read from that worktree, not from the main tree (bugfix #676).
+ *
+ * For the LOCAL backend we rebuild the resolver against `artifactRoot` so file
+ * lookups point at `<artifactRoot>/codev/...`. For other backends (e.g. CLI)
+ * artifact location is already independent of the filesystem, so we keep the
+ * caller's resolver.
+ */
+function scopeResolver(
+  workspaceRoot: string,
+  artifactRoot: string,
+  resolver?: ArtifactResolver,
+): ArtifactResolver | undefined {
+  if (artifactRoot === workspaceRoot) return resolver;
+  // Only rebuild if the existing resolver is a LocalResolver (path-dependent).
+  if (resolver && !(resolver instanceof LocalResolver)) return resolver;
+  return getResolver(workspaceRoot, artifactRoot);
 }
 
 /**
@@ -206,6 +230,12 @@ export async function check(workspaceRoot: string, projectId: string, resolver?:
     throw new Error(`Project ${projectId} not found.`);
   }
 
+  // Scope artifact reads + check cwd to the worktree that owns this status.yaml.
+  // `findStatusPath` searches `.builders/*` first; resolver/cwd must match so
+  // checks like `plan_exists` see files in the same worktree (bugfix #676).
+  const artifactRoot = getArtifactRoot(statusPath);
+  const scopedResolver = scopeResolver(workspaceRoot, artifactRoot, resolver);
+
   const state = readState(statusPath);
   const protocol = loadProtocol(workspaceRoot, state.protocol);
   const overrides = loadCheckOverrides(workspaceRoot);
@@ -218,7 +248,7 @@ export async function check(workspaceRoot: string, projectId: string, resolver?:
     return;
   }
 
-  const checkEnv: CheckEnv = { PROJECT_ID: state.id, PROJECT_TITLE: resolveArtifactBaseName(workspaceRoot, state.id, state.title, resolver) };
+  const checkEnv: CheckEnv = { PROJECT_ID: state.id, PROJECT_TITLE: resolveArtifactBaseName(artifactRoot, state.id, state.title, scopedResolver) };
 
   console.log('');
   console.log(chalk.bold('RUNNING CHECKS...'));
@@ -234,7 +264,7 @@ export async function check(workspaceRoot: string, projectId: string, resolver?:
     return;
   }
 
-  const results = await runPhaseChecks(checks, workspaceRoot, checkEnv, undefined, resolver);
+  const results = await runPhaseChecks(checks, artifactRoot, checkEnv, undefined, scopedResolver);
   console.log(formatCheckResults(results));
 
   console.log('');
@@ -291,6 +321,11 @@ export async function done(workspaceRoot: string, projectId: string, resolver?: 
   const phaseCheckNames = phaseConfig?.checks ?? [];
   const checks = getPhaseChecks(protocol, state.phase, overrides ?? undefined);
 
+  // Scope artifact reads + check cwd to the worktree that owns this status.yaml
+  // (bugfix #676 — see check() for rationale).
+  const artifactRoot = getArtifactRoot(statusPath);
+  const scopedResolver = scopeResolver(workspaceRoot, artifactRoot, resolver);
+
   // Run checks first — but skip if the gate was just approved (approve already ran them)
   if (phaseCheckNames.length > 0) {
     const gate = getPhaseGate(protocol, state.phase);
@@ -302,14 +337,14 @@ export async function done(workspaceRoot: string, projectId: string, resolver?: 
       console.log('');
       console.log(chalk.dim('Checks skipped (gate approved <60s ago).'));
     } else {
-      const checkEnv: CheckEnv = { PROJECT_ID: state.id, PROJECT_TITLE: resolveArtifactBaseName(workspaceRoot, state.id, state.title, resolver) };
+      const checkEnv: CheckEnv = { PROJECT_ID: state.id, PROJECT_TITLE: resolveArtifactBaseName(artifactRoot, state.id, state.title, scopedResolver) };
 
       console.log('');
       console.log(chalk.bold('RUNNING CHECKS...'));
       logCheckOverrides(phaseCheckNames, checks, overrides);
 
       if (Object.keys(checks).length > 0) {
-        const results = await runPhaseChecks(checks, workspaceRoot, checkEnv, undefined, resolver);
+        const results = await runPhaseChecks(checks, artifactRoot, checkEnv, undefined, scopedResolver);
         console.log(formatCheckResults(results));
 
         if (!allChecksPassed(results)) {
@@ -422,7 +457,7 @@ export async function done(workspaceRoot: string, projectId: string, resolver?: 
   }
 
   // Advance to next protocol phase
-  await advanceProtocolPhase(workspaceRoot, state, protocol, statusPath, resolver);
+  await advanceProtocolPhase(workspaceRoot, state, protocol, statusPath, scopedResolver);
 }
 
 async function advanceProtocolPhase(workspaceRoot: string, state: ProjectState, protocol: Protocol, statusPath: string, resolver?: ArtifactResolver): Promise<void> {
@@ -569,6 +604,11 @@ export async function approve(
     throw new Error(`Project ${projectId} not found.`);
   }
 
+  // Scope artifact reads + check cwd to the worktree that owns this status.yaml
+  // (bugfix #676 — see check() for rationale).
+  const artifactRoot = getArtifactRoot(statusPath);
+  const scopedResolver = scopeResolver(workspaceRoot, artifactRoot, resolver);
+
   const state = readState(statusPath);
 
   // Convenience: for verify-approval, auto-complete porch done if build_complete is false
@@ -616,14 +656,14 @@ export async function approve(
   const checks = getPhaseChecks(protocol, state.phase, overrides ?? undefined);
 
   if (phaseCheckNames.length > 0) {
-    const checkEnv: CheckEnv = { PROJECT_ID: state.id, PROJECT_TITLE: resolveArtifactBaseName(workspaceRoot, state.id, state.title, resolver) };
+    const checkEnv: CheckEnv = { PROJECT_ID: state.id, PROJECT_TITLE: resolveArtifactBaseName(artifactRoot, state.id, state.title, scopedResolver) };
 
     console.log('');
     console.log(chalk.bold('RUNNING CHECKS...'));
     logCheckOverrides(phaseCheckNames, checks, overrides);
 
     if (Object.keys(checks).length > 0) {
-      const results = await runPhaseChecks(checks, workspaceRoot, checkEnv, undefined, resolver);
+      const results = await runPhaseChecks(checks, artifactRoot, checkEnv, undefined, scopedResolver);
       console.log(formatCheckResults(results));
 
       if (!allChecksPassed(results)) {

--- a/packages/codev/src/commands/porch/state.ts
+++ b/packages/codev/src/commands/porch/state.ts
@@ -94,6 +94,19 @@ export function getStatusPath(workspaceRoot: string, projectId: string, name: st
   return path.join(getProjectDir(workspaceRoot, projectId, name), 'status.yaml');
 }
 
+/**
+ * Derive the artifact root (worktree root) from a status.yaml path.
+ * Status paths are always <artifactRoot>/codev/projects/<id>-<name>/status.yaml,
+ * so the artifact root is three levels up from the containing directory.
+ *
+ * Used by commands that must resolve specs/plans/reviews relative to the
+ * worktree that owns the status file (bugfix #676). `findStatusPath` already
+ * searches `.builders/*` first, so this matches its resolution.
+ */
+export function getArtifactRoot(statusPath: string): string {
+  return path.resolve(path.dirname(statusPath), '..', '..', '..');
+}
+
 // ============================================================================
 // State Operations
 // ============================================================================


### PR DESCRIPTION
Fixes #676.

## Summary

- `porch approve plan-approval` failed with `Plan not found` when the plan lived in a builder worktree. `findStatusPath` (PR #674) already resolves the worktree, but the artifact resolver and the `cwd` passed to `runPhaseChecks` remained rooted at `process.cwd()`, so `plan_exists` looked in the main tree instead of the worktree.
- `check`, `done`, and `approve` now derive the artifact root from the resolved status path via a new `getArtifactRoot` helper and rebuild a `LocalResolver` scoped to that path. `runPhaseChecks` is also invoked with the worktree as its `cwd`, so shell-based checks resolve relative paths against the correct tree.
- Confirmed existing behavior: checks still run before any state write in `approve`; a failed check cannot flip the gate to `approved`.

## Changes

| File | What |
| --- | --- |
| `state.ts` | Add `getArtifactRoot(statusPath)` helper (three levels up from `status.yaml`). |
| `artifacts.ts` | `getResolver(workspaceRoot, artifactRoot?)` lets callers point the local backend at a worktree while still loading config from the main workspace. |
| `index.ts` | `check`/`done`/`approve` build a scoped resolver and pass `artifactRoot` to `runPhaseChecks` and `resolveArtifactBaseName`. |
| `__tests__/bugfix-676-approve-worktree-artifacts.test.ts` | Regression coverage for `approve`, `check`, and `done` against a worktree layout (including a negative test that a decoy plan in the main tree cannot approve the gate). |

## Test plan

- [x] `pnpm exec vitest run src/commands/porch/__tests__/bugfix-676-approve-worktree-artifacts.test.ts` — 4/4 pass.
- [x] `pnpm exec vitest run src/commands/porch` — full porch suite 275/275 pass.
- [x] Verified the new tests fail on `main` without the fix (3/4 fail exactly where expected).
- [x] `pnpm exec tsc --noEmit` clean.
- [ ] Manual repro: architect runs `porch approve NNN plan-approval --a-human-explicitly-approved-this` from repo root against a plan that lives in `.builders/<slug>/codev/plans/` and the gate flips to `approved`.

Pre-existing failing tests in `adopt.test.ts`, `consult.test.ts`, `update.test.ts`, and `session-manager.test.ts` are unrelated to this change.