### PR TITLE
Fix #742: rewrite BUGFIX consult templates to drop SPIR criteria

### DIFF
--- a/codev-skeleton/protocols/bugfix/consult-types/impl-review.md
+++ b/codev-skeleton/protocols/bugfix/consult-types/impl-review.md
@@ -1,38 +1,54 @@
-# Implementation Review Prompt
+# Implementation Review Prompt (BUGFIX)
 
 ## Context
-You are reviewing implementation work during the Implement phase. A builder has completed a plan phase and needs feedback before proceeding. Your job is to verify the implementation matches the spec and plan.
+You are reviewing in-progress fix work for a **BUGFIX protocol** project. A builder has investigated a GitHub Issue, identified a root cause, and is implementing the fix + regression test. Your job is to verify the fix matches the issue's symptom and meets BUGFIX standards.
+
+**BUGFIX is not SPIR.** There is **no spec, no plan, and no review document**. The GitHub Issue is the spec. The PR body will be the review. Do **not** request changes for missing `codev/specs/`, `codev/plans/`, or `codev/reviews/` artifacts.
 
 ## CRITICAL: Verify Before Flagging
 
 Before requesting changes for missing configuration, incorrect patterns, or framework issues:
-1. **Check `package.json`** for actual dependency versions — framework conventions change between major versions
-2. **Read the actual config files** (or confirm their deliberate absence) before flagging missing configs
-3. **Do not assume** your training data reflects the version in use — verify against project files
-4. If "Previous Iteration Context" is provided, read it carefully before re-raising concerns that were already disputed
+1. **Check `package.json`** for actual dependency versions — framework conventions change between major versions.
+2. **Read the actual config files** (or confirm their deliberate absence) before flagging missing configs.
+3. **Do not assume** your training data reflects the version in use — verify against project files.
+4. If "Previous Iteration Context" is provided, read it carefully before re-raising concerns that were already disputed.
 
 ## Focus Areas
 
-1. **Spec Adherence**
-   - Does the implementation fulfill the spec requirements for this phase?
-   - Are acceptance criteria met?
+1. **Issue Adherence**
+   - Does the implementation actually resolve the symptom described in the GitHub Issue?
+   - Is the root cause fix targeted, or is it a workaround that masks the symptom?
 
-2. **Code Quality**
+2. **Regression Test**
+   - Is there a regression test that exercises the exact scenario from the issue?
+   - Without the fix applied, would this test fail? (The whole point.)
+   - Is the test deterministic?
+   - If no test was added, has the builder justified why (e.g., docs-only change with no testable behavior)?
+
+3. **Scope Discipline**
+   - Is the change focused on the root cause only — no unrelated refactors, no drive-by fixes?
+   - Is the net diff staying under ~300 LOC? If it has grown larger, should this escalate to SPIR/TICK?
+
+4. **Code Quality**
    - Is the code readable and maintainable?
-   - Are there obvious bugs or issues?
-   - Are error cases handled appropriately?
+   - Are there obvious bugs or issues introduced by the fix?
+   - Are error cases handled appropriately for the path that was changed?
+   - No debug code, stray `console.log`, or commented-out code.
 
-3. **Test Coverage**
-   - Are the tests adequate for this phase?
-   - Do tests cover the main paths AND edge cases?
+5. **Test Status**
+   - Existing tests still pass.
+   - Build still passes.
+   - No new flaky tests introduced.
 
-4. **Plan Alignment**
-   - Does the implementation follow the plan?
-   - Are there plan items skipped or partially completed?
+## Out of Scope (Do NOT request changes for)
 
-5. **UX Verification** (if spec has UX requirements)
-   - Does the actual user experience match what the spec describes?
-   - If spec says "async" or "non-blocking", is it actually async?
+The following are **not** part of the BUGFIX protocol and must **not** be cited as REQUEST_CHANGES reasons:
+
+- Missing `codev/specs/<N>-*.md`, `codev/plans/<N>-*.md`, or `codev/reviews/<N>-*.md` — BUGFIX produces none of these. The GitHub Issue is the spec; the PR body is the review.
+- Commit format `[Spec NNNN][Phase]` — BUGFIX uses `Fix #N: ...` or `[Bugfix #N] ...`. This is the protocol-mandated format, **not** a bug.
+- `status.yaml` fields such as `build_complete: false` — porch manages `status.yaml`; the builder is **forbidden** from editing it manually. Treat porch state as informational, not a fixable issue.
+- "Plan Alignment" or "Spec Adherence" — there is no plan and no spec to align with.
+- Phase-scoping concerns — BUGFIX is single-phase by design. There are no plan phases to scope against.
 
 ## Verdict Format
 
@@ -51,22 +67,13 @@ KEY_ISSUES:
 ```
 
 **Verdict meanings:**
-- `APPROVE`: Phase is complete, builder can proceed
-- `REQUEST_CHANGES`: Issues that must be fixed before proceeding
-- `COMMENT`: Minor suggestions, can proceed but note feedback
-
-## Scoping (Multi-Phase Plans)
-
-When the implementation plan has multiple phases (e.g., scaffolding, landing, media_rtl):
-- **ONLY review work belonging to the current plan phase**
-- The query will specify which phase you are reviewing
-- Do NOT request changes for functionality scheduled in later phases
-- Do NOT flag missing features that are out of scope for this phase
-- If unsure whether something belongs to this phase, check the plan file
+- `APPROVE`: Fix and regression test are in good shape; builder can proceed to PR creation.
+- `REQUEST_CHANGES`: Real BUGFIX-relevant issues (fix doesn't resolve the symptom, missing regression test without justification, scope creep, broken existing tests, etc.).
+- `COMMENT`: Minor suggestions; builder can proceed but should consider the feedback.
 
 ## Notes
 
-- This is a phase-level review, not the final PR review
-- Focus on "does this phase work" not "is the whole feature done"
-- If referencing line numbers, use `file:line` format
-- The builder needs actionable feedback to continue
+- This is an implementation-level review, not the final PR review.
+- Focus on "does this fix actually resolve the issue, and is it protected by a regression test" — not on artifacts from other protocols.
+- If referencing line numbers, use `file:line` format.
+- The builder needs actionable, protocol-correct feedback to continue.

--- a/codev-skeleton/protocols/bugfix/consult-types/pr-review.md
+++ b/codev-skeleton/protocols/bugfix/consult-types/pr-review.md
@@ -1,36 +1,59 @@
-# PR Ready Review Prompt
+# PR Ready Review Prompt (BUGFIX)
 
 ## Context
-You are performing a final self-check during the Review phase. The builder has completed all implementation phases and is about to create a PR. This is the last check before the work goes to the architect for integration review.
+You are performing a final self-check during the PR phase of the **BUGFIX protocol**. The builder has investigated a GitHub Issue, implemented a focused fix, and added a regression test. They are about to create — or have just created — a PR for the architect's integration review.
+
+**BUGFIX is not SPIR.** Do **not** review against the SPIR three-document trinity. The artifacts of a BUGFIX project are:
+- The originating **GitHub Issue** (serves as the spec)
+- The **code fix** (minimal, focused on root cause)
+- A **regression test** that fails without the fix and passes with it
+- The **PR body** (Summary, Root Cause, Fix, Test Plan)
+
+There is **no `codev/specs/`, `codev/plans/`, or `codev/reviews/` file** for a BUGFIX, and there should not be one. The commit format is `Fix #NNNN: <description>` (or `[Bugfix #NNNN] ...`), **not** `[Spec NNNN][Phase]`.
 
 ## Focus Areas
 
-1. **Completeness**
-   - Are all spec requirements implemented?
-   - Are all plan phases complete?
-   - Is the review document written (`codev/reviews/XXXX-name.md`)?
-   - Are all commits properly formatted (`[Spec XXXX][Phase]`)?
+1. **Issue Resolution**
+   - Does the fix actually resolve the symptom described in the issue?
+   - Does the PR body include `Fixes #<N>` so the issue auto-closes on merge?
+   - Does the PR description cover: Summary, Root Cause, Fix, Test Plan?
 
-2. **Test Status**
-   - Do all tests pass?
-   - Is test coverage adequate for the changes?
-   - Are there any skipped or flaky tests?
+2. **Regression Test**
+   - Is there a regression test that targets the exact scenario from the issue?
+   - Would the test fail without the fix? (If reviewers can't tell, ask the builder to demonstrate.)
+   - Is the test deterministic (not flaky)?
+   - If the fix is documentation-only or otherwise truly untestable, has the builder explicitly justified the absence of a test?
 
-3. **Code Cleanliness**
-   - Is there any debug code left in?
-   - Are there any TODO comments that should be resolved?
-   - Are there any `// REVIEW:` comments that weren't addressed?
-   - Is the code properly formatted?
+3. **Scope Discipline**
+   - Is the change focused on the root cause? No unrelated refactors, no drive-by fixes for other bugs.
+   - Is the net diff under ~300 LOC (additions + deletions, excluding generated/lockfiles)?
+   - If the scope grew beyond a bugfix, should the builder have escalated to SPIR/TICK instead?
 
-4. **Documentation**
-   - Are inline comments clear where needed?
-   - Is the review document comprehensive?
-   - Are any new APIs documented?
+4. **Code Cleanliness**
+   - No debug code, `console.log`, or commented-out blocks left behind.
+   - No stray TODOs introduced by this fix.
+   - Code follows existing project conventions.
 
-5. **PR Readiness**
-   - Is the branch up to date with main?
-   - Are commits atomic and well-described?
-   - Is the change diff reasonable in size?
+5. **Test Status**
+   - All existing tests pass.
+   - Build passes.
+   - No new flaky tests introduced.
+
+6. **PR Hygiene**
+   - Commits use the BUGFIX format: `Fix #<N>: ...` or `[Bugfix #<N>] ...` (**not** `[Spec NNNN][Phase]`).
+   - Branch is up to date with main (or close enough for clean merge).
+   - PR is linked to the issue.
+
+## Out of Scope (Do NOT request changes for)
+
+The following are **not** part of the BUGFIX protocol and must **not** be cited as REQUEST_CHANGES reasons:
+
+- Missing `codev/specs/<N>-*.md` — BUGFIX has no spec; the GitHub Issue is the spec.
+- Missing `codev/plans/<N>-*.md` — BUGFIX has no plan.
+- Missing `codev/reviews/<N>-*.md` — BUGFIX has no review document; review lives in the PR body.
+- Commit format `[Spec NNNN][Phase]` — BUGFIX intentionally uses `Fix #N:` / `[Bugfix #N]`.
+- `status.yaml` fields like `build_complete: false` — porch manages `status.yaml`; the builder is **forbidden** from editing it directly. Treat porch state as informational, not a fixable issue.
+- Phase-scoping concerns — BUGFIX is a single-phase protocol; there are no plan phases to scope against.
 
 ## Verdict Format
 
@@ -49,24 +72,26 @@ KEY_ISSUES:
 
 PR_SUMMARY: |
   ## Summary
-  [2-3 sentences describing what this PR does]
+  Fixes #<N>. [1-2 sentences on what was fixed.]
 
-  ## Key Changes
-  - [Change 1]
-  - [Change 2]
+  ## Root Cause
+  [Brief explanation of what caused the bug]
+
+  ## Fix
+  [Brief explanation of the fix]
 
   ## Test Plan
-  - [How to test]
+  - [Regression test description]
+  - [Manual verification, if applicable]
 ```
 
 **Verdict meanings:**
-- `APPROVE`: Ready to create PR
-- `REQUEST_CHANGES`: Issues to fix before PR creation
-- `COMMENT`: Minor items, can create PR but note feedback
+- `APPROVE`: Bug is resolved, regression test is in place, PR is ready for architect review.
+- `REQUEST_CHANGES`: Real BUGFIX-relevant issues to fix (missing regression test, fix doesn't resolve the symptom, scope creep, etc.).
+- `COMMENT`: Minor items, can proceed but note feedback.
 
 ## Notes
 
-- This is the builder's final self-review before hand-off
-- The PR_SUMMARY in your output can be used as the PR description
-- Focus on "is this ready for someone else to review" not "is this perfect"
-- Any issues found here are cheaper to fix than during integration review
+- This is the builder's final self-review before hand-off to the architect.
+- The `PR_SUMMARY` block can be used directly as the PR description.
+- Focus on "is this bug actually fixed and protected by a test" — not on artifacts from other protocols.

--- a/codev/projects/bugfix-742-bug-bugfix-protocol-consult-te/status.yaml
+++ b/codev/projects/bugfix-742-bug-bugfix-protocol-consult-te/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-742
 title: bug-bugfix-protocol-consult-te
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-14T20:31:50.498Z'
-updated_at: '2026-05-14T20:31:50.499Z'
+updated_at: '2026-05-14T20:34:06.650Z'

--- a/codev/projects/bugfix-742-bug-bugfix-protocol-consult-te/status.yaml
+++ b/codev/projects/bugfix-742-bug-bugfix-protocol-consult-te/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-742
 title: bug-bugfix-protocol-consult-te
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-14T20:31:50.498Z'
-updated_at: '2026-05-14T20:40:59.224Z'
+updated_at: '2026-05-14T20:45:22.674Z'

--- a/codev/projects/bugfix-742-bug-bugfix-protocol-consult-te/status.yaml
+++ b/codev/projects/bugfix-742-bug-bugfix-protocol-consult-te/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-742
 title: bug-bugfix-protocol-consult-te
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-14T20:31:50.498Z'
-updated_at: '2026-05-14T20:34:06.650Z'
+updated_at: '2026-05-14T20:40:59.224Z'

--- a/codev/projects/bugfix-742-bug-bugfix-protocol-consult-te/status.yaml
+++ b/codev/projects/bugfix-742-bug-bugfix-protocol-consult-te/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-742
+title: bug-bugfix-protocol-consult-te
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-14T20:31:50.498Z'
+updated_at: '2026-05-14T20:31:50.499Z'

--- a/codev/protocols/bugfix/consult-types/impl-review.md
+++ b/codev/protocols/bugfix/consult-types/impl-review.md
@@ -1,38 +1,54 @@
-# Implementation Review Prompt
+# Implementation Review Prompt (BUGFIX)
 
 ## Context
-You are reviewing implementation work during the Implement phase. A builder has completed a plan phase and needs feedback before proceeding. Your job is to verify the implementation matches the spec and plan.
+You are reviewing in-progress fix work for a **BUGFIX protocol** project. A builder has investigated a GitHub Issue, identified a root cause, and is implementing the fix + regression test. Your job is to verify the fix matches the issue's symptom and meets BUGFIX standards.
+
+**BUGFIX is not SPIR.** There is **no spec, no plan, and no review document**. The GitHub Issue is the spec. The PR body will be the review. Do **not** request changes for missing `codev/specs/`, `codev/plans/`, or `codev/reviews/` artifacts.
 
 ## CRITICAL: Verify Before Flagging
 
 Before requesting changes for missing configuration, incorrect patterns, or framework issues:
-1. **Check `package.json`** for actual dependency versions — framework conventions change between major versions
-2. **Read the actual config files** (or confirm their deliberate absence) before flagging missing configs
-3. **Do not assume** your training data reflects the version in use — verify against project files
-4. If "Previous Iteration Context" is provided, read it carefully before re-raising concerns that were already disputed
+1. **Check `package.json`** for actual dependency versions — framework conventions change between major versions.
+2. **Read the actual config files** (or confirm their deliberate absence) before flagging missing configs.
+3. **Do not assume** your training data reflects the version in use — verify against project files.
+4. If "Previous Iteration Context" is provided, read it carefully before re-raising concerns that were already disputed.
 
 ## Focus Areas
 
-1. **Spec Adherence**
-   - Does the implementation fulfill the spec requirements for this phase?
-   - Are acceptance criteria met?
+1. **Issue Adherence**
+   - Does the implementation actually resolve the symptom described in the GitHub Issue?
+   - Is the root cause fix targeted, or is it a workaround that masks the symptom?
 
-2. **Code Quality**
+2. **Regression Test**
+   - Is there a regression test that exercises the exact scenario from the issue?
+   - Without the fix applied, would this test fail? (The whole point.)
+   - Is the test deterministic?
+   - If no test was added, has the builder justified why (e.g., docs-only change with no testable behavior)?
+
+3. **Scope Discipline**
+   - Is the change focused on the root cause only — no unrelated refactors, no drive-by fixes?
+   - Is the net diff staying under ~300 LOC? If it has grown larger, should this escalate to SPIR/TICK?
+
+4. **Code Quality**
    - Is the code readable and maintainable?
-   - Are there obvious bugs or issues?
-   - Are error cases handled appropriately?
+   - Are there obvious bugs or issues introduced by the fix?
+   - Are error cases handled appropriately for the path that was changed?
+   - No debug code, stray `console.log`, or commented-out code.
 
-3. **Test Coverage**
-   - Are the tests adequate for this phase?
-   - Do tests cover the main paths AND edge cases?
+5. **Test Status**
+   - Existing tests still pass.
+   - Build still passes.
+   - No new flaky tests introduced.
 
-4. **Plan Alignment**
-   - Does the implementation follow the plan?
-   - Are there plan items skipped or partially completed?
+## Out of Scope (Do NOT request changes for)
 
-5. **UX Verification** (if spec has UX requirements)
-   - Does the actual user experience match what the spec describes?
-   - If spec says "async" or "non-blocking", is it actually async?
+The following are **not** part of the BUGFIX protocol and must **not** be cited as REQUEST_CHANGES reasons:
+
+- Missing `codev/specs/<N>-*.md`, `codev/plans/<N>-*.md`, or `codev/reviews/<N>-*.md` — BUGFIX produces none of these. The GitHub Issue is the spec; the PR body is the review.
+- Commit format `[Spec NNNN][Phase]` — BUGFIX uses `Fix #N: ...` or `[Bugfix #N] ...`. This is the protocol-mandated format, **not** a bug.
+- `status.yaml` fields such as `build_complete: false` — porch manages `status.yaml`; the builder is **forbidden** from editing it manually. Treat porch state as informational, not a fixable issue.
+- "Plan Alignment" or "Spec Adherence" — there is no plan and no spec to align with.
+- Phase-scoping concerns — BUGFIX is single-phase by design. There are no plan phases to scope against.
 
 ## Verdict Format
 
@@ -51,22 +67,13 @@ KEY_ISSUES:
 ```
 
 **Verdict meanings:**
-- `APPROVE`: Phase is complete, builder can proceed
-- `REQUEST_CHANGES`: Issues that must be fixed before proceeding
-- `COMMENT`: Minor suggestions, can proceed but note feedback
-
-## Scoping (Multi-Phase Plans)
-
-When the implementation plan has multiple phases (e.g., scaffolding, landing, media_rtl):
-- **ONLY review work belonging to the current plan phase**
-- The query will specify which phase you are reviewing
-- Do NOT request changes for functionality scheduled in later phases
-- Do NOT flag missing features that are out of scope for this phase
-- If unsure whether something belongs to this phase, check the plan file
+- `APPROVE`: Fix and regression test are in good shape; builder can proceed to PR creation.
+- `REQUEST_CHANGES`: Real BUGFIX-relevant issues (fix doesn't resolve the symptom, missing regression test without justification, scope creep, broken existing tests, etc.).
+- `COMMENT`: Minor suggestions; builder can proceed but should consider the feedback.
 
 ## Notes
 
-- This is a phase-level review, not the final PR review
-- Focus on "does this phase work" not "is the whole feature done"
-- If referencing line numbers, use `file:line` format
-- The builder needs actionable feedback to continue
+- This is an implementation-level review, not the final PR review.
+- Focus on "does this fix actually resolve the issue, and is it protected by a regression test" — not on artifacts from other protocols.
+- If referencing line numbers, use `file:line` format.
+- The builder needs actionable, protocol-correct feedback to continue.

--- a/codev/protocols/bugfix/consult-types/pr-review.md
+++ b/codev/protocols/bugfix/consult-types/pr-review.md
@@ -1,36 +1,59 @@
-# PR Ready Review Prompt
+# PR Ready Review Prompt (BUGFIX)
 
 ## Context
-You are performing a final self-check during the Review phase. The builder has completed all implementation phases and is about to create a PR. This is the last check before the work goes to the architect for integration review.
+You are performing a final self-check during the PR phase of the **BUGFIX protocol**. The builder has investigated a GitHub Issue, implemented a focused fix, and added a regression test. They are about to create — or have just created — a PR for the architect's integration review.
+
+**BUGFIX is not SPIR.** Do **not** review against the SPIR three-document trinity. The artifacts of a BUGFIX project are:
+- The originating **GitHub Issue** (serves as the spec)
+- The **code fix** (minimal, focused on root cause)
+- A **regression test** that fails without the fix and passes with it
+- The **PR body** (Summary, Root Cause, Fix, Test Plan)
+
+There is **no `codev/specs/`, `codev/plans/`, or `codev/reviews/` file** for a BUGFIX, and there should not be one. The commit format is `Fix #NNNN: <description>` (or `[Bugfix #NNNN] ...`), **not** `[Spec NNNN][Phase]`.
 
 ## Focus Areas
 
-1. **Completeness**
-   - Are all spec requirements implemented?
-   - Are all plan phases complete?
-   - Is the review document written (`codev/reviews/XXXX-name.md`)?
-   - Are all commits properly formatted (`[Spec XXXX][Phase]`)?
+1. **Issue Resolution**
+   - Does the fix actually resolve the symptom described in the issue?
+   - Does the PR body include `Fixes #<N>` so the issue auto-closes on merge?
+   - Does the PR description cover: Summary, Root Cause, Fix, Test Plan?
 
-2. **Test Status**
-   - Do all tests pass?
-   - Is test coverage adequate for the changes?
-   - Are there any skipped or flaky tests?
+2. **Regression Test**
+   - Is there a regression test that targets the exact scenario from the issue?
+   - Would the test fail without the fix? (If reviewers can't tell, ask the builder to demonstrate.)
+   - Is the test deterministic (not flaky)?
+   - If the fix is documentation-only or otherwise truly untestable, has the builder explicitly justified the absence of a test?
 
-3. **Code Cleanliness**
-   - Is there any debug code left in?
-   - Are there any TODO comments that should be resolved?
-   - Are there any `// REVIEW:` comments that weren't addressed?
-   - Is the code properly formatted?
+3. **Scope Discipline**
+   - Is the change focused on the root cause? No unrelated refactors, no drive-by fixes for other bugs.
+   - Is the net diff under ~300 LOC (additions + deletions, excluding generated/lockfiles)?
+   - If the scope grew beyond a bugfix, should the builder have escalated to SPIR/TICK instead?
 
-4. **Documentation**
-   - Are inline comments clear where needed?
-   - Is the review document comprehensive?
-   - Are any new APIs documented?
+4. **Code Cleanliness**
+   - No debug code, `console.log`, or commented-out blocks left behind.
+   - No stray TODOs introduced by this fix.
+   - Code follows existing project conventions.
 
-5. **PR Readiness**
-   - Is the branch up to date with main?
-   - Are commits atomic and well-described?
-   - Is the change diff reasonable in size?
+5. **Test Status**
+   - All existing tests pass.
+   - Build passes.
+   - No new flaky tests introduced.
+
+6. **PR Hygiene**
+   - Commits use the BUGFIX format: `Fix #<N>: ...` or `[Bugfix #<N>] ...` (**not** `[Spec NNNN][Phase]`).
+   - Branch is up to date with main (or close enough for clean merge).
+   - PR is linked to the issue.
+
+## Out of Scope (Do NOT request changes for)
+
+The following are **not** part of the BUGFIX protocol and must **not** be cited as REQUEST_CHANGES reasons:
+
+- Missing `codev/specs/<N>-*.md` — BUGFIX has no spec; the GitHub Issue is the spec.
+- Missing `codev/plans/<N>-*.md` — BUGFIX has no plan.
+- Missing `codev/reviews/<N>-*.md` — BUGFIX has no review document; review lives in the PR body.
+- Commit format `[Spec NNNN][Phase]` — BUGFIX intentionally uses `Fix #N:` / `[Bugfix #N]`.
+- `status.yaml` fields like `build_complete: false` — porch manages `status.yaml`; the builder is **forbidden** from editing it directly. Treat porch state as informational, not a fixable issue.
+- Phase-scoping concerns — BUGFIX is a single-phase protocol; there are no plan phases to scope against.
 
 ## Verdict Format
 
@@ -49,24 +72,26 @@ KEY_ISSUES:
 
 PR_SUMMARY: |
   ## Summary
-  [2-3 sentences describing what this PR does]
+  Fixes #<N>. [1-2 sentences on what was fixed.]
 
-  ## Key Changes
-  - [Change 1]
-  - [Change 2]
+  ## Root Cause
+  [Brief explanation of what caused the bug]
+
+  ## Fix
+  [Brief explanation of the fix]
 
   ## Test Plan
-  - [How to test]
+  - [Regression test description]
+  - [Manual verification, if applicable]
 ```
 
 **Verdict meanings:**
-- `APPROVE`: Ready to create PR
-- `REQUEST_CHANGES`: Issues to fix before PR creation
-- `COMMENT`: Minor items, can create PR but note feedback
+- `APPROVE`: Bug is resolved, regression test is in place, PR is ready for architect review.
+- `REQUEST_CHANGES`: Real BUGFIX-relevant issues to fix (missing regression test, fix doesn't resolve the symptom, scope creep, etc.).
+- `COMMENT`: Minor items, can proceed but note feedback.
 
 ## Notes
 
-- This is the builder's final self-review before hand-off
-- The PR_SUMMARY in your output can be used as the PR description
-- Focus on "is this ready for someone else to review" not "is this perfect"
-- Any issues found here are cheaper to fix than during integration review
+- This is the builder's final self-review before hand-off to the architect.
+- The `PR_SUMMARY` block can be used directly as the PR description.
+- Focus on "is this bug actually fixed and protected by a test" — not on artifacts from other protocols.

--- a/packages/codev/src/__tests__/bugfix-742-consult-templates.test.ts
+++ b/packages/codev/src/__tests__/bugfix-742-consult-templates.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression test for GitHub Issue #742
+ *
+ * The BUGFIX protocol's `pr-review.md` and `impl-review.md` consult templates
+ * were byte-identical to the SPIR versions, causing reviewer models to apply
+ * SPIR-specific criteria (spec/plan/review trinity, `[Spec NNNN]` commit
+ * format, `status.yaml.build_complete`, multi-phase scoping) to BUGFIX PRs.
+ *
+ * These checks pin the BUGFIX templates so they:
+ *   1. Diverge from their SPIR counterparts
+ *   2. Do not reference SPIR-only artifacts as review criteria
+ *   3. Explicitly call out the BUGFIX-relevant artifacts (issue + regression
+ *      test + `Fix #N` commits)
+ *   4. Stay in sync between codev/ (self-hosted) and codev-skeleton/ (shipped
+ *      template)
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const repoRoot = path.resolve(import.meta.dirname, '../../../..');
+
+const templates = {
+  bugfixPrReview: path.join(repoRoot, 'codev/protocols/bugfix/consult-types/pr-review.md'),
+  bugfixImplReview: path.join(repoRoot, 'codev/protocols/bugfix/consult-types/impl-review.md'),
+  spirPrReview: path.join(repoRoot, 'codev/protocols/spir/consult-types/pr-review.md'),
+  spirImplReview: path.join(repoRoot, 'codev/protocols/spir/consult-types/impl-review.md'),
+  skeletonBugfixPrReview: path.join(
+    repoRoot,
+    'codev-skeleton/protocols/bugfix/consult-types/pr-review.md',
+  ),
+  skeletonBugfixImplReview: path.join(
+    repoRoot,
+    'codev-skeleton/protocols/bugfix/consult-types/impl-review.md',
+  ),
+};
+
+const read = (p: string) => fs.readFileSync(p, 'utf-8');
+
+describe('BUGFIX consult templates (#742)', () => {
+  describe('codev/ (self-hosted)', () => {
+    it('pr-review.md must differ from the SPIR version', () => {
+      const bugfix = read(templates.bugfixPrReview);
+      const spir = read(templates.spirPrReview);
+      expect(bugfix).not.toEqual(spir);
+    });
+
+    it('impl-review.md must differ from the SPIR version', () => {
+      const bugfix = read(templates.bugfixImplReview);
+      const spir = read(templates.spirImplReview);
+      expect(bugfix).not.toEqual(spir);
+    });
+  });
+
+  describe('codev-skeleton/ (shipped template)', () => {
+    it('pr-review.md must match the codev/ copy byte-for-byte', () => {
+      expect(read(templates.skeletonBugfixPrReview)).toEqual(read(templates.bugfixPrReview));
+    });
+
+    it('impl-review.md must match the codev/ copy byte-for-byte', () => {
+      expect(read(templates.skeletonBugfixImplReview)).toEqual(read(templates.bugfixImplReview));
+    });
+  });
+
+  describe.each([
+    ['codev/ pr-review.md', templates.bugfixPrReview],
+    ['codev/ impl-review.md', templates.bugfixImplReview],
+    ['skeleton pr-review.md', templates.skeletonBugfixPrReview],
+    ['skeleton impl-review.md', templates.skeletonBugfixImplReview],
+  ])('content of %s', (_label, filePath) => {
+    const content = read(filePath);
+
+    it('does not require SPIR commit format `[Spec NNNN][Phase]` as a review criterion', () => {
+      // The SPIR template asked: "Are all commits properly formatted (`[Spec XXXX][Phase]`)?"
+      // That exact phrasing is the bug. The BUGFIX template may still *mention*
+      // `[Spec NNNN][Phase]` in its "Out of Scope" section to explicitly forbid
+      // citing it as a review reason — that's correct, not a regression.
+      expect(content).not.toMatch(/Are all commits properly formatted.*\[Spec/i);
+      expect(content).not.toMatch(/commits.*properly formatted.*`?\[Spec\s+X{3,4}\]\[Phase/i);
+    });
+
+    it('does not cite missing `codev/specs/`, `codev/plans/`, or `codev/reviews/` files as REQUEST_CHANGES criteria', () => {
+      const lower = content.toLowerCase();
+      // The new template references these paths only to mark them as out-of-scope.
+      // It must NOT use them as review focus areas: e.g., "Is the review document
+      // written (`codev/reviews/XXXX-name.md`)?" was the bug.
+      expect(content).not.toMatch(/is the review document written.*codev\/reviews/i);
+      expect(content).not.toMatch(/are all spec requirements implemented/i);
+      expect(content).not.toMatch(/are all plan phases complete/i);
+      // The phrase "Spec Adherence" was a SPIR-only focus area.
+      expect(lower).not.toContain('1. **spec adherence**');
+      expect(lower).not.toContain('**spec adherence**');
+      // Likewise "Plan Alignment".
+      expect(lower).not.toContain('**plan alignment**');
+    });
+
+    it('does not contain SPIR multi-phase scoping section', () => {
+      expect(content).not.toMatch(/##\s*Scoping\s*\(Multi-Phase Plans\)/i);
+    });
+
+    it('explicitly identifies itself as a BUGFIX template', () => {
+      expect(content).toMatch(/BUGFIX/);
+    });
+
+    it('mentions the BUGFIX commit format `Fix #N`', () => {
+      expect(content).toMatch(/Fix\s+#/);
+    });
+
+    it('mentions the regression test as a required BUGFIX artifact', () => {
+      expect(content.toLowerCase()).toMatch(/regression test/);
+    });
+
+    it('explicitly marks SPIR artifacts as out-of-scope for BUGFIX review', () => {
+      // The template must explicitly list at least the spec/plan/review trinity
+      // and the [Spec NNNN] commit format as things NOT to flag.
+      expect(content.toLowerCase()).toMatch(/out of scope/);
+      expect(content).toMatch(/status\.yaml/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The BUGFIX protocol's `pr-review.md` and `impl-review.md` consult templates were byte-identical to the SPIR versions, causing reviewer models (Codex in particular) to return `REQUEST_CHANGES` on legitimate BUGFIX PRs for criteria that don't apply to the BUGFIX protocol.

Fixes #742

## Root Cause

Reported by Shannon architect after seeing it 4× the same evening (PRs #1357, #1358, #1359, #1370). Confirmed via:

```bash
$ diff codev/protocols/bugfix/consult-types/pr-review.md \
       codev/protocols/spir/consult-types/pr-review.md
$  # (empty — files were byte-identical)
```

The same was true for `impl-review.md`, both in `codev/` (self-hosted) and `codev-skeleton/` (shipped template). Reviewer models followed the SPIR-flavored instructions correctly — they asked about the SPIR three-document trinity (`codev/specs/`, `codev/plans/`, `codev/reviews/`), demanded `[Spec NNNN][Phase]` commit format, flagged `status.yaml.build_complete: false` as a builder-fixable issue, and applied multi-phase scoping that doesn't exist in BUGFIX. None of this is valid for a BUGFIX PR.

## Fix

Rewrote four template files to reflect what BUGFIX actually produces:

- `codev/protocols/bugfix/consult-types/pr-review.md`
- `codev/protocols/bugfix/consult-types/impl-review.md`
- `codev-skeleton/protocols/bugfix/consult-types/pr-review.md`
- `codev-skeleton/protocols/bugfix/consult-types/impl-review.md`

Each template now:
- Identifies itself as a BUGFIX template
- Lists the protocol's actual artifacts: GitHub Issue + code fix + regression test + PR body
- Documents the BUGFIX commit format (`Fix #N:` / `[Bugfix #N]`)
- Includes an explicit "Out of Scope" section that forbids citing the SPIR-only artifacts (specs/plans/reviews trinity, `[Spec NNNN][Phase]` format, `status.yaml.build_complete`, multi-phase scoping) as REQUEST_CHANGES reasons
- Keeps the same `APPROVE | REQUEST_CHANGES | COMMENT` verdict format so the consult-output pipeline doesn't need changes

`codev-skeleton/` copies match `codev/` copies byte-for-byte, so projects that adopt the template via `codev init` / `codev adopt` get the same fix.

## Test Plan

- [x] Regression test added: `packages/codev/src/__tests__/bugfix-742-consult-templates.test.ts`
  - Verifies bugfix templates diverge from SPIR copies (would fail if anyone re-syncs them)
  - Verifies `codev-skeleton/` stays in sync with `codev/`
  - Verifies each template does NOT contain the seven SPIR-template focus-area phrasings that triggered the original bug (`Are all commits properly formatted... [Spec`, `is the review document written... codev/reviews`, `are all spec requirements implemented`, `are all plan phases complete`, `**Spec Adherence**`, `**Plan Alignment**`, `## Scoping (Multi-Phase Plans)`)
  - All 7 regex patterns were verified against the SPIR-version content — each one catches the bug-state
- [x] `pnpm build` passes
- [x] Unit test suite (26 files, 571 tests) passes
- [x] Real-world verification: Shannon offered to retest on a fresh BUGFIX PR once landed