### PR TITLE
[Bugfix #706] afx spawn --protocol falls back to skeleton

### DIFF
--- a/codev/projects/bugfix-706-afx-spawn-protocol-fails-on-v3/status.yaml
+++ b/codev/projects/bugfix-706-afx-spawn-protocol-fails-on-v3/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-706
+title: afx-spawn-protocol-fails-on-v3
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-04-29T01:00:10.880Z'
+updated_at: '2026-04-29T01:00:10.881Z'

--- a/codev/projects/bugfix-706-afx-spawn-protocol-fails-on-v3/status.yaml
+++ b/codev/projects/bugfix-706-afx-spawn-protocol-fails-on-v3/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-706
 title: afx-spawn-protocol-fails-on-v3
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-04-29T01:00:10.880Z'
-updated_at: '2026-04-29T01:00:10.881Z'
+updated_at: '2026-04-29T01:11:43.609Z'

--- a/codev/projects/bugfix-706-afx-spawn-protocol-fails-on-v3/status.yaml
+++ b/codev/projects/bugfix-706-afx-spawn-protocol-fails-on-v3/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-706
 title: afx-spawn-protocol-fails-on-v3
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-04-29T01:00:10.880Z'
-updated_at: '2026-04-29T01:11:43.609Z'
+updated_at: '2026-04-29T01:12:47.802Z'

--- a/packages/codev/src/agent-farm/__tests__/spawn-roles.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/spawn-roles.test.ts
@@ -6,7 +6,16 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderTemplate, buildPromptFromTemplate, buildResumeNotice, resolveMode, findSpecFile } from '../commands/spawn-roles.js';
+import {
+  renderTemplate,
+  buildPromptFromTemplate,
+  buildResumeNotice,
+  resolveMode,
+  findSpecFile,
+  validateProtocol,
+  loadProtocol,
+  loadProtocolRole,
+} from '../commands/spawn-roles.js';
 import type { TemplateContext } from '../commands/spawn-roles.js';
 
 // Mock dependencies
@@ -22,6 +31,32 @@ vi.mock('../utils/logger.js', () => ({
 vi.mock('../utils/roles.js', () => ({
   loadRolePrompt: vi.fn(() => ({ content: 'builder role', source: 'codev' })),
 }));
+
+// Hoisted shared state for the skeleton mock (vi.mock factories are hoisted, so
+// we use vi.hoisted to make this state available before the factory runs).
+const skeletonMock = vi.hoisted(() => ({ root: '' as string }));
+
+vi.mock('../../lib/skeleton.js', async () => {
+  const fs = await import('node:fs');
+  const path = await import('node:path');
+  return {
+    // Mirrors the real four-tier resolver: .codev/ → codev/ → cache → skeleton.
+    // The cache tier is omitted (irrelevant to these tests).
+    resolveCodevFile: (relativePath: string, workspaceRoot?: string): string | null => {
+      const root = workspaceRoot || process.cwd();
+      const overridePath = path.join(root, '.codev', relativePath);
+      if (fs.existsSync(overridePath)) return overridePath;
+      const localPath = path.join(root, 'codev', relativePath);
+      if (fs.existsSync(localPath)) return localPath;
+      if (skeletonMock.root) {
+        const skeletonPath = path.join(skeletonMock.root, relativePath);
+        if (fs.existsSync(skeletonPath)) return skeletonPath;
+      }
+      return null;
+    },
+    getSkeletonDir: (): string => skeletonMock.root,
+  };
+});
 
 // We need fs mocks for findSpecFile tests but must preserve real behavior for other tests.
 // Use spyOn approach within the findSpecFile describe block instead.
@@ -232,6 +267,114 @@ describe('spawn-roles', () => {
     it('returns null when specs directory does not exist', async () => {
       const result = await findSpecFile('/nonexistent-codev-dir', '76');
       expect(result).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // Skeleton Fallback (Issue #706)
+  //
+  // v3-cleaned projects don't carry a local codev/protocols/ directory. The
+  // resolver must fall back to the bundled skeleton in those cases — the
+  // hardcoded resolve(config.codevDir, 'protocols', ...) lookups previously
+  // failed with "Protocol not found".
+  // =========================================================================
+  describe('skeleton fallback (issue #706)', () => {
+    let workspaceRoot: string;
+    let skeletonRoot: string;
+    let codevDir: string;
+
+    function makeConfig() {
+      return {
+        workspaceRoot,
+        codevDir,
+        buildersDir: `${workspaceRoot}/.builders`,
+        stateDir: `${workspaceRoot}/.builders/state`,
+        templatesDir: '',
+        serversDir: '',
+        bundledRolesDir: '',
+        terminalBackend: 'node-pty' as const,
+      };
+    }
+
+    beforeEach(async () => {
+      const os = await import('node:os');
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+
+      workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'spawn-roles-ws-'));
+      skeletonRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'spawn-roles-skel-'));
+      // Simulate a v3-cleaned project: codev/ exists but protocols/ does not.
+      codevDir = path.join(workspaceRoot, 'codev');
+      fs.mkdirSync(codevDir, { recursive: true });
+
+      // Skeleton has spir/ and bugfix/ protocols.
+      fs.mkdirSync(path.join(skeletonRoot, 'protocols', 'spir'), { recursive: true });
+      fs.writeFileSync(
+        path.join(skeletonRoot, 'protocols', 'spir', 'protocol.json'),
+        JSON.stringify({ name: 'spir', version: '1', phases: [] }),
+      );
+      fs.writeFileSync(
+        path.join(skeletonRoot, 'protocols', 'spir', 'role.md'),
+        '# SPIR builder role',
+      );
+      fs.writeFileSync(
+        path.join(skeletonRoot, 'protocols', 'spir', 'builder-prompt.md'),
+        '# {{protocol_name}} prompt for {{input_description}}',
+      );
+      fs.mkdirSync(path.join(skeletonRoot, 'protocols', 'bugfix'), { recursive: true });
+      fs.writeFileSync(
+        path.join(skeletonRoot, 'protocols', 'bugfix', 'protocol.json'),
+        JSON.stringify({ name: 'bugfix', phases: [] }),
+      );
+
+      skeletonMock.root = skeletonRoot;
+    });
+
+    it('validateProtocol succeeds when protocol exists only in skeleton', () => {
+      // Local codev/protocols/ does not exist (v3-cleaned project).
+      expect(() => validateProtocol(makeConfig(), 'spir')).not.toThrow();
+    });
+
+    it('validateProtocol lists skeleton protocols when local dir is empty', () => {
+      expect(() => validateProtocol(makeConfig(), 'bogus')).toThrow(
+        /Protocol not found: bogus[\s\S]*Available protocols:[\s\S]*spir/,
+      );
+    });
+
+    it('loadProtocol falls back to skeleton', () => {
+      const protocol = loadProtocol(makeConfig(), 'spir');
+      expect(protocol).toEqual({ name: 'spir', version: '1', phases: [] });
+    });
+
+    it('loadProtocolRole falls back to skeleton', () => {
+      const role = loadProtocolRole(makeConfig(), 'spir');
+      expect(role).toEqual({ content: '# SPIR builder role', source: 'protocol' });
+    });
+
+    it('buildPromptFromTemplate uses skeleton template when local is missing', () => {
+      const ctx: TemplateContext = {
+        protocol_name: 'SPIR',
+        mode: 'strict',
+        mode_soft: false,
+        mode_strict: true,
+        input_description: 'a v3 feature',
+      };
+      const prompt = buildPromptFromTemplate(makeConfig(), 'spir', ctx);
+      expect(prompt).toContain('SPIR prompt for a v3 feature');
+    });
+
+    it('local codev/protocols/ takes precedence over skeleton', async () => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+      const localProtocolDir = path.join(codevDir, 'protocols', 'spir');
+      fs.mkdirSync(localProtocolDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(localProtocolDir, 'protocol.json'),
+        JSON.stringify({ name: 'spir-local', phases: [] }),
+      );
+
+      const protocol = loadProtocol(makeConfig(), 'spir');
+      expect(protocol).toEqual({ name: 'spir-local', phases: [] });
     });
   });
 });

--- a/packages/codev/src/agent-farm/commands/spawn-roles.ts
+++ b/packages/codev/src/agent-farm/commands/spawn-roles.ts
@@ -6,13 +6,14 @@
  * for builder sessions.
  */
 
-import { resolve } from 'node:path';
+import { resolve, join } from 'node:path';
 import { existsSync, readFileSync, readdirSync, type Dirent } from 'node:fs';
 import { readdir } from 'node:fs/promises';
 import type { SpawnOptions, Config, ProtocolDefinition } from '../types.js';
 import { logger, fatal } from '../utils/logger.js';
 import { loadRolePrompt } from '../utils/roles.js';
 import { stripLeadingZeros } from '../utils/agent-names.js';
+import { resolveCodevFile, getSkeletonDir } from '../../lib/skeleton.js';
 
 // =============================================================================
 // Template Rendering
@@ -92,11 +93,15 @@ export function renderTemplate(template: string, context: TemplateContext): stri
 }
 
 /**
- * Load builder-prompt.md template for a protocol
+ * Load builder-prompt.md template for a protocol.
+ * Resolves through .codev/ → codev/ → cache → skeleton (via resolveCodevFile).
  */
 function loadBuilderPromptTemplate(config: Config, protocolName: string): string | null {
-  const templatePath = resolve(config.codevDir, 'protocols', protocolName, 'builder-prompt.md');
-  if (existsSync(templatePath)) {
+  const templatePath = resolveCodevFile(
+    `protocols/${protocolName}/builder-prompt.md`,
+    config.workspaceRoot,
+  );
+  if (templatePath) {
     return readFileSync(templatePath, 'utf-8');
   }
   return null;
@@ -189,11 +194,15 @@ If porch reports "not found", run \`porch init\` to re-initialize.
 // =============================================================================
 
 /**
- * Load a protocol-specific role if it exists
+ * Load a protocol-specific role if it exists.
+ * Resolves through .codev/ → codev/ → cache → skeleton (via resolveCodevFile).
  */
 export function loadProtocolRole(config: Config, protocolName: string): { content: string; source: string } | null {
-  const protocolRolePath = resolve(config.codevDir, 'protocols', protocolName, 'role.md');
-  if (existsSync(protocolRolePath)) {
+  const protocolRolePath = resolveCodevFile(
+    `protocols/${protocolName}/role.md`,
+    config.workspaceRoot,
+  );
+  if (protocolRolePath) {
     return { content: readFileSync(protocolRolePath, 'utf-8'), source: 'protocol' };
   }
   // Fall back to builder role
@@ -239,38 +248,62 @@ export async function findSpecFile(codevDir: string, projectId: string): Promise
 }
 
 /**
- * Validate that a protocol exists
+ * List all protocol directory names visible across the resolver tiers
+ * (.codev/protocols, codev/protocols, embedded skeleton). Used to surface
+ * available alternatives when a requested protocol is not found.
+ */
+function listAvailableProtocols(config: Config): string[] {
+  const seen = new Set<string>();
+  const candidates = [
+    resolve(config.workspaceRoot, '.codev', 'protocols'),
+    resolve(config.codevDir, 'protocols'),
+    join(getSkeletonDir(), 'protocols'),
+  ];
+  for (const dir of candidates) {
+    if (!existsSync(dir)) continue;
+    try {
+      readdirSync(dir, { withFileTypes: true })
+        .filter((d: Dirent) => d.isDirectory())
+        .forEach((d: Dirent) => seen.add(d.name));
+    } catch {
+      // Ignore unreadable directories
+    }
+  }
+  return Array.from(seen).sort();
+}
+
+/**
+ * Validate that a protocol exists.
+ * Resolves through .codev/ → codev/ → cache → skeleton (via resolveCodevFile),
+ * so v3-cleaned projects without local protocols still find the skeleton copy.
  */
 export function validateProtocol(config: Config, protocolName: string): void {
-  const protocolDir = resolve(config.codevDir, 'protocols', protocolName);
-  const protocolFile = resolve(protocolDir, 'protocol.md');
+  const protocolJson = resolveCodevFile(
+    `protocols/${protocolName}/protocol.json`,
+    config.workspaceRoot,
+  );
+  const protocolMd = resolveCodevFile(
+    `protocols/${protocolName}/protocol.md`,
+    config.workspaceRoot,
+  );
 
-  if (!existsSync(protocolDir)) {
-    const protocolsDir = resolve(config.codevDir, 'protocols');
-    let available = '';
-    if (existsSync(protocolsDir)) {
-      const dirs = readdirSync(protocolsDir, { withFileTypes: true })
-        .filter((d: Dirent) => d.isDirectory())
-        .map((d: Dirent) => d.name);
-      if (dirs.length > 0) {
-        available = `\n\nAvailable protocols: ${dirs.join(', ')}`;
-      }
-    }
+  if (!protocolJson && !protocolMd) {
+    const dirs = listAvailableProtocols(config);
+    const available = dirs.length > 0 ? `\n\nAvailable protocols: ${dirs.join(', ')}` : '';
     fatal(`Protocol not found: ${protocolName}${available}`);
-  }
-
-  const protocolJson = resolve(protocolDir, 'protocol.json');
-  if (!existsSync(protocolFile) && !existsSync(protocolJson)) {
-    fatal(`Protocol ${protocolName} exists but has no protocol.md or protocol.json file`);
   }
 }
 
 /**
- * Load and parse a protocol.json file
+ * Load and parse a protocol.json file.
+ * Resolves through .codev/ → codev/ → cache → skeleton (via resolveCodevFile).
  */
 export function loadProtocol(config: Config, protocolName: string): ProtocolDefinition | null {
-  const protocolJsonPath = resolve(config.codevDir, 'protocols', protocolName, 'protocol.json');
-  if (!existsSync(protocolJsonPath)) {
+  const protocolJsonPath = resolveCodevFile(
+    `protocols/${protocolName}/protocol.json`,
+    config.workspaceRoot,
+  );
+  if (!protocolJsonPath) {
     return null;
   }
   try {


### PR DESCRIPTION
## Summary
Fixes #706 — `afx spawn --protocol <name>` now resolves protocols through the unified `.codev/` → `codev/` → cache → skeleton chain, so v3-cleaned projects (no local `codev/protocols/`) can spawn builders against the bundled skeleton.

## Root Cause
`packages/codev/src/agent-farm/commands/spawn-roles.ts` had five hardcoded `resolve(config.codevDir, 'protocols', ...)` lookups that never fell back to the embedded skeleton:

- L98 — `loadBuilderPromptTemplate` (`builder-prompt.md`)
- L195 — `loadProtocolRole` (`role.md`)
- L245 — `validateProtocol` (protocol directory existence)
- L249 — `validateProtocol` (listing alternatives)
- L272 — `loadProtocol` (`protocol.json`)

The unified resolver `resolveCodevFile()` in `packages/codev/src/lib/skeleton.ts` already walks the four-tier resolution chain correctly; afx just wasn't using it. `packages/codev/src/commands/porch/protocol.ts:loadProtocol()` was the existing reference implementation.

## Fix
- Replaced all five hardcoded lookups in `spawn-roles.ts` with `resolveCodevFile(\`protocols/<name>/<file>\`, config.workspaceRoot)`.
- Added a `listAvailableProtocols(config)` helper that enumerates protocol directory names across `.codev/protocols`, `codev/protocols`, and the embedded skeleton, so the "Available protocols:" error message stays useful when the local dir is empty.
- Did not touch `porch/protocol.ts` (already correct, kept as reference) or the v3 cleanup migration (out of scope).

## Test Plan
- [x] Added regression tests in `spawn-roles.test.ts` covering:
  - `validateProtocol` succeeds when only the skeleton has the protocol
  - `validateProtocol` lists skeleton protocols when local dir is empty
  - `loadProtocol` falls back to skeleton
  - `loadProtocolRole` falls back to skeleton
  - `buildPromptFromTemplate` uses skeleton template
  - Local `codev/protocols/` takes precedence over skeleton
- [x] All 70 agent-farm test files (1445 tests) pass
- [x] `pnpm exec tsc` clean
- [x] End-to-end smoke test against built `dist/` confirms all acceptance criteria from the issue

## Pre-existing test failures (not caused by this PR)
6 tests in `src/terminal/__tests__/session-manager.test.ts` fail because they require the shellper binary to be built — completely unrelated to this fix.

## CMAP Review

| Reviewer | Verdict | Confidence |
|----------|---------|------------|
| Gemini   | APPROVE | HIGH       |
| Codex    | APPROVE | HIGH       |
| Claude   | APPROVE | HIGH       |

**Key issues:** None. All three reviewers confirmed the fix correctly delegates to the unified resolver, mirrors the existing `porch/protocol.ts` reference pattern, and that regression tests cover the right scenarios.

**One non-blocking observation (Claude):** `listAvailableProtocols()` does not enumerate the framework cache tier — only `.codev/`, `codev/`, and skeleton. The cache is still found by `resolveCodevFile()` itself, so cache-only protocols still validate; only the "Available protocols:" error message would omit them. Cosmetic; can be addressed if framework-cache usage becomes common.