### PR TITLE
feat(release): split vscode bump + prebuild core/types; release 3.0.3

### DIFF
--- a/codev/protocols/release/protocol.md
+++ b/codev/protocols/release/protocol.md
@@ -55,6 +55,8 @@ bats tests/e2e/
 
 **Normal releases — use lockstep bump.** Run `pnpm bump-version` from the repo root to set every publishable package (`@cluesmith/codev`, `@cluesmith/codev-core`, `@cluesmith/codev-types`, and the VS Code extension) to the same version in one shot. This keeps every workspace package on the same version, preventing the class of drift bug where a release ships pointing at outdated internal dependencies and end users hit runtime API mismatches.
 
+For VS Code stable releases the script delegates to `scripts/bump-vscode.sh` (also exposed as `pnpm bump-vscode-version` for standalone use), which bumps the extension manifest **and** renames `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` in `packages/vscode/CHANGELOG.md` so the Marketplace listing reflects the new version. No fresh `[Unreleased]` heading is inserted — the next PR with notes adds one back. Skipped for pre-release versions (vscode is skipped entirely then). Use `pnpm bump-vscode-version` directly when shipping a vscode-only patch outside the lockstep cadence.
+
 The script anchors on the root `package.json`'s current version (Vue/Babel pattern) and accepts several invocation forms:
 
 | Command | Effect |

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "scripts/check-main-fresh.sh && pnpm --filter @cluesmith/codev-core build && pnpm --filter @cluesmith/codev build",
     "test": "pnpm --filter @cluesmith/codev test",
     "local-install": "scripts/local-install.sh",
-    "bump-version": "scripts/bump-all.sh"
+    "bump-version": "scripts/bump-all.sh",
+    "bump-vscode-version": "scripts/bump-vscode.sh"
   }
 }

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 What's changed in the Codev VS Code extension, version by version, written for the developers who use it.
 
-## [Unreleased]
+## [3.0.3] - 2026-05-13
 
 ### What's new
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -298,7 +298,7 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "pnpm package",
+    "vscode:prepublish": "pnpm --filter @cluesmith/codev-core --filter @cluesmith/codev-types build && pnpm package",
     "compile": "pnpm check-types && pnpm lint && node esbuild.js",
     "watch": "pnpm run --parallel '/^watch:/'",
     "watch:esbuild": "node esbuild.js --watch",

--- a/scripts/bump-all.sh
+++ b/scripts/bump-all.sh
@@ -84,10 +84,17 @@ bump_file() {
 # Root first — always bumped (private, no marketplace constraints).
 bump_file "package.json"
 
-for pkg in packages/codev packages/core packages/types packages/vscode; do
-  if [ "$pkg" = "packages/vscode" ] && [ "$IS_PRERELEASE" = "1" ]; then
-    echo "Skipping packages/vscode ($VERSION is a pre-release; VS Code Marketplace requires plain semver)"
-    continue
-  fi
+# Bump the npm-published packages (codev, core, types).
+for pkg in packages/codev packages/core packages/types; do
   bump_file "$pkg/package.json"
 done
+
+# vscode lives in its own script — version + CHANGELOG promotion + marketplace
+# constraints. Delegate to scripts/bump-vscode.sh, which is also callable on
+# its own when bumping the extension independently from a codev release.
+if [ "$IS_PRERELEASE" = "1" ]; then
+  echo "Skipping packages/vscode ($VERSION is a pre-release; VS Code Marketplace requires plain semver)"
+else
+  SCRIPT_DIR="$(dirname "$0")"
+  "$SCRIPT_DIR/bump-vscode.sh" "$VERSION"
+fi

--- a/scripts/bump-vscode.sh
+++ b/scripts/bump-vscode.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# Bump the VS Code extension — version field in packages/vscode/package.json
+# AND promote `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` in
+# packages/vscode/CHANGELOG.md so the Marketplace listing reflects the new
+# version.
+#
+# Standalone: anchors on vscode's OWN current version. When called from
+# scripts/bump-all.sh, the lockstep version is passed explicitly.
+#
+# Usage:
+#   scripts/bump-vscode.sh                # default: patch bump from current vscode version
+#   scripts/bump-vscode.sh patch          # patch bump (same as no-arg)
+#   scripts/bump-vscode.sh minor          # minor bump
+#   scripts/bump-vscode.sh major          # major bump
+#   scripts/bump-vscode.sh 3.0.4          # explicit version (must NOT be pre-release)
+#
+# Pre-release versions (anything containing '-') are rejected: VS Code
+# Marketplace requires plain semver. Bump vscode independently when promoting
+# an RC to stable.
+#
+# Like scripts/bump-all.sh, this only rewrites files — no commit, no tag.
+
+set -e
+
+INPUT="${1:-patch}"
+
+CURRENT="$(node -e '
+  const fs = require("fs");
+  const p = JSON.parse(fs.readFileSync("packages/vscode/package.json", "utf8"));
+  if (!p.version) { console.error("packages/vscode/package.json has no version field"); process.exit(1); }
+  console.log(p.version);
+')"
+
+case "$INPUT" in
+  patch|minor|major)
+    case "$CURRENT" in
+      *-*)
+        echo "Cannot semantic-bump from pre-release version '$CURRENT'. Pass an explicit version instead." >&2
+        exit 1
+        ;;
+    esac
+    VERSION="$(CURRENT="$CURRENT" INPUT="$INPUT" node -e '
+      const [maj, min, patch] = process.env.CURRENT.split(".").map(Number);
+      const out = process.env.INPUT === "major" ? [maj + 1, 0, 0]
+                : process.env.INPUT === "minor" ? [maj, min + 1, 0]
+                : [maj, min, patch + 1];
+      console.log(out.join("."));
+    ')"
+    echo "vscode @$CURRENT → $INPUT bump → $VERSION"
+    ;;
+  *)
+    VERSION="$INPUT"
+    ;;
+esac
+
+case "$VERSION" in
+  *-*)
+    echo "VS Code Marketplace rejects pre-release versions like '$VERSION'. Use plain semver (e.g. 3.0.4)." >&2
+    exit 1
+    ;;
+esac
+
+# Bump packages/vscode/package.json (byte-preserving regex on the version line).
+PKG_FILE="packages/vscode/package.json" VERSION="$VERSION" node -e '
+  const fs = require("fs");
+  const p = process.env.PKG_FILE;
+  const content = fs.readFileSync(p, "utf8");
+  const pattern = /^(  "version"\s*:\s*")[^"]*(")/m;
+  if (!pattern.test(content)) {
+    console.error("Failed to find top-level version field in " + p);
+    process.exit(1);
+  }
+  const newContent = content.replace(pattern, `$1${process.env.VERSION}$2`);
+  fs.writeFileSync(p, newContent);
+  const pkg = JSON.parse(newContent);
+  console.log("Bumped " + pkg.name + " → " + pkg.version);
+'
+
+# Promote Keep-a-Changelog `## [Unreleased]` → `## [X.Y.Z] - DATE`.
+# No fresh [Unreleased] heading is inserted — the next PR with notes adds one
+# back. Keeps the published Marketplace changelog free of empty sections.
+FILE="packages/vscode/CHANGELOG.md" VERSION="$VERSION" DATE="$(date +%Y-%m-%d)" node -e '
+  const fs = require("fs");
+  const f = process.env.FILE;
+  if (!fs.existsSync(f)) {
+    console.log("No changelog at " + f + " — skipping promotion");
+    process.exit(0);
+  }
+  const content = fs.readFileSync(f, "utf8");
+  const heading = "## [Unreleased]";
+  const idx = content.indexOf(heading);
+  if (idx === -1) {
+    console.log("No [Unreleased] section in " + f + " — skipping promotion");
+    process.exit(0);
+  }
+  const replacement = "## [" + process.env.VERSION + "] - " + process.env.DATE;
+  const newContent = content.slice(0, idx) + replacement + content.slice(idx + heading.length);
+  fs.writeFileSync(f, newContent);
+  console.log("Promoted " + f + ": [Unreleased] → [" + process.env.VERSION + "] - " + process.env.DATE);
+'


### PR DESCRIPTION
## Summary

Two commits:

1. **`feat(release): split vscode bump into standalone script + prebuild core/types`** — tooling
2. **`chore(vscode): release 3.0.3`** — promotes `## [Unreleased]` → `## [3.0.3] - 2026-05-13` in `packages/vscode/CHANGELOG.md` so the next Marketplace publish shows release notes for the 3.0.3 already in `packages/vscode/package.json`

## Tooling changes (commit 1)

- New `scripts/bump-vscode.sh` (and `pnpm bump-vscode-version` alias) that handles vscode versioning + CHANGELOG promotion as a single standalone operation. Defaults to patch bump from vscode's own current version; accepts `patch`/`minor`/`major`/explicit. Refuses pre-release versions (Marketplace constraint).
- `scripts/bump-all.sh` delegates the vscode step to the new script, passing the lockstep version explicitly so no double-bump occurs. Pre-release lockstep bumps still skip vscode entirely.
- `vscode:prepublish` extended to `pnpm --filter @cluesmith/codev-core --filter @cluesmith/codev-types build && pnpm package`. The vscode bundle inlines code from those workspace `dist/` directories (esbuild + `bundle: true`); without this prebuild a stale `dist/` could ship into the .vsix. Same staleness class as `prepublishOnly` on the npm side, just for vsce.
- Release protocol step 4 updated with a note about the standalone script.

## Marketplace changelog policy

Promoted `[Unreleased]` heading becomes `[X.Y.Z] - YYYY-MM-DD`. **No fresh `[Unreleased]` heading is inserted** — the next PR with notes adds one back. Keeps the published Marketplace changelog free of empty sections (Vue/Babel-style).

## Test plan

- [x] `pnpm bump-version` (lockstep) bumps root + 4 packages and promotes vscode CHANGELOG
- [x] `pnpm bump-version 3.5.0-rc.1` (lockstep RC) bumps root/codev/core/types; vscode + CHANGELOG untouched
- [x] `pnpm bump-vscode-version` (standalone default patch) bumps only vscode + CHANGELOG
- [x] `pnpm bump-vscode-version 3.5.0` (standalone explicit) bumps to explicit
- [x] `pnpm bump-vscode-version 3.5.0-rc.1` (standalone pre-release) refused with clear error
- [x] `pnpm vscode:prepublish` builds core + types before esbuild, produces a clean production bundle
- [x] First actual `pnpm vscode:publish` after this PR merges