### PR TITLE
chore: consolidate local-install flow into a single shell script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,24 +41,18 @@ To test changes locally before publishing to npm:
 # 1. Build (Tower stays up during this)
 pnpm build
 
-# 2. Pack both tarballs
-pnpm --filter @cluesmith/codev-core pack
-pnpm --filter @cluesmith/codev pack
-
-# 3. Install globally (Tower stays up)
-pnpm local-install
-
-# 3. Restart (only this step needs downtime)
-afx tower stop && afx tower start
+# 2. Pack, install globally, and restart Tower (one command)
+pnpm -w run local-install
 ```
 
 - `pnpm build` builds core first, then codev (including dashboard)
-- `pnpm --filter <package> pack` creates tarballs (run for core and codev separately)
-- `pnpm local-install` installs both tarballs in a single `npm install -g` command — separate installs fail because `@cluesmith/codev-core` isn't on the public npm registry
-- Install while Tower is running — it doesn't affect the running process
-- Do NOT stop Tower before installing — unnecessary downtime
-- Do NOT delete the tarballs — keep them for debugging if restart fails
-- Do NOT build between stop and start
+- `pnpm -w run local-install` runs `scripts/local-install.sh`, which:
+  - Packs both `@cluesmith/codev-core` and `@cluesmith/codev` tarballs into their package directories
+  - Globally installs both in one `npm install -g` (separate installs fail because `@cluesmith/codev-core` isn't on the public npm registry)
+  - Restores the executable bit on `scripts/forge/**/*.sh` (pnpm pack strips it, causing "GitHub CLI unavailable" errors otherwise)
+  - Restarts Tower so it picks up the new code
+- Install runs while Tower is up — only the final restart causes downtime
+- Do NOT stop Tower yourself before running the script — the script handles restart at the end
 - Do NOT use `npm link` or `pnpm link` — it breaks global installs
 
 ### Testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,24 +41,18 @@ To test changes locally before publishing to npm:
 # 1. Build (Tower stays up during this)
 pnpm build
 
-# 2. Pack both tarballs
-pnpm --filter @cluesmith/codev-core pack
-pnpm --filter @cluesmith/codev pack
-
-# 3. Install globally (Tower stays up)
-pnpm local-install
-
-# 3. Restart (only this step needs downtime)
-afx tower stop && afx tower start
+# 2. Pack, install globally, and restart Tower (one command)
+pnpm -w run local-install
 ```
 
 - `pnpm build` builds core first, then codev (including dashboard)
-- `pnpm --filter <package> pack` creates tarballs (run for core and codev separately)
-- `pnpm local-install` installs both tarballs in a single `npm install -g` command — separate installs fail because `@cluesmith/codev-core` isn't on the public npm registry
-- Install while Tower is running — it doesn't affect the running process
-- Do NOT stop Tower before installing — unnecessary downtime
-- Do NOT delete the tarballs — keep them for debugging if restart fails
-- Do NOT build between stop and start
+- `pnpm -w run local-install` runs `scripts/local-install.sh`, which:
+  - Packs both `@cluesmith/codev-core` and `@cluesmith/codev` tarballs into their package directories
+  - Globally installs both in one `npm install -g` (separate installs fail because `@cluesmith/codev-core` isn't on the public npm registry)
+  - Restores the executable bit on `scripts/forge/**/*.sh` (pnpm pack strips it, causing "GitHub CLI unavailable" errors otherwise)
+  - Restarts Tower so it picks up the new code
+- Install runs while Tower is up — only the final restart causes downtime
+- Do NOT stop Tower yourself before running the script — the script handles restart at the end
 - Do NOT use `npm link` or `pnpm link` — it breaks global installs
 
 ### Testing

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
   "scripts": {
     "build": "pnpm --filter @cluesmith/codev-core build && pnpm --filter @cluesmith/codev build",
     "test": "pnpm --filter @cluesmith/codev test",
-    "local-install": "npm install -g ./packages/core/cluesmith-codev-core-*.tgz ./packages/codev/cluesmith-codev-*.tgz"
+    "local-install": "scripts/local-install.sh"
   }
 }

--- a/scripts/local-install.sh
+++ b/scripts/local-install.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Pack workspace packages into tarballs and install them globally for testing.
+# Run from the monorepo root: pnpm -w run local-install
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Pack — clear stale tarballs first so the install glob matches exactly one file.
+rm -f packages/core/*.tgz packages/codev/*.tgz
+pnpm --filter @cluesmith/codev-core pack --pack-destination packages/core
+pnpm --filter @cluesmith/codev pack --pack-destination packages/codev
+
+# Uninstall first — `npm install -g` over an existing same-name package
+# is sometimes a silent no-op, leaving the previous version installed.
+npm uninstall -g @cluesmith/codev @cluesmith/codev-core 2>/dev/null || true
+
+npm install -g \
+  "$REPO_ROOT/packages/core/cluesmith-codev-core-"*.tgz \
+  "$REPO_ROOT/packages/codev/cluesmith-codev-"*.tgz
+
+# pnpm pack strips the executable bit from shell scripts in the tarball,
+# which causes "GitHub CLI unavailable" errors when overview.ts tries to
+# spawn scripts/forge/github/*.sh. Restore +x after install.
+chmod -R +x "$(npm root -g)/@cluesmith/codev/scripts/forge"
+
+echo "Installed: $(codev --version)"
+
+# Restart Tower so it picks up the new code.
+afx tower stop && afx tower start
+
+echo "Tower restarted — new code is now live."


### PR DESCRIPTION
## Summary

Moves the pack + install + chmod + Tower-restart sequence into `scripts/local-install.sh` so the root `package.json` script stays a one-liner. Primary use case: iterating on the Codev CLI (porch, afx, Tower, forge) during local dev. Also enables end-to-end testing of extension ↔ Tower features.

## Why

The previous multi-step flow (`pnpm build` → two `pnpm pack`s → `pnpm local-install` → `afx tower stop && afx tower start`) had three latent bugs I hit during PR #682 testing:

1. **Stale tarballs** — `pnpm --filter <pkg> pack` writes to the repo root, not the package directory. `local-install`'s glob (`./packages/codev/cluesmith-codev-*.tgz`) picked up leftover tarballs from prior runs instead of the fresh one. I was testing old code without realizing it. Script now uses `--pack-destination` and `rm -f` stale tarballs upfront.
2. **Silent no-op on reinstall** — `npm install -g <same-version.tgz>` over an existing install often does nothing visible. Fresh code never replaced the old install. Script uninstalls explicitly before reinstalling.
3. **"GitHub CLI unavailable" in sidebar** — `pnpm pack` strips the executable bit from `scripts/forge/**/*.sh`. Without `chmod +x` after install, `overview.ts`'s `spawn('scripts/forge/github/pr-list.sh')` hits permission-denied, surfacing as "GitHub CLI unavailable — could not fetch PRs" in the extension. Script restores `+x` as part of install.

Plus ergonomics: one command instead of four, harder to forget the Tower restart.

## Changes

- **New**: `scripts/local-install.sh` — pack (to package dirs), uninstall globals, install fresh, chmod forge scripts, `afx tower stop && afx tower start`
- **`package.json`**: `local-install` script reduced to `scripts/local-install.sh`
- **`CLAUDE.md`** and **`AGENTS.md`**: Local Build Testing section simplified to `pnpm build` + `pnpm -w run local-install`, bullet list rewritten to describe what the script does

## Scope

| Beneficiary | Applies? |
|-------------|----------|
| Iterating on Codev CLI | Primary — each iteration needs fresh global install + Tower restart |
| End-to-end testing of extension ↔ Tower (SSE flows, new routes, etc.) | Yes — extension talks to locally-installed Tower |
| Extension-only UI work | No — F5 dev host or `.vsix` reload handles that |
| Production users (`npm install -g @cluesmith/codev`) | No — this script is dev-only |

## Test plan

- [x] `pnpm -w run local-install` from a clean state — confirms install succeeds, Tower restarts, version reports correctly
- [x] Reproduces the chmod fix: before the `chmod +x` step, running the installed `scripts/forge/github/pr-list.sh` directly fails with "permission denied"; after, it returns `[]`
- [ ] Sidebar smoke test after install: Pull Requests and Backlog views populate instead of showing "GitHub CLI unavailable"

## Out of scope

- Release-time publish flow — still goes through the release protocol's `pnpm publish --filter` sequence, not this script
- VS Code extension install — separate workflow (F5 or `vsce publish`)