### PR TITLE
[Bugfix #711] fix(porch): add --version flag and implement 'pending' command

### DIFF
--- a/codev/projects/bugfix-711-porch-cli-add-version-flag-and/status.yaml
+++ b/codev/projects/bugfix-711-porch-cli-add-version-flag-and/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-711
 title: porch-cli-add-version-flag-and
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-04-30T19:34:01.012Z'
-updated_at: '2026-04-30T19:34:01.014Z'
+updated_at: '2026-04-30T22:54:33.205Z'

--- a/codev/projects/bugfix-711-porch-cli-add-version-flag-and/status.yaml
+++ b/codev/projects/bugfix-711-porch-cli-add-version-flag-and/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-711
 title: porch-cli-add-version-flag-and
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,7 +9,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-04-30T19:34:01.012Z'
-updated_at: '2026-04-30T22:56:52.081Z'
+updated_at: '2026-04-30T22:56:57.904Z'
 pr_history:
   - phase: pr
     pr_number: 714

--- a/codev/projects/bugfix-711-porch-cli-add-version-flag-and/status.yaml
+++ b/codev/projects/bugfix-711-porch-cli-add-version-flag-and/status.yaml
@@ -9,4 +9,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-04-30T19:34:01.012Z'
-updated_at: '2026-04-30T22:56:00.401Z'
+updated_at: '2026-04-30T22:56:52.081Z'
+pr_history:
+  - phase: pr
+    pr_number: 714
+    branch: builder/bugfix-711
+    created_at: '2026-04-30T22:56:52.080Z'

--- a/codev/projects/bugfix-711-porch-cli-add-version-flag-and/status.yaml
+++ b/codev/projects/bugfix-711-porch-cli-add-version-flag-and/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-711
 title: porch-cli-add-version-flag-and
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-04-30T19:34:01.012Z'
-updated_at: '2026-04-30T22:54:33.205Z'
+updated_at: '2026-04-30T22:56:00.401Z'

--- a/codev/projects/bugfix-711-porch-cli-add-version-flag-and/status.yaml
+++ b/codev/projects/bugfix-711-porch-cli-add-version-flag-and/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-711
+title: porch-cli-add-version-flag-and
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-04-30T19:34:01.012Z'
+updated_at: '2026-04-30T19:34:01.014Z'

--- a/packages/codev/src/commands/porch/__tests__/bugfix-711-pending-and-version.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/bugfix-711-pending-and-version.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Regression test for issue #711:
+ *   - `porch --version` should print the package version, not help.
+ *   - `porch pending` should be a real command (was documented but missing).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import { cli, pending } from '../index.js';
+import { writeState, getStatusPath } from '../state.js';
+import type { ProjectState } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createTestDir(prefix: string): string {
+  const dir = path.join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeState(overrides: Partial<ProjectState> = {}): ProjectState {
+  const now = new Date().toISOString();
+  return {
+    id: '0001',
+    title: 'test-feature',
+    protocol: 'spir',
+    phase: 'specify',
+    plan_phases: [],
+    current_plan_phase: null,
+    gates: {},
+    iteration: 1,
+    build_complete: false,
+    history: [],
+    started_at: now,
+    updated_at: now,
+    ...overrides,
+  };
+}
+
+function writeProject(workspaceRoot: string, state: ProjectState): string {
+  const statusPath = getStatusPath(workspaceRoot, state.id, state.title);
+  fs.mkdirSync(path.dirname(statusPath), { recursive: true });
+  writeState(statusPath, state);
+  return statusPath;
+}
+
+function captureStdout<T>(fn: () => Promise<T>): Promise<{ result: T; stdout: string }> {
+  const lines: string[] = [];
+  const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    lines.push(args.map((a) => String(a)).join(' '));
+  });
+  return fn()
+    .then((result) => ({ result, stdout: lines.join('\n') }))
+    .finally(() => spy.mockRestore());
+}
+
+// ---------------------------------------------------------------------------
+// --version
+// ---------------------------------------------------------------------------
+
+describe('porch --version', () => {
+  it('prints a semver-shaped version string and does not exit', async () => {
+    const { stdout } = await captureStdout(() => cli(['--version']));
+    expect(stdout).toMatch(/^\d+\.\d+\.\d+/);
+    // Crucially: it does NOT print the help banner.
+    expect(stdout).not.toContain('Protocol Orchestrator');
+  });
+
+  it('-v shorthand also prints the version', async () => {
+    const { stdout } = await captureStdout(() => cli(['-v']));
+    expect(stdout).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pending
+// ---------------------------------------------------------------------------
+
+describe('porch pending', () => {
+  let testDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    testDir = createTestDir('porch-711-pending');
+    process.chdir(testDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('reports "no gates pending" when the workspace is empty', async () => {
+    const { stdout } = await captureStdout(() => pending(testDir));
+    expect(stdout).toContain('No gates pending approval');
+  });
+
+  it('lists projects whose gate is pending and has a requested_at timestamp', async () => {
+    writeProject(
+      testDir,
+      makeState({
+        id: '0042',
+        title: 'feature-a',
+        gates: {
+          'spec-approval': { status: 'pending', requested_at: '2026-01-01T00:00:00Z' },
+        },
+      }),
+    );
+    writeProject(
+      testDir,
+      makeState({
+        id: '0043',
+        title: 'feature-b',
+        phase: 'plan',
+        gates: {
+          'plan-approval': { status: 'approved', approved_at: '2026-01-02T00:00:00Z' },
+        },
+      }),
+    );
+
+    const { stdout } = await captureStdout(() => pending(testDir));
+
+    expect(stdout).toContain('1 gate pending approval');
+    expect(stdout).toContain('0042');
+    expect(stdout).toContain('feature-a');
+    expect(stdout).toContain('spec-approval');
+    // approved gates and projects without a pending gate must NOT appear.
+    expect(stdout).not.toContain('0043');
+    expect(stdout).not.toContain('plan-approval');
+  });
+
+  it('skips pending gates that have not yet been requested', async () => {
+    // Gate is "pending" by default but no requested_at — porch hasn't asked
+    // for human approval yet, so it shouldn't be surfaced as actionable.
+    writeProject(
+      testDir,
+      makeState({
+        gates: { 'spec-approval': { status: 'pending' } },
+      }),
+    );
+
+    const { stdout } = await captureStdout(() => pending(testDir));
+    expect(stdout).toContain('No gates pending approval');
+  });
+
+  it('finds gates inside builder worktrees under .builders/*', async () => {
+    const worktreeRoot = path.join(testDir, '.builders', 'spir-77-thing');
+    fs.mkdirSync(worktreeRoot, { recursive: true });
+    writeProject(
+      worktreeRoot,
+      makeState({
+        id: '0077',
+        title: 'thing',
+        phase: 'plan',
+        gates: {
+          'plan-approval': { status: 'pending', requested_at: '2026-04-30T00:00:00Z' },
+        },
+      }),
+    );
+
+    const { stdout } = await captureStdout(() => pending(testDir));
+    expect(stdout).toContain('0077');
+    expect(stdout).toContain('plan-approval');
+  });
+
+  it('sorts oldest-requested first', async () => {
+    writeProject(
+      testDir,
+      makeState({
+        id: '0050',
+        title: 'newer',
+        gates: { 'spec-approval': { status: 'pending', requested_at: '2026-04-29T00:00:00Z' } },
+      }),
+    );
+    writeProject(
+      testDir,
+      makeState({
+        id: '0049',
+        title: 'older',
+        gates: { 'spec-approval': { status: 'pending', requested_at: '2026-04-15T00:00:00Z' } },
+      }),
+    );
+
+    const { stdout } = await captureStdout(() => pending(testDir));
+    const olderIdx = stdout.indexOf('0049');
+    const newerIdx = stdout.indexOf('0050');
+    expect(olderIdx).toBeGreaterThan(-1);
+    expect(newerIdx).toBeGreaterThan(-1);
+    expect(olderIdx).toBeLessThan(newerIdx);
+  });
+});

--- a/packages/codev/src/commands/porch/index.ts
+++ b/packages/codev/src/commands/porch/index.ts
@@ -49,6 +49,7 @@ import {
 } from './checks.js';
 import { loadCheckOverrides } from './config.js';
 import { loadConfig } from '../../lib/config.js';
+import { version } from '../../version.js';
 
 // ============================================================================
 // Output Helpers
@@ -882,6 +883,87 @@ function getNextAction(state: ProjectState, protocol: Protocol): string {
   return `Complete the phase work, then run: porch done ${state.id}`;
 }
 
+/**
+ * porch pending
+ * List all projects with gates awaiting human approval.
+ * Scans both the local workspace and any builder worktrees under .builders/*.
+ */
+export async function pending(workspaceRoot: string): Promise<void> {
+  type PendingGate = {
+    id: string;
+    title: string;
+    phase: string;
+    gate: string;
+    requested_at?: string;
+    statusPath: string;
+  };
+
+  const seen = new Set<string>(); // dedupe by status.yaml path
+  const results: PendingGate[] = [];
+
+  // Build the list of project directories to scan: main + every builder worktree.
+  const projectsDirs: string[] = [path.join(workspaceRoot, 'codev', 'projects')];
+  const buildersDir = path.join(workspaceRoot, '.builders');
+  if (fs.existsSync(buildersDir)) {
+    for (const wt of fs.readdirSync(buildersDir, { withFileTypes: true })) {
+      if (!wt.isDirectory()) continue;
+      projectsDirs.push(path.join(buildersDir, wt.name, 'codev', 'projects'));
+    }
+  }
+
+  for (const projectsDir of projectsDirs) {
+    if (!fs.existsSync(projectsDir)) continue;
+    for (const entry of fs.readdirSync(projectsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const statusPath = path.join(projectsDir, entry.name, 'status.yaml');
+      if (!fs.existsSync(statusPath)) continue;
+
+      const realPath = fs.realpathSync(statusPath);
+      if (seen.has(realPath)) continue;
+      seen.add(realPath);
+
+      let state: ProjectState;
+      try {
+        state = readState(statusPath);
+      } catch {
+        continue; // skip corrupted status files
+      }
+
+      for (const [gateName, gateStatus] of Object.entries(state.gates)) {
+        if (gateStatus?.status === 'pending' && gateStatus.requested_at) {
+          results.push({
+            id: state.id,
+            title: state.title,
+            phase: state.phase,
+            gate: gateName,
+            requested_at: gateStatus.requested_at,
+            statusPath,
+          });
+        }
+      }
+    }
+  }
+
+  console.log('');
+  if (results.length === 0) {
+    console.log(chalk.dim('No gates pending approval.'));
+    console.log('');
+    return;
+  }
+
+  // Sort oldest-first so the longest-waiting gates surface at the top.
+  results.sort((a, b) => (a.requested_at ?? '').localeCompare(b.requested_at ?? ''));
+
+  console.log(chalk.bold(`${results.length} gate${results.length === 1 ? '' : 's'} pending approval:`));
+  console.log('');
+  for (const r of results) {
+    console.log(`  ${chalk.cyan(r.id)} ${chalk.dim('—')} ${r.title}`);
+    console.log(`    phase: ${r.phase}  gate: ${chalk.yellow(r.gate)}  requested: ${r.requested_at}`);
+    console.log(chalk.dim(`    approve: porch approve ${r.id} ${r.gate} --a-human-explicitly-approved-this`));
+    console.log('');
+  }
+}
+
 function getArtifactForPhase(workspaceRoot: string, state: ProjectState, resolver?: ArtifactResolver): string | null {
   const baseName = resolveArtifactBaseName(workspaceRoot, state.id, state.title, resolver);
   switch (state.phase) {
@@ -902,6 +984,14 @@ function getArtifactForPhase(workspaceRoot: string, state: ProjectState, resolve
 
 export async function cli(args: string[]): Promise<void> {
   const [command, ...rest] = args;
+
+  // Handle --version / -v before any project resolution — version output
+  // must work from any directory and never require a project context.
+  if (command === '--version' || command === '-v') {
+    console.log(version);
+    return;
+  }
+
   const workspaceRoot = process.cwd();
   const resolver = getResolver(workspaceRoot);
 
@@ -918,6 +1008,10 @@ export async function cli(args: string[]): Promise<void> {
 
   try {
     switch (command) {
+      case 'pending':
+        await pending(workspaceRoot);
+        break;
+
       case 'next': {
         const { next: porchNext } = await import('./next.js');
         const result = await porchNext(workspaceRoot, getProjectId(rest[0]));
@@ -1023,10 +1117,14 @@ export async function cli(args: string[]): Promise<void> {
         console.log('  done [id] --pr N --branch NAME   Record PR creation (no phase advancement)');
         console.log('  done [id] --merged N             Mark PR as merged (no phase advancement)');
         console.log('  gate [id]                Request human approval');
+        console.log('  pending                  List all gates awaiting approval across projects');
         console.log('  approve <id> <gate> --a-human-explicitly-approved-this');
         console.log('  verify <id> --skip "reason"      Skip verification and mark as verified');
         console.log('  rollback <id> <phase>    Rewind project to an earlier phase');
         console.log('  init <protocol> <id> <name>  Initialize a new project');
+        console.log('');
+        console.log('Flags:');
+        console.log('  --version, -v            Print porch (codev) version');
         console.log('');
         console.log('Project ID is auto-detected from worktree path or when exactly one project exists.');
         console.log('');


### PR DESCRIPTION
## Summary

Two minor CLI gaps in `porch` from issue #711:

- **`porch --version` / `-v`** — was falling through to the help banner. Now prints the package version (`3.0.1`).
- **`porch pending`** — was documented in `architect.md`, the porch SKILL doc, the cheatsheet, and elsewhere, but **the command did not exist**. Implemented per the issue's "Option A": scans `codev/projects/*/status.yaml` plus every `.builders/*/codev/projects/*/status.yaml`, lists every gate with `status: pending` + `requested_at` set, sorts oldest-first, and prints a ready-to-paste `porch approve` line for each.

Closes #711.

## Verification

```text
$ porch --version
3.0.1

$ porch pending
1 gate pending approval:

  671 — hermes-consult-optional-backend
    phase: review  gate: pr  requested: 2026-04-15T21:49:59.445Z
    approve: porch approve 671 pr --a-human-explicitly-approved-this
```

The `pending` output also surfaces in the help banner alongside a new `Flags` section that lists `--version` / `-v`.

## What changed

- `packages/codev/src/commands/porch/index.ts`
  - Imports the package `version` and short-circuits `--version` / `-v` before any project resolution (so it works from any directory).
  - New `pending(workspaceRoot)` exported function. Dedupes by `realpath` so a status file that lives in both main and a worktree is only listed once.
  - New `case 'pending'` in the CLI switch.
  - Help banner advertises both.
- `packages/codev/src/commands/porch/__tests__/bugfix-711-pending-and-version.test.ts` (new)
  - 7 tests: `--version` shape, `-v` shape, empty workspace, mixed approved/pending, unrequested gates skipped, builder-worktree discovery, oldest-first ordering.

## Test plan

- [x] `pnpm --filter @cluesmith/codev test src/commands/porch/__tests__/` — 19 files / 282 tests pass
- [x] Manual: `porch --version` prints `3.0.1`
- [x] Manual: `porch pending` correctly surfaces a real pending gate (project 671)
- [x] Manual: `porch` (no args) help banner lists `pending` and `--version, -v`
- [x] `pnpm build` clean