### PR TITLE
[Bugfix #710] Skip E2E tests that depend on removed porch run orchestrator

### DIFF
--- a/codev/projects/bugfix-710-e2e-12-porch-single-phase-happ/status.yaml
+++ b/codev/projects/bugfix-710-e2e-12-porch-single-phase-happ/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-710
 title: e2e-12-porch-single-phase-happ
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,7 +9,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-04-30T19:33:52.093Z'
-updated_at: '2026-04-30T23:05:42.271Z'
+updated_at: '2026-04-30T23:05:47.776Z'
 pr_history:
   - phase: investigate
     pr_number: 715

--- a/codev/projects/bugfix-710-e2e-12-porch-single-phase-happ/status.yaml
+++ b/codev/projects/bugfix-710-e2e-12-porch-single-phase-happ/status.yaml
@@ -9,4 +9,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-04-30T19:33:52.093Z'
-updated_at: '2026-04-30T19:33:52.094Z'
+updated_at: '2026-04-30T23:05:42.271Z'
+pr_history:
+  - phase: investigate
+    pr_number: 715
+    branch: builder/bugfix-710
+    created_at: '2026-04-30T23:05:42.270Z'

--- a/codev/projects/bugfix-710-e2e-12-porch-single-phase-happ/status.yaml
+++ b/codev/projects/bugfix-710-e2e-12-porch-single-phase-happ/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-710
 title: e2e-12-porch-single-phase-happ
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,7 +9,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-04-30T19:33:52.093Z'
-updated_at: '2026-04-30T23:05:47.776Z'
+updated_at: '2026-04-30T23:08:27.967Z'
 pr_history:
   - phase: investigate
     pr_number: 715

--- a/codev/projects/bugfix-710-e2e-12-porch-single-phase-happ/status.yaml
+++ b/codev/projects/bugfix-710-e2e-12-porch-single-phase-happ/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-710
+title: e2e-12-porch-single-phase-happ
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-04-30T19:33:52.093Z'
+updated_at: '2026-04-30T19:33:52.094Z'

--- a/packages/codev/src/commands/porch/__tests__/e2e/scenarios/benchmark.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/e2e/scenarios/benchmark.test.ts
@@ -9,6 +9,12 @@
  * Specs and plans are pre-approved to skip specify/plan phases.
  *
  * Run with: npm run test:e2e -- --grep benchmark
+ *
+ * NOTE (issue #710): The benchmark is skipped because the strict-mode arm
+ * relies on the `porch run` orchestrator removed in spec 0095 (commit
+ * ed2012ae). With no orchestrator, there is no "strict mode" to benchmark
+ * against soft mode. Reviving the benchmark needs a planner-architecture
+ * comparison and its own spec.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -255,7 +261,7 @@ function formatTimingSummary(result: BenchmarkResult): string {
   return lines.join('\n');
 }
 
-describe('Porch Benchmark: Strict vs Soft Mode', () => {
+describe.skip('Porch Benchmark: Strict vs Soft Mode', () => {
   let strictCtx: TestContext;
   let softCtx: TestContext;
 

--- a/packages/codev/src/commands/porch/__tests__/e2e/scenarios/feedback-loop.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/e2e/scenarios/feedback-loop.test.ts
@@ -5,6 +5,12 @@
  * Also tests the max iterations limit.
  *
  * Run with: npm run test:e2e
+ *
+ * NOTE (issue #710): These tests are skipped because they depend on the
+ * `porch run` orchestrator removed in spec 0095 (commit ed2012ae). The
+ * iteration / feedback loop is now driven by the parent agent calling
+ * `porch next` repeatedly, not by an internal porch loop. Re-enabling
+ * this coverage needs a planner-aware test harness and its own spec.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -25,7 +31,7 @@ import {
   assertIteration,
 } from '../helpers/assertions.js';
 
-describe('Porch E2E: Feedback Loop', () => {
+describe.skip('Porch E2E: Feedback Loop', () => {
   let ctx: TestContext;
 
   beforeAll(async () => {
@@ -83,7 +89,7 @@ describe('Porch E2E: Feedback Loop', () => {
   });
 });
 
-describe('Porch E2E: Max Iterations', () => {
+describe.skip('Porch E2E: Max Iterations', () => {
   let ctx: TestContext;
 
   beforeAll(async () => {
@@ -120,7 +126,7 @@ describe('Porch E2E: Max Iterations', () => {
  * Test with mock consult that always rejects.
  * This verifies porch stops at max iterations even with constant rejection.
  */
-describe('Porch E2E: Max Iterations with Mock Consult', () => {
+describe.skip('Porch E2E: Max Iterations with Mock Consult', () => {
   let ctx: TestContext;
   let originalPath: string | undefined;
 

--- a/packages/codev/src/commands/porch/__tests__/e2e/scenarios/happy-path.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/e2e/scenarios/happy-path.test.ts
@@ -5,6 +5,12 @@
  * This is an expensive test (~$4, ~40 minutes).
  *
  * Run with: npm run test:e2e
+ *
+ * NOTE (issue #710): These tests are skipped because they depend on the
+ * `porch run` orchestrator removed in spec 0095 (commit ed2012ae). The new
+ * planner architecture (`porch next`) requires a parent agent to execute
+ * tasks, so an orchestrator-style E2E test no longer applies. Rewriting
+ * these tests for the planner architecture needs its own spec.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -29,7 +35,7 @@ import {
   assertGateApproved,
 } from '../helpers/assertions.js';
 
-describe('Porch E2E: Happy Path', () => {
+describe.skip('Porch E2E: Happy Path', () => {
   let ctx: TestContext;
 
   beforeAll(async () => {
@@ -103,7 +109,7 @@ describe('Porch E2E: Happy Path', () => {
  * Full lifecycle test with auto-approve.
  * This runs the entire SPIR protocol from start to finish.
  */
-describe('Porch E2E: Full Lifecycle', () => {
+describe.skip('Porch E2E: Full Lifecycle', () => {
   let ctx: TestContext;
 
   beforeAll(async () => {

--- a/packages/codev/src/commands/porch/__tests__/e2e/scenarios/single-phase.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/e2e/scenarios/single-phase.test.ts
@@ -7,6 +7,13 @@
  * 3. Exits after the phase completes (or hits a gate)
  *
  * Run with: npm run test:e2e
+ *
+ * NOTE (issue #710): These tests are skipped because they depend on the
+ * `porch run --single-phase` mode removed in spec 0095 (commit ed2012ae).
+ * The Agent SDK orchestration was deliberately moved out of porch — the
+ * parent agent now executes tasks emitted by `porch next`. Re-enabling
+ * single-phase E2E coverage requires a new test harness for the planner
+ * architecture and needs its own spec.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -27,7 +34,7 @@ import {
   assertGateApproved,
 } from '../helpers/assertions.js';
 
-describe('Porch E2E: Single Phase Mode', () => {
+describe.skip('Porch E2E: Single Phase Mode', () => {
   let ctx: TestContext;
 
   beforeAll(async () => {
@@ -103,7 +110,7 @@ describe('Porch E2E: Single Phase Mode', () => {
   }, 600000);
 });
 
-describe('Porch E2E: Single Phase Result Format', () => {
+describe.skip('Porch E2E: Single Phase Result Format', () => {
   let ctx: TestContext;
 
   beforeAll(async () => {

--- a/packages/codev/src/commands/porch/__tests__/run-removed.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/run-removed.test.ts
@@ -6,31 +6,55 @@
  * test pins the migration message so the deprecation remains discoverable
  * for anyone (including the E2E test runner) that still invokes the old
  * command.
+ *
+ * Calls `cli()` directly rather than spawning `bin/porch.js` as a
+ * subprocess: unit tests run before `pnpm build`, so `dist/` may be
+ * absent in CI.
  */
 
-import { describe, it, expect } from 'vitest';
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { cli } from '../index.js';
 
-const PORCH_BIN = path.resolve(__dirname, '..', '..', '..', '..', 'bin', 'porch.js');
+function captureRun(args: string[]): { stderr: string; exitCode: number } {
+  const stderr: string[] = [];
+  let exitCode = 0;
+
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    stderr.push(a.map(String).join(' '));
+  });
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    exitCode = code ?? 0;
+    throw new Error('__process_exit__');
+  }) as never);
+
+  try {
+    // cli() is async and the 'run' branch calls process.exit synchronously
+    // inside the switch. Our mock throws to unwind the stack so the test
+    // doesn't hang waiting on the promise.
+    cli(args).catch(() => { /* swallowed: __process_exit__ */ });
+  } finally {
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  }
+
+  return { stderr: stderr.join('\n'), exitCode };
+}
 
 describe('porch run (removed)', () => {
-  it('exits 1 with a migration message pointing to porch next', () => {
-    const result = spawnSync('node', [PORCH_BIN, 'run', 'some-id'], {
-      encoding: 'utf-8',
-    });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain("'porch run' has been removed");
-    expect(result.stderr).toContain("porch next");
+  it('exits 1 with a migration message pointing to porch next', () => {
+    const { stderr, exitCode } = captureRun(['run', 'some-id']);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("'porch run' has been removed");
+    expect(stderr).toContain('porch next');
   });
 
   it('exits 1 even when extra flags are passed (e.g. --single-phase)', () => {
-    const result = spawnSync('node', [PORCH_BIN, 'run', 'some-id', '--single-phase'], {
-      encoding: 'utf-8',
-    });
-
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain("'porch run' has been removed");
+    const { stderr, exitCode } = captureRun(['run', 'some-id', '--single-phase']);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("'porch run' has been removed");
   });
 });

--- a/packages/codev/src/commands/porch/__tests__/run-removed.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/run-removed.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Regression test for issue #710.
+ *
+ * `porch run` was removed in spec 0095 (commit ed2012ae) when the
+ * orchestrator was deleted in favor of the `porch next` planner. This
+ * test pins the migration message so the deprecation remains discoverable
+ * for anyone (including the E2E test runner) that still invokes the old
+ * command.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+
+const PORCH_BIN = path.resolve(__dirname, '..', '..', '..', '..', 'bin', 'porch.js');
+
+describe('porch run (removed)', () => {
+  it('exits 1 with a migration message pointing to porch next', () => {
+    const result = spawnSync('node', [PORCH_BIN, 'run', 'some-id'], {
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("'porch run' has been removed");
+    expect(result.stderr).toContain("porch next");
+  });
+
+  it('exits 1 even when extra flags are passed (e.g. --single-phase)', () => {
+    const result = spawnSync('node', [PORCH_BIN, 'run', 'some-id', '--single-phase'], {
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("'porch run' has been removed");
+  });
+});


### PR DESCRIPTION
Fixes #710

## Root Cause

The four affected E2E scenario files (`single-phase`, `happy-path`, `feedback-loop`, `benchmark`) all spawn `porch run` or `porch run --single-phase` via the helpers in `runner.ts`:

- `runPorchUntilGate`, `runPorchWithAutoApprove` → `porch run`
- `runPorchSinglePhase` → `porch run --single-phase`
- `runPorchOnce` → `porch run --once`

`porch run` was removed in spec 0095 (commit `ed2012ae`, "[Spec 0095][Phase: phase_2] refactor: Remove porch orchestrator"). The CLI now responds with:

```
Error: 'porch run' has been removed. Use 'porch next <id>' instead.
```

…and exits with code 1 before writing anything to stdout. The runner's gate / `__PORCH_RESULT__` regexes therefore never match, `singlePhaseResult` stays `null`, and `hitGate` stays `null` — which is exactly the failure shape described in the issue.

## Fix

The orchestration loop these tests describe was deliberately moved out of porch — the parent agent now executes tasks emitted by `porch next`, so an "orchestrator-style" E2E test no longer applies. Reviving the coverage requires a planner-aware harness and belongs to its own spec.

This PR:

- Marks the four affected scenario describes as `describe.skip` with a clear annotation pointing to issue #710 and spec 0095.
- Adds `__tests__/run-removed.test.ts`, a regression test that pins the migration message so anyone (including the previously-broken runner) who still invokes `porch run` keeps getting a clear pointer to `porch next`. The test invokes `cli()` directly (mocking `console.error` + `process.exit`) so it does not depend on `dist/` — same pattern as `bugfix-711-pending-and-version.test.ts`.

## Test Plan

- [x] All 277 porch unit tests pass (`pnpm test src/commands/porch/__tests__`)
- [x] New regression test passes locally (and in CI without a prior build, after the cli()-rewrite fix)
- [x] E2E scenario tests now report as skipped (`vitest run --config vitest.e2e.config.ts` on each affected file shows 0 failed, all skipped)
- [x] Net diff: 110 LOC (well under 300)

## CMAP Review

Three-way review run with `--protocol bugfix --type pr`:

| Reviewer | Verdict | Confidence | Notes |
|----------|---------|------------|-------|
| Gemini   | APPROVE | HIGH | "Correctly skips obsolete E2E tests relying on the deleted 'porch run' orchestrator and adds a robust regression test." |
| Codex    | REQUEST_CHANGES | HIGH | Flagged stale in-progress `status.yaml` and missing CMAP section in PR body. Both addressed. |
| Claude   | COMMENT | HIGH | Flagged the regression test's `dist/` dependency via `spawnSync`. Addressed by switching to direct `cli()` invocation. |

All blocking issues addressed:
- `status.yaml` advanced from `investigate` → `fix` via `porch done` with `--pr 715 --branch builder/bugfix-710` (recorded in pr_history)
- Regression test rewritten to call `cli()` directly so it works without `dist/`
- This PR body updated with CMAP results