### PR TITLE
[Bugfix #698] Fix ambiguous team-tab test card locator

### DIFF
--- a/codev/projects/bugfix-698-dashboard-e2e-team-tab-review-/status.yaml
+++ b/codev/projects/bugfix-698-dashboard-e2e-team-tab-review-/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-698
+title: dashboard-e2e-team-tab-review-
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-04-23T09:01:55.935Z'
+updated_at: '2026-04-23T09:01:55.936Z'

--- a/codev/projects/bugfix-698-dashboard-e2e-team-tab-review-/status.yaml
+++ b/codev/projects/bugfix-698-dashboard-e2e-team-tab-review-/status.yaml
@@ -9,4 +9,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-04-23T09:01:55.935Z'
-updated_at: '2026-04-23T09:01:55.936Z'
+updated_at: '2026-04-23T09:18:07.702Z'
+pr_history:
+  - phase: investigate
+    pr_number: 699
+    branch: builder/bugfix-698
+    created_at: '2026-04-23T09:18:07.701Z'

--- a/codev/projects/bugfix-698-dashboard-e2e-team-tab-review-/status.yaml
+++ b/codev/projects/bugfix-698-dashboard-e2e-team-tab-review-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-698
 title: dashboard-e2e-team-tab-review-
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,7 +9,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-04-23T09:01:55.935Z'
-updated_at: '2026-04-23T09:18:28.955Z'
+updated_at: '2026-04-23T09:18:59.985Z'
 pr_history:
   - phase: investigate
     pr_number: 699

--- a/codev/projects/bugfix-698-dashboard-e2e-team-tab-review-/status.yaml
+++ b/codev/projects/bugfix-698-dashboard-e2e-team-tab-review-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-698
 title: dashboard-e2e-team-tab-review-
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,7 +9,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-04-23T09:01:55.935Z'
-updated_at: '2026-04-23T09:18:07.702Z'
+updated_at: '2026-04-23T09:18:28.955Z'
 pr_history:
   - phase: investigate
     pr_number: 699

--- a/codev/projects/bugfix-698-dashboard-e2e-team-tab-review-/status.yaml
+++ b/codev/projects/bugfix-698-dashboard-e2e-team-tab-review-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-698
 title: dashboard-e2e-team-tab-review-
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,7 +9,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-04-23T09:01:55.935Z'
-updated_at: '2026-04-23T09:18:59.985Z'
+updated_at: '2026-04-23T09:19:12.176Z'
 pr_history:
   - phase: investigate
     pr_number: 699

--- a/packages/codev/src/agent-farm/__tests__/e2e/team-tab.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/team-tab.test.ts
@@ -201,14 +201,23 @@ test.describe('Team tab: review-blocking rendering (spec 694)', () => {
     await teamTab.click();
     await page.locator('.team-review-blocking').first().waitFor({ state: 'visible', timeout: 5_000 });
 
+    // Identify each card by its GitHub handle element (unique per member),
+    // not by substring match on the whole card — review-blocking sentences
+    // legitimately mention the other member's name, which would otherwise
+    // cause `hasText: 'Amr'` / `hasText: 'Waleed'` to match multiple cards.
+    const amrCard = page
+      .locator('.team-member-card')
+      .filter({ has: page.locator('.team-member-github', { hasText: /^@amr$/ }) });
+    const waleedCard = page
+      .locator('.team-member-card')
+      .filter({ has: page.locator('.team-member-github', { hasText: /^@waleed$/ }) });
+
     // Amr's card: second-person "You're waiting for Waleed".
-    const amrCard = page.locator('.team-member-card', { hasText: 'Amr' });
     await expect(amrCard).toContainText("You're waiting for");
     await expect(amrCard).toContainText('Waleed');
     await expect(amrCard).toContainText('#688');
 
     // Waleed's card: "Amr is waiting for you".
-    const waleedCard = page.locator('.team-member-card', { hasText: 'Waleed' });
     await expect(waleedCard).toContainText('is waiting for you to review');
     await expect(waleedCard).toContainText('#688');
 


### PR DESCRIPTION
## Summary
Fixes #698

## Root Cause
`packages/codev/src/agent-farm/__tests__/e2e/team-tab.test.ts` filtered each team member card by `hasText: 'Amr'` / `hasText: 'Waleed'`. After PR #695 shipped review-blocking sentences (e.g. *"Amr is waiting for you to review #688"* rendered inside Waleed's card), those substrings appeared in multiple cards and Playwright strict mode errored with "resolved to 2 elements".

## Fix
Identify each card by its `.team-member-github` child (the `@handle` element is unique per member and is never mirrored inside review-blocking sentences), using an anchored regex:

```ts
const amrCard = page
  .locator('.team-member-card')
  .filter({ has: page.locator('.team-member-github', { hasText: /^@amr$/ }) });
```

The anchored `/^@amr$/` also guards against future members with overlapping handle prefixes (e.g. `@amrit`).

## Test Plan
- [x] Ran `TOWER_TEST_PORT=4199 pnpm exec playwright test team-tab.test.ts` — all 5 tests pass (6.8s)
- [x] Kept the rest of the assertions (text content, href) intact — only the card locator changed
- [x] Net diff: 11 additions, 2 deletions (1 source file; `status.yaml` is porch-managed)

## CMAP Review

| Model  | Verdict         | Confidence |
|--------|-----------------|------------|
| Gemini | APPROVE         | HIGH       |
| Claude | APPROVE         | HIGH       |
| Codex  | REQUEST_CHANGES | HIGH       |

- **Gemini**: "Clean and correct fix for Playwright strict mode failures using precise, anchored locators."
- **Claude**: "Clean, minimal fix that correctly addresses the strict-mode locator ambiguity with an idiomatic Playwright pattern."
- **Codex**: Concern about `codev/projects/bugfix-698-.../status.yaml` being included. This file is porch-managed — it was created by `chore(porch): bugfix-698 init bugfix` (074d487d) at spawn time, and strict-mode builder rules explicitly prohibit editing `status.yaml` directly. Porch advances it at merge time; this mirrors past bugfixes (e.g. `chore(porch): bugfix-693 protocol complete`). Not a real blocker.