### PR TITLE
[Bugfix #717] Fall back to Tower terminal_sessions when local state misses a builder

### DIFF
--- a/codev/projects/bugfix-717-afx-attach-can-t-find-builders/status.yaml
+++ b/codev/projects/bugfix-717-afx-attach-can-t-find-builders/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-717
 title: afx-attach-can-t-find-builders
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-02T01:51:59.248Z'
-updated_at: '2026-05-02T02:10:38.520Z'
+updated_at: '2026-05-02T02:10:47.664Z'

--- a/codev/projects/bugfix-717-afx-attach-can-t-find-builders/status.yaml
+++ b/codev/projects/bugfix-717-afx-attach-can-t-find-builders/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-717
 title: afx-attach-can-t-find-builders
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-02T01:51:59.248Z'
-updated_at: '2026-05-02T02:09:12.105Z'
+updated_at: '2026-05-02T02:10:38.520Z'

--- a/codev/projects/bugfix-717-afx-attach-can-t-find-builders/status.yaml
+++ b/codev/projects/bugfix-717-afx-attach-can-t-find-builders/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-717
 title: afx-attach-can-t-find-builders
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-02T01:51:59.248Z'
-updated_at: '2026-05-02T01:51:59.249Z'
+updated_at: '2026-05-02T02:09:12.105Z'

--- a/codev/projects/bugfix-717-afx-attach-can-t-find-builders/status.yaml
+++ b/codev/projects/bugfix-717-afx-attach-can-t-find-builders/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-717
+title: afx-attach-can-t-find-builders
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-02T01:51:59.248Z'
+updated_at: '2026-05-02T01:51:59.249Z'

--- a/packages/codev/src/agent-farm/__tests__/attach.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/attach.test.ts
@@ -57,9 +57,10 @@ vi.mock('../utils/logger.js', () => ({
 
 // Mock DB — configurable per test
 const mockDbGet = vi.fn();
+const mockDbAll = vi.fn().mockReturnValue([]);
 vi.mock('../db/index.js', () => ({
   getGlobalDb: () => ({
-    prepare: () => ({ get: mockDbGet }),
+    prepare: () => ({ get: mockDbGet, all: mockDbAll }),
   }),
 }));
 
@@ -126,6 +127,7 @@ describe('attach command', () => {
   beforeEach(() => {
     mockBuilders.length = 0;
     mockDbGet.mockReset();
+    mockDbAll.mockReset().mockReturnValue([]);
     mockExistsSync.mockReset().mockReturnValue(false);
     mockAccessSync.mockReset();
     mockReaddirSync.mockReset().mockReturnValue([]);
@@ -172,6 +174,26 @@ describe('attach command', () => {
       await expect(attach({ issue: 999 })).rejects.toThrow();
       expect(fatal).toHaveBeenCalledWith(expect.stringContaining('No builder found for issue #999'));
     });
+
+    // Regression for bugfix #717: when local state.db is empty but Tower's
+    // terminal_sessions table knows about the builder, attach must fall back
+    // to that registry instead of erroring "Builder not found."
+    it('should fall back to Tower terminal_sessions when local state has no match', async () => {
+      mockDbAll.mockReturnValue([
+        {
+          role_id: 'builder-bugfix-717',
+          cwd: '/workspace/.builders/bugfix-717',
+          label: 'Bugfix #717',
+        },
+      ]);
+
+      const { attach } = await import('../commands/attach.js');
+      const { openBrowser } = await import('../utils/shell.js');
+
+      await attach({ issue: 717, browser: true });
+
+      expect(openBrowser).toHaveBeenCalledWith(expect.stringContaining('localhost:4100/workspace/'));
+    });
   });
 
   describe('findBuilderById', () => {
@@ -215,6 +237,59 @@ describe('attach command', () => {
     });
 
     it('should error when builder not found', async () => {
+      const { attach } = await import('../commands/attach.js');
+      const { fatal } = await import('../utils/logger.js');
+
+      await expect(attach({ project: 'nonexistent' })).rejects.toThrow();
+      expect(fatal).toHaveBeenCalledWith(expect.stringContaining('Builder "nonexistent" not found'));
+    });
+
+    // Regression for bugfix #717: a builder visible in Tower (via
+    // terminal_sessions.role_id) but missing from local state.db must still
+    // be resolvable by `afx attach -p`.
+    it('should fall back to Tower terminal_sessions for exact ID', async () => {
+      mockDbAll.mockReturnValue([
+        {
+          role_id: 'builder-spir-118',
+          cwd: '/workspace/.builders/spir-118',
+          label: '118-feature',
+        },
+      ]);
+
+      const { attach } = await import('../commands/attach.js');
+      const { openBrowser } = await import('../utils/shell.js');
+
+      await attach({ project: 'builder-spir-118', browser: true });
+
+      expect(openBrowser).toHaveBeenCalledWith(expect.stringContaining('localhost:4100/workspace/'));
+    });
+
+    it('should fall back to Tower terminal_sessions for substring match', async () => {
+      mockDbAll.mockReturnValue([
+        {
+          role_id: 'builder-bugfix-717',
+          cwd: '/workspace/.builders/bugfix-717',
+          label: 'Bugfix #717',
+        },
+      ]);
+
+      const { attach } = await import('../commands/attach.js');
+      const { openBrowser } = await import('../utils/shell.js');
+
+      await attach({ project: '717', browser: true });
+
+      expect(openBrowser).toHaveBeenCalledWith(expect.stringContaining('localhost:4100/workspace/'));
+    });
+
+    it('should error when Tower fallback also has no match', async () => {
+      mockDbAll.mockReturnValue([
+        {
+          role_id: 'builder-spir-100',
+          cwd: '/workspace/.builders/spir-100',
+          label: '100-other',
+        },
+      ]);
+
       const { attach } = await import('../commands/attach.js');
       const { fatal } = await import('../utils/logger.js');
 

--- a/packages/codev/src/agent-farm/__tests__/attach.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/attach.test.ts
@@ -373,7 +373,11 @@ describe('attach command', () => {
       expect(result).toBe('/tmp/shellper-test.sock');
     });
 
-    it('should pass workspace_path and role_id to SQLite query', async () => {
+    // Regression for bugfix #717: terminal_sessions.workspace_path stores
+    // config.workspaceRoot (the workspace ROOT), not the builder's worktree
+    // path. Querying with the worktree would always miss and the fallback
+    // scan could attach to the wrong builder.
+    it('should query SQLite with workspace ROOT, not builder.worktree', async () => {
       const { findShellperSocket } = await import('../commands/attach.js');
 
       mockDbGet.mockReturnValue(undefined);
@@ -390,7 +394,8 @@ describe('attach command', () => {
 
       findShellperSocket(builder);
 
-      expect(mockDbGet).toHaveBeenCalledWith('/workspace/.builders/spir-118', 'spir-118');
+      // Mock config.workspaceRoot is '/test/workspace' (see top of file).
+      expect(mockDbGet).toHaveBeenCalledWith('/test/workspace', 'spir-118');
     });
 
     it('should return null when no socket found in DB or filesystem', async () => {
@@ -638,6 +643,44 @@ describe('attach command', () => {
 
       await expect(attach({ project: '0116' })).rejects.toThrow();
       expect(fatal).toHaveBeenCalledWith(expect.stringContaining('No shellper socket found'));
+    });
+
+    // Regression for bugfix #717: end-to-end terminal-mode attach when the
+    // builder is only in Tower's terminal_sessions (not local state.db) —
+    // must locate the right shellper socket via the SQLite lookup, not the
+    // first-socket-found scan.
+    it('should attach to Tower-only builder using its socket from SQLite', async () => {
+      mockDbAll.mockReturnValue([
+        {
+          role_id: 'builder-spir-118',
+          cwd: '/workspace/.builders/spir-118',
+          label: '118-feature',
+        },
+      ]);
+      mockDbGet.mockReturnValue({ shellper_socket: '/tmp/shellper-118.sock' });
+      mockExistsSync.mockImplementation((p) => p === '/tmp/shellper-118.sock');
+
+      // Make attachTerminal exit immediately so the test doesn't hang.
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('process.exit called');
+      }) as never);
+      mockShellperConnect.mockImplementation(() => {
+        throw new Error('attachTerminal aborted for test');
+      });
+
+      const { attach } = await import('../commands/attach.js');
+      const { fatal } = await import('../utils/logger.js');
+
+      await expect(attach({ project: 'builder-spir-118' })).rejects.toThrow();
+
+      // Tower fallback must have been queried.
+      expect(mockDbAll).toHaveBeenCalled();
+      // SQLite socket lookup must use workspace ROOT + role_id.
+      expect(mockDbGet).toHaveBeenCalledWith('/test/workspace', 'builder-spir-118');
+      // We should fail on the connect step (socket was found), not "no socket".
+      expect(fatal).toHaveBeenCalledWith(expect.stringContaining('Failed to attach'));
+
+      exitSpy.mockRestore();
     });
   });
 });

--- a/packages/codev/src/agent-farm/commands/attach.ts
+++ b/packages/codev/src/agent-farm/commands/attach.ts
@@ -32,7 +32,12 @@ export interface AttachOptions {
  */
 function findBuilderByIssue(issueNumber: number): Builder | null {
   const builders = getBuilders();
-  return builders.find((b) => b.issueNumber === issueNumber) ?? null;
+  const local = builders.find((b) => b.issueNumber === issueNumber);
+  if (local) return local;
+
+  // Fallback: Tower's terminal_sessions table may know about builders that
+  // were never written to local state.db (Bugfix #717).
+  return findBuilderInTowerByIssue(issueNumber);
 }
 
 /**
@@ -59,7 +64,101 @@ function findBuilderById(id: string): Builder | null {
     return null;
   }
 
+  // Fallback: Tower's terminal_sessions table may know about builders that
+  // were never written to local state.db (Bugfix #717).
+  return findBuilderInTowerById(id);
+}
+
+/**
+ * Row shape we read from terminal_sessions for builder reconstruction.
+ */
+interface TowerBuilderRow {
+  role_id: string;
+  cwd: string | null;
+  label: string | null;
+}
+
+/**
+ * Load all builder-type terminal sessions for the current workspace from
+ * Tower's global SQLite db. Returns [] if Tower db is unavailable.
+ */
+function loadTowerBuilderRows(): TowerBuilderRow[] {
+  try {
+    const db = getGlobalDb();
+    const config = getConfig();
+    const workspacePath = normalizeWorkspacePath(config.workspaceRoot);
+    return db.prepare(`
+      SELECT role_id, cwd, label
+      FROM terminal_sessions
+      WHERE workspace_path = ?
+        AND type = 'builder'
+        AND role_id IS NOT NULL
+      ORDER BY created_at DESC
+    `).all(workspacePath) as TowerBuilderRow[];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Reconstruct a minimal Builder from a Tower terminal_sessions row. The
+ * resulting object has the fields needed by attach (id, worktree) and
+ * placeholder values elsewhere — it's enough to drive findShellperSocket.
+ */
+function towerRowToBuilder(row: TowerBuilderRow): Builder {
+  const isBugfix = row.role_id.includes('-bugfix-');
+  const issueMatch = isBugfix ? row.role_id.match(/-bugfix-(\d+)/) : null;
+  return {
+    id: row.role_id,
+    name: row.label ?? row.role_id,
+    status: 'implementing',
+    phase: 'unknown',
+    worktree: row.cwd ?? '',
+    branch: '',
+    type: isBugfix ? 'bugfix' : 'spec',
+    issueNumber: issueMatch ? Number(issueMatch[1]) : undefined,
+  };
+}
+
+/**
+ * Tower fallback for findBuilderById. Applies the same exact-then-substring
+ * matching used against local state.
+ */
+function findBuilderInTowerById(id: string): Builder | null {
+  const rows = loadTowerBuilderRows();
+  if (rows.length === 0) return null;
+
+  const exact = rows.find((r) => r.role_id === id);
+  if (exact) return towerRowToBuilder(exact);
+
+  const matches = rows.filter((r) => r.role_id.startsWith(id) || r.role_id.includes(id));
+  if (matches.length === 1) return towerRowToBuilder(matches[0]);
+
+  if (matches.length > 1) {
+    logger.error(`Ambiguous builder ID "${id}" in Tower terminal registry. Matches:`);
+    for (const r of matches) {
+      logger.info(`  - ${r.role_id}`);
+    }
+    return null;
+  }
+
   return null;
+}
+
+/**
+ * Tower fallback for findBuilderByIssue. Matches builder-bugfix-<n> rows
+ * with leading zeros stripped from the issue number.
+ */
+function findBuilderInTowerByIssue(issueNumber: number): Builder | null {
+  const rows = loadTowerBuilderRows();
+  if (rows.length === 0) return null;
+
+  const stripped = String(issueNumber);
+  const match = rows.find((r) => {
+    const m = r.role_id.match(/-bugfix-(\d+)/);
+    return m !== null && m[1] === stripped;
+  });
+  return match ? towerRowToBuilder(match) : null;
 }
 
 /**

--- a/packages/codev/src/agent-farm/commands/attach.ts
+++ b/packages/codev/src/agent-farm/commands/attach.ts
@@ -214,10 +214,14 @@ async function displayBuilderList(): Promise<void> {
  * 2. Fallback: scan ~/.codev/run/shellper-*.sock
  */
 export function findShellperSocket(builder: Builder): string | null {
-  // 1. Try SQLite lookup
+  // 1. Try SQLite lookup. terminal_sessions.workspace_path is the workspace
+  // ROOT (set to config.workspaceRoot at spawn time), not the builder's
+  // worktree path — querying by builder.worktree would never match. Without
+  // this scoping, the fallback scan below could attach to the wrong builder
+  // when multiple shellper sockets exist.
   try {
     const db = getGlobalDb();
-    const workspacePath = normalizeWorkspacePath(builder.worktree);
+    const workspacePath = normalizeWorkspacePath(getConfig().workspaceRoot);
 
     const session = db.prepare(`
       SELECT shellper_socket FROM terminal_sessions


### PR DESCRIPTION
## Summary
Fixes #717

## Root Cause
Two related bugs combined to make `afx attach` unreliable:

1. **Lookup miss**: `findBuilderById` / `findBuilderByIssue` only consulted the local `state.db builders` table. Tower's terminal registry (`global.db terminal_sessions`) was never consulted, so a builder visible to `afx status` and `afx send` could still error as "Builder not found" from `afx attach -p <id>` whenever the local row was missing — e.g. spawned in a different session, lost during a `state.db` reset, or never written due to a spawn-time race.

2. **Socket attribution** *(uncovered by CMAP review)*: `findShellperSocket` queried `terminal_sessions WHERE workspace_path = ?` using `normalizeWorkspacePath(builder.worktree)` — but Tower stores `workspace_path = config.workspaceRoot` at spawn time. The SQLite lookup never matched a builder, so socket discovery always fell through to a directory scan that returns the *first* shellper socket — i.e. potentially the wrong builder when multiple are running. The first commit's Tower fallback inherited this bug.

## Fix
**Commit 1**: Tower-registry fallback in `findBuilderById` and `findBuilderByIssue`. When local lookup misses, query `terminal_sessions WHERE workspace_path = ? AND type = 'builder'` and reconstruct a minimal `Builder` from `role_id` (id), `cwd` (worktree), and `label` (name). For `--issue`, parse the `bugfix-<n>` suffix from `role_id`.

**Commit 2**: Switch `findShellperSocket`'s SQLite query to use `getConfig().workspaceRoot` instead of `builder.worktree`, so socket discovery correctly identifies the right shellper for the right builder.

Local-state lookup is unchanged when it succeeds; existing happy-path behavior is preserved.

## Test Plan
- [x] 28 attach tests pass (23 pre-existing + 5 new)
- [x] New regression tests:
  - `--issue` falls back to Tower when local state has no match
  - `--project` exact match falls back to Tower
  - `--project` substring match falls back to Tower
  - `--project` errors when neither registry knows the builder
  - End-to-end terminal-mode attach for a Tower-only builder verifies SQLite is queried with workspace ROOT (not worktree) and finds the correct socket
- [x] Pre-existing test that asserted the broken `findShellperSocket` arg signature was corrected
- [x] TypeScript check passes
- [x] Net diff: 226 LOC across both commits (under 300 LOC bugfix threshold)

## CMAP Review

| Model  | Verdict          | Notes |
|--------|------------------|-------|
| Gemini | REQUEST_CHANGES → addressed | Flagged the `findShellperSocket` workspace-root mismatch as critical. Fixed in commit 2. |
| Codex  | REQUEST_CHANGES → addressed | Same finding as Gemini, plus noted that the first commit's tests only exercised `--browser` mode. Both fixed in commit 2 (terminal-mode end-to-end test added). |
| Claude | APPROVE          | Verified the workspace_path semantics for the new fallback are correct. Noted the `findShellperSocket` issue as pre-existing/unrelated; commit 2 chooses to fix it anyway since the fallback inherits the same trap. |