### PR TITLE
[Bugfix #766] Add missing CSS for .architect-pane / .architect-pane-body

### DIFF
--- a/codev/projects/bugfix-766-bug-architect-pane-shrinks-to-/status.yaml
+++ b/codev/projects/bugfix-766-bug-architect-pane-shrinks-to-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-766
 title: bug-architect-pane-shrinks-to-
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-19T00:27:56.031Z'
-updated_at: '2026-05-19T00:37:30.337Z'
+updated_at: '2026-05-19T00:38:18.602Z'

--- a/codev/projects/bugfix-766-bug-architect-pane-shrinks-to-/status.yaml
+++ b/codev/projects/bugfix-766-bug-architect-pane-shrinks-to-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-766
 title: bug-architect-pane-shrinks-to-
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-19T00:27:56.031Z'
-updated_at: '2026-05-19T00:27:56.032Z'
+updated_at: '2026-05-19T00:37:30.337Z'

--- a/codev/projects/bugfix-766-bug-architect-pane-shrinks-to-/status.yaml
+++ b/codev/projects/bugfix-766-bug-architect-pane-shrinks-to-/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-766
+title: bug-architect-pane-shrinks-to-
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-19T00:27:56.031Z'
+updated_at: '2026-05-19T00:27:56.032Z'

--- a/codev/projects/bugfix-766-bug-architect-pane-shrinks-to-/status.yaml
+++ b/codev/projects/bugfix-766-bug-architect-pane-shrinks-to-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-766
 title: bug-architect-pane-shrinks-to-
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-19T00:27:56.031Z'
-updated_at: '2026-05-19T00:38:18.602Z'
+updated_at: '2026-05-19T00:59:00.634Z'

--- a/packages/codev/src/agent-farm/__tests__/e2e/architect-pane-layout.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/architect-pane-layout.test.ts
@@ -4,8 +4,9 @@
  * PR #762 introduced `.architect-pane` / `.architect-pane-body` wrappers in the
  * N>1 branch of `App.tsx` but never added matching CSS, so the architect
  * terminal collapsed to ~1/4 of the SplitPane left side. The fix in
- * `packages/dashboard/src/index.css` makes `.architect-pane` a `flex-direction:
- * column` host with `height: 100%` and `.architect-pane-body` a `flex: 1`
+ * `packages/dashboard/src/index.css` makes `.architect-pane` a
+ * `position: absolute; inset: 0` flex column anchored against `.split-left`
+ * (which is `position: relative`), with `.architect-pane-body` as a `flex: 1`
  * filler. This test pins the layout invariant by mocking `/api/state` with
  * N=2 architects and asserting the architect-pane-body fills almost all of the
  * SplitPane left side minus the tab strip.

--- a/packages/codev/src/agent-farm/__tests__/e2e/architect-pane-layout.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/architect-pane-layout.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Bugfix #766: regression guard for the multi-architect (N>1) left pane layout.
+ *
+ * PR #762 introduced `.architect-pane` / `.architect-pane-body` wrappers in the
+ * N>1 branch of `App.tsx` but never added matching CSS, so the architect
+ * terminal collapsed to ~1/4 of the SplitPane left side. The fix in
+ * `packages/dashboard/src/index.css` makes `.architect-pane` a `flex-direction:
+ * column` host with `height: 100%` and `.architect-pane-body` a `flex: 1`
+ * filler. This test pins the layout invariant by mocking `/api/state` with
+ * N=2 architects and asserting the architect-pane-body fills almost all of the
+ * SplitPane left side minus the tab strip.
+ *
+ * Prerequisites:
+ *   - Tower running on TOWER_TEST_PORT (default 4100)
+ *   - npx playwright install chromium
+ *
+ * Run: npx playwright test architect-pane-layout
+ */
+
+import { test, expect } from '@playwright/test';
+import { resolve } from 'node:path';
+
+const TOWER_URL = `http://localhost:${process.env.TOWER_TEST_PORT || '4100'}`;
+const WORKSPACE_PATH = resolve(import.meta.dirname, '../../../../../../');
+const ENCODED_PATH = Buffer.from(WORKSPACE_PATH).toString('base64url');
+const DASH_URL = `${TOWER_URL}/workspace/${ENCODED_PATH}/`;
+
+test.describe('Bugfix #766: multi-architect pane fills SplitPane left side', () => {
+  test('N=2 architect-pane-body fills the SplitPane left side', async ({ page }) => {
+    // Mock /api/state with two architects so the N>1 branch in App.tsx renders
+    // the `.architect-pane` / `.architect-pane-body` wrappers.
+    await page.route('**/api/state', async (route) => {
+      const response = await route.fetch();
+      const base = response.ok() ? await response.json().catch(() => ({})) : {};
+      const mainArchitect = { name: 'main', port: 0, pid: 1, terminalId: 'term-766-main', persistent: false };
+      const siblingArchitect = { name: 'sibling-766', port: 0, pid: 2, terminalId: 'term-766-sibling', persistent: false };
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...base,
+          architect: mainArchitect,
+          architects: [mainArchitect, siblingArchitect],
+          builders: [],
+          utils: [],
+          annotations: [],
+        }),
+      });
+    });
+
+    await page.goto(DASH_URL);
+    await page.locator('#root').waitFor({ state: 'attached', timeout: 10_000 });
+
+    // Confirm the N>1 branch rendered: architect tab strip is visible.
+    const tabStrip = page.locator('[aria-label="Architect tabs"]');
+    await expect(tabStrip).toBeVisible({ timeout: 10_000 });
+
+    const splitLeft = page.locator('.split-left');
+    const architectPane = page.locator('.architect-pane');
+    const architectBody = page.locator('.architect-pane-body');
+
+    await expect(splitLeft).toBeVisible();
+    await expect(architectPane).toBeVisible();
+    await expect(architectBody).toBeAttached();
+
+    // The architect-pane wrapper should fill the full height of the SplitPane
+    // left side. Allow a small delta for borders / sub-pixel rounding.
+    const [leftBox, paneBox, stripBox, bodyBox] = await Promise.all([
+      splitLeft.boundingBox(),
+      architectPane.boundingBox(),
+      tabStrip.boundingBox(),
+      architectBody.boundingBox(),
+    ]);
+
+    expect(leftBox, '.split-left must have a bounding box').not.toBeNull();
+    expect(paneBox, '.architect-pane must have a bounding box').not.toBeNull();
+    expect(stripBox, 'architect tab strip must have a bounding box').not.toBeNull();
+    expect(bodyBox, '.architect-pane-body must have a bounding box').not.toBeNull();
+
+    // .architect-pane fills .split-left vertically (within 2px tolerance).
+    expect(Math.abs(paneBox!.height - leftBox!.height)).toBeLessThanOrEqual(2);
+
+    // .architect-pane-body fills the remaining space below the tab strip.
+    // Pre-fix, the body collapsed to ~0px (children-only intrinsic height
+    // since `Terminal` had no fixed height inside an undefined-height flex
+    // child). Post-fix it must be at least 60% of the left pane height.
+    const expectedMinBodyHeight = (leftBox!.height - stripBox!.height) * 0.6;
+    expect(bodyBox!.height).toBeGreaterThanOrEqual(expectedMinBodyHeight);
+
+    // And the body's bottom should reach (within 2px) the bottom of the
+    // split-left container — i.e. the pane is not collapsed to ~1/4 height.
+    const leftBottom = leftBox!.y + leftBox!.height;
+    const bodyBottom = bodyBox!.y + bodyBox!.height;
+    expect(Math.abs(leftBottom - bodyBottom)).toBeLessThanOrEqual(2);
+  });
+});

--- a/packages/dashboard/src/index.css
+++ b/packages/dashboard/src/index.css
@@ -309,11 +309,15 @@ body {
 
 /* Bugfix #766: multi-architect left-pane wrapper (Spec 761 N>1 path).
  * Without these rules the wrappers collapse to intrinsic block height,
- * leaving the architect terminal at ~1/4 of the SplitPane left side. */
+ * leaving the architect terminal at ~1/4 of the SplitPane left side.
+ * `.split-left` already sets `position: relative`, so positioning the pane
+ * absolutely against it sidesteps any flex/percentage-height plumbing in
+ * ancestor containers. */
 .architect-pane {
+  position: absolute;
+  inset: 0;
   display: flex;
   flex-direction: column;
-  height: 100%;
   min-height: 0;
 }
 

--- a/packages/dashboard/src/index.css
+++ b/packages/dashboard/src/index.css
@@ -307,6 +307,21 @@ body {
   font-size: 14px;
 }
 
+/* Bugfix #766: multi-architect left-pane wrapper (Spec 761 N>1 path).
+ * Without these rules the wrappers collapse to intrinsic block height,
+ * leaving the architect terminal at ~1/4 of the SplitPane left side. */
+.architect-pane {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.architect-pane-body {
+  flex: 1;
+  min-height: 0;
+}
+
 /* Virtual keyboard for mobile terminals (Issue #254) */
 .virtual-keyboard {
   display: flex;


### PR DESCRIPTION
## Summary

Fixes #766.

## Root Cause

PR #762's multi-architect dashboard introduced `.architect-pane` and `.architect-pane-body` wrappers in the N>1 branch of `App.tsx` but never added matching CSS. The wrappers collapsed to intrinsic block height, so the architect terminal rendered at ~1/4 of the SplitPane left side whenever a workspace had more than one architect.

The N=1 path renders `<Terminal>` directly without these wrappers, so the regression slipped past the DOM-snapshot-identical unit test in `App.architect-tabs.test.tsx` (only N=0/N=1/N=2 *DOM structure* was asserted — not layout).

## Fix

`packages/dashboard/src/index.css`:

```css
.architect-pane {
  position: absolute;
  inset: 0;
  display: flex;
  flex-direction: column;
  min-height: 0;
}

.architect-pane-body {
  flex: 1;
  min-height: 0;
}
```

`.architect-pane` is positioned absolutely against `.split-left` (which already has `position: relative`). This sidesteps the percentage-height plumbing in the ancestor chain — the pane just fills its positioned ancestor. As a flex column, the tab strip takes its natural ~34px and `.architect-pane-body` flex-fills the rest. `min-height: 0` lets the body shrink inside the flex container so the inner `<Terminal>`'s xterm canvas does not push it past the SplitPane bottom.

## Regression Test

`packages/codev/src/agent-farm/__tests__/e2e/architect-pane-layout.test.ts`: Playwright test that mocks `/api/state` with N=2 architects, confirms the architect tab strip is rendered (i.e. the N>1 branch in `App.tsx` is exercised), and asserts:

- `.architect-pane` height matches `.split-left` height (±2px)
- `.architect-pane-body` reaches the bottom of `.split-left` (±2px)
- `.architect-pane-body` fills ≥60% of the available height below the tab strip

Verified the test correctly catches the regression: pre-fix run reported the architect-pane height was 263px short of the SplitPane left side.

## Iterations

- **iter-1** (`61327066`): `display: flex; flex-direction: column; height: 100%; min-height: 0` on `.architect-pane`.
- **iter-2** (`e94b514f`): switched to `position: absolute; inset: 0` per architect feedback. More robust — does not rely on the entire ancestor flex/percentage-height chain.

## Test Plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (porch fix-phase check, 20.5s)
- [x] New Playwright test passes against the worktree's own Tower (verified `TOWER_TEST_PORT=4101`, `4102`)
- [x] New Playwright test fails against the pre-fix bundle (263px height delta → 0px)
- [x] Existing `App.architect-tabs.test.tsx` still passes (8/8)

**Test caveat**: `playwright.config.ts` sets `reuseExistingServer: true` on port 4100. If a globally-installed Tower is running on 4100 (e.g. via `pnpm -w run local-install`), the test reuses it and may validate stale dashboard code. Run with `TOWER_TEST_PORT=4101` or rebuild and restart the global Tower to verify on a fresh build.

## CMAP Review

- **Gemini**: APPROVE (HIGH) — "fix correctly addresses the layout regression, and the Playwright regression test effectively guards against future regressions"
- **Codex**: APPROVE (HIGH) — "focused fix with an appropriate regression test"
- **Claude**: COMMENT (HIGH) — flagged that the PR body and test JSDoc described the iter-1 `height: 100%` approach while the committed code is iter-2 `position: absolute; inset: 0`. Addressed in this PR description and in `architect-pane-layout.test.ts` JSDoc.

Fixes #766