### PR TITLE
fix(vscode): lower engines.vscode floor for fork compatibility; dual-publish script; release 3.0.4

### DIFF
--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 What's changed in the Codev VS Code extension, version by version, written for the developers who use it.
 
+## [3.0.4] - 2026-05-13
+
+### Bug fixes
+
+- **Lower `engines.vscode` floor from `^1.110.0` to `^1.105.0`** so the extension installs on Cursor 3.3.30 (VSCode 1.105.1), Antigravity 1.107.0, and AWS Kiro 0.12.184 (VSCode 1.107.1). Windsurf and standard VSCode (≥1.110) are unaffected. `@types/vscode` pinned to `~1.105.0` so tsc validates against the actual supported API surface.
+
 ## [3.0.3] - 2026-05-13
 
 ### What's new

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "publisher": "cluesmith",
   "displayName": "Codev for VS Code",
   "description": "Codev helps humans and agents co-develop both the context and the code of the project.",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "license": "Apache-2.0",
   "icon": "icons/codev.png",
   "pricing": "Free",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -22,7 +22,7 @@
     "theme": "dark"
   },
   "engines": {
-    "vscode": "^1.110.0"
+    "vscode": "^1.105.0"
   },
   "categories": [
     "AI",
@@ -320,7 +320,7 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
-    "@types/vscode": "^1.110.0",
+    "@types/vscode": "~1.105.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "22.x",
     "@types/ws": "^8.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,8 +193,8 @@ importers:
         specifier: 22.x
         version: 22.19.17
       '@types/vscode':
-        specifier: ^1.110.0
-        version: 1.115.0
+        specifier: ~1.105.0
+        version: 1.105.0
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -1287,8 +1287,8 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
-  '@types/vscode@1.115.0':
-    resolution: {integrity: sha512-/M8cdznOlqtMqduHKKlIF00v4eum4ZWKgn8YoPRKcN6PDdvoWeeqDaQSnw63ipDbq1Uzz78Wndk/d0uSPwORfA==}
+  '@types/vscode@1.105.0':
+    resolution: {integrity: sha512-Lotk3CTFlGZN8ray4VxJE7axIyLZZETQJVWi/lYoUVQuqfRxlQhVOfoejsD2V3dVXPSbS15ov5ZyowMAzgUqcw==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -4182,7 +4182,7 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@types/vscode@1.115.0': {}
+  '@types/vscode@1.105.0': {}
 
   '@types/ws@8.18.1':
     dependencies:

--- a/scripts/publish-vscode.sh
+++ b/scripts/publish-vscode.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Publish the VS Code extension to BOTH registries from a single packaged
+# .vsix — keeps VS Code Marketplace and Open VSX byte-identical.
+#
+# Usage:
+#   scripts/publish-vscode.sh                # stable, both registries
+#   scripts/publish-vscode.sh --pre-release  # pre-release channel, both registries
+#
+# Auth:
+#   VSCE_PAT  — VS Code Marketplace token, or run `vsce login cluesmith` once
+#               (stored in OS keychain under service `vscode-vsce`)
+#   OVSX_PAT  — Open VSX token. ovsx has no keychain support; export via shell rc
+#               or pull from a secrets manager. See codev/protocols/release/protocol.md.
+#
+# Failure recovery:
+#   Both registries reject duplicate-version uploads. If Marketplace succeeds
+#   and Open VSX fails, the .vsix is still on disk — retry just the failed one:
+#       ovsx publish packages/vscode/codev-vscode-X.Y.Z.vsix
+#
+# Why one script instead of two separate publishes:
+#   Running `vsce publish` then `ovsx publish` would each rebuild + repackage,
+#   producing two functionally-equivalent but byte-different .vsix files.
+#   Packaging once guarantees both registries receive identical bytes.
+
+set -e
+
+cd packages/vscode
+
+PRE=""
+if [ "$1" = "--pre-release" ]; then
+  PRE="--pre-release"
+fi
+
+VERSION="$(node -e "console.log(require('./package.json').version)")"
+VSIX="codev-vscode-${VERSION}.vsix"
+
+# Sanity-check OVSX_PAT before we package anything — fail fast if missing.
+if [ -z "$OVSX_PAT" ]; then
+  echo "OVSX_PAT not set. Open VSX publish will fail." >&2
+  echo "Export it from your shell rc, secrets manager, or keychain:" >&2
+  echo "  export OVSX_PAT=\"<token from https://open-vsx.org/user-settings/tokens>\"" >&2
+  exit 1
+fi
+
+# Package once. The vscode:prepublish hook builds @cluesmith/codev-core and
+# @cluesmith/codev-types first, then runs check-types + lint + esbuild --production.
+rm -f *.vsix
+echo "▶ packaging $VSIX..."
+vsce package --no-dependencies
+
+echo ""
+echo "▶ publishing to VS Code Marketplace..."
+vsce publish $PRE --packagePath "$VSIX" --no-dependencies
+
+echo ""
+echo "▶ publishing to Open VSX..."
+ovsx publish $PRE "$VSIX"
+
+echo ""
+echo "✓ Published $VSIX to Marketplace + Open VSX"


### PR DESCRIPTION
## Summary

Three commits on this branch, in causal order:

1. **`fix(vscode): lower engines.vscode floor to 1.105 for fork compatibility`** — the actual fix
2. **`feat(release): scripts/publish-vscode.sh for dual-publish to Marketplace + Open VSX`** — release tooling (independent of the fix)
3. **`chore(vscode): release 3.0.4`** — the release event

## Why

The `cluesmith.codev-vscode@3.0.3` already on both registries declares `engines.vscode: ^1.110.0`, which blocks installation on VSCode-based forks running older bases:

| Host | VSCode base | 3.0.3 (`^1.110.0`) | 3.0.4 (`^1.105.0`) |
|---|---|---|---|
| Cursor 3.3.30 | 1.105.1 | ❌ blocked | ✅ |
| Antigravity 1.107.0 | 1.107.0 | ❌ blocked | ✅ |
| AWS Kiro 0.12.184 | 1.107.1 | ❌ blocked | ✅ |
| Windsurf (latest) | ≥1.110 | ✅ | ✅ |
| Standard VSCode | ≥1.110 | ✅ | ✅ |

Cursor was the tightest constraint at 1.105.1. `^1.105.0` is the tightest floor that satisfies all four forks — no speculation about untested host versions.

## Hidden bug we also closed

`@types/vscode` was declared `^1.110.0` but resolved to `1.115.0` via the caret. That meant tsc was happily validating the codebase against 5 minor versions of newer API surface than the engine constraint actually promised — a silent staleness window where we could use a 1.115-only API and ship a runtime-broken build to a 1.110 host.

Pinned to `~1.105.0` now: tsc validates against exactly what we promise to support. `check-types` passed cleanly at 1.105, so no APIs from 1.106-1.115 were in use anyway.

## Dual-publish script (commit 2)

`scripts/publish-vscode.sh` packages once with `vsce package --no-dependencies` then uploads the same `.vsix` to **both** the VS Code Marketplace and Open VSX. Single-source-of-bytes — avoids the small risk of two consecutive publishes each re-triggering `vscode:prepublish` and producing functionally-equivalent but byte-different bundles.

```bash
scripts/publish-vscode.sh                # stable, both registries
scripts/publish-vscode.sh --pre-release  # pre-release channel, both registries
```

Auth: `VSCE_PAT` (or `vsce login cluesmith` in the OS keychain) and `OVSX_PAT` (ovsx has no keychain, so export from shell rc / 1Password / macOS Keychain). Script fails fast if `OVSX_PAT` is missing — no half-publishes.

## Extension Links
VS Marketplace: https://marketplace.visualstudio.com/items?itemName=cluesmith.codev-vscode
VSX Open Registry: https://open-vsx.org/extension/cluesmith/codev-vscode

## VS Fork Smoke Testing

### Cursor
<img width="2630" height="2054" alt="cursor" src="https://github.com/user-attachments/assets/4408a53f-644e-4b5d-82d7-786314b90f96" />

### Kiro
<img width="2624" height="1920" alt="aws-kiro" src="https://github.com/user-attachments/assets/13a8a584-8257-4f5d-b85f-585af183b6c2" />

### Antigravity
<img width="2624" height="1916" alt="antigravity" src="https://github.com/user-attachments/assets/34d3f9eb-bf06-4aee-8033-ee620f29f07d" />

### Windsurf
<img width="2624" height="1920" alt="windsurf" src="https://github.com/user-attachments/assets/fc055b40-4261-4630-bcf3-f30d70ee6f78" />

## Test plan

- [x] tsc check-types green at `~1.105.0` — no 1.106-1.115 APIs in use
- [x] `pnpm bump-vscode-version` correctly promoted `## [Unreleased]` → `## [3.0.4] - 2026-05-13`
- [x] vscode/package.json byte-preserving rewrite preserved (no JSON reformatting)
- [x] After merge: `scripts/publish-vscode.sh` succeeds on both registries
- [x] After publish: install `cluesmith.codev-vscode@3.0.4` in Cursor 3.3.30 / Antigravity 1.107.0 / Kiro 0.12.184 — all three should accept