### PR TITLE
chore(vscode): reliability + UX cleanup, PR #682 follow-up, bugfixes #718/#728

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/tower-routes.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tower-routes.test.ts
@@ -18,6 +18,7 @@ import type { RouteContext } from '../servers/tower-routes.js';
 
 const { mockGetInstances, mockGetTerminalManager, mockGetSession,
   mockListSessions, mockGetWorkspaceTerminalsEntry, mockGetTerminalsForWorkspace,
+  mockGetRehydratedTerminalsEntry,
   mockIsSessionPersistent, mockGetNextShellId,
   mockResolveTarget, mockBroadcastMessage, mockIsResolveError,
   mockParseJsonBody,
@@ -31,6 +32,11 @@ const { mockGetInstances, mockGetTerminalManager, mockGetSession,
   mockListSessions: vi.fn(),
   mockGetWorkspaceTerminalsEntry: vi.fn(),
   mockGetTerminalsForWorkspace: vi.fn(),
+  mockGetRehydratedTerminalsEntry: vi.fn(async () => ({
+    builders: new Map(),
+    shells: new Map(),
+    fileTabs: new Map(),
+  })),
   mockIsSessionPersistent: vi.fn(),
   mockGetNextShellId: vi.fn(),
   mockResolveTarget: vi.fn(),
@@ -70,6 +76,7 @@ vi.mock('../servers/tower-terminals.js', () => ({
   saveFileTab: vi.fn(),
   deleteFileTab: vi.fn(),
   getTerminalsForWorkspace: mockGetTerminalsForWorkspace,
+  getRehydratedTerminalsEntry: mockGetRehydratedTerminalsEntry,
 }));
 
 vi.mock('../servers/tower-tunnel.js', () => ({
@@ -474,7 +481,7 @@ describe('tower-routes', () => {
 
     it('includes lastDataAt in shell entries of /api/state response (Spec 467)', async () => {
       const now = Date.now();
-      mockGetWorkspaceTerminalsEntry.mockReturnValue({
+      mockGetRehydratedTerminalsEntry.mockResolvedValueOnce({
         architect: undefined,
         shells: new Map([['shell-1', 'term-abc']]),
         builders: new Map(),

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -19,7 +19,7 @@ import crypto from 'node:crypto';
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import { homedir, tmpdir } from 'node:os';
-import { encodeWorkspacePath, decodeWorkspacePath } from '../lib/tower-client.js';
+import { decodeWorkspacePath } from '../lib/tower-client.js';
 import { readCloudConfig } from '../lib/cloud-config.js';
 import { fileURLToPath } from 'node:url';
 import { version } from '../../version.js';
@@ -73,7 +73,7 @@ import {
   deleteFileTabsForWorkspace,
   saveFileTab,
   deleteFileTab,
-  getTerminalsForWorkspace,
+  getRehydratedTerminalsEntry,
   getTerminalSessionById,
   getActiveShellLabels,
   updateTerminalLabel,
@@ -686,14 +686,15 @@ async function handleOverview(res: http.ServerResponse, url: URL, workspaceOverr
     return;
   }
 
-  // Build set of active builder role_ids (lowercased) from live terminal sessions
-  const wsTerminals = getWorkspaceTerminals();
-  const entry = wsTerminals.get(normalizeWorkspacePath(workspaceRoot));
+  // Build set of active builder role_ids (lowercased) from live terminal sessions.
+  // Bugfix #718: rehydrate the wsTerminals entry from SQLite + shellper before
+  // reading, matching what /api/state has always done. Without this the sidebar
+  // diverges from the dashboard after any state-loss event (Tower restart with
+  // non-shellper sessions, crashed builders, etc.).
+  const entry = await getRehydratedTerminalsEntry(workspaceRoot);
   const activeBuilderRoleIds = new Set<string>();
-  if (entry) {
-    for (const key of entry.builders.keys()) {
-      activeBuilderRoleIds.add(key.toLowerCase());
-    }
+  for (const key of entry.builders.keys()) {
+    activeBuilderRoleIds.add(key.toLowerCase());
   }
 
   const data = await overviewCache.getOverview(workspaceRoot, activeBuilderRoleIds);
@@ -1377,14 +1378,10 @@ async function handleWorkspaceState(
   res: http.ServerResponse,
   workspacePath: string,
 ): Promise<void> {
-  // Refresh cache via getTerminalsForWorkspace (handles SQLite sync
-  // and shellper reconnection in one place)
-  const encodedPath = encodeWorkspacePath(workspacePath);
-  const proxyUrl = `/workspace/${encodedPath}/`;
-  await getTerminalsForWorkspace(workspacePath, proxyUrl);
-
-  // Now read from the refreshed cache
-  const entry = getWorkspaceTerminalsEntry(workspacePath);
+  // Rehydrate wsTerminals (SQLite sync + shellper reconnect) before reading.
+  // Shared with /api/overview so both endpoints always see a freshly-reconciled
+  // entry — see getRehydratedTerminalsEntry doc.
+  const entry = await getRehydratedTerminalsEntry(workspacePath);
   const manager = getTerminalManager();
   const state: {
     architect: { port: number; pid: number; terminalId?: string; persistent?: boolean } | null;

--- a/packages/codev/src/agent-farm/servers/tower-terminals.ts
+++ b/packages/codev/src/agent-farm/servers/tower-terminals.ts
@@ -8,7 +8,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { AGENT_FARM_DIR } from '../lib/tower-client.js';
+import { AGENT_FARM_DIR, encodeWorkspacePath } from '../lib/tower-client.js';
 import { loadConfig } from '../../lib/config.js';
 import { getGlobalDb } from '../db/index.js';
 import {
@@ -138,6 +138,26 @@ export function getWorkspaceTerminalsEntry(workspacePath: string): WorkspaceTerm
     entry.fileTabs = new Map();
   }
   return entry;
+}
+
+/**
+ * Get the wsTerminals entry for a workspace after rehydrating it from SQLite
+ * and reconnecting any missing shellper sessions. Use this in any HTTP route
+ * that reads wsTerminals to build a UI response — it ensures the read sees
+ * a freshly-reconciled entry instead of whatever drift has accumulated since
+ * the last write.
+ *
+ * Bugfix #718: /api/overview previously read wsTerminals directly while
+ * /api/state had its own ad-hoc rehydration call. The two endpoints diverged
+ * after any state-loss event (Tower restart with non-shellper sessions,
+ * crashed builders, etc.), and the extension's sidebar showed empty while
+ * the dashboard self-healed. Centralizing the read path here keeps every
+ * future endpoint consistent without each having to remember to opt in.
+ */
+export async function getRehydratedTerminalsEntry(workspacePath: string): Promise<WorkspaceTerminals> {
+  const proxyUrl = `/workspace/${encodeWorkspacePath(workspacePath)}/`;
+  await getTerminalsForWorkspace(workspacePath, proxyUrl);
+  return getWorkspaceTerminalsEntry(workspacePath);
 }
 
 /**

--- a/packages/codev/src/agent-farm/utils/agent-names.ts
+++ b/packages/codev/src/agent-farm/utils/agent-names.ts
@@ -8,26 +8,15 @@
  *   Branch name:   builder/{protocol}-{id}[-{slug}]
  *
  * All names are stored and compared in lowercase per spec.
- */
-
-import type { Builder, BuilderType } from '../types.js';
-
-/**
- * Strip leading zeros from a numeric ID string.
- * Non-numeric IDs are returned unchanged.
  *
- * Examples:
- *   '0109' → '109'
- *   '0001' → '1'
- *   '0'    → '0'
- *   'AbCd' → 'AbCd'
+ * `stripLeadingZeros` and `resolveAgentName` live in codev-core so the
+ * VS Code extension can use the same matching semantics; we re-export
+ * them here so existing agent-farm callsites are unaffected.
  */
-export function stripLeadingZeros(id: string): string {
-  if (/^\d+$/.test(id)) {
-    return String(Number(id));
-  }
-  return id;
-}
+
+import type { BuilderType } from '../types.js';
+export { stripLeadingZeros, resolveAgentName } from '@cluesmith/codev-core/agent-names';
+import { stripLeadingZeros } from '@cluesmith/codev-core/agent-names';
 
 /**
  * Build a canonical agent name from builder type and ID.
@@ -106,46 +95,3 @@ export function parseAddress(target: string): { project?: string; agent: string 
   return { agent: target.toLowerCase() };
 }
 
-/**
- * Resolve an agent name against a list of builders using case-insensitive
- * matching with tail-match fallback.
- *
- * Resolution order:
- * 1. Exact match (case-insensitive): 'builder-spir-109' matches 'builder-spir-109'
- * 2. Tail match: bare ID matches the trailing segment of builder-{protocol}-{id}.
- *    E.g., '109' matches 'builder-spir-109' because the name ends with '-109'.
- *    Leading zeros are stripped before comparison: '0109' → '109'.
- *    Also handles partial names: 'bugfix-42' matches 'builder-bugfix-42'.
- * 3. Returns null if no match found or multiple ambiguous tail matches.
- *
- * @returns { builder, ambiguous? } — builder is the matched Builder or null.
- *   If ambiguous, candidates are provided for error messaging.
- */
-export function resolveAgentName(
-  target: string,
-  builders: Builder[],
-): { builder: Builder | null; ambiguous?: Builder[] } {
-  const originalTarget = target.toLowerCase();
-  const strippedTarget = stripLeadingZeros(target).toLowerCase();
-
-  // 1. Exact match (case-insensitive) — try original first, then stripped
-  const exact = builders.find(b => {
-    const id = b.id.toLowerCase();
-    return id === originalTarget || id === strippedTarget;
-  });
-  if (exact) return { builder: exact };
-
-  // 2. Tail match: check if any builder ID ends with -{strippedTarget}
-  const tailMatches = builders.filter(b => {
-    const builderId = b.id.toLowerCase();
-    // Check if the builder ID ends with the target as a tail segment
-    // e.g., builder-spir-109 ends with -109, -spir-109
-    return builderId.endsWith(`-${strippedTarget}`);
-  });
-
-  if (tailMatches.length === 1) return { builder: tailMatches[0] };
-  if (tailMatches.length > 1) return { builder: null, ambiguous: tailMatches };
-
-  // 3. No match
-  return { builder: null };
-}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,10 @@
     "./escape-buffer": {
       "types": "./dist/escape-buffer.d.ts",
       "default": "./dist/escape-buffer.js"
+    },
+    "./agent-names": {
+      "types": "./dist/agent-names.d.ts",
+      "default": "./dist/agent-names.js"
     }
   },
   "files": [

--- a/packages/core/src/agent-names.ts
+++ b/packages/core/src/agent-names.ts
@@ -1,0 +1,61 @@
+/**
+ * Agent naming utilities shared across packages.
+ *
+ * Lives in codev-core so the VS Code extension and the agent-farm server
+ * can both resolve bare numeric IDs (e.g. '153') against canonical builder
+ * IDs (e.g. 'builder-spir-153') with identical semantics.
+ */
+
+/**
+ * Strip leading zeros from a numeric ID string.
+ * Non-numeric IDs are returned unchanged.
+ *
+ *   '0109' → '109'
+ *   '0001' → '1'
+ *   '0'    → '0'
+ *   'AbCd' → 'AbCd'
+ */
+export function stripLeadingZeros(id: string): string {
+  if (/^\d+$/.test(id)) {
+    return String(Number(id));
+  }
+  return id;
+}
+
+/**
+ * Resolve an agent name against a list of builders using case-insensitive
+ * matching with tail-match fallback.
+ *
+ * Resolution order:
+ *   1. Exact match (case-insensitive): 'builder-spir-109' matches 'builder-spir-109'
+ *   2. Tail match: bare ID matches the trailing segment of builder-{protocol}-{id}.
+ *      E.g., '109' matches 'builder-spir-109' because the name ends with '-109'.
+ *      Leading zeros are stripped before comparison: '0109' → '109'.
+ *      Also handles partial names: 'bugfix-42' matches 'builder-bugfix-42'.
+ *   3. Returns null if no match found or multiple ambiguous tail matches.
+ *
+ * Generic over the builder shape — anything with a string `id` works.
+ */
+export function resolveAgentName<T extends { id: string }>(
+  target: string,
+  builders: T[],
+): { builder: T | null; ambiguous?: T[] } {
+  const originalTarget = target.toLowerCase();
+  const strippedTarget = stripLeadingZeros(target).toLowerCase();
+
+  const exact = builders.find((b) => {
+    const id = b.id.toLowerCase();
+    return id === originalTarget || id === strippedTarget;
+  });
+  if (exact) { return { builder: exact }; }
+
+  const tailMatches = builders.filter((b) => {
+    const id = b.id.toLowerCase();
+    return id.endsWith(`-${strippedTarget}`);
+  });
+
+  if (tailMatches.length === 1) { return { builder: tailMatches[0] }; }
+  if (tailMatches.length > 1) { return { builder: null, ambiguous: tailMatches }; }
+
+  return { builder: null };
+}

--- a/packages/vscode/.gitignore
+++ b/packages/vscode/.gitignore
@@ -1,0 +1,1 @@
+.vscode-test/

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,9 +1,39 @@
 # Change Log
 
-All notable changes to the "codev" extension will be documented in this file.
+What's changed in the Codev VS Code extension, version by version, written for the developers who use it.
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+## [3.0.2] - 2026-05-10
 
-## [Unreleased]
+### What's new
 
-- Initial release
+- **Workspace sidebar view.** New top-level section above Needs Attention with two shortcut rows: **Open Architect** (same as `Cmd+K A`) and **Open Web Interface** (opens the Tower dashboard for the current workspace in your browser).
+- **Click a builder row to open its terminal.** Builders and the blocked-row entries in Needs Attention are now actionable — clicking opens that builder's terminal in the editor area, focused and ready for input.
+- **Reconnect to Tower from anywhere.** New `Codev: Reconnect to Tower` command in the Command Palette, plus the status-bar `Codev: Offline` / `Codev: Reconnecting…` indicator now triggers a reconnect on click. (#728)
+- **Refresh and reconnect icons on the sidebar.** Each Work view (Needs Attention, Builders, Pull Requests, Backlog) has a refresh icon in its title bar, and the Status view has a reconnect icon — so you no longer need the Command Palette to recover from a stale view. (#718)
+- **Branded terminal tabs.** Architect, builder, and shell terminals now display the Codev icon on their tab instead of VS Code's default `>_` glyph, so you can tell Codev terminals apart at a glance.
+
+### Bug fixes
+
+- **The extension no longer gets stuck on "Offline" when VS Code starts before Tower.** Previously a failed initial connection parked the extension at `disconnected` with no retry; you'd have to reload the window. It now self-heals within ~30 seconds of Tower coming up, with no user action. (#728)
+- **The sidebar now stays in sync with Tower across restarts and crashed builders.** It used to silently show empty even though `afx status` and the Tower dashboard listed your builders correctly. (#718)
+- **Clicking a builder row no longer fails with "No active terminal for 153"** (or whatever the issue number was). The sidebar's short ID and Tower's canonical role ID now resolve to the same terminal.
+- **Architect terminal opens with keyboard focus.** Whether you launch it from the sidebar, the Command Palette, or `Cmd+K A`, the terminal is ready for input — previously the tab was revealed but not focused.
+- **Auto-spawning a builder no longer steals focus from what you were typing.** Background paths (auto-spawn, terminal-link expansion) reveal the terminal without stealing focus; only intentional click actions (sidebar row, link, QuickPick, "Open Terminal" toast) focus.
+- **Newly-opened terminal tabs no longer show a blank pane until you press a key.** First-paint priming works around a VS Code rendering quirk where async writes after `open()` could be dropped on a brand-new editor-area terminal.
+- **Spawning a builder from a symlinked workspace path** no longer silently mismatches Tower's registered path. (#682-followup)
+- **Reopening a builder terminal in rapid succession** no longer occasionally leaks the previous session's connection. (#682-followup)
+
+## [3.0.0] - 2026-04-26
+
+First public release on the Visual Studio Marketplace. Versioned to align with the broader Codev release line (skipping 0.x → 3.0.0).
+
+### What's included
+
+- **Tower connection** — auto-connects on activation, auto-starts Tower if it isn't already running, reconnects automatically if the session drops. Status-bar indicator shows the current connection state.
+- **Codev sidebar** — Needs Attention, Builders, Pull Requests, Backlog, Recently Closed, Team, and Status views, populated from your live workspace. Updates automatically when builders are spawned.
+- **Embedded terminals** — open the architect, any builder, or a fresh shell as a VS Code terminal backed by Tower. Configurable position (editor area or bottom panel).
+- **Command Palette** — spawn builder, send message, approve gate, cleanup builder, refresh overview, connect/disconnect tunnel, list cron tasks, open architect/builder terminals, new shell, add review comment.
+- **Keyboard shortcuts** — `Ctrl/Cmd+K A` opens the architect terminal, `Ctrl/Cmd+K D` sends a message, `Ctrl/Cmd+K G` approves a gate.
+- **Builder spawn behaviour** — auto-open or notify when Tower reports a new builder spawn, configurable via `codev.autoOpenBuilderTerminal`.
+- **Review comment snippets** in markdown.
+- **Settings** — configure `towerHost`, `towerPort`, `workspacePath` override, `autoConnect`, `autoStartTower`, `terminalPosition`, and `autoOpenBuilderTerminal`. No telemetry collected.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -83,6 +83,10 @@
         "title": "Codev: Refresh Overview"
       },
       {
+        "command": "codev.reconnect",
+        "title": "Codev: Reconnect to Tower"
+      },
+      {
         "command": "codev.connectTunnel",
         "title": "Codev: Connect Tunnel"
       },

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -168,6 +168,7 @@
     },
     "views": {
       "codev": [
+        { "id": "codev.workspace", "name": "Workspace" },
         { "id": "codev.needsAttention", "name": "Needs Attention" },
         { "id": "codev.builders", "name": "Builders" },
         { "id": "codev.pullRequests", "name": "Pull Requests" },

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "publisher": "cluesmith",
   "displayName": "Codev for VS Code",
   "description": "Codev helps humans and agents co-develop both the context and the code of the project.",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "license": "Apache-2.0",
   "icon": "icons/codev.png",
   "pricing": "Free",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -80,11 +80,13 @@
       },
       {
         "command": "codev.refreshOverview",
-        "title": "Codev: Refresh Overview"
+        "title": "Codev: Refresh Overview",
+        "icon": "$(refresh)"
       },
       {
         "command": "codev.reconnect",
-        "title": "Codev: Reconnect to Tower"
+        "title": "Codev: Reconnect to Tower",
+        "icon": "$(sync)"
       },
       {
         "command": "codev.connectTunnel",
@@ -103,6 +105,35 @@
         "title": "Codev: Add Review Comment"
       }
     ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "codev.refreshOverview",
+          "when": "view == codev.needsAttention",
+          "group": "navigation"
+        },
+        {
+          "command": "codev.refreshOverview",
+          "when": "view == codev.builders",
+          "group": "navigation"
+        },
+        {
+          "command": "codev.refreshOverview",
+          "when": "view == codev.pullRequests",
+          "group": "navigation"
+        },
+        {
+          "command": "codev.refreshOverview",
+          "when": "view == codev.backlog",
+          "group": "navigation"
+        },
+        {
+          "command": "codev.reconnect",
+          "when": "view == codev.status",
+          "group": "navigation"
+        }
+      ]
+    },
     "snippets": [
       {
         "language": "markdown",

--- a/packages/vscode/src/builder-spawn-handler.ts
+++ b/packages/vscode/src/builder-spawn-handler.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { BuilderSpawnedPayload } from '@cluesmith/codev-types';
 import type { ConnectionManager } from './connection-manager.js';
@@ -37,8 +38,11 @@ export class BuilderSpawnHandler {
 
     if (!payload.terminalId || !payload.roleId || !payload.workspacePath) { return; }
 
+    // path.resolve handles trailing-slash and `..` normalization. Symlink
+    // realpath is intentionally skipped — Tower passes canonical paths and
+    // realpath would add sync FS I/O on every event.
     const active = this.connectionManager.getWorkspacePath();
-    if (active && payload.workspacePath !== active) { return; }
+    if (active && path.resolve(payload.workspacePath) !== path.resolve(active)) { return; }
 
     if (this.seen.has(payload.terminalId)) { return; }
     this.seen.add(payload.terminalId);

--- a/packages/vscode/src/builder-spawn-handler.ts
+++ b/packages/vscode/src/builder-spawn-handler.ts
@@ -54,23 +54,26 @@ export class BuilderSpawnHandler {
     if (mode === 'off') { return; }
 
     if (mode === 'auto') {
-      void this.open(payload);
+      // Background open: never steal focus from the user's current terminal.
+      void this.open(payload, false);
       return;
     }
 
     void vscode.window
       .showInformationMessage(`Builder ${payload.roleId} spawned.`, 'Open Terminal')
       .then((choice) => {
-        if (choice === 'Open Terminal') { void this.open(payload); }
+        // Toast click is an explicit user action — focus the new terminal.
+        if (choice === 'Open Terminal') { void this.open(payload, true); }
       });
   }
 
-  private async open(payload: BuilderSpawnedPayload): Promise<void> {
+  private async open(payload: BuilderSpawnedPayload, focus: boolean): Promise<void> {
     try {
       await this.terminalManager.openBuilder(
         payload.terminalId,
         payload.roleId,
         `Codev: ${payload.roleId}`,
+        focus,
       );
     } catch (err) {
       this.log('ERROR', `Failed to open builder terminal ${payload.roleId}: ${(err as Error).message}`);

--- a/packages/vscode/src/connection-manager.ts
+++ b/packages/vscode/src/connection-manager.ts
@@ -24,6 +24,7 @@ export class ConnectionManager {
   private reconnectAttempt = 0;
   private readonly maxReconnectDelay = 30000;
   private disposed = false;
+  private autoStartInFlight = false;
 
   private readonly stateChangeEmitter = new vscode.EventEmitter<ConnectionState>();
   readonly onStateChange = this.stateChangeEmitter.event;
@@ -80,11 +81,23 @@ export class ConnectionManager {
     if (autoConnect) {
       // Try connecting; if Tower isn't running, try auto-start
       await this.connect();
-      if (this.state === 'disconnected' && config.get<boolean>('autoStartTower', true)) {
-        this.log('INFO', 'Tower not running, attempting auto-start...');
-        const started = await autoStartTower(this.client!, this.workspacePath, this.outputChannel);
-        if (started) {
-          await this.connect();
+      if (this.state !== 'connected' && config.get<boolean>('autoStartTower', true)) {
+        // A failed connect() will have scheduled a backoff retry; cancel it so the
+        // explicit auto-start path isn't racing the timer.
+        if (this.reconnectTimer) {
+          clearTimeout(this.reconnectTimer);
+          this.reconnectTimer = null;
+          this.setState('disconnected');
+        }
+        this.autoStartInFlight = true;
+        try {
+          this.log('INFO', 'Tower not running, attempting auto-start...');
+          const started = await autoStartTower(this.client!, this.workspacePath, this.outputChannel);
+          if (started) {
+            await this.connect();
+          }
+        } finally {
+          this.autoStartInFlight = false;
         }
       }
     }
@@ -95,11 +108,16 @@ export class ConnectionManager {
    */
   async connect(): Promise<void> {
     if (this.disposed || !this.client) { return; }
+    if (this.state === 'connecting' || this.state === 'connected') { return; }
     this.setState('connecting');
 
     try {
       const health = await this.client.getHealth();
       if (health) {
+        if (this.reconnectTimer) {
+          clearTimeout(this.reconnectTimer);
+          this.reconnectTimer = null;
+        }
         this.setState('connected');
         this.reconnectAttempt = 0;
         this.log('INFO', `Connected to Tower (status: ${health.status}, uptime: ${health.uptime}s)`);
@@ -108,25 +126,59 @@ export class ConnectionManager {
       } else {
         this.log('WARN', 'Tower not responding');
         this.setState('disconnected');
+        this.scheduleReconnect();
       }
     } catch (err) {
       this.log('ERROR', `Connection failed: ${(err as Error).message}`);
       this.setState('disconnected');
+      this.scheduleReconnect();
     }
+  }
+
+  /**
+   * User-initiated reconnect. Bypasses backoff and skips any pending timer.
+   * No-op when already connected or already trying.
+   */
+  async reconnect(): Promise<void> {
+    if (this.disposed) { return; }
+    if (this.state === 'connected' || this.state === 'connecting') { return; }
+
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.reconnectAttempt = 0;
+    this.log('INFO', 'Manual reconnect requested');
+
+    const config = vscode.workspace.getConfiguration('codev');
+    if (config.get<boolean>('autoStartTower', true) && this.client && !this.autoStartInFlight) {
+      this.autoStartInFlight = true;
+      try {
+        await autoStartTower(this.client, this.workspacePath, this.outputChannel);
+      } finally {
+        this.autoStartInFlight = false;
+      }
+    }
+
+    await this.connect();
   }
 
   /**
    * Schedule reconnection with exponential backoff.
    */
   scheduleReconnect(): void {
-    if (this.disposed || this.state === 'connected') { return; }
+    if (this.disposed || this.state === 'connected' || this.state === 'connecting') { return; }
+    if (this.reconnectTimer) { return; }
 
     this.setState('reconnecting');
     const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempt), this.maxReconnectDelay);
     this.reconnectAttempt++;
 
     this.log('INFO', `Reconnecting in ${delay}ms (attempt ${this.reconnectAttempt})`);
-    this.reconnectTimer = setTimeout(() => this.connect(), delay);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.connect();
+    }, delay);
   }
 
   /**

--- a/packages/vscode/src/connection-manager.ts
+++ b/packages/vscode/src/connection-manager.ts
@@ -118,10 +118,13 @@ export class ConnectionManager {
           clearTimeout(this.reconnectTimer);
           this.reconnectTimer = null;
         }
-        this.setState('connected');
         this.reconnectAttempt = 0;
         this.log('INFO', `Connected to Tower (status: ${health.status}, uptime: ${health.uptime}s)`);
+        // Activate the workspace before announcing 'connected' so onStateChange
+        // subscribers (e.g. OverviewCache.refresh) see a fully-registered
+        // workspace on their first fetch instead of racing the activate POST.
         await this.activateWorkspace();
+        this.setState('connected');
         this.startSSE();
       } else {
         this.log('WARN', 'Tower not responding');

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -65,7 +65,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	});
 
 	// Terminal Manager
-	terminalManager = new TerminalManager(connectionManager, outputChannel);
+	terminalManager = new TerminalManager(connectionManager, outputChannel, context.extensionUri);
 	context.subscriptions.push({ dispose: () => terminalManager?.dispose() });
 
 	// Update status bar with builder/gate counts

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -153,7 +153,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					{ placeHolder: 'Select a builder' },
 				);
 				if (picked) {
-					await terminalManager?.openBuilder(picked.terminalId, picked.id, `Codev: ${picked.label}`);
+					await terminalManager?.openBuilder(picked.terminalId, picked.id, `Codev: ${picked.label}`, true);
 				}
 			} catch {
 				vscode.window.showErrorMessage('Codev: Failed to get builders');
@@ -178,7 +178,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		}),
 		vscode.commands.registerCommand('codev.openBuilderById', async (roleOrId: string) => {
 			if (!roleOrId) { return; }
-			await terminalManager?.openBuilderByRoleOrId(roleOrId);
+			await terminalManager?.openBuilderByRoleOrId(roleOrId, true);
 		}),
 		vscode.commands.registerCommand('codev.spawnBuilder', () => spawnBuilder()),
 		vscode.commands.registerCommand('codev.sendMessage', () => sendMessage(connectionManager!)),

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -19,6 +19,7 @@ import { BacklogProvider } from './views/backlog.js';
 import { RecentlyClosedProvider } from './views/recently-closed.js';
 import { TeamProvider } from './views/team.js';
 import { StatusProvider } from './views/status.js';
+import { WorkspaceProvider } from './views/workspace.js';
 
 let connectionManager: ConnectionManager | null = null;
 let terminalManager: TerminalManager | null = null;
@@ -86,6 +87,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	overviewCache.onDidChange(updateStatusBarCounts);
 
 	context.subscriptions.push(
+		vscode.window.registerTreeDataProvider('codev.workspace', new WorkspaceProvider(connectionManager)),
 		vscode.window.registerTreeDataProvider('codev.needsAttention', new NeedsAttentionProvider(overviewCache)),
 		vscode.window.registerTreeDataProvider('codev.builders', new BuildersProvider(overviewCache)),
 		vscode.window.registerTreeDataProvider('codev.pullRequests', new PullRequestsProvider(overviewCache)),
@@ -126,7 +128,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			try {
 				const state = await client.getWorkspaceState(workspacePath);
 				if (state?.architect?.terminalId) {
-					await terminalManager?.openArchitect(state.architect.terminalId);
+					await terminalManager?.openArchitect(state.architect.terminalId, true);
 				} else {
 					vscode.window.showWarningMessage('Codev: No architect terminal found — is the workspace activated?');
 				}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -176,6 +176,10 @@ export async function activate(context: vscode.ExtensionContext) {
 				vscode.window.showErrorMessage('Codev: Failed to create shell');
 			}
 		}),
+		vscode.commands.registerCommand('codev.openBuilderById', async (roleOrId: string) => {
+			if (!roleOrId) { return; }
+			await terminalManager?.openBuilderByRoleOrId(roleOrId);
+		}),
 		vscode.commands.registerCommand('codev.spawnBuilder', () => spawnBuilder()),
 		vscode.commands.registerCommand('codev.sendMessage', () => sendMessage(connectionManager!)),
 		vscode.commands.registerCommand('codev.approveGate', () => approveGate(connectionManager!)),
@@ -200,7 +204,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	// Make builder names clickable in any terminal output
 	context.subscriptions.push(
 		vscode.window.registerTerminalLinkProvider(
-			new BuilderTerminalLinkProvider(connectionManager, terminalManager, outputChannel),
+			new BuilderTerminalLinkProvider(terminalManager),
 		),
 	);
 

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -37,6 +37,8 @@ export async function activate(context: vscode.ExtensionContext) {
 	// Status bar
 	statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
 	statusBarItem.text = '$(circle-slash) Codev: Offline';
+	statusBarItem.command = 'codev.reconnect';
+	statusBarItem.tooltip = 'Click to reconnect to Tower';
 	statusBarItem.show();
 	context.subscriptions.push(statusBarItem);
 
@@ -179,6 +181,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('codev.approveGate', () => approveGate(connectionManager!)),
 		vscode.commands.registerCommand('codev.cleanupBuilder', () => cleanupBuilder(connectionManager!)),
 		vscode.commands.registerCommand('codev.refreshOverview', () => overviewCache.refresh()),
+		vscode.commands.registerCommand('codev.reconnect', () => connectionManager?.reconnect()),
 		vscode.commands.registerCommand('codev.connectTunnel', () => connectTunnel(connectionManager!)),
 		vscode.commands.registerCommand('codev.disconnectTunnel', () => disconnectTunnel(connectionManager!)),
 		vscode.commands.registerCommand('codev.cronTasks', () => listCronTasks(connectionManager!)),

--- a/packages/vscode/src/sse-client.ts
+++ b/packages/vscode/src/sse-client.ts
@@ -5,15 +5,14 @@ export type SSEListener = (eventType: string, data: string) => void;
 /**
  * SSE client for Tower's /api/events endpoint.
  *
- * Handles heartbeat filtering, rate-limited refresh dispatch,
- * and reconnection via the Connection Manager's state machine.
+ * Filters heartbeats and dispatches every other event to listeners.
+ * Throttling, if needed, is the consumer's responsibility (e.g. the
+ * overview cache self-throttles via its `loading` guard) — coalescing
+ * here would silently drop payload-carrying events like `builder-spawned`.
  */
 export class SSEClient {
   private eventSource: EventSource | null = null;
   private listeners: SSEListener[] = [];
-  private lastRefreshAt = 0;
-  private pendingRefresh: ReturnType<typeof setTimeout> | null = null;
-  private readonly minRefreshInterval = 1000; // max 1 refresh/second
   private disposed = false;
 
   constructor(
@@ -51,10 +50,6 @@ export class SSEClient {
     if (this.eventSource) {
       this.eventSource.close();
       this.eventSource = null;
-    }
-    if (this.pendingRefresh) {
-      clearTimeout(this.pendingRefresh);
-      this.pendingRefresh = null;
     }
   }
 
@@ -135,28 +130,10 @@ export class SSEClient {
   }
 
   private handleEvent(eventType: string, data: string): void {
-    // Filter heartbeats — don't trigger refresh
     if (eventType === 'heartbeat' || eventType === 'ping') {
       return;
     }
-
-    // Rate-limit refresh dispatch
-    const now = Date.now();
-    const elapsed = now - this.lastRefreshAt;
-
-    if (elapsed >= this.minRefreshInterval) {
-      this.lastRefreshAt = now;
-      this.dispatch(eventType, data);
-    } else if (!this.pendingRefresh) {
-      // Schedule a deferred refresh
-      const delay = this.minRefreshInterval - elapsed;
-      this.pendingRefresh = setTimeout(() => {
-        this.pendingRefresh = null;
-        this.lastRefreshAt = Date.now();
-        this.dispatch(eventType, data);
-      }, delay);
-    }
-    // If a refresh is already pending, skip — the pending one covers it
+    this.dispatch(eventType, data);
   }
 
   private dispatch(eventType: string, data: string): void {

--- a/packages/vscode/src/terminal-adapter.ts
+++ b/packages/vscode/src/terminal-adapter.ts
@@ -35,6 +35,11 @@ export class CodevPseudoterminal implements vscode.Pseudoterminal {
   ) {}
 
   open(_initialDimensions: vscode.TerminalDimensions | undefined): void {
+    // Prime the renderer synchronously inside open() — VS Code drops or
+    // mis-orders writes that arrive purely asynchronously after open()
+    // when the terminal becomes the active editor (microsoft/vscode#108298),
+    // which manifests as a blank pane when openTerminal calls show(false).
+    this.writeEmitter.fire('');
     this.connect();
   }
 

--- a/packages/vscode/src/terminal-link-provider.ts
+++ b/packages/vscode/src/terminal-link-provider.ts
@@ -31,6 +31,6 @@ export class BuilderTerminalLinkProvider implements vscode.TerminalLinkProvider<
   }
 
   async handleTerminalLink(link: BuilderLink): Promise<void> {
-    await this.terminalManager.openBuilderByRoleOrId(link.roleId);
+    await this.terminalManager.openBuilderByRoleOrId(link.roleId, true);
   }
 }

--- a/packages/vscode/src/terminal-link-provider.ts
+++ b/packages/vscode/src/terminal-link-provider.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import type { ConnectionManager } from './connection-manager.js';
 import type { TerminalManager } from './terminal-manager.js';
 
 // Matches Codev builder role names like `builder-spir-153`, `builder-bugfix-42`.
@@ -14,11 +13,7 @@ interface BuilderLink extends vscode.TerminalLink {
  * Clicking opens (or focuses) that builder's terminal.
  */
 export class BuilderTerminalLinkProvider implements vscode.TerminalLinkProvider<BuilderLink> {
-  constructor(
-    private connectionManager: ConnectionManager,
-    private terminalManager: TerminalManager,
-    private outputChannel: vscode.OutputChannel,
-  ) {}
+  constructor(private terminalManager: TerminalManager) {}
 
   provideTerminalLinks(context: vscode.TerminalLinkContext): BuilderLink[] {
     const links: BuilderLink[] = [];
@@ -36,29 +31,6 @@ export class BuilderTerminalLinkProvider implements vscode.TerminalLinkProvider<
   }
 
   async handleTerminalLink(link: BuilderLink): Promise<void> {
-    const client = this.connectionManager.getClient();
-    const workspacePath = this.connectionManager.getWorkspacePath();
-    if (!client || !workspacePath) {
-      vscode.window.showErrorMessage('Codev: Not connected to Tower');
-      return;
-    }
-
-    try {
-      const state = await client.getWorkspaceState(workspacePath);
-      const builder = state?.builders?.find(b => b.name === link.roleId || b.id === link.roleId);
-      if (!builder?.terminalId) {
-        vscode.window.showWarningMessage(`Codev: No active terminal for ${link.roleId}`);
-        return;
-      }
-      await this.terminalManager.openBuilder(builder.terminalId, builder.id, `Codev: ${builder.name}`);
-    } catch (err) {
-      this.log('ERROR', `Failed to open builder ${link.roleId}: ${(err as Error).message}`);
-      vscode.window.showErrorMessage(`Codev: Failed to open ${link.roleId}`);
-    }
-  }
-
-  private log(level: string, message: string): void {
-    const timestamp = new Date().toISOString();
-    this.outputChannel.appendLine(`[${timestamp}] [BuilderLinks] [${level}] ${message}`);
+    await this.terminalManager.openBuilderByRoleOrId(link.roleId);
   }
 }

--- a/packages/vscode/src/terminal-manager.ts
+++ b/packages/vscode/src/terminal-manager.ts
@@ -60,6 +60,32 @@ export class TerminalManager {
   }
 
   /**
+   * Resolve a builder by `roleId` or `id` via Tower workspace state, then
+   * open its terminal. Used by the sidebar tree views, terminal link
+   * provider, and command palette so the lookup logic lives in one place.
+   */
+  async openBuilderByRoleOrId(roleOrId: string): Promise<void> {
+    const client = this.connectionManager.getClient();
+    const workspacePath = this.connectionManager.getWorkspacePath();
+    if (!client || !workspacePath) {
+      vscode.window.showErrorMessage('Codev: Not connected to Tower');
+      return;
+    }
+    try {
+      const state = await client.getWorkspaceState(workspacePath);
+      const builder = state?.builders?.find((b) => b.name === roleOrId || b.id === roleOrId);
+      if (!builder?.terminalId) {
+        vscode.window.showWarningMessage(`Codev: No active terminal for ${roleOrId}`);
+        return;
+      }
+      await this.openBuilder(builder.terminalId, builder.id, `Codev: ${builder.name}`);
+    } catch (err) {
+      this.log('ERROR', `Failed to open builder ${roleOrId}: ${(err as Error).message}`);
+      vscode.window.showErrorMessage(`Codev: Failed to open ${roleOrId}`);
+    }
+  }
+
+  /**
    * Open a shell terminal.
    */
   async openShell(terminalId: string, shellNumber: number): Promise<void> {

--- a/packages/vscode/src/terminal-manager.ts
+++ b/packages/vscode/src/terminal-manager.ts
@@ -21,10 +21,16 @@ export class TerminalManager {
   private terminals = new Map<string, ManagedTerminal>();
   private outputChannel: vscode.OutputChannel;
   private connectionManager: ConnectionManager;
+  private readonly iconPath: vscode.Uri;
 
-  constructor(connectionManager: ConnectionManager, outputChannel: vscode.OutputChannel) {
+  constructor(
+    connectionManager: ConnectionManager,
+    outputChannel: vscode.OutputChannel,
+    extensionUri: vscode.Uri,
+  ) {
     this.connectionManager = connectionManager;
     this.outputChannel = outputChannel;
+    this.iconPath = vscode.Uri.joinPath(extensionUri, 'icons', 'codev.svg');
   }
 
   /**
@@ -145,7 +151,7 @@ export class TerminalManager {
       ? { viewColumn: type === 'architect' ? vscode.ViewColumn.One : vscode.ViewColumn.Two }
       : vscode.TerminalLocation.Panel;
 
-    const terminal = vscode.window.createTerminal({ name, pty, location });
+    const terminal = vscode.window.createTerminal({ name, pty, location, iconPath: this.iconPath });
 
     const mapKey = key ?? type;
     this.terminals.set(mapKey, { terminal, pty, type, id: terminalId });

--- a/packages/vscode/src/terminal-manager.ts
+++ b/packages/vscode/src/terminal-manager.ts
@@ -44,20 +44,26 @@ export class TerminalManager {
    * but points at a different (stale) Tower session, dispose it before
    * opening a new one — happens when a builder is re-spawned and Tower
    * issues a new terminalId for the same roleId.
+   *
+   * `focus` defaults to false so background paths (e.g. auto-spawn when
+   * the architect spawns a new builder) don't steal focus mid-typing.
+   * Explicit user actions — sidebar click, terminal-link click, toast
+   * click, command-palette pick — pass `true` to activate the terminal
+   * for keyboard input.
    */
-  async openBuilder(terminalId: string, builderId: string, label: string): Promise<void> {
+  async openBuilder(terminalId: string, builderId: string, label: string, focus = false): Promise<void> {
     const key = `builder-${builderId}`;
     const existing = this.terminals.get(key);
     if (existing) {
       if (existing.id === terminalId) {
-        existing.terminal.show();
+        existing.terminal.show(!focus);
         return;
       }
       existing.pty.close();
       existing.terminal.dispose();
       this.terminals.delete(key);
     }
-    await this.openTerminal(terminalId, 'builder', label, key);
+    await this.openTerminal(terminalId, 'builder', label, key, focus);
   }
 
   /**
@@ -65,7 +71,7 @@ export class TerminalManager {
    * open its terminal. Used by the sidebar tree views, terminal link
    * provider, and command palette so the lookup logic lives in one place.
    */
-  async openBuilderByRoleOrId(roleOrId: string): Promise<void> {
+  async openBuilderByRoleOrId(roleOrId: string, focus = false): Promise<void> {
     const client = this.connectionManager.getClient();
     const workspacePath = this.connectionManager.getWorkspacePath();
     if (!client || !workspacePath) {
@@ -89,7 +95,7 @@ export class TerminalManager {
         vscode.window.showWarningMessage(`Codev: No active terminal for ${roleOrId}`);
         return;
       }
-      await this.openBuilder(builder.terminalId, builder.id, `Codev: ${builder.name}`);
+      await this.openBuilder(builder.terminalId, builder.id, `Codev: ${builder.name}`, focus);
     } catch (err) {
       this.log('ERROR', `Failed to open builder ${roleOrId}: ${(err as Error).message}`);
       vscode.window.showErrorMessage(`Codev: Failed to open ${roleOrId}`);
@@ -119,6 +125,7 @@ export class TerminalManager {
     type: 'architect' | 'builder' | 'shell',
     name: string,
     key?: string,
+    focus = false,
   ): Promise<void> {
     if (this.terminals.size >= MAX_TERMINALS) {
       vscode.window.showWarningMessage(`Too many terminals (${MAX_TERMINALS} max) — close unused terminals`);
@@ -156,7 +163,7 @@ export class TerminalManager {
       disposable.dispose();
     });
 
-    terminal.show(true);
+    terminal.show(!focus);
   }
 
   private buildWsUrl(terminalId: string): string | null {

--- a/packages/vscode/src/terminal-manager.ts
+++ b/packages/vscode/src/terminal-manager.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { CodevPseudoterminal } from './terminal-adapter.js';
 import type { ConnectionManager } from './connection-manager.js';
 import { encodeWorkspacePath } from '@cluesmith/codev-core/workspace';
+import { resolveAgentName } from '@cluesmith/codev-core/agent-names';
 
 const MAX_TERMINALS = 10;
 
@@ -73,7 +74,17 @@ export class TerminalManager {
     }
     try {
       const state = await client.getWorkspaceState(workspacePath);
-      const builder = state?.builders?.find((b) => b.name === roleOrId || b.id === roleOrId);
+      const builders = state?.builders ?? [];
+      // Use resolveAgentName so the bare numeric IDs the sidebar passes
+      // (e.g. '153' from OverviewBuilder) tail-match canonical
+      // 'builder-spir-153' IDs from Tower's runtime state.
+      const { builder, ambiguous } = resolveAgentName(roleOrId, builders);
+      if (ambiguous) {
+        vscode.window.showWarningMessage(
+          `Codev: Multiple builders match "${roleOrId}": ${ambiguous.map(b => b.name).join(', ')}`,
+        );
+        return;
+      }
       if (!builder?.terminalId) {
         vscode.window.showWarningMessage(`Codev: No active terminal for ${roleOrId}`);
         return;

--- a/packages/vscode/src/terminal-manager.ts
+++ b/packages/vscode/src/terminal-manager.ts
@@ -34,15 +34,16 @@ export class TerminalManager {
   }
 
   /**
-   * Open the architect terminal.
+   * Open the architect terminal. `focus` defaults to false so background
+   * paths don't steal focus; click paths pass true.
    */
-  async openArchitect(terminalId: string): Promise<void> {
-    if (this.terminals.has('architect')) {
-      // Focus existing
-      this.terminals.get('architect')!.terminal.show();
+  async openArchitect(terminalId: string, focus = false): Promise<void> {
+    const existing = this.terminals.get('architect');
+    if (existing) {
+      existing.terminal.show(!focus);
       return;
     }
-    await this.openTerminal(terminalId, 'architect', 'Codev: Architect');
+    await this.openTerminal(terminalId, 'architect', 'Codev: Architect', undefined, focus);
   }
 
   /**

--- a/packages/vscode/src/terminal-manager.ts
+++ b/packages/vscode/src/terminal-manager.ts
@@ -106,13 +106,17 @@ export class TerminalManager {
     const mapKey = key ?? type;
     this.terminals.set(mapKey, { terminal, pty, type, id: terminalId });
 
-    // Clean up when terminal is closed by user
+    // Clean up when terminal is closed by user. The map-delete is guarded
+    // because a stale terminal disposed via openBuilder's re-spawn path can
+    // emit onDidCloseTerminal *after* the replacement registers under the
+    // same mapKey — without the identity check we'd unmap the live one.
     const disposable = vscode.window.onDidCloseTerminal((t) => {
-      if (t === terminal) {
-        pty.close();
+      if (t !== terminal) { return; }
+      pty.close();
+      if (this.terminals.get(mapKey)?.terminal === terminal) {
         this.terminals.delete(mapKey);
-        disposable.dispose();
       }
+      disposable.dispose();
     });
 
     terminal.show(true);

--- a/packages/vscode/src/test/builder-spawn-handler.test.ts
+++ b/packages/vscode/src/test/builder-spawn-handler.test.ts
@@ -1,0 +1,181 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { BuilderSpawnHandler } from '../builder-spawn-handler.js';
+import type { ConnectionManager } from '../connection-manager.js';
+import type { TerminalManager } from '../terminal-manager.js';
+
+const fakeOutputChannel = (): vscode.OutputChannel => ({
+	name: 'test',
+	append: () => {},
+	appendLine: () => {},
+	clear: () => {},
+	show: () => {},
+	hide: () => {},
+	dispose: () => {},
+	replace: () => {},
+});
+
+interface OpenCall {
+	terminalId: string;
+	roleId: string;
+	label: string;
+}
+
+function makeHarness(activeWorkspace: string | null = '/Users/x/repo') {
+	const opens: OpenCall[] = [];
+	const terminalManager = {
+		openBuilder: async (terminalId: string, roleId: string, label: string) => {
+			opens.push({ terminalId, roleId, label });
+		},
+	} as unknown as TerminalManager;
+
+	const connectionManager = {
+		getWorkspacePath: () => activeWorkspace,
+	} as unknown as ConnectionManager;
+
+	const handler = new BuilderSpawnHandler(connectionManager, terminalManager, fakeOutputChannel());
+	return { handler, opens };
+}
+
+function spawnEnvelope(payload: object): string {
+	return JSON.stringify({ type: 'builder-spawned', body: JSON.stringify(payload) });
+}
+
+const validPayload = {
+	terminalId: 't-1',
+	roleId: 'builder-spir-42',
+	workspacePath: '/Users/x/repo',
+};
+
+async function flush(): Promise<void> {
+	// `notify` mode chains through .then() on showInformationMessage —
+	// give microtasks a tick to settle before assertions.
+	await new Promise((r) => setTimeout(r, 0));
+}
+
+suite('BuilderSpawnHandler', () => {
+	let originalShowInfo: typeof vscode.window.showInformationMessage;
+	let originalGetConfig: typeof vscode.workspace.getConfiguration;
+	let infoChoice: string | undefined;
+	let configMode: 'off' | 'notify' | 'auto' = 'notify';
+
+	setup(() => {
+		originalShowInfo = vscode.window.showInformationMessage;
+		originalGetConfig = vscode.workspace.getConfiguration;
+
+		(vscode.window as any).showInformationMessage = async (..._args: unknown[]) => infoChoice;
+
+		(vscode.workspace as any).getConfiguration = (section?: string) => {
+			if (section === 'codev') {
+				return {
+					get: <T>(_k: string, fallback: T) => (configMode as unknown as T) ?? fallback,
+				} as unknown as vscode.WorkspaceConfiguration;
+			}
+			return originalGetConfig.call(vscode.workspace, section);
+		};
+	});
+
+	teardown(() => {
+		(vscode.window as any).showInformationMessage = originalShowInfo;
+		(vscode.workspace as any).getConfiguration = originalGetConfig;
+		infoChoice = undefined;
+		configMode = 'notify';
+	});
+
+	test('ignores non-builder-spawned envelope', async () => {
+		const { handler, opens } = makeHarness();
+		handler.handle('', JSON.stringify({ type: 'overview-changed', body: '{}' }));
+		await flush();
+		assert.strictEqual(opens.length, 0);
+	});
+
+	test('ignores malformed envelope JSON without throwing', async () => {
+		const { handler, opens } = makeHarness();
+		assert.doesNotThrow(() => handler.handle('', 'not-json'));
+		await flush();
+		assert.strictEqual(opens.length, 0);
+	});
+
+	test('logs and ignores malformed payload body', async () => {
+		const { handler, opens } = makeHarness();
+		handler.handle('', JSON.stringify({ type: 'builder-spawned', body: 'not-json' }));
+		await flush();
+		assert.strictEqual(opens.length, 0);
+	});
+
+	test('ignores payload missing required fields', async () => {
+		const { handler, opens } = makeHarness();
+		const cases: Array<Partial<typeof validPayload>> = [
+			{ ...validPayload, terminalId: '' },
+			{ ...validPayload, roleId: '' },
+			{ ...validPayload, workspacePath: '' },
+		];
+		for (const p of cases) { handler.handle('', spawnEnvelope(p)); }
+		await flush();
+		assert.strictEqual(opens.length, 0);
+	});
+
+	test('ignores payload from a different workspace', async () => {
+		const { handler, opens } = makeHarness('/Users/x/repo');
+		handler.handle('', spawnEnvelope({ ...validPayload, workspacePath: '/Users/x/other' }));
+		await flush();
+		assert.strictEqual(opens.length, 0);
+	});
+
+	test('accepts payload with trailing-slash workspace mismatch (path normalization)', async () => {
+		// Regression for PR #682 review #5.
+		configMode = 'auto';
+		const { handler, opens } = makeHarness('/Users/x/repo');
+		handler.handle('', spawnEnvelope({ ...validPayload, workspacePath: '/Users/x/repo/' }));
+		await flush();
+		assert.strictEqual(opens.length, 1);
+	});
+
+	test('dedups by terminalId', async () => {
+		configMode = 'auto';
+		const { handler, opens } = makeHarness();
+		handler.handle('', spawnEnvelope(validPayload));
+		handler.handle('', spawnEnvelope(validPayload));
+		await flush();
+		assert.strictEqual(opens.length, 1);
+	});
+
+	test('mode "off" skips dispatch', async () => {
+		configMode = 'off';
+		const { handler, opens } = makeHarness();
+		handler.handle('', spawnEnvelope(validPayload));
+		await flush();
+		assert.strictEqual(opens.length, 0);
+	});
+
+	test('mode "auto" opens immediately', async () => {
+		configMode = 'auto';
+		const { handler, opens } = makeHarness();
+		handler.handle('', spawnEnvelope(validPayload));
+		await flush();
+		assert.strictEqual(opens.length, 1);
+		assert.deepStrictEqual(opens[0], {
+			terminalId: 't-1',
+			roleId: 'builder-spir-42',
+			label: 'Codev: builder-spir-42',
+		});
+	});
+
+	test('mode "notify" + Open Terminal click opens', async () => {
+		configMode = 'notify';
+		infoChoice = 'Open Terminal';
+		const { handler, opens } = makeHarness();
+		handler.handle('', spawnEnvelope(validPayload));
+		await flush();
+		assert.strictEqual(opens.length, 1);
+	});
+
+	test('mode "notify" + dismissed toast does not open', async () => {
+		configMode = 'notify';
+		infoChoice = undefined;
+		const { handler, opens } = makeHarness();
+		handler.handle('', spawnEnvelope(validPayload));
+		await flush();
+		assert.strictEqual(opens.length, 0);
+	});
+});

--- a/packages/vscode/src/test/sse-client.test.ts
+++ b/packages/vscode/src/test/sse-client.test.ts
@@ -1,0 +1,78 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { SSEClient } from '../sse-client.js';
+
+const fakeOutputChannel = (): vscode.OutputChannel => ({
+	name: 'test',
+	append: () => {},
+	appendLine: () => {},
+	clear: () => {},
+	show: () => {},
+	hide: () => {},
+	dispose: () => {},
+	replace: () => {},
+});
+
+function envelope(type: string, body: object = {}): string {
+	return JSON.stringify({ type, body: JSON.stringify(body) });
+}
+
+function feed(client: SSEClient, eventType: string, data: string): void {
+	(client as unknown as { handleEvent(t: string, d: string): void }).handleEvent(eventType, data);
+}
+
+suite('SSEClient.handleEvent', () => {
+	test('drops heartbeat and ping events', () => {
+		const received: Array<[string, string]> = [];
+		const client = new SSEClient('http://localhost:0', fakeOutputChannel(), () => {});
+		client.onEvent((t, d) => received.push([t, d]));
+
+		feed(client, 'heartbeat', '');
+		feed(client, 'ping', '');
+
+		assert.strictEqual(received.length, 0);
+		client.dispose();
+	});
+
+	test('dispatches every non-heartbeat event without coalescing', () => {
+		// Regression for PR #682 review #1: a same-window builder-spawned must
+		// not be dropped behind a coalesced overview-changed.
+		const received: Array<[string, string]> = [];
+		const client = new SSEClient('http://localhost:0', fakeOutputChannel(), () => {});
+		client.onEvent((t, d) => received.push([t, d]));
+
+		feed(client, '', envelope('overview-changed'));
+		feed(client, '', envelope('builder-spawned', { terminalId: 't1', roleId: 'builder-spir-1', workspacePath: '/x' }));
+		feed(client, '', envelope('overview-changed'));
+
+		assert.strictEqual(received.length, 3);
+		assert.match(received[0][1], /overview-changed/);
+		assert.match(received[1][1], /builder-spawned/);
+		assert.match(received[2][1], /overview-changed/);
+		client.dispose();
+	});
+
+	test('malformed and empty data are dispatched verbatim (no throw)', () => {
+		const received: Array<[string, string]> = [];
+		const client = new SSEClient('http://localhost:0', fakeOutputChannel(), () => {});
+		client.onEvent((t, d) => received.push([t, d]));
+
+		assert.doesNotThrow(() => feed(client, '', 'not-json'));
+		assert.doesNotThrow(() => feed(client, '', ''));
+
+		assert.strictEqual(received.length, 2);
+		client.dispose();
+	});
+
+	test('listener exceptions do not break the dispatch loop', () => {
+		const ok: string[] = [];
+		const client = new SSEClient('http://localhost:0', fakeOutputChannel(), () => {});
+		client.onEvent(() => { throw new Error('boom'); });
+		client.onEvent((t) => ok.push(t));
+
+		feed(client, '', envelope('overview-changed'));
+
+		assert.deepStrictEqual(ok, ['']);
+		client.dispose();
+	});
+});

--- a/packages/vscode/src/test/terminal-link-provider.test.ts
+++ b/packages/vscode/src/test/terminal-link-provider.test.ts
@@ -1,31 +1,21 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { BuilderTerminalLinkProvider } from '../terminal-link-provider.js';
-import type { ConnectionManager } from '../connection-manager.js';
 import type { TerminalManager } from '../terminal-manager.js';
-
-const fakeOutputChannel = (): vscode.OutputChannel => ({
-	name: 'test',
-	append: () => {},
-	appendLine: () => {},
-	clear: () => {},
-	show: () => {},
-	hide: () => {},
-	dispose: () => {},
-	replace: () => {},
-});
 
 function fakeContext(line: string): vscode.TerminalLinkContext {
 	return { line, terminal: undefined as unknown as vscode.Terminal };
 }
 
+// A TerminalManager that throws if any method is called from render.
+const guardedTerminalManager = {
+	openBuilderByRoleOrId: () => { throw new Error('openBuilderByRoleOrId called from provideTerminalLinks'); },
+	openBuilder: () => { throw new Error('openBuilder called from provideTerminalLinks'); },
+} as unknown as TerminalManager;
+
 suite('BuilderTerminalLinkProvider.provideTerminalLinks', () => {
 	test('matches a single builder role name', () => {
-		const provider = new BuilderTerminalLinkProvider(
-			{} as ConnectionManager,
-			{} as TerminalManager,
-			fakeOutputChannel(),
-		);
+		const provider = new BuilderTerminalLinkProvider(guardedTerminalManager);
 		const links = provider.provideTerminalLinks(fakeContext('starting builder-spir-153 now'));
 		assert.strictEqual(links.length, 1);
 		assert.strictEqual(links[0].roleId, 'builder-spir-153');
@@ -33,11 +23,7 @@ suite('BuilderTerminalLinkProvider.provideTerminalLinks', () => {
 	});
 
 	test('matches multiple builder role names on one line', () => {
-		const provider = new BuilderTerminalLinkProvider(
-			{} as ConnectionManager,
-			{} as TerminalManager,
-			fakeOutputChannel(),
-		);
+		const provider = new BuilderTerminalLinkProvider(guardedTerminalManager);
 		const links = provider.provideTerminalLinks(
 			fakeContext('builders: builder-spir-153, builder-bugfix-42, builder-air-7'),
 		);
@@ -48,36 +34,23 @@ suite('BuilderTerminalLinkProvider.provideTerminalLinks', () => {
 	});
 
 	test('does not match non-builder text', () => {
-		const provider = new BuilderTerminalLinkProvider(
-			{} as ConnectionManager,
-			{} as TerminalManager,
-			fakeOutputChannel(),
-		);
+		const provider = new BuilderTerminalLinkProvider(guardedTerminalManager);
 		assert.strictEqual(provider.provideTerminalLinks(fakeContext('no role here')).length, 0);
 		assert.strictEqual(provider.provideTerminalLinks(fakeContext('foo-bar-baz')).length, 0);
 	});
 
-	test('does not call into ConnectionManager during render', () => {
+	test('does not call into TerminalManager during render', () => {
 		// Regression pin for PR #682 review #2: provideTerminalLinks fires per
 		// terminal paint, so it must stay pure. Tower lookup belongs in
-		// handleTerminalLink (click handler).
-		const guarded = {
-			getClient: () => { throw new Error('getClient called from provideTerminalLinks'); },
-			getWorkspacePath: () => { throw new Error('getWorkspacePath called from provideTerminalLinks'); },
-		} as unknown as ConnectionManager;
-		const provider = new BuilderTerminalLinkProvider(guarded, {} as TerminalManager, fakeOutputChannel());
-
+		// handleTerminalLink (click handler) via openBuilderByRoleOrId.
+		const provider = new BuilderTerminalLinkProvider(guardedTerminalManager);
 		assert.doesNotThrow(() =>
 			provider.provideTerminalLinks(fakeContext('builder-spir-1 builder-spir-2 builder-spir-3')),
 		);
 	});
 
 	test('regex re-resets between calls (statefulness check)', () => {
-		const provider = new BuilderTerminalLinkProvider(
-			{} as ConnectionManager,
-			{} as TerminalManager,
-			fakeOutputChannel(),
-		);
+		const provider = new BuilderTerminalLinkProvider(guardedTerminalManager);
 		// Module-level regex with /g flag carries lastIndex; provider must reset.
 		const a = provider.provideTerminalLinks(fakeContext('builder-spir-1'));
 		const b = provider.provideTerminalLinks(fakeContext('builder-spir-2'));

--- a/packages/vscode/src/test/terminal-link-provider.test.ts
+++ b/packages/vscode/src/test/terminal-link-provider.test.ts
@@ -1,0 +1,87 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { BuilderTerminalLinkProvider } from '../terminal-link-provider.js';
+import type { ConnectionManager } from '../connection-manager.js';
+import type { TerminalManager } from '../terminal-manager.js';
+
+const fakeOutputChannel = (): vscode.OutputChannel => ({
+	name: 'test',
+	append: () => {},
+	appendLine: () => {},
+	clear: () => {},
+	show: () => {},
+	hide: () => {},
+	dispose: () => {},
+	replace: () => {},
+});
+
+function fakeContext(line: string): vscode.TerminalLinkContext {
+	return { line, terminal: undefined as unknown as vscode.Terminal };
+}
+
+suite('BuilderTerminalLinkProvider.provideTerminalLinks', () => {
+	test('matches a single builder role name', () => {
+		const provider = new BuilderTerminalLinkProvider(
+			{} as ConnectionManager,
+			{} as TerminalManager,
+			fakeOutputChannel(),
+		);
+		const links = provider.provideTerminalLinks(fakeContext('starting builder-spir-153 now'));
+		assert.strictEqual(links.length, 1);
+		assert.strictEqual(links[0].roleId, 'builder-spir-153');
+		assert.strictEqual(links[0].length, 'builder-spir-153'.length);
+	});
+
+	test('matches multiple builder role names on one line', () => {
+		const provider = new BuilderTerminalLinkProvider(
+			{} as ConnectionManager,
+			{} as TerminalManager,
+			fakeOutputChannel(),
+		);
+		const links = provider.provideTerminalLinks(
+			fakeContext('builders: builder-spir-153, builder-bugfix-42, builder-air-7'),
+		);
+		assert.deepStrictEqual(
+			links.map((l) => l.roleId),
+			['builder-spir-153', 'builder-bugfix-42', 'builder-air-7'],
+		);
+	});
+
+	test('does not match non-builder text', () => {
+		const provider = new BuilderTerminalLinkProvider(
+			{} as ConnectionManager,
+			{} as TerminalManager,
+			fakeOutputChannel(),
+		);
+		assert.strictEqual(provider.provideTerminalLinks(fakeContext('no role here')).length, 0);
+		assert.strictEqual(provider.provideTerminalLinks(fakeContext('foo-bar-baz')).length, 0);
+	});
+
+	test('does not call into ConnectionManager during render', () => {
+		// Regression pin for PR #682 review #2: provideTerminalLinks fires per
+		// terminal paint, so it must stay pure. Tower lookup belongs in
+		// handleTerminalLink (click handler).
+		const guarded = {
+			getClient: () => { throw new Error('getClient called from provideTerminalLinks'); },
+			getWorkspacePath: () => { throw new Error('getWorkspacePath called from provideTerminalLinks'); },
+		} as unknown as ConnectionManager;
+		const provider = new BuilderTerminalLinkProvider(guarded, {} as TerminalManager, fakeOutputChannel());
+
+		assert.doesNotThrow(() =>
+			provider.provideTerminalLinks(fakeContext('builder-spir-1 builder-spir-2 builder-spir-3')),
+		);
+	});
+
+	test('regex re-resets between calls (statefulness check)', () => {
+		const provider = new BuilderTerminalLinkProvider(
+			{} as ConnectionManager,
+			{} as TerminalManager,
+			fakeOutputChannel(),
+		);
+		// Module-level regex with /g flag carries lastIndex; provider must reset.
+		const a = provider.provideTerminalLinks(fakeContext('builder-spir-1'));
+		const b = provider.provideTerminalLinks(fakeContext('builder-spir-2'));
+		assert.strictEqual(a.length, 1);
+		assert.strictEqual(b.length, 1);
+	});
+});

--- a/packages/vscode/src/views/builders.ts
+++ b/packages/vscode/src/views/builders.ts
@@ -25,6 +25,11 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
       item.iconPath = b.blocked
         ? new vscode.ThemeIcon('debug-pause', new vscode.ThemeColor('testing.iconFailed'))
         : new vscode.ThemeIcon('play', new vscode.ThemeColor('testing.iconPassed'));
+      item.command = {
+        command: 'codev.openBuilderById',
+        title: 'Open Builder Terminal',
+        arguments: [b.id],
+      };
       return item;
     });
   }

--- a/packages/vscode/src/views/needs-attention.ts
+++ b/packages/vscode/src/views/needs-attention.ts
@@ -27,6 +27,11 @@ export class NeedsAttentionProvider implements vscode.TreeDataProvider<vscode.Tr
       const item = new vscode.TreeItem(`#${b.issueId ?? b.id} — blocked on ${b.blocked} ${waitTime}`);
       item.iconPath = new vscode.ThemeIcon('bell', new vscode.ThemeColor('notificationsWarningIcon.foreground'));
       item.contextValue = 'blocked-builder';
+      item.command = {
+        command: 'codev.openBuilderById',
+        title: 'Open Builder Terminal',
+        arguments: [b.id],
+      };
       items.push(item);
     }
 

--- a/packages/vscode/src/views/workspace.ts
+++ b/packages/vscode/src/views/workspace.ts
@@ -1,0 +1,59 @@
+import * as vscode from 'vscode';
+import { encodeWorkspacePath } from '@cluesmith/codev-core/workspace';
+import type { ConnectionManager } from '../connection-manager.js';
+import { getTowerAddress } from '../workspace-detector.js';
+
+/**
+ * Workspace-level entry points: architect terminal + Tower web dashboard.
+ * Sits at the top of the Codev sidebar so users can launch either with
+ * one click instead of hunting in the command palette.
+ */
+export class WorkspaceProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+  private readonly changeEmitter = new vscode.EventEmitter<void>();
+  readonly onDidChangeTreeData = this.changeEmitter.event;
+
+  constructor(private connectionManager: ConnectionManager) {
+    connectionManager.onStateChange(() => this.changeEmitter.fire());
+  }
+
+  getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(): vscode.TreeItem[] {
+    const items: vscode.TreeItem[] = [];
+
+    const architect = new vscode.TreeItem('Open Architect');
+    architect.iconPath = new vscode.ThemeIcon('person');
+    architect.tooltip = 'Open the architect terminal';
+    architect.contextValue = 'workspace-architect';
+    architect.command = {
+      command: 'codev.openArchitectTerminal',
+      title: 'Open Architect Terminal',
+    };
+    items.push(architect);
+
+    const webUrl = this.buildDashboardUrl();
+    if (webUrl) {
+      const web = new vscode.TreeItem('Open Web Interface');
+      web.iconPath = new vscode.ThemeIcon('globe');
+      web.tooltip = webUrl;
+      web.contextValue = 'workspace-web';
+      web.command = {
+        command: 'vscode.open',
+        title: 'Open Tower dashboard in browser',
+        arguments: [vscode.Uri.parse(webUrl)],
+      };
+      items.push(web);
+    }
+
+    return items;
+  }
+
+  private buildDashboardUrl(): string | null {
+    const workspacePath = this.connectionManager.getWorkspacePath();
+    if (!workspacePath) { return null; }
+    const { host, port } = getTowerAddress();
+    return `http://${host}:${port}/workspace/${encodeWorkspacePath(workspacePath)}/`;
+  }
+}

--- a/scripts/local-install.sh
+++ b/scripts/local-install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Pack workspace packages into tarballs and install them globally for testing.
 # Run from the monorepo root: pnpm -w run local-install
 
@@ -38,7 +38,7 @@ npm install -g \
 # pnpm pack strips the executable bit from shell scripts in the tarball,
 # which causes "GitHub CLI unavailable" errors when overview.ts tries to
 # spawn scripts/forge/github/*.sh. Restore +x after install.
-chmod -R +x "$(npm root -g)/@cluesmith/codev/scripts/forge"
+find "$(npm root -g)/@cluesmith/codev/scripts/forge" -name '*.sh' -exec chmod +x {} +
 
 echo "Installed: $(codev --version)"
 


### PR DESCRIPTION
## Summary

Bundle of VS Code extension reliability fixes, sidebar UX improvements, and the PR #682 review follow-up onto a single branch. Three themes:

1. **PR #682 follow-up** — addresses Waleed's review feedback (SSE coalescing, terminal close-race, path normalization, plus unit coverage).
2. **Bugfixes #718 + #728** — sidebar refresh/reconnect UX, cold-start self-heal, workspace-activation ordering.
3. **Sidebar UX** — make Builders / Needs Attention rows clickable, add a Workspace view with architect/web entry points, brand terminal tabs with the Codev SVG.

Plus a v3.0.2 release commit (changelog + version bump from a parallel agent).

## Commits by theme

### PR #682 follow-up (4 commits)

- `0ca117ed` `fix(vscode/sse): drop redundant rate limiter` — every consumer self-throttles where it matters (`overview-data` has a `loading` guard, tree views fire batched EventEmitters), so the SSE-layer 1s coalescer was solving a problem that wasn't there while creating the bug Waleed flagged: a `builder-spawned` event arriving inside a coalesced `overview-changed` window was silently dropped. Removed entirely.
- `1376ed12` `fix(vscode/terminal): guard openBuilder close-race on stale-replace` — when `openBuilder` disposes a stale terminal and immediately registers a replacement under the same `mapKey`, the stale `onDidCloseTerminal` event can fire after registration. Identity-check the current map entry before deleting.
- `999ef8da` `fix(vscode/spawn-handler): normalize workspace paths + add unit coverage` — `path.resolve` both sides of the workspace comparison so trailing-slash variants don't drop events. Adds `builder-spawn-handler.test.ts` (parsing/dedup/path-norm/mode-dispatch) and `sse-client.test.ts` (regression test for the SSE drop).
- `4407a9a4` `test(vscode): pin BuilderTerminalLinkProvider purity` — `provideTerminalLinks` was already correct on inspection (regex-only, no Tower I/O); this test pins the contract so a future refactor that pulls connection state into the render path fails loudly.

> **Skipped item #6 (toast spam on reconnect)** — discussed and judged not worth the code: persistent activation failures only re-toast when Tower restarts, mostly affects local dev iteration on a broken config, and the first toast is the useful signal.

### Sidebar UX + terminal lifecycle (5 commits)

- `7b7b3e97` `feat(vscode): make Builders and Needs Attention rows clickable` — extracted `TerminalManager.openBuilderByRoleOrId` so the link provider, sidebar trees, and command palette share one resolution path. Click a builder row → opens its terminal.
- `7bcbba3d` `fix(vscode): tail-match builder IDs in openBuilderByRoleOrId` — fixes "Codev: No active terminal for 153" toast. `OverviewBuilder.id` from the sidebar is `'153'` (parsed from `.builders/spir-153-foo/`) but Tower's runtime `Builder.id` is `'builder-spir-153'`. Lifted `resolveAgentName` + `stripLeadingZeros` into a new `@cluesmith/codev-core/agent-names` subpath (generic over `{ id: string }`) so vscode and the agent-farm utility share identical matching semantics. Existing agent-farm callsites unaffected via re-export.
- `2458ca61` `feat(vscode): focus terminal on click; preserve focus on auto-spawn` — `focus` parameter through `openBuilder`/`openBuilderByRoleOrId`/`openTerminal`, defaulting to false so background paths (auto-spawn) don't steal focus mid-typing. Click paths opt in. Also primes `CodevPseudoterminal.open()` with an empty write — VS Code drops or mis-orders writes that arrive purely asynchronously after `open()` when the terminal becomes the active editor (microsoft/vscode#108298), causing a blank pane until first input.
- `89a5c22c` `feat(vscode): brand terminal tabs with the Codev SVG` — `createTerminal` now sets `iconPath: icons/codev.svg`; architect, builder, and shell tabs all show the Codev mark instead of the default `>_` glyph.
- `8d98c0bc` `feat(vscode): add Workspace sidebar view; focus architect on click` — new top-level Workspace view above Needs Attention. Two clickable rows: **Open Architect** (invokes `codev.openArchitectTerminal`, shared by palette + `Cmd-K A` keybinding) and **Open Web Interface** (opens `http://{host}:{port}/workspace/{enc}/` in browser). Threads `focus` through `openArchitect` so all three architect entry points (sidebar / palette / keybinding) focus the terminal on click.

### Bugfixes #718 / #728 / PR #688 (5 commits, parallel agent)

- `e0281cae` `[Bugfix #718] fix(tower): centralise wsTerminals rehydration so /api/overview self-heals like /api/state`
- `c03356b8` `[Bugfix #718] fix(vscode): activate workspace before announcing 'connected'`
- `dfc0378c` `[Bugfix #718] feat(vscode): surface refresh + reconnect buttons on sidebar views`
- `cbe1b9ad` `[Bugfix #728] feat(vscode): add codev.reconnect command + status-bar click`
- `a0d0c126` `[Bugfix #728] fix(vscode): self-heal cold-start failures + connect() re-entry guard`
- `31352591` `chore: address PR #688 review nits on local-install.sh`

### Release (1 commit, parallel agent)

- `c892992d` `chore(vscode): release 3.0.2 — changelog, version bump, .gitignore`

## Sidebar layout note

We considered tuning view sizes via `contributes.views[*].initialSize`, but VS Code's implementation is widely incomplete (see microsoft/vscode#163043, and `initialSize` isn't even mentioned on the official contribution-points page). Doesn't apply on a fresh workspace either, in our testing. Reverted those changes; sidebar uses VS Code's default equal-split. Tracked separately if we want to revisit by moving fixed-content sections out of tree views.

## Test plan

- [x] `pnpm --filter @cluesmith/codev-vscode test` — 21 passing (4 new SSE tests, 11 new BuilderSpawnHandler tests, 5 link-provider tests, 1 existing).
- [x] `pnpm --filter @cluesmith/codev test` — 2588 passing / 13 skipped (full vitest suite, no regressions from the agent-names re-export).
- [x] Type-check: `pnpm check-types` clean across `packages/vscode`, `packages/core`, `packages/codev`.
- [x] Manual: rebuild + reinstall extension, click each Builders / Needs Attention row → opens correct builder terminal with focus and content.
- [x] Manual: Workspace > Open Architect → architect terminal opens focused. Workspace > Open Web Interface → browser opens Tower dashboard.
- [x] Manual: terminal tabs show the Codev SVG icon for architect, builder, and shell types.
- [x] Manual cross-check the parallel-agent #718/#728/#688 changes still behave (refresh button, reconnect, cold-start self-heal) — owner of those commits to confirm.

## Reviewer notes

- The `agent-names` move from `packages/codev/src/agent-farm/utils/` to a new `@cluesmith/codev-core/agent-names` subpath is the only cross-package change. The original file re-exports from core so existing agent-farm imports are unaffected; the agent-names test in `packages/codev` runs against the same exported functions and continues to pass.
- The pty-prime in `terminal-adapter.ts:open()` deserves a once-over — a single `writeEmitter.fire('')` synchronously inside `open()` is the documented workaround for microsoft/vscode#108298 ("output emitted before open() is dropped"). Without it, `terminal.show(false)` on a brand-new editor-area pty leaves the pane blank until first input.

## Closes

- Closes #718 — VS Code extension doesn't show builder terminals from Tower
- Closes #728 — VSCode extension: no way to manually reconnect when stuck Offline