### PR TITLE
Dashboard backlog: show assignee alongside reporter (#700)

### DIFF
--- a/codev/projects/700-dashboard-backlog-show-assigne/status.yaml
+++ b/codev/projects/700-dashboard-backlog-show-assigne/status.yaml
@@ -1,7 +1,7 @@
 id: '700'
 title: dashboard-backlog-show-assigne
 protocol: air
-phase: implement
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-04-26T01:12:08.135Z'
-updated_at: '2026-04-26T01:12:08.136Z'
+updated_at: '2026-04-26T01:17:50.460Z'

--- a/codev/projects/700-dashboard-backlog-show-assigne/status.yaml
+++ b/codev/projects/700-dashboard-backlog-show-assigne/status.yaml
@@ -1,0 +1,14 @@
+id: '700'
+title: dashboard-backlog-show-assigne
+protocol: air
+phase: implement
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-04-26T01:12:08.135Z'
+updated_at: '2026-04-26T01:12:08.136Z'

--- a/packages/codev/scripts/forge/github/issue-list.sh
+++ b/packages/codev/scripts/forge/github/issue-list.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # Forge concept: issue-list (GitHub via gh CLI)
-# Output: JSON [{number, title, url, labels, createdAt, author}]
-exec gh issue list --limit 200 --json number,title,url,labels,createdAt,author
+# Output: JSON [{number, title, url, labels, createdAt, author, assignees}]
+exec gh issue list --limit 200 --json number,title,url,labels,createdAt,author,assignees

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -1266,6 +1266,33 @@ describe('overview', () => {
       const backlog = deriveBacklog(issues, tmpDir, new Set(), new Set());
       expect(backlog[0].author).toBeUndefined();
     });
+
+    it('maps a single assignee login', () => {
+      const issues = [{ ...issueItem(42, 'Test'), assignees: [{ login: 'amr' }] }];
+
+      const backlog = deriveBacklog(issues, tmpDir, new Set(), new Set());
+      expect(backlog[0].assignees).toEqual(['amr']);
+    });
+
+    it('maps multiple assignee logins', () => {
+      const issues = [
+        { ...issueItem(42, 'Test'), assignees: [{ login: 'amr' }, { login: 'bob' }] },
+      ];
+
+      const backlog = deriveBacklog(issues, tmpDir, new Set(), new Set());
+      expect(backlog[0].assignees).toEqual(['amr', 'bob']);
+    });
+
+    it('omits assignees when array is empty or missing', () => {
+      const empty = [{ ...issueItem(42, 'Test'), assignees: [] }];
+      const missing = [issueItem(43, 'Test')];
+
+      const backlogEmpty = deriveBacklog(empty, tmpDir, new Set(), new Set());
+      const backlogMissing = deriveBacklog(missing, tmpDir, new Set(), new Set());
+
+      expect(backlogEmpty[0].assignees).toBeUndefined();
+      expect(backlogMissing[0].assignees).toBeUndefined();
+    });
   });
 
   // ==========================================================================

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -70,6 +70,7 @@ export interface BacklogItem {
   hasBuilder: boolean;
   createdAt: string;
   author?: string;
+  assignees?: string[];
   specPath?: string;
   planPath?: string;
   reviewPath?: string;
@@ -659,6 +660,8 @@ export function deriveBacklog(
         createdAt: issue.createdAt,
         author: issue.author?.login,
       };
+      const assignees = issue.assignees?.map(a => a.login) ?? [];
+      if (assignees.length > 0) item.assignees = assignees;
       if (specFile) item.specPath = `codev/specs/${specFile}`;
       if (planFile) item.planPath = `codev/plans/${planFile}`;
       if (reviewFile) item.reviewPath = `codev/reviews/${reviewFile}`;

--- a/packages/codev/src/lib/forge-contracts.ts
+++ b/packages/codev/src/lib/forge-contracts.ts
@@ -37,6 +37,7 @@ export interface IssueListItem {
   createdAt: string;
   closedAt?: string;
   author?: { login: string };
+  assignees?: Array<{ login: string }>;
 }
 
 /** Output of the `issue-list` concept command. */

--- a/packages/dashboard/__tests__/BacklogList.test.tsx
+++ b/packages/dashboard/__tests__/BacklogList.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { BacklogList } from '../src/components/BacklogList.js';
+import type { OverviewBacklogItem } from '../src/lib/api.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeItem(overrides: Partial<OverviewBacklogItem> = {}): OverviewBacklogItem {
+  return {
+    id: '1',
+    title: 'Test issue',
+    url: 'https://github.com/org/repo/issues/1',
+    type: 'project',
+    priority: 'medium',
+    hasSpec: false,
+    hasPlan: false,
+    hasReview: false,
+    hasBuilder: false,
+    createdAt: new Date().toISOString(),
+    author: 'waleedkadous',
+    ...overrides,
+  };
+}
+
+describe('BacklogList assignee rendering', () => {
+  it('renders "a: none" when there are no assignees', () => {
+    const items = [makeItem({ id: '1', title: 'Unassigned' })];
+    render(<BacklogList items={items} />);
+
+    expect(screen.getByText('r: @waleedkadous')).toBeInTheDocument();
+    expect(screen.getByText('a: none')).toBeInTheDocument();
+  });
+
+  it('renders a single assignee as "a: @login"', () => {
+    const items = [
+      makeItem({ id: '2', title: 'One assignee', assignees: ['amr'] }),
+    ];
+    render(<BacklogList items={items} />);
+
+    expect(screen.getByText('a: @amr')).toBeInTheDocument();
+  });
+
+  it('renders multiple assignees comma-separated', () => {
+    const items = [
+      makeItem({ id: '3', title: 'Many assignees', assignees: ['amr', 'bob'] }),
+    ];
+    render(<BacklogList items={items} />);
+
+    expect(screen.getByText('a: @amr, @bob')).toBeInTheDocument();
+  });
+
+  it('treats empty assignees array as no assignees', () => {
+    const items = [makeItem({ id: '4', title: 'Empty list', assignees: [] })];
+    render(<BacklogList items={items} />);
+
+    expect(screen.getByText('a: none')).toBeInTheDocument();
+  });
+});

--- a/packages/dashboard/src/components/BacklogList.tsx
+++ b/packages/dashboard/src/components/BacklogList.tsx
@@ -60,7 +60,14 @@ export function BacklogList({ items, onRefresh }: BacklogListProps) {
             <span className="backlog-row-number">#{item.id}</span>
             <span className={`backlog-type-tag ${TYPE_CLASS[item.type] ?? ''}`}>{item.type}</span>
             <span className="backlog-row-title">{item.title}</span>
-            {item.author && <span className="backlog-row-author">@{item.author}</span>}
+            {item.author && (
+              <span className="backlog-row-author">r: @{item.author}</span>
+            )}
+            <span className="backlog-row-assignees">
+              a: {item.assignees && item.assignees.length > 0
+                ? item.assignees.map(a => `@${a}`).join(', ')
+                : 'none'}
+            </span>
             <span className="backlog-row-age">{timeAgo(item.createdAt)}</span>
           </a>
           {(item.specPath || item.planPath || item.reviewPath) && (

--- a/packages/dashboard/src/index.css
+++ b/packages/dashboard/src/index.css
@@ -1408,7 +1408,8 @@ a.attention-row {
   white-space: nowrap;
 }
 
-.backlog-row-author {
+.backlog-row-author,
+.backlog-row-assignees {
   font-size: 12px;
   color: var(--text-muted);
   white-space: nowrap;

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -110,6 +110,7 @@ export interface OverviewBacklogItem {
   hasBuilder: boolean;
   createdAt: string;
   author?: string;
+  assignees?: string[];
   specPath?: string;
   planPath?: string;
   reviewPath?: string;


### PR DESCRIPTION
## Summary

Adds the issue assignee to dashboard backlog rows. Each row now shows both the reporter (`r:`) and assignee (`a:`) on the same line:

```
r: @waleedkadous  a: none
r: @waleedkadous  a: @amr
r: @waleedkadous  a: @amr, @bob
```

Closes #700.

## Changes

Touched the four layers that needed plumbing for the new `assignees` field:

1. **`packages/codev/src/lib/forge-contracts.ts`** — added `assignees?: Array<{ login: string }>` to `IssueListItem`.
2. **`packages/codev/scripts/forge/github/issue-list.sh`** — added `assignees` to the `gh issue list --json` flag (gitlab/gitea presets unchanged — they already return all fields by default).
3. **`packages/codev/src/agent-farm/servers/overview.ts`** — added `assignees?: string[]` to `BacklogItem` and mapped `issue.assignees?.map(a => a.login)` in `deriveBacklog`. Empty/missing arrays become `undefined`.
4. **`packages/types/src/api.ts`** — mirrored the `assignees?: string[]` field on `OverviewBacklogItem`.
5. **`packages/dashboard/src/components/BacklogList.tsx`** — renders `r: @<reporter>  a: @<assignee>` (or `a: none` when unassigned, comma-separated for multiple). Also added a CSS rule so the new span shares the muted style of the reporter span.

## Out of scope

- No filtering or sorting by assignee (display only, per the issue).
- Team page and other views untouched.

## Tests

Added explicit coverage for the three required cases (none / one / many) at both layers:

- **Backend** (`packages/codev/src/agent-farm/__tests__/overview.test.ts`): three new `deriveBacklog` cases — single assignee, multiple assignees, and missing/empty arrays staying `undefined`.
- **UI** (`packages/dashboard/__tests__/BacklogList.test.tsx`, new file): four cases — `a: none`, single `@login`, comma-separated multiple, and empty array treated as none.

All 133 backend overview tests and the 4 new BacklogList tests pass. Full codev build is green.

## Review

**Decisions worth flagging**

- `BacklogItem.assignees` is left `undefined` when the array would be empty, mirroring the existing convention for `author`. Components see one shape (`undefined` or non-empty array), and the `a: none` rendering is decided at the view layer.
- `r:` is only rendered when an author exists (matching the prior behavior — the existing `item.author && ...` guard is preserved). `a:` always renders to keep the visual format unambiguous.
- The gh script change is GitHub-only — gitlab/gitea presets emit their CLIs' default JSON, which already includes assignees on the items they return. If those presets need normalization, that's a follow-up beyond this issue.

**Test plan**
- [x] `pnpm --filter @cluesmith/codev-types build`
- [x] `pnpm --filter @cluesmith/codev-core build`
- [x] `pnpm --filter @cluesmith/codev build` (green, including dashboard build)
- [x] Backend: `npx vitest run src/agent-farm/__tests__/overview.test.ts` (133/133)
- [x] UI: `npx vitest run BacklogList` (4/4)
- [ ] Visual sanity check in running dashboard (architect to verify)