### PR TITLE
fix + feat: surface activation failures; builder terminal lifecycle improvements

### DIFF
--- a/codev/resources/arch.md
+++ b/codev/resources/arch.md
@@ -553,6 +553,18 @@ This dual-source strategy (SQLite + live shellper processes) ensures sessions su
 | `GET` | `/api/events` | SSE stream for push notifications |
 | `POST` | `/api/notify` | Broadcast notification to SSE clients |
 
+**SSE event types** broadcast on `/api/events` (each arrives as a JSON envelope `{ type, title, body, workspace?, id }` on the `data:` field):
+
+| Type | Emitted when | `body` payload |
+|------|--------------|----------------|
+| `overview-changed` | Overview cache invalidated | Human-readable string |
+| `notification` | `POST /api/notify` called | Caller-supplied string |
+| `builder-spawned` | Tower registers a new builder terminal (in `handleTerminalCreate`) | JSON-stringified `BuilderSpawnedPayload`: `{ terminalId, roleId, workspacePath }` (see `packages/types/src/sse.ts`) |
+| `connected` | SSE client first connects | Client id |
+| `heartbeat` | Every 30s keepalive | `:heartbeat` (not JSON) |
+
+Clients may ignore unknown event types — older clients silently drop `builder-spawned`, and newer clients fall back to `overview-changed` when connected to older Tower builds.
+
 **Workspace-scoped APIs (via Tower proxy):**
 
 | Method | Path | Purpose |

--- a/packages/codev/src/agent-farm/__tests__/tower-instances.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tower-instances.test.ts
@@ -447,7 +447,15 @@ describe('tower-instances', () => {
       fs.mkdirSync(path.join(tmpDir, 'codev'));
 
       try {
-        const deps = makeDeps();
+        const deps = makeDeps({
+          getTerminalManager: vi.fn().mockReturnValue({
+            getSession: vi.fn(),
+            killSession: vi.fn(),
+            createSession: vi.fn().mockResolvedValue({ id: 'test-session', pid: 1234 }),
+            createSessionRaw: vi.fn(),
+            listSessions: vi.fn().mockReturnValue([]),
+          }) as any,
+        });
         initInstances(deps);
 
         const result = await launchInstance(tmpDir);
@@ -501,6 +509,37 @@ describe('tower-instances', () => {
         } else {
           process.env.TOWER_ARCHITECT_CMD = originalEnv;
         }
+        fs.rmSync(tmpDir, { recursive: true });
+      }
+    });
+
+    it('returns failure when architect spawn throws', async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tower-launch-fail-'));
+      fs.mkdirSync(path.join(tmpDir, 'codev'));
+
+      try {
+        const logSpy = vi.fn();
+        const deps = makeDeps({
+          log: logSpy,
+          getTerminalManager: vi.fn().mockReturnValue({
+            getSession: vi.fn(),
+            killSession: vi.fn(),
+            createSession: vi.fn().mockRejectedValue(new Error('spawn claude ENOENT')),
+            createSessionRaw: vi.fn(),
+            listSessions: vi.fn().mockReturnValue([]),
+          }) as any,
+        });
+        initInstances(deps);
+
+        const result = await launchInstance(tmpDir);
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/Failed to create architect terminal/);
+        expect(result.error).toMatch(/spawn claude ENOENT/);
+        expect(logSpy).toHaveBeenCalledWith(
+          'ERROR',
+          expect.stringMatching(/Failed to create architect terminal/),
+        );
+      } finally {
         fs.rmSync(tmpDir, { recursive: true });
       }
     });

--- a/packages/codev/src/agent-farm/__tests__/tower-routes.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tower-routes.test.ts
@@ -606,6 +606,25 @@ describe('tower-routes', () => {
 
       expect(statusCode()).toBe(200);
     });
+
+    it('returns 400 with error body when launchInstance fails', async () => {
+      const { launchInstance } = await import('../servers/tower-instances.js');
+      (launchInstance as any).mockResolvedValueOnce({
+        success: false,
+        error: 'Failed to create architect terminal: spawn claude ENOENT',
+      });
+
+      const encoded = Buffer.from('/test/workspace').toString('base64url');
+      const req = makeReq('POST', `/api/workspaces/${encoded}/activate`);
+      const { res, statusCode, body } = makeRes();
+      await handleRequest(req, res, makeCtx());
+
+      expect(statusCode()).toBe(400);
+      const json = JSON.parse(body());
+      expect(json.success).toBe(false);
+      expect(json.error).toMatch(/Failed to create architect terminal/);
+      expect(json.error).toMatch(/spawn claude ENOENT/);
+    });
   });
 
   // =========================================================================

--- a/packages/codev/src/agent-farm/servers/tower-instances.ts
+++ b/packages/codev/src/agent-farm/servers/tower-instances.ts
@@ -468,8 +468,9 @@ export async function launchInstance(workspacePath: string): Promise<{ success: 
 
         _deps.log('INFO', `Created architect terminal for workspace: ${workspacePath}`);
       } catch (err) {
-        _deps.log('WARN', `Failed to create architect terminal: ${(err as Error).message}`);
-        // Don't fail the launch - workspace is still active, just without architect
+        const errMsg = `Failed to create architect terminal: ${(err as Error).message}`;
+        _deps.log('ERROR', errMsg);
+        return { success: false, error: errMsg, adopted };
       }
     }
 

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -27,6 +27,7 @@ import { version } from '../../version.js';
 const execAsync = promisify(exec);
 import type { SessionManager } from '../../terminal/session-manager.js';
 import type { PtySessionInfo } from '../../terminal/pty-session.js';
+import type { BuilderSpawnedPayload } from '@cluesmith/codev-types';
 import { DEFAULT_COLS, defaultSessionOptions } from '../../terminal/index.js';
 import type { SSEClient } from './tower-types.js';
 import { parseJsonBody, isRequestAllowed } from '../utils/server-utils.js';
@@ -360,6 +361,15 @@ async function handleWorkspaceAction(
   }
 }
 
+function emitBuilderSpawned(ctx: RouteContext, payload: BuilderSpawnedPayload): void {
+  ctx.broadcastNotification({
+    type: 'builder-spawned',
+    title: `Builder ${payload.roleId} spawned`,
+    body: JSON.stringify(payload),
+    workspace: payload.workspacePath,
+  });
+}
+
 async function handleTerminalCreate(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -424,6 +434,7 @@ async function handleTerminalCreate(
           const entry = getWorkspaceTerminalsEntry(normalizeWorkspacePath(workspacePath));
           if (termType === 'builder') {
             entry.builders.set(roleId, session.id);
+            emitBuilderSpawned(ctx, { terminalId: session.id, roleId, workspacePath });
           } else {
             entry.shells.set(roleId, session.id);
           }
@@ -446,6 +457,7 @@ async function handleTerminalCreate(
         const entry = getWorkspaceTerminalsEntry(normalizeWorkspacePath(workspacePath));
         if (termType === 'builder') {
           entry.builders.set(roleId, info.id);
+          emitBuilderSpawned(ctx, { terminalId: info.id, roleId, workspacePath });
         } else {
           entry.shells.set(roleId, info.id);
         }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -8,6 +8,7 @@ export {
 export {
   type SSEEventType,
   type SSENotification,
+  type BuilderSpawnedPayload,
 } from './sse.js';
 
 export {

--- a/packages/types/src/sse.ts
+++ b/packages/types/src/sse.ts
@@ -5,6 +5,7 @@
 export type SSEEventType =
   | 'overview-changed'
   | 'notification'
+  | 'builder-spawned'
   | 'connected'
   | 'heartbeat';
 
@@ -13,4 +14,14 @@ export interface SSENotification {
   title: string;
   body: string;
   workspace?: string;
+}
+
+/**
+ * Payload carried in the `body` field of a `builder-spawned` notification.
+ * JSON-stringified on the wire; parse before use.
+ */
+export interface BuilderSpawnedPayload {
+  terminalId: string;
+  roleId: string;
+  workspacePath: string;
 }

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -6,6 +6,7 @@ Bring Codev's Agent Farm into VS Code — monitor builders, open terminals, appr
 
 - **Unified Sidebar** — Needs Attention, Builders, Pull Requests, Backlog, Team, and Status in a single pane
 - **Native Terminals** — Architect and builder terminals in the editor area with full vertical height
+- **Live Spawn Notifications** — Get notified (or auto-open a terminal) the moment a new builder starts
 - **Status Bar** — Connection state, builder count, blocked gates at a glance
 - **Command Palette** — Open terminals, send messages, approve gates via keyboard
 - **Auto-Connect** — Detects Codev workspaces and connects to Tower automatically
@@ -57,6 +58,14 @@ Bring Codev's Agent Farm into VS Code — monitor builders, open terminals, appr
 | Codev: Cron Tasks | | List, run, enable, or disable cron tasks |
 | Codev: Add Review Comment | | Insert a `REVIEW(@architect):` comment at cursor |
 
+## When a Builder Spawns
+
+Whenever a new builder starts (e.g. you ran `afx spawn 42`), the extension can open its terminal for you. Choose how with the `codev.autoOpenBuilderTerminal` setting:
+
+- **Notify** (default) — A toast appears with an **Open Terminal** button.
+- **Auto** — The terminal opens immediately in the right editor group.
+- **Off** — No toast, no terminal. Click the builder in the sidebar when you want it.
+
 ## Review Comments
 
 - **Snippet**: Type `rev` + Tab in markdown files to insert a review comment
@@ -73,3 +82,4 @@ Bring Codev's Agent Farm into VS Code — monitor builders, open terminals, appr
 | `codev.terminalPosition` | `editor` | Terminal placement (`editor` or `panel`) |
 | `codev.autoConnect` | `true` | Connect to Tower on activation |
 | `codev.autoStartTower` | `true` | Auto-start Tower if not running |
+| `codev.autoOpenBuilderTerminal` | `notify` | Behavior on builder-spawned events (`off` / `notify` / `auto`) |

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -157,6 +157,17 @@
           "type": "boolean",
           "default": false,
           "description": "No telemetry collected"
+        },
+        "codev.autoOpenBuilderTerminal": {
+          "type": "string",
+          "enum": ["off", "notify", "auto"],
+          "enumDescriptions": [
+            "Do nothing when a builder is spawned (sidebar still updates)",
+            "Show a notification with an Open Terminal button",
+            "Open the builder terminal in the editor immediately"
+          ],
+          "default": "notify",
+          "description": "Behavior when Tower reports a new builder spawn"
         }
       }
     }

--- a/packages/vscode/src/builder-spawn-handler.ts
+++ b/packages/vscode/src/builder-spawn-handler.ts
@@ -1,0 +1,80 @@
+import * as vscode from 'vscode';
+import type { BuilderSpawnedPayload } from '@cluesmith/codev-types';
+import type { ConnectionManager } from './connection-manager.js';
+import type { TerminalManager } from './terminal-manager.js';
+
+type AutoOpenMode = 'off' | 'notify' | 'auto';
+
+export class BuilderSpawnHandler {
+  private seen = new Set<string>();
+
+  constructor(
+    private connectionManager: ConnectionManager,
+    private terminalManager: TerminalManager,
+    private outputChannel: vscode.OutputChannel,
+  ) {}
+
+  handle(_eventType: string, data: string): void {
+    // Tower emits events as a JSON-serialized envelope on the SSE `data:` field
+    // with no `event:` name, so we must inspect the envelope's `type` ourselves.
+    let envelope: { type?: unknown; body?: unknown };
+    try {
+      envelope = JSON.parse(data);
+    } catch {
+      return;
+    }
+
+    if (envelope.type !== 'builder-spawned') { return; }
+
+    const body = typeof envelope.body === 'string' ? envelope.body : '';
+    let payload: BuilderSpawnedPayload;
+    try {
+      payload = JSON.parse(body);
+    } catch {
+      this.log('WARN', `Malformed builder-spawned body: ${body.slice(0, 200)}`);
+      return;
+    }
+
+    if (!payload.terminalId || !payload.roleId || !payload.workspacePath) { return; }
+
+    const active = this.connectionManager.getWorkspacePath();
+    if (active && payload.workspacePath !== active) { return; }
+
+    if (this.seen.has(payload.terminalId)) { return; }
+    this.seen.add(payload.terminalId);
+
+    const mode = vscode.workspace
+      .getConfiguration('codev')
+      .get<AutoOpenMode>('autoOpenBuilderTerminal', 'notify');
+
+    if (mode === 'off') { return; }
+
+    if (mode === 'auto') {
+      void this.open(payload);
+      return;
+    }
+
+    void vscode.window
+      .showInformationMessage(`Builder ${payload.roleId} spawned.`, 'Open Terminal')
+      .then((choice) => {
+        if (choice === 'Open Terminal') { void this.open(payload); }
+      });
+  }
+
+  private async open(payload: BuilderSpawnedPayload): Promise<void> {
+    try {
+      await this.terminalManager.openBuilder(
+        payload.terminalId,
+        payload.roleId,
+        `Codev: ${payload.roleId}`,
+      );
+    } catch (err) {
+      this.log('ERROR', `Failed to open builder terminal ${payload.roleId}: ${(err as Error).message}`);
+    }
+  }
+
+  private log(level: string, message: string): void {
+    const timestamp = new Date().toISOString();
+    this.outputChannel.appendLine(`[${timestamp}] [BuilderSpawn] [${level}] ${message}`);
+  }
+}

--- a/packages/vscode/src/connection-manager.ts
+++ b/packages/vscode/src/connection-manager.ts
@@ -151,10 +151,14 @@ export class ConnectionManager {
       if (result.ok) {
         this.log('INFO', `Workspace activated: ${this.workspacePath}`);
       } else {
-        this.log('WARN', `Workspace activation failed: ${result.error}`);
+        const msg = `Workspace activation failed: ${result.error}`;
+        this.log('ERROR', msg);
+        vscode.window.showErrorMessage(`Codev: ${msg}`);
       }
     } catch (err) {
-      this.log('ERROR', `Workspace activation error: ${(err as Error).message}`);
+      const msg = `Workspace activation error: ${(err as Error).message}`;
+      this.log('ERROR', msg);
+      vscode.window.showErrorMessage(`Codev: ${msg}`);
     }
   }
 

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -11,6 +11,7 @@ import { listCronTasks } from './commands/cron.js';
 import { addReviewComment } from './commands/review.js';
 import { activateReviewDecorations } from './review-decorations.js';
 import { BuilderSpawnHandler } from './builder-spawn-handler.js';
+import { BuilderTerminalLinkProvider } from './terminal-link-provider.js';
 import { NeedsAttentionProvider } from './views/needs-attention.js';
 import { BuildersProvider } from './views/builders.js';
 import { PullRequestsProvider } from './views/pull-requests.js';
@@ -191,6 +192,13 @@ export async function activate(context: vscode.ExtensionContext) {
 	const builderSpawnHandler = new BuilderSpawnHandler(connectionManager, terminalManager, outputChannel);
 	context.subscriptions.push(
 		connectionManager.onSSEEvent(({ type, data }) => builderSpawnHandler.handle(type, data)),
+	);
+
+	// Make builder names clickable in any terminal output
+	context.subscriptions.push(
+		vscode.window.registerTerminalLinkProvider(
+			new BuilderTerminalLinkProvider(connectionManager, terminalManager, outputChannel),
+		),
 	);
 
 	// Connect

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -10,6 +10,7 @@ import { connectTunnel, disconnectTunnel } from './commands/tunnel.js';
 import { listCronTasks } from './commands/cron.js';
 import { addReviewComment } from './commands/review.js';
 import { activateReviewDecorations } from './review-decorations.js';
+import { BuilderSpawnHandler } from './builder-spawn-handler.js';
 import { NeedsAttentionProvider } from './views/needs-attention.js';
 import { BuildersProvider } from './views/builders.js';
 import { PullRequestsProvider } from './views/pull-requests.js';
@@ -185,6 +186,12 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// Review comment decorations
 	activateReviewDecorations(context);
+
+	// Auto-open builder terminals on Tower spawn events
+	const builderSpawnHandler = new BuilderSpawnHandler(connectionManager, terminalManager, outputChannel);
+	context.subscriptions.push(
+		connectionManager.onSSEEvent(({ type, data }) => builderSpawnHandler.handle(type, data)),
+	);
 
 	// Connect
 	await connectionManager.initialize();

--- a/packages/vscode/src/terminal-link-provider.ts
+++ b/packages/vscode/src/terminal-link-provider.ts
@@ -1,0 +1,64 @@
+import * as vscode from 'vscode';
+import type { ConnectionManager } from './connection-manager.js';
+import type { TerminalManager } from './terminal-manager.js';
+
+// Matches Codev builder role names like `builder-spir-153`, `builder-bugfix-42`.
+const BUILDER_REGEX = /\bbuilder-[a-z]+-[a-z0-9]+\b/g;
+
+interface BuilderLink extends vscode.TerminalLink {
+  roleId: string;
+}
+
+/**
+ * Makes builder role names in terminal output clickable.
+ * Clicking opens (or focuses) that builder's terminal.
+ */
+export class BuilderTerminalLinkProvider implements vscode.TerminalLinkProvider<BuilderLink> {
+  constructor(
+    private connectionManager: ConnectionManager,
+    private terminalManager: TerminalManager,
+    private outputChannel: vscode.OutputChannel,
+  ) {}
+
+  provideTerminalLinks(context: vscode.TerminalLinkContext): BuilderLink[] {
+    const links: BuilderLink[] = [];
+    BUILDER_REGEX.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = BUILDER_REGEX.exec(context.line)) !== null) {
+      links.push({
+        startIndex: match.index,
+        length: match[0].length,
+        tooltip: `Open ${match[0]} terminal`,
+        roleId: match[0],
+      });
+    }
+    return links;
+  }
+
+  async handleTerminalLink(link: BuilderLink): Promise<void> {
+    const client = this.connectionManager.getClient();
+    const workspacePath = this.connectionManager.getWorkspacePath();
+    if (!client || !workspacePath) {
+      vscode.window.showErrorMessage('Codev: Not connected to Tower');
+      return;
+    }
+
+    try {
+      const state = await client.getWorkspaceState(workspacePath);
+      const builder = state?.builders?.find(b => b.name === link.roleId || b.id === link.roleId);
+      if (!builder?.terminalId) {
+        vscode.window.showWarningMessage(`Codev: No active terminal for ${link.roleId}`);
+        return;
+      }
+      await this.terminalManager.openBuilder(builder.terminalId, builder.id, `Codev: ${builder.name}`);
+    } catch (err) {
+      this.log('ERROR', `Failed to open builder ${link.roleId}: ${(err as Error).message}`);
+      vscode.window.showErrorMessage(`Codev: Failed to open ${link.roleId}`);
+    }
+  }
+
+  private log(level: string, message: string): void {
+    const timestamp = new Date().toISOString();
+    this.outputChannel.appendLine(`[${timestamp}] [BuilderLinks] [${level}] ${message}`);
+  }
+}

--- a/packages/vscode/src/terminal-manager.ts
+++ b/packages/vscode/src/terminal-manager.ts
@@ -39,13 +39,22 @@ export class TerminalManager {
   }
 
   /**
-   * Open a builder terminal.
+   * Open a builder terminal. If a terminal already exists for this builder
+   * but points at a different (stale) Tower session, dispose it before
+   * opening a new one — happens when a builder is re-spawned and Tower
+   * issues a new terminalId for the same roleId.
    */
   async openBuilder(terminalId: string, builderId: string, label: string): Promise<void> {
     const key = `builder-${builderId}`;
-    if (this.terminals.has(key)) {
-      this.terminals.get(key)!.terminal.show();
-      return;
+    const existing = this.terminals.get(key);
+    if (existing) {
+      if (existing.id === terminalId) {
+        existing.terminal.show();
+        return;
+      }
+      existing.pty.close();
+      existing.terminal.dispose();
+      this.terminals.delete(key);
     }
     await this.openTerminal(terminalId, 'builder', label, key);
   }


### PR DESCRIPTION
Four commits on this branch:

## 1. [Spec 0602] feat: emit and handle builder-spawned SSE event (1c6285e1)

Tower broadcasts a `builder-spawned` notification from `handleTerminalCreate` after a new builder terminal is registered, carrying `terminalId`, `roleId`, and `workspacePath`. The VS Code extension subscribes via the existing SSE wiring, filters by active workspace, dedups by `terminalId`, and dispatches based on the new `codev.autoOpenBuilderTerminal` setting:

- `notify` (default): show a toast with an Open Terminal button
- `auto`: open the terminal in the right editor group immediately
- `off`: ignore (sidebar still updates via `overview-changed`)

Older clients silently ignore the new event; older Tower instances never emit it. No version handshake required.

### Sample

<img width="1482" height="744" alt="image" src="https://github.com/user-attachments/assets/abd882a6-639f-4cc7-a5c4-b32183e45918" />

## 2. fix: surface architect spawn failures from workspace activation (ae427a8b)

`launchInstance` used to swallow architect spawn errors and return success, so clients saw "workspace activated" even when the architect never started. It now returns `{ success: false, error, adopted }` and logs at `ERROR`. The VS Code extension's `ConnectionManager.activateWorkspace` surfaces activation failures via `vscode.window.showErrorMessage` in addition to writing them to the output channel.

### Why
Reproduced on a workspace with a legacy `af-config.json`: extension logged "Workspace activated" successfully, then the user got the generic "No architect terminal found" warning when opening the architect. Tower's log had the real cause — `af-config.json is no longer supported. Run 'codev update' ...` — thrown from `buildArchitectArgs` and swallowed by the outer catch.

Two layers of silent failure combined:
1. `tower-instances.ts:470-473` — outer catch logged `WARN` but still returned `success: true`.
2. `connection-manager.ts:147-159` — activation errors only went to the Codev output channel, which users rarely open.
3. 
### Sample

<img width="1176" height="668" alt="image" src="https://github.com/user-attachments/assets/c4ab33de-7692-40d6-9b90-3e88d6586deb" />

## 3. [Spec 0602] fix: dispose stale builder terminal on re-spawn (6566d82a)

When a builder is re-spawned (same `roleId`, new Tower `terminalId`), `TerminalManager.openBuilder` previously focused the cached terminal — which still pointed at the dead Tower session. The user saw a disconnected terminal even though Tower had a live session at the new id.

Now `openBuilder` compares the cached terminal's id against the incoming `terminalId`; on mismatch it closes the PTY, disposes the VS Code terminal, and opens a fresh one against the new session. Same-id case still just focuses (no flicker for benign repeats).

## 4. [Spec 0602] feat: clickable builder names in terminal output (0af4b9ef)

Adds a `TerminalLinkProvider` that matches Codev builder role names (`builder-spir-153`, `builder-bugfix-42`, etc.) in any terminal and opens the corresponding builder terminal on click.

Resolves the role to a live `terminalId` via `TowerClient.getWorkspaceState` and delegates to `TerminalManager.openBuilder` (which handles stale terminals correctly thanks to commit 3). Works in the architect's own terminal — when Claude prints a list of builders, each name becomes a one-click target.

### Sample

<img width="829" height="327" alt="image" src="https://github.com/user-attachments/assets/fbe562f9-5091-4b64-98ae-e888261b4849" />

## Test plan
- [x] `pnpm --filter @cluesmith/codev test -- tower-instances tower-routes` — 2473 passed, 13 skipped, 0 failed.
- [x] Manual: built extension, reopened a workspace with legacy `af-config.json`. Toast appears: ``Codev: Workspace activation failed: Failed to create architect terminal: af-config.json is no longer supported. Run 'codev update' to migrate to .codev/config.json.``
- [x] Sanity: reopen a healthy workspace and confirm no toast appears and the architect opens normally.
- [x] Builder auto-open: spawn a builder via `afx spawn`, confirm the three modes (`notify`/`auto`/`off`) behave as described.
- [x] Clickable builder names: in any terminal, type or paste `builder-spir-153` (or any active builder role); confirm the name is underlined and Cmd-click opens that builder's terminal.