### PR TITLE
feat(release): lockstep version bumps via pnpm bump-version

### DIFF
--- a/codev/protocols/release/protocol.md
+++ b/codev/protocols/release/protocol.md
@@ -53,6 +53,32 @@ bats tests/e2e/
 
 ### 4. Update Version and Tag
 
+**Normal releases — use lockstep bump.** Run `pnpm bump-version` from the repo root to set every publishable package (`@cluesmith/codev`, `@cluesmith/codev-core`, `@cluesmith/codev-types`, and the VS Code extension) to the same version in one shot. This keeps every workspace package on the same version, preventing the class of drift bug where a release ships pointing at outdated internal dependencies and end users hit runtime API mismatches.
+
+The script anchors on the root `package.json`'s current version (Vue/Babel pattern) and accepts several invocation forms:
+
+| Command | Effect |
+|---|---|
+| `pnpm bump-version` | **Default** — patch bump from the current root version (e.g. `3.0.2` → `3.0.3`) |
+| `pnpm bump-version patch` | Same as no-arg |
+| `pnpm bump-version minor` | Minor bump (e.g. `3.0.2` → `3.1.0`) |
+| `pnpm bump-version major` | Major bump (e.g. `3.0.2` → `4.0.0`) |
+| `pnpm bump-version 3.1.0-rc.1` | Explicit version (use for RCs; pre-release versions auto-skip `packages/vscode` because the VS Code Marketplace rejects pre-release suffixes) |
+
+Replace `X.Y.Z` below with the version the script just wrote (it prints it as `Bumped … → X.Y.Z`).
+
+```bash
+pnpm bump-version            # or: pnpm bump-version minor / major / 3.1.0-rc.1
+
+# Commit and tag (root package.json is the version anchor — Vue/Babel pattern)
+git add package.json packages/codev/package.json packages/core/package.json packages/types/package.json packages/vscode/package.json pnpm-lock.yaml
+git commit -m "Release @cluesmith/codev@X.Y.Z (Codename)"
+git tag -a vX.Y.Z -m "vX.Y.Z Codename - Brief description"
+git push && git push origin vX.Y.Z
+```
+
+**Backport path (single-package patch on a release branch)** — use `pnpm version` directly:
+
 ```bash
 cd packages/codev
 
@@ -127,7 +153,7 @@ cd packages/codev && pnpm publish --no-git-checks            # stable → tag la
 cd packages/codev && pnpm publish --tag next --no-git-checks # RC → tag next
 ```
 
-**When to bump workspace dep versions:** if you've changed `packages/core/src/**` or `packages/types/src/**` since the last release, bump that package's version (`pnpm --filter @cluesmith/codev-core version patch`) before publishing. Otherwise the publish step will skip it (existing version) and consumers will get the old code.
+**When to bump workspace dep versions:** unnecessary if step 4 used `pnpm bump-version` (lockstep already bumped core and types). If you took the backport path and `packages/core/src/**` or `packages/types/src/**` changed since the last release, bump that package's version (`pnpm --filter @cluesmith/codev-core version patch`) before publishing — otherwise the publish step will skip it (existing version) and consumers will get the old code.
 
 **Verification:** the `Post-Release E2E Verification` GitHub Actions workflow (triggered automatically on release) installs the published tarball on macOS and Ubuntu. If it fails with E404 on a `@cluesmith/*` package, that workspace dep is missing from npm — publish it and re-run the workflow with `gh workflow run "Post-Release E2E Verification" -f version=X.Y.Z`.
 
@@ -201,13 +227,13 @@ Starting with v1.7.0, minor releases use a release candidate workflow for testin
 ### RC Publishing
 
 ```bash
-# Set version to RC
-cd packages/codev
-pnpm version 1.7.0-rc.1 --no-git-tag-version
+# Set version to RC. bump-all.sh auto-skips packages/vscode for pre-release
+# versions (VS Code Marketplace rejects semver pre-release suffixes), so only
+# codev, core, and types are bumped here. vscode catches up at RC → stable.
+pnpm bump-version 1.7.0-rc.1
 
-# Commit and tag
-cd ../..
-git add packages/codev/package.json pnpm-lock.yaml
+# Commit and tag (note: no packages/vscode/package.json — it wasn't bumped)
+git add package.json packages/codev/package.json packages/core/package.json packages/types/package.json pnpm-lock.yaml
 git commit -m "v1.7.0-rc.1"
 git tag -a v1.7.0-rc.1 -m "v1.7.0-rc.1 - Release candidate"
 git push && git push origin v1.7.0-rc.1
@@ -222,9 +248,8 @@ cd packages/codev && pnpm publish --tag next --no-git-checks
 When an RC is validated and ready for stable release:
 
 ```bash
-# Bump to stable version
-cd packages/codev
-pnpm version 1.7.0 --no-git-tag-version
+# Bump to stable version (lockstep)
+pnpm bump-version 1.7.0
 
 # Follow standard release process (steps 4-9 above)
 ```

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "cluesmith-codev",
+  "version": "3.0.2",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {
     "build": "scripts/check-main-fresh.sh && pnpm --filter @cluesmith/codev-core build && pnpm --filter @cluesmith/codev build",
     "test": "pnpm --filter @cluesmith/codev test",
-    "local-install": "scripts/local-install.sh"
+    "local-install": "scripts/local-install.sh",
+    "bump-version": "scripts/bump-all.sh"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "prepublishOnly": "pnpm build"
   },
   "devDependencies": {
     "@cluesmith/codev-types": "workspace:*",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,7 +15,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "prepublishOnly": "pnpm build"
   },
   "devDependencies": {
     "typescript": "^5.7.0"

--- a/scripts/bump-all.sh
+++ b/scripts/bump-all.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# Set every workspace package to the same version, anchored on the root
+# package.json's version field. The root is private (never published), but
+# its version is the canonical "what version is this monorepo" — same pattern
+# used by Vue (vuejs/core) and Babel (babel/babel).
+#
+# Usage:
+#   scripts/bump-all.sh                 # default: patch bump from root version
+#   scripts/bump-all.sh patch           # patch bump (same as no-arg)
+#   scripts/bump-all.sh minor           # minor bump
+#   scripts/bump-all.sh major           # major bump
+#   scripts/bump-all.sh 3.1.0-rc.1      # explicit version (for RCs, etc.)
+#
+# This script only rewrites the version field of each package.json — it does
+# NOT commit or tag (so no `--no-git-tag-version` passthrough is needed,
+# unlike `pnpm version` which auto-commits by default). It also does NOT
+# reformat the JSON: the version line is patched in place so hand-formatted
+# files (e.g. packages/vscode/package.json with compact view arrays) are
+# preserved byte-for-byte outside the version field. Stage, commit, and tag
+# yourself afterward.
+#
+# VS Code Marketplace rejects semver pre-release suffixes (e.g. 1.7.0-rc.1),
+# so packages/vscode is skipped when VERSION contains a '-'. The extension
+# catches up when an RC is promoted to a stable version.
+
+set -e
+
+INPUT="${1:-patch}"
+
+CURRENT="$(PKG=. node -e '
+  const fs = require("fs");
+  const p = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  if (!p.version) { console.error("Root package.json has no version field"); process.exit(1); }
+  console.log(p.version);
+')"
+
+case "$INPUT" in
+  patch|minor|major)
+    case "$CURRENT" in
+      *-*)
+        echo "Cannot semantic-bump from pre-release version '$CURRENT'. Pass an explicit version instead." >&2
+        exit 1
+        ;;
+    esac
+    VERSION="$(CURRENT="$CURRENT" INPUT="$INPUT" node -e '
+      const [maj, min, patch] = process.env.CURRENT.split(".").map(Number);
+      const out = process.env.INPUT === "major" ? [maj + 1, 0, 0]
+                : process.env.INPUT === "minor" ? [maj, min + 1, 0]
+                : [maj, min, patch + 1];
+      console.log(out.join("."));
+    ')"
+    echo "Anchor (root) @$CURRENT → $INPUT bump → $VERSION"
+    ;;
+  *)
+    VERSION="$INPUT"
+    ;;
+esac
+
+case "$VERSION" in
+  *-*) IS_PRERELEASE=1 ;;
+  *)   IS_PRERELEASE=0 ;;
+esac
+
+bump_file() {
+  PKG_FILE="$1" VERSION="$VERSION" node -e '
+    const fs = require("fs");
+    const p = process.env.PKG_FILE;
+    const newVersion = process.env.VERSION;
+    const content = fs.readFileSync(p, "utf8");
+    // Match the FIRST top-level "version" field (2-space indent, root level).
+    // Anything deeper (e.g. version strings inside dependencies) is left alone.
+    const pattern = /^(  "version"\s*:\s*")[^"]*(")/m;
+    if (!pattern.test(content)) {
+      console.error("Failed to find top-level version field in " + p);
+      process.exit(1);
+    }
+    const newContent = content.replace(pattern, `$1${newVersion}$2`);
+    fs.writeFileSync(p, newContent);
+    const pkg = JSON.parse(newContent);
+    console.log("Bumped " + pkg.name + " → " + pkg.version);
+  '
+}
+
+# Root first — always bumped (private, no marketplace constraints).
+bump_file "package.json"
+
+for pkg in packages/codev packages/core packages/types packages/vscode; do
+  if [ "$pkg" = "packages/vscode" ] && [ "$IS_PRERELEASE" = "1" ]; then
+    echo "Skipping packages/vscode ($VERSION is a pre-release; VS Code Marketplace requires plain semver)"
+    continue
+  fi
+  bump_file "$pkg/package.json"
+done


### PR DESCRIPTION
## Summary

- Add `pnpm bump-version` to set every workspace package and the root anchor to the same version in one shot, replacing the per-package `pnpm version` flow that has caused drift between `@cluesmith/codev` and its workspace deps (current state: codev@3.0.2, core@0.0.3, types@0.0.2).
- Anchor is the root `package.json`'s `version` field — the same pattern used by Vue (vuejs/core) and Babel (babel/babel) for synchronized-version monorepos.
- Add `prepublishOnly: pnpm build` to `packages/core` and `packages/types` so `dist/` is guaranteed fresh at publish time (closes the source/dist staleness window — orthogonal to version drift).
- Update release protocol step 4 with the lockstep flow, an invocation modes table, and aligned RC Publishing + RC→Stable + step-7 footnote. Backport path keeps the per-package `pnpm version` flow.

## Invocation modes

| Command | Effect |
|---|---|
| `pnpm bump-version` | Default — patch bump from current root version |
| `pnpm bump-version patch` / `minor` / `major` | Semantic bumps |
| `pnpm bump-version 3.1.0-rc.1` | Explicit version (auto-skips `packages/vscode` because VS Code Marketplace rejects pre-release suffixes) |

## Why this design

- **Root anchor (not packages/codev)**: Vue and Babel both treat the root `version` field as the canonical monorepo version, even though the root is private. Decouples lockstep anchor from any specific publishable package — future-proof if a publishable package is renamed or split.
- **Byte-preserving rewrite**: the script patches only the version line via a regex anchored to root-level 2-space indent. Hand-formatted JSON elsewhere in the file (`packages/vscode/package.json` has compact `views[]` / `enum[]` arrays) is preserved byte-for-byte. Naive `JSON.stringify(pkg, null, 2)` would have bloated the diff with formatting churn.
- **Script doesn't commit or tag**: leaves git operations to the human, mirroring `pnpm version --no-git-tag-version` semantics. The protocol then does `git add` + `git commit` + `git tag` explicitly.
- **VS Code Marketplace constraint**: the Marketplace rejects semver pre-release suffixes (`-rc.1` etc.), so the script auto-skips `packages/vscode` for pre-release versions. The extension catches up at RC → stable promotion.
- **`prepublishOnly` on core + types**: closes a different bug class than version drift. If `src/` is ahead of `dist/` and you publish, the tarball ships stale runtime code regardless of version field correctness. `pnpm publish` honors the hook automatically — npm-standard, no `--ignore-scripts` anywhere in the publish path.

## Tooling-only

This PR does **not** bump versions for a release. The next release should run `pnpm bump-version` to do the one-time alignment of core/types up from their stale `0.0.x` values to the current codev version.

## Test plan

- [x] `pnpm bump-version` (no args) — bumps root + 4 packages to next patch (`3.0.2 → 3.0.3`)
- [x] `pnpm bump-version minor` / `major` — semantic bumps (`3.0.2 → 3.1.0` / `4.0.0`)
- [x] `pnpm bump-version 3.1.0-rc.1` — bumps root + codev + core + types; skips vscode with explanatory message
- [x] Byte-preserving rewrite: `git diff packages/vscode/package.json` after a bump shows exactly one line changed (the `version` field), compact `views[]` formatting preserved
- [x] Semantic bump from pre-release version errors out with a clear message (forces explicit version)
- [ ] First actual release using `pnpm bump-version` (deferred to next release)

Closes #692