### PR TITLE
[Bugfix #693] Restore executable bit on forge scripts after install

### DIFF
--- a/codev/projects/bugfix-693-forge-scripts-ship-without-exe/status.yaml
+++ b/codev/projects/bugfix-693-forge-scripts-ship-without-exe/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-693
 title: forge-scripts-ship-without-exe
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-04-22T13:23:57.250Z'
-updated_at: '2026-04-22T13:23:57.251Z'
+updated_at: '2026-04-22T14:29:22.831Z'

--- a/codev/projects/bugfix-693-forge-scripts-ship-without-exe/status.yaml
+++ b/codev/projects/bugfix-693-forge-scripts-ship-without-exe/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-693
 title: forge-scripts-ship-without-exe
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-04-22T13:23:57.250Z'
-updated_at: '2026-04-22T14:29:22.831Z'
+updated_at: '2026-04-22T14:29:54.780Z'

--- a/codev/projects/bugfix-693-forge-scripts-ship-without-exe/status.yaml
+++ b/codev/projects/bugfix-693-forge-scripts-ship-without-exe/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-693
+title: forge-scripts-ship-without-exe
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-04-22T13:23:57.250Z'
+updated_at: '2026-04-22T13:23:57.251Z'

--- a/codev/projects/bugfix-693-forge-scripts-ship-without-exe/status.yaml
+++ b/codev/projects/bugfix-693-forge-scripts-ship-without-exe/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-693
 title: forge-scripts-ship-without-exe
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-04-22T13:23:57.250Z'
-updated_at: '2026-04-22T14:29:54.780Z'
+updated_at: '2026-04-22T14:30:03.204Z'

--- a/packages/codev/package.json
+++ b/packages/codev/package.json
@@ -18,7 +18,8 @@
     "skeleton",
     "templates",
     "dashboard-dist",
-    "scripts/forge"
+    "scripts/forge",
+    "scripts/postinstall.mjs"
   ],
   "scripts": {
     "clean": "rm -rf dist",
@@ -33,7 +34,7 @@
     "test:e2e:watch": "vitest --config vitest.e2e.config.ts",
     "test:e2e:playwright": "pnpm exec playwright test",
     "test:e2e:cli": "pnpm build && vitest run --config vitest.cli.config.ts",
-    "postinstall": "node -e \"try{require('fs').chmodSync(require('path').join(require.resolve('node-pty'),'..','..','prebuilds',process.platform+'-'+process.arch,'spawn-helper'),0o755)}catch{}\"",
+    "postinstall": "node ./scripts/postinstall.mjs",
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {

--- a/packages/codev/scripts/postinstall.mjs
+++ b/packages/codev/scripts/postinstall.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+// Restores executable bits that pnpm pack/publish strips from files outside
+// the `bin` field. See issue #693 — without this, `afx spawn` fails with
+// Permission denied when invoking forge concept scripts.
+
+import { chmodSync, readdirSync, statSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const forgeRoot = join(here, 'forge');
+
+function chmodForgeScripts(root) {
+  let stat;
+  try {
+    stat = statSync(root);
+  } catch {
+    return 0;
+  }
+  if (!stat.isDirectory()) return 0;
+
+  let count = 0;
+  for (const dir of readdirSync(root)) {
+    const dirPath = join(root, dir);
+    if (!statSync(dirPath).isDirectory()) continue;
+    for (const file of readdirSync(dirPath)) {
+      if (!file.endsWith('.sh')) continue;
+      const filePath = join(dirPath, file);
+      chmodSync(filePath, 0o755);
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function chmodNodePtySpawnHelper() {
+  try {
+    const require = createRequire(import.meta.url);
+    const ptyEntry = require.resolve('node-pty');
+    const helper = join(
+      ptyEntry,
+      '..',
+      '..',
+      'prebuilds',
+      `${process.platform}-${process.arch}`,
+      'spawn-helper'
+    );
+    chmodSync(helper, 0o755);
+  } catch {
+    // node-pty may not ship a prebuild for this platform; harmless.
+  }
+}
+
+chmodForgeScripts(forgeRoot);
+chmodNodePtySpawnHelper();

--- a/packages/codev/scripts/postinstall.mjs
+++ b/packages/codev/scripts/postinstall.mjs
@@ -4,7 +4,7 @@
 // the `bin` field. See issue #693 — without this, `afx spawn` fails with
 // Permission denied when invoking forge concept scripts.
 
-import { chmodSync, readdirSync, statSync } from 'node:fs';
+import { chmodSync, readdirSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -13,26 +13,20 @@ const here = dirname(fileURLToPath(import.meta.url));
 const forgeRoot = join(here, 'forge');
 
 function chmodForgeScripts(root) {
-  let stat;
+  let providers;
   try {
-    stat = statSync(root);
+    providers = readdirSync(root, { withFileTypes: true });
   } catch {
-    return 0;
+    return;
   }
-  if (!stat.isDirectory()) return 0;
-
-  let count = 0;
-  for (const dir of readdirSync(root)) {
-    const dirPath = join(root, dir);
-    if (!statSync(dirPath).isDirectory()) continue;
-    for (const file of readdirSync(dirPath)) {
-      if (!file.endsWith('.sh')) continue;
-      const filePath = join(dirPath, file);
-      chmodSync(filePath, 0o755);
-      count += 1;
+  for (const provider of providers) {
+    if (!provider.isDirectory()) continue;
+    const providerDir = join(root, provider.name);
+    for (const entry of readdirSync(providerDir, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith('.sh')) continue;
+      chmodSync(join(providerDir, entry.name), 0o755);
     }
   }
-  return count;
 }
 
 function chmodNodePtySpawnHelper() {

--- a/packages/codev/src/__tests__/bugfix-693-forge-exec-bit.test.ts
+++ b/packages/codev/src/__tests__/bugfix-693-forge-exec-bit.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Regression test for bugfix #693: forge scripts ship without executable bit.
+ *
+ * pnpm pack/publish strips executable bits from files outside the `bin` field.
+ * The package.json postinstall hook restores them. This test guards:
+ *
+ *   1. package.json still wires postinstall → scripts/postinstall.mjs
+ *      and ships the script in the `files` array.
+ *   2. postinstall.mjs actually chmods every forge script it finds.
+ *   3. Every forge script tracked in the repo lives where postinstall
+ *      expects it (scripts/forge/<provider>/<name>.sh), so nothing is
+ *      silently missed when a new script is added.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const codevPkgRoot = resolve(__dirname, '..', '..');
+const realPostinstall = join(codevPkgRoot, 'scripts', 'postinstall.mjs');
+
+describe('bugfix #693: forge scripts retain +x after install', () => {
+  it('package.json wires postinstall to scripts/postinstall.mjs and ships the file', () => {
+    const pkg = JSON.parse(readFileSync(join(codevPkgRoot, 'package.json'), 'utf8'));
+    expect(pkg.scripts.postinstall).toContain('scripts/postinstall.mjs');
+    expect(pkg.files).toContain('scripts/postinstall.mjs');
+    expect(pkg.files).toContain('scripts/forge');
+  });
+
+  it('postinstall.mjs makes every forge script executable', () => {
+    const fixture = mkdtempSync(join(tmpdir(), 'codev-693-'));
+    try {
+      const providers = ['github', 'gitlab', 'gitea'];
+      const scriptNames = ['issue-view.sh', 'pr-merge.sh', 'auth-status.sh'];
+      const forgeRoot = join(fixture, 'scripts', 'forge');
+
+      for (const provider of providers) {
+        mkdirSync(join(forgeRoot, provider), { recursive: true });
+        for (const name of scriptNames) {
+          const path = join(forgeRoot, provider, name);
+          writeFileSync(path, '#!/bin/sh\nexit 0\n', { mode: 0o644 });
+          chmodSync(path, 0o644);
+          expect(statSync(path).mode & 0o111).toBe(0);
+        }
+      }
+
+      copyFileSync(realPostinstall, join(fixture, 'scripts', 'postinstall.mjs'));
+      execFileSync('node', ['./scripts/postinstall.mjs'], { cwd: fixture });
+
+      for (const provider of providers) {
+        for (const name of scriptNames) {
+          const mode = statSync(join(forgeRoot, provider, name)).mode & 0o777;
+          expect(mode).toBe(0o755);
+        }
+      }
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it('every committed forge script sits at scripts/forge/<provider>/<name>.sh', () => {
+    const forgeRoot = join(codevPkgRoot, 'scripts', 'forge');
+    const providers = readdirSync(forgeRoot, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+    expect(providers.length).toBeGreaterThan(0);
+
+    for (const provider of providers) {
+      const providerDir = join(forgeRoot, provider);
+      const entries = readdirSync(providerDir, { withFileTypes: true });
+      for (const entry of entries) {
+        expect(
+          entry.isFile() && entry.name.endsWith('.sh'),
+          `unexpected entry ${provider}/${entry.name} — postinstall only chmods *.sh files one level deep`
+        ).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #693 — `afx spawn` failing with `Permission denied` on fresh installs because forge concept scripts (`scripts/forge/<provider>/*.sh`) ship as `0644`.

## Root Cause

`pnpm pack` / `pnpm publish` strips executable bits from every file outside the `bin` field, even when the source is tracked in git with mode `100755`. The scripts at `packages/codev/scripts/forge/**/*.sh` are all `100755` in the repo (confirmed via `git ls-files -s`), but the produced tarball has them as `0644`:

```text
# pnpm pack tarball contents
-rw-r--r--  0 ...  package/scripts/forge/github/issue-view.sh
```

`npm pack` on the same tree preserves the bits, so this is a pnpm-specific packaging bug rather than a git state issue.

The issue's suggested fix (`chmod +x` + commit) does not help — the files are already 100755 in git.

## Fix

Move the existing one-liner `postinstall` into a dedicated `packages/codev/scripts/postinstall.mjs` that chmods every `scripts/forge/<provider>/*.sh` back to `0755`. The pre-existing node-pty `spawn-helper` chmod is preserved. `scripts/postinstall.mjs` is added to `files` so it ships in the tarball.

Implementation uses `readdirSync(..., { withFileTypes: true })` so a broken symlink in the provider dir wouldn't crash postinstall.

This is robust against both pnpm-packed and npm-packed tarballs, and does not require changing the release workflow.

### Verification

```bash
cd packages/codev && pnpm pack
# Install the tarball into a scratch dir — postinstall runs:
cd /tmp/scratch && npm install /path/to/cluesmith-codev-3.0.0-rc.11.tgz --no-save
ls -la node_modules/@cluesmith/codev/scripts/forge/github/issue-view.sh
# -rwxr-xr-x ...
```

All 42 forge scripts (github/16, gitlab/14, gitea/12) end up at `0755`.

## Test Plan

- [x] New regression test: `packages/codev/src/__tests__/bugfix-693-forge-exec-bit.test.ts`
  - Verifies `package.json` wires postinstall + ships the script via `files`.
  - Runs `postinstall.mjs` against a fixture tree of mode-`0644` scripts and asserts they become `0755`.
  - Asserts every committed forge script lives at `scripts/forge/<provider>/<name>.sh` (one level deep), so new scripts are not silently missed.
- [x] Full suite: `pnpm vitest run` → `Test Files 126 passed (126), Tests 2523 passed | 13 skipped (2536)`
- [x] Manual verification: packed with `pnpm pack`, installed into a scratch dir, confirmed `-rwxr-xr-x` on all forge scripts.

## CMAP Review

- **Claude**: APPROVE (HIGH) — "Clean, well-scoped bugfix with correct root cause analysis, proper ESM postinstall implementation, and solid regression tests."
- **Codex**: APPROVE (MEDIUM) — "Cleanly fixes the packaged forge-script executable-bit issue with a focused postinstall hook and solid regression coverage."
- **Gemini**: REQUEST_CHANGES (HIGH) → addressed in follow-up commit. Gemini flagged a correctness nit: the original `statSync` loop could throw on a broken symlink and crash postinstall. Fixed by switching to `readdirSync(..., { withFileTypes: true })` (commit 6779092f). Gemini's other two "issues" (missing `codev/reviews/` doc, `status.yaml` still at `investigate`) don't apply: the BUGFIX protocol keeps the review in the PR body, and `status.yaml` is now advanced to `verified` via `porch done` — builders aren't allowed to edit it directly.