### PR TITLE
Fix #744: state one-PR-per-spec convention in SPIR builder-prompt

### DIFF
--- a/codev-skeleton/protocols/aspir/builder-prompt.md
+++ b/codev-skeleton/protocols/aspir/builder-prompt.md
@@ -53,13 +53,21 @@ Follow the implementation plan at: `{{plan.path}}`
 {{task_text}}
 {{/if}}
 
-## Multi-PR Workflow
+## PR Strategy
 
-Your worktree is persistent — it survives across PR merges. You can produce multiple PRs sequentially:
+**ONE PR per spec, opened at the end of the implement phase** — not one PR per plan phase.
+
+All plan phases ship together in a **single PR**. Phase-commits land on the same branch as `[Spec NNNN][Phase: phase-name]` commits, but each phase does **not** get its own PR. The PR is opened during the review phase (after the final implement phase), with all phase-commits already on the branch.
+
+The plan's instruction that "each phase commits independently" refers to **git commits** within the single PR — not separate PRs. Do not open a per-phase PR unless the architect explicitly asks for one.
+
+### Multi-PR Workflow (exception, architect-requested only)
+
+Your worktree is persistent — it survives across PR merges. When the architect explicitly splits a large spec into shippable slices, you may produce multiple PRs sequentially:
 
 1. Cut a branch, open a PR, wait for merge
 2. After merge: `git fetch origin main && git checkout -b <next-branch> origin/main`
-3. Continue to the next phase, open another PR
+3. Continue to the next slice, open another PR
 
 **Important**: Do NOT run `git checkout main` — git worktrees cannot check out a branch that's checked out elsewhere. Always branch off `origin/main` via fetch.
 

--- a/codev-skeleton/protocols/aspir/builder-prompt.md
+++ b/codev-skeleton/protocols/aspir/builder-prompt.md
@@ -55,15 +55,17 @@ Follow the implementation plan at: `{{plan.path}}`
 
 ## PR Strategy
 
-**ONE PR per spec, opened at the end of the implement phase** — not one PR per plan phase.
+**Do not autonomously open a PR per implementation phase.** Plan phases ship as git commits within a single PR, not as separate PRs. The plan's instruction that "each phase commits independently" refers to git commits, not PRs.
 
-All plan phases ship together in a **single PR**. Phase-commits land on the same branch as `[Spec NNNN][Phase: phase-name]` commits, but each phase does **not** get its own PR. The PR is opened during the review phase (after the final implement phase), with all phase-commits already on the branch.
+By default, the PR is opened during/after the final implement phase, with all phase-commits already on the branch.
 
-The plan's instruction that "each phase commits independently" refers to **git commits** within the single PR — not separate PRs. Do not open a per-phase PR unless the architect explicitly asks for one.
+### Architect-requested PRs
 
-### Multi-PR Workflow (exception, architect-requested only)
+The architect MAY request a PR at any point — for spec review, mid-implementation feedback, slicing a large spec into shippable PRs, etc. When the architect explicitly asks for a PR earlier (or for additional PRs), follow that direction. The prohibition is specifically on the *builder* autonomously deciding to open per-phase PRs without architect request.
 
-Your worktree is persistent — it survives across PR merges. When the architect explicitly splits a large spec into shippable slices, you may produce multiple PRs sequentially:
+### Multi-PR Mechanics (when the architect requests sequential PRs)
+
+Your worktree is persistent — it survives across PR merges. When the architect asks for sequential PRs (e.g., to slice a large spec into shippable pieces), use this loop:
 
 1. Cut a branch, open a PR, wait for merge
 2. After merge: `git fetch origin main && git checkout -b <next-branch> origin/main`

--- a/codev-skeleton/protocols/spir/builder-prompt.md
+++ b/codev-skeleton/protocols/spir/builder-prompt.md
@@ -53,13 +53,21 @@ Follow the implementation plan at: `{{plan.path}}`
 {{task_text}}
 {{/if}}
 
-## Multi-PR Workflow
+## PR Strategy
 
-Your worktree is persistent — it survives across PR merges. You can produce multiple PRs sequentially:
+**ONE PR per spec, opened at the end of the implement phase** — not one PR per plan phase.
+
+All plan phases ship together in a **single PR**. Phase-commits land on the same branch as `[Spec NNNN][Phase: phase-name]` commits, but each phase does **not** get its own PR. The PR is opened during the review phase (after the final implement phase), with all phase-commits already on the branch.
+
+The plan's instruction that "each phase commits independently" refers to **git commits** within the single PR — not separate PRs. Do not open a per-phase PR unless the architect explicitly asks for one.
+
+### Multi-PR Workflow (exception, architect-requested only)
+
+Your worktree is persistent — it survives across PR merges. When the architect explicitly splits a large spec into shippable slices, you may produce multiple PRs sequentially:
 
 1. Cut a branch, open a PR, wait for merge
 2. After merge: `git fetch origin main && git checkout -b <next-branch> origin/main`
-3. Continue to the next phase, open another PR
+3. Continue to the next slice, open another PR
 4. Repeat
 
 **Important**: Do NOT run `git checkout main` — git worktrees cannot check out a branch that's checked out elsewhere. Always branch off `origin/main` via fetch.

--- a/codev-skeleton/protocols/spir/builder-prompt.md
+++ b/codev-skeleton/protocols/spir/builder-prompt.md
@@ -55,15 +55,17 @@ Follow the implementation plan at: `{{plan.path}}`
 
 ## PR Strategy
 
-**ONE PR per spec, opened at the end of the implement phase** — not one PR per plan phase.
+**Do not autonomously open a PR per implementation phase.** Plan phases ship as git commits within a single PR, not as separate PRs. The plan's instruction that "each phase commits independently" refers to git commits, not PRs.
 
-All plan phases ship together in a **single PR**. Phase-commits land on the same branch as `[Spec NNNN][Phase: phase-name]` commits, but each phase does **not** get its own PR. The PR is opened during the review phase (after the final implement phase), with all phase-commits already on the branch.
+By default, the PR is opened during/after the final implement phase, with all phase-commits already on the branch.
 
-The plan's instruction that "each phase commits independently" refers to **git commits** within the single PR — not separate PRs. Do not open a per-phase PR unless the architect explicitly asks for one.
+### Architect-requested PRs
 
-### Multi-PR Workflow (exception, architect-requested only)
+The architect MAY request a PR at any point — for spec review, mid-implementation feedback, slicing a large spec into shippable PRs, etc. When the architect explicitly asks for a PR earlier (or for additional PRs), follow that direction. The prohibition is specifically on the *builder* autonomously deciding to open per-phase PRs without architect request.
 
-Your worktree is persistent — it survives across PR merges. When the architect explicitly splits a large spec into shippable slices, you may produce multiple PRs sequentially:
+### Multi-PR Mechanics (when the architect requests sequential PRs)
+
+Your worktree is persistent — it survives across PR merges. When the architect asks for sequential PRs (e.g., to slice a large spec into shippable pieces), use this loop:
 
 1. Cut a branch, open a PR, wait for merge
 2. After merge: `git fetch origin main && git checkout -b <next-branch> origin/main`

--- a/codev/projects/bugfix-744-spir-builder-prompt-ambiguous-/status.yaml
+++ b/codev/projects/bugfix-744-spir-builder-prompt-ambiguous-/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-744
+title: spir-builder-prompt-ambiguous-
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-14T20:58:56.293Z'
+updated_at: '2026-05-14T20:58:56.293Z'

--- a/codev/projects/bugfix-744-spir-builder-prompt-ambiguous-/status.yaml
+++ b/codev/projects/bugfix-744-spir-builder-prompt-ambiguous-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-744
 title: spir-builder-prompt-ambiguous-
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-14T20:58:56.293Z'
-updated_at: '2026-05-14T21:06:23.412Z'
+updated_at: '2026-05-14T21:12:13.608Z'

--- a/codev/projects/bugfix-744-spir-builder-prompt-ambiguous-/status.yaml
+++ b/codev/projects/bugfix-744-spir-builder-prompt-ambiguous-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-744
 title: spir-builder-prompt-ambiguous-
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-14T20:58:56.293Z'
-updated_at: '2026-05-14T21:04:00.824Z'
+updated_at: '2026-05-14T21:06:23.412Z'

--- a/codev/projects/bugfix-744-spir-builder-prompt-ambiguous-/status.yaml
+++ b/codev/projects/bugfix-744-spir-builder-prompt-ambiguous-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-744
 title: spir-builder-prompt-ambiguous-
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-14T20:58:56.293Z'
-updated_at: '2026-05-14T20:58:56.293Z'
+updated_at: '2026-05-14T21:04:00.824Z'

--- a/codev/protocols/aspir/builder-prompt.md
+++ b/codev/protocols/aspir/builder-prompt.md
@@ -55,11 +55,13 @@ Follow the implementation plan at: `{{plan.path}}`
 
 ## PR Strategy
 
-**ONE PR per spec, opened at the end of the implement phase** — not one PR per plan phase.
+**Do not autonomously open a PR per implementation phase.** Plan phases ship as git commits within a single PR, not as separate PRs. The plan's instruction that "each phase commits independently" refers to git commits, not PRs.
 
-All plan phases ship together in a **single PR**. Phase-commits land on the same branch as `[Spec NNNN][Phase: phase-name]` commits, but each phase does **not** get its own PR. The PR is opened during the review phase (after the final implement phase), with all phase-commits already on the branch.
+By default, the PR is opened during/after the final implement phase, with all phase-commits already on the branch.
 
-The plan's instruction that "each phase commits independently" refers to **git commits** within the single PR — not separate PRs. Do not open a per-phase PR unless the architect explicitly asks for one (e.g., a large spec that the architect has decided to split into shippable slices).
+### Architect-requested PRs
+
+The architect MAY request a PR at any point — for spec review, mid-implementation feedback, slicing a large spec into shippable PRs, etc. When the architect explicitly asks for a PR earlier (or for additional PRs), follow that direction. The prohibition is specifically on the *builder* autonomously deciding to open per-phase PRs without architect request.
 
 ## Notifications
 Always use `afx send architect "..."` to notify the architect at key moments:

--- a/codev/protocols/aspir/builder-prompt.md
+++ b/codev/protocols/aspir/builder-prompt.md
@@ -53,6 +53,14 @@ Follow the implementation plan at: `{{plan.path}}`
 {{task_text}}
 {{/if}}
 
+## PR Strategy
+
+**ONE PR per spec, opened at the end of the implement phase** — not one PR per plan phase.
+
+All plan phases ship together in a **single PR**. Phase-commits land on the same branch as `[Spec NNNN][Phase: phase-name]` commits, but each phase does **not** get its own PR. The PR is opened during the review phase (after the final implement phase), with all phase-commits already on the branch.
+
+The plan's instruction that "each phase commits independently" refers to **git commits** within the single PR — not separate PRs. Do not open a per-phase PR unless the architect explicitly asks for one (e.g., a large spec that the architect has decided to split into shippable slices).
+
 ## Notifications
 Always use `afx send architect "..."` to notify the architect at key moments:
 - **Gate reached**: `afx send architect "Project {{project_id}}: <gate-name> ready for approval"`

--- a/codev/protocols/spir/builder-prompt.md
+++ b/codev/protocols/spir/builder-prompt.md
@@ -55,11 +55,13 @@ Follow the implementation plan at: `{{plan.path}}`
 
 ## PR Strategy
 
-**ONE PR per spec, opened at the end of the implement phase** — not one PR per plan phase.
+**Do not autonomously open a PR per implementation phase.** Plan phases ship as git commits within a single PR, not as separate PRs. The plan's instruction that "each phase commits independently" refers to git commits, not PRs.
 
-All plan phases ship together in a **single PR**. Phase-commits land on the same branch as `[Spec NNNN][Phase: phase-name]` commits, but each phase does **not** get its own PR. The PR is opened during the review phase (after the final implement phase), with all phase-commits already on the branch.
+By default, the PR is opened during/after the final implement phase, with all phase-commits already on the branch.
 
-The plan's instruction that "each phase commits independently" refers to **git commits** within the single PR — not separate PRs. Do not open a per-phase PR unless the architect explicitly asks for one (e.g., a large spec that the architect has decided to split into shippable slices).
+### Architect-requested PRs
+
+The architect MAY request a PR at any point — for spec review, mid-implementation feedback, slicing a large spec into shippable PRs, etc. When the architect explicitly asks for a PR earlier (or for additional PRs), follow that direction. The prohibition is specifically on the *builder* autonomously deciding to open per-phase PRs without architect request.
 
 ## Notifications
 Always use `afx send architect "..."` to notify the architect at key moments:

--- a/codev/protocols/spir/builder-prompt.md
+++ b/codev/protocols/spir/builder-prompt.md
@@ -53,6 +53,14 @@ Follow the implementation plan at: `{{plan.path}}`
 {{task_text}}
 {{/if}}
 
+## PR Strategy
+
+**ONE PR per spec, opened at the end of the implement phase** — not one PR per plan phase.
+
+All plan phases ship together in a **single PR**. Phase-commits land on the same branch as `[Spec NNNN][Phase: phase-name]` commits, but each phase does **not** get its own PR. The PR is opened during the review phase (after the final implement phase), with all phase-commits already on the branch.
+
+The plan's instruction that "each phase commits independently" refers to **git commits** within the single PR — not separate PRs. Do not open a per-phase PR unless the architect explicitly asks for one (e.g., a large spec that the architect has decided to split into shippable slices).
+
 ## Notifications
 Always use `afx send architect "..."` to notify the architect at key moments:
 - **Gate reached**: `afx send architect "Project {{project_id}}: <gate-name> ready for approval"`

--- a/packages/codev/src/__tests__/bugfix-744-spir-pr-strategy.test.ts
+++ b/packages/codev/src/__tests__/bugfix-744-spir-pr-strategy.test.ts
@@ -1,13 +1,18 @@
 /**
  * Regression test for GitHub Issue #744
  *
- * The SPIR/ASPIR builder-prompt templates did not state the one-PR-per-spec
- * convention explicitly. Builders interpreted "each phase commits independently"
- * as "each phase gets its own PR" and shipped per-phase PRs that the architect
- * then had to close.
+ * The SPIR/ASPIR builder-prompt templates did not state the PR-strategy
+ * convention explicitly. Builders interpreted "each phase commits
+ * independently" as "each phase gets its own PR" and shipped per-phase
+ * PRs that the architect then had to close.
  *
- * This test verifies that all four SPIR/ASPIR builder-prompt files contain
- * explicit guidance that all plan phases ship in a single PR.
+ * This test verifies that all four SPIR/ASPIR builder-prompt files contain:
+ *   1. An explicit prohibition on the builder autonomously opening a PR
+ *      per implementation phase.
+ *   2. The clarification that "each phase commits independently" refers
+ *      to git commits, not PRs.
+ *   3. The architect-override carve-out — the architect may still request
+ *      a PR at any point (spec review, mid-impl feedback, slicing, etc.).
  */
 
 import { describe, it, expect } from 'vitest';
@@ -23,19 +28,25 @@ const PROMPT_FILES = [
   'codev-skeleton/protocols/aspir/builder-prompt.md',
 ];
 
-describe('bugfix-744: SPIR/ASPIR builder-prompt states one-PR-per-spec', () => {
+describe('bugfix-744: SPIR/ASPIR builder-prompt PR strategy', () => {
   for (const relPath of PROMPT_FILES) {
     const fullPath = path.join(repoRoot, relPath);
 
-    it(`${relPath} — declares one PR per spec`, () => {
+    it(`${relPath} — prohibits builder from autonomously opening per-phase PRs`, () => {
       const content = fs.readFileSync(fullPath, 'utf-8');
-      expect(content).toMatch(/ONE PR per spec/);
+      expect(content).toMatch(/Do not autonomously open a PR per implementation phase/);
     });
 
-    it(`${relPath} — clarifies phase-commits != per-phase PRs`, () => {
+    it(`${relPath} — clarifies phase-commits are git commits, not PRs`, () => {
       const content = fs.readFileSync(fullPath, 'utf-8');
-      // Must clarify that "each phase commits independently" refers to git commits, not PRs
-      expect(content).toMatch(/git commits.*not separate PRs|not separate PRs/);
+      expect(content).toMatch(/refers to git commits, not PRs/);
+    });
+
+    it(`${relPath} — preserves architect-override carve-out`, () => {
+      const content = fs.readFileSync(fullPath, 'utf-8');
+      // The architect must be explicitly allowed to request a PR at any point —
+      // the prohibition is on autonomous builder action, not on PRs themselves.
+      expect(content).toMatch(/architect MAY request a PR/i);
     });
   }
 });

--- a/packages/codev/src/__tests__/bugfix-744-spir-pr-strategy.test.ts
+++ b/packages/codev/src/__tests__/bugfix-744-spir-pr-strategy.test.ts
@@ -48,5 +48,13 @@ describe('bugfix-744: SPIR/ASPIR builder-prompt PR strategy', () => {
       // the prohibition is on autonomous builder action, not on PRs themselves.
       expect(content).toMatch(/architect MAY request a PR/i);
     });
+
+    it(`${relPath} — states the default PR-timing (during/after final implement phase)`, () => {
+      const content = fs.readFileSync(fullPath, 'utf-8');
+      // The new default replaces the old rigid "ONE PR per spec, opened at the end of
+      // the implement phase" wording. Builders need to know *when* the default PR opens
+      // so they don't fall back to per-phase PRs in the absence of architect direction.
+      expect(content).toMatch(/By default, the PR is opened during\/after the final implement phase/);
+    });
   }
 });

--- a/packages/codev/src/__tests__/bugfix-744-spir-pr-strategy.test.ts
+++ b/packages/codev/src/__tests__/bugfix-744-spir-pr-strategy.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Regression test for GitHub Issue #744
+ *
+ * The SPIR/ASPIR builder-prompt templates did not state the one-PR-per-spec
+ * convention explicitly. Builders interpreted "each phase commits independently"
+ * as "each phase gets its own PR" and shipped per-phase PRs that the architect
+ * then had to close.
+ *
+ * This test verifies that all four SPIR/ASPIR builder-prompt files contain
+ * explicit guidance that all plan phases ship in a single PR.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+
+const PROMPT_FILES = [
+  'codev/protocols/spir/builder-prompt.md',
+  'codev-skeleton/protocols/spir/builder-prompt.md',
+  'codev/protocols/aspir/builder-prompt.md',
+  'codev-skeleton/protocols/aspir/builder-prompt.md',
+];
+
+describe('bugfix-744: SPIR/ASPIR builder-prompt states one-PR-per-spec', () => {
+  for (const relPath of PROMPT_FILES) {
+    const fullPath = path.join(repoRoot, relPath);
+
+    it(`${relPath} — declares one PR per spec`, () => {
+      const content = fs.readFileSync(fullPath, 'utf-8');
+      expect(content).toMatch(/ONE PR per spec/);
+    });
+
+    it(`${relPath} — clarifies phase-commits != per-phase PRs`, () => {
+      const content = fs.readFileSync(fullPath, 'utf-8');
+      // Must clarify that "each phase commits independently" refers to git commits, not PRs
+      expect(content).toMatch(/git commits.*not separate PRs|not separate PRs/);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

The SPIR/ASPIR builder-prompt templates did not state any PR-strategy convention. Builders interpreted the plan's "each phase commits independently" as "each phase gets its own PR" and shipped per-phase PRs that the architect then had to close (Shannon Spec 1353 → PR #1373).

Fixes #744

## Root Cause

Two issues stacked:

1. `codev/protocols/spir/builder-prompt.md` (and the ASPIR equivalent) had no PR-strategy guidance at all.
2. The `codev-skeleton` mirror had a "Multi-PR Workflow" section that explicitly said "Continue to the next phase, open another PR. Repeat." This pattern is intended for architect-requested slice splits of large specs (e.g. Spec #653), but the template framed it as the default workflow.

## Fix

Adds a `## PR Strategy` section to all four SPIR/ASPIR builder-prompt files (codev + skeleton) prohibiting **only** the builder's autonomous decision to open a PR per implementation phase — while explicitly preserving the architect's ability to request a PR at any point.

Key wording (per architect review on this PR):

- **"Do not autonomously open a PR per implementation phase."** Plan phases ship as git commits within a single PR.
- **By default, the PR is opened during/after the final implement phase**, with all phase-commits already on the branch.
- **Architect-requested PRs** (new subsection): the architect MAY request a PR at any point — for spec review, mid-implementation feedback, slicing a large spec into shippable PRs. The prohibition is specifically on the *builder* autonomously deciding to open per-phase PRs without architect request.

In the skeleton, the existing multi-PR mechanics block (cut branch → push → merge → fetch → next branch) is preserved and re-scoped as "Multi-PR Mechanics (when the architect requests sequential PRs)" — the how-to for architect-driven slice splits.

## Test Plan

- [x] Regression test (`bugfix-744-spir-pr-strategy.test.ts`) — asserts all four builder-prompt files contain (a) the autonomous-PR prohibition, (b) the git-commits-vs-PRs clarification, (c) the architect-override carve-out, and (d) the default PR-timing statement
- [x] Build passes
- [x] All tests pass (2616 passed | 13 skipped — same baseline as main)