### PR TITLE
[Bugfix #749][Bugfix #750] Fix Gitea forge crash and field normalization

### DIFF
--- a/codev/projects/bugfix-749-gitea-forge-500-error-bug-with/status.yaml
+++ b/codev/projects/bugfix-749-gitea-forge-500-error-bug-with/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-749
 title: gitea-forge-500-error-bug-with
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-19T00:32:06.931Z'
-updated_at: '2026-05-19T00:38:00.773Z'
+updated_at: '2026-05-19T00:38:33.632Z'

--- a/codev/projects/bugfix-749-gitea-forge-500-error-bug-with/status.yaml
+++ b/codev/projects/bugfix-749-gitea-forge-500-error-bug-with/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-749
+title: gitea-forge-500-error-bug-with
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-19T00:32:06.931Z'
+updated_at: '2026-05-19T00:32:06.931Z'

--- a/codev/projects/bugfix-749-gitea-forge-500-error-bug-with/status.yaml
+++ b/codev/projects/bugfix-749-gitea-forge-500-error-bug-with/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-749
 title: gitea-forge-500-error-bug-with
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-19T00:32:06.931Z'
-updated_at: '2026-05-19T00:32:06.931Z'
+updated_at: '2026-05-19T00:38:00.773Z'

--- a/packages/codev/scripts/forge/gitea/issue-list.sh
+++ b/packages/codev/scripts/forge/gitea/issue-list.sh
@@ -1,3 +1,26 @@
 #!/bin/sh
 # Forge concept: issue-list (Gitea via tea CLI)
-exec tea issues list --limit 200 --output json
+#
+# tea's default JSON output uses fields that don't match the GitHub-compatible
+# shape codev's overview expects (see codev/src/lib/forge-contracts.ts).
+# Normalize via jq so the same overview code path works for both forges:
+#   index           -> number (int)
+#   created         -> createdAt
+#   author (string) -> author.login
+#   labels    (CSV) -> labels[].name
+#   assignees (CSV) -> assignees[].login
+exec tea issues list --limit 200 \
+  --fields index,title,state,author,url,created,labels,assignees \
+  --output json \
+  | jq '[.[] | {
+      number: (.index | tonumber),
+      title,
+      state,
+      url,
+      createdAt: .created,
+      author: {login: .author},
+      labels: (if (.labels // "") == "" then []
+               else (.labels | split(",") | map({name: ltrimstr(" ")})) end),
+      assignees: (if (.assignees // "") == "" then []
+                  else (.assignees | split(",") | map({login: ltrimstr(" ")})) end)
+    }]'

--- a/packages/codev/scripts/forge/gitea/pr-list.sh
+++ b/packages/codev/scripts/forge/gitea/pr-list.sh
@@ -1,3 +1,23 @@
 #!/bin/sh
 # Forge concept: pr-list (Gitea via tea CLI)
-exec tea pulls list --output json
+#
+# Normalize tea's PR shape to the GitHub-compatible shape codev expects
+# (see PrListItem in codev/src/lib/forge-contracts.ts):
+#   index            -> number (int)
+#   description      -> body
+#   created          -> createdAt
+#   author (string)  -> author.login
+#   reviewDecision   -> ""  (Gitea has no GitHub-equivalent review-decision summary)
+exec tea pulls list --limit 200 \
+  --fields index,title,state,author,url,created,description \
+  --output json \
+  | jq '[.[] | {
+      number: (.index | tonumber),
+      title,
+      state,
+      url,
+      reviewDecision: "",
+      body: (.description // ""),
+      createdAt: .created,
+      author: {login: .author}
+    }]'

--- a/packages/codev/scripts/forge/gitea/recently-closed.sh
+++ b/packages/codev/scripts/forge/gitea/recently-closed.sh
@@ -1,3 +1,21 @@
 #!/bin/sh
 # Forge concept: recently-closed (Gitea via tea CLI)
-exec tea issues list --state closed --limit 1000 --output json
+#
+# Normalize to GitHub-compatible shape (see IssueListItem in forge-contracts.ts).
+# Gitea exposes no separate `closed_at` field on issue list output, so we map
+# `updated` -> `closedAt`. For issues closed without subsequent edits this is
+# exactly the close time; for issues edited after close it overestimates, which
+# is acceptable for the "recently closed" overview filter.
+exec tea issues list --state closed --limit 1000 \
+  --fields index,title,state,author,url,created,updated,labels \
+  --output json \
+  | jq '[.[] | {
+      number: (.index | tonumber),
+      title,
+      state,
+      url,
+      createdAt: .created,
+      closedAt: .updated,
+      labels: (if (.labels // "") == "" then []
+               else (.labels | split(",") | map({name: ltrimstr(" ")})) end)
+    }]'

--- a/packages/codev/scripts/forge/gitea/recently-merged.sh
+++ b/packages/codev/scripts/forge/gitea/recently-merged.sh
@@ -1,3 +1,27 @@
 #!/bin/sh
 # Forge concept: recently-merged (Gitea via tea CLI)
-exec tea pulls list --state closed --limit 1000 --output json
+#
+# `tea pulls list --state closed` returns both merged PRs and closed-without-
+# merge PRs. Filter to merged only via `.merged == true` (the same predicate
+# scripts/forge/gitea/pr-exists.sh already relies on), then map to the
+# GitHub-compatible shape:
+#   index           -> number (int)
+#   created         -> createdAt
+#   updated         -> mergedAt  (tea exposes no merged_at field via --fields;
+#                                 close-then-edit overestimates merged time
+#                                 but is acceptable for the 24h overview window)
+#   head.ref        -> headRefName
+#   description     -> body
+exec tea pulls list --state closed --limit 1000 \
+  --fields index,title,state,author,url,created,updated,head,description,merged \
+  --output json \
+  | jq '[.[] | select(.merged == true) | {
+      number: (.index | tonumber),
+      title,
+      state,
+      url,
+      body: (.description // ""),
+      createdAt: .created,
+      mergedAt: .updated,
+      headRefName: (.head.ref // "")
+    }]'

--- a/packages/codev/src/__tests__/github.test.ts
+++ b/packages/codev/src/__tests__/github.test.ts
@@ -258,6 +258,40 @@ describe('parseLabelDefaults', () => {
     expect(parseLabelDefaults([], 'Create issue template').type).toBe('project');
     expect(parseLabelDefaults([], 'Improve issue search').type).toBe('project');
   });
+
+  // Regression: issue #749 — Gitea/Forgejo returns `labels: ""` or `null` for
+  // unlabeled issues, where GitHub always returns []. parseLabelDefaults used
+  // to crash with "labels.map is not a function" and 500 the Tower overview.
+  it('coerces empty-string labels (Gitea/Forgejo) to no-labels result', () => {
+    // @ts-expect-error — exercising the non-GitHub forge runtime shape
+    expect(parseLabelDefaults('', 'Fix login bug')).toEqual({
+      type: 'bug',
+      priority: 'medium',
+    });
+  });
+
+  it('coerces null labels to no-labels result', () => {
+    // @ts-expect-error — exercising the non-GitHub forge runtime shape
+    expect(parseLabelDefaults(null)).toEqual({
+      type: 'project',
+      priority: 'medium',
+    });
+  });
+
+  it('coerces undefined labels to no-labels result', () => {
+    // @ts-expect-error — exercising the non-GitHub forge runtime shape
+    expect(parseLabelDefaults(undefined, 'Add dark mode')).toEqual({
+      type: 'project',
+      priority: 'medium',
+    });
+  });
+
+  it('still extracts type from a real label array (GitHub path)', () => {
+    expect(parseLabelDefaults([{ name: 'type:bug' }])).toEqual({
+      type: 'bug',
+      priority: 'medium',
+    });
+  });
 });
 
 // =============================================================================

--- a/packages/codev/src/__tests__/github.test.ts
+++ b/packages/codev/src/__tests__/github.test.ts
@@ -263,7 +263,6 @@ describe('parseLabelDefaults', () => {
   // unlabeled issues, where GitHub always returns []. parseLabelDefaults used
   // to crash with "labels.map is not a function" and 500 the Tower overview.
   it('coerces empty-string labels (Gitea/Forgejo) to no-labels result', () => {
-    // @ts-expect-error — exercising the non-GitHub forge runtime shape
     expect(parseLabelDefaults('', 'Fix login bug')).toEqual({
       type: 'bug',
       priority: 'medium',
@@ -271,7 +270,6 @@ describe('parseLabelDefaults', () => {
   });
 
   it('coerces null labels to no-labels result', () => {
-    // @ts-expect-error — exercising the non-GitHub forge runtime shape
     expect(parseLabelDefaults(null)).toEqual({
       type: 'project',
       priority: 'medium',
@@ -279,7 +277,6 @@ describe('parseLabelDefaults', () => {
   });
 
   it('coerces undefined labels to no-labels result', () => {
-    // @ts-expect-error — exercising the non-GitHub forge runtime shape
     expect(parseLabelDefaults(undefined, 'Add dark mode')).toEqual({
       type: 'project',
       priority: 'medium',

--- a/packages/codev/src/lib/github.ts
+++ b/packages/codev/src/lib/github.ts
@@ -466,13 +466,17 @@ const BARE_TYPE_LABELS = new Set(['bug', 'project', 'spike']);
 const BUG_TITLE_PATTERNS = /\b(fix|bug|broken|error|crash|fail|wrong|regression|not working)/i;
 
 export function parseLabelDefaults(
-  labels: Array<{ name: string }>,
+  labels: Array<{ name: string }> | null | undefined | string,
   title?: string,
 ): {
   type: string;
   priority: string;
 } {
-  const names = labels.map(l => l.name);
+  // Forge providers vary: GitHub returns an array of {name} objects, while
+  // Gitea/Forgejo returns "" (empty string) or null when an issue has no
+  // labels. Coerce non-array inputs to [] so the array methods below can't
+  // throw "labels.map is not a function" in non-GitHub forges.
+  const names = Array.isArray(labels) ? labels.map(l => l.name) : [];
 
   const typeLabels = names
     .filter(n => n.startsWith('type:'))


### PR DESCRIPTION
## Summary

Two tightly-coupled Gitea-forge regressions reported in v3.0.3 against a Forgejo instance, fixed together since the second was masked by the first (Tower 500'd before the rendering bug was visible).

### #749 — `labels.map is not a function` 500 on Tower overview

Forgejo/Gitea returns `labels: ""` (or `null`) for unlabeled issues, where GitHub always returns `[]`. `parseLabelDefaults()` in `lib/github.ts` called `.map()` unconditionally and crashed.

- Coerce non-array inputs to `[]` before mapping: `Array.isArray(labels) ? labels.map(...) : []`
- Widen the parameter type to `Array<{name}> | null | undefined | string` to reflect the actual cross-forge runtime shape (the project's forge-contracts already document presets as "best-effort" with non-conforming shapes treated as nulls; this lifts the contract into the type system at one call site)
- Regression tests for empty-string, null, and undefined paths alongside the existing array (GitHub) path

### #750 — `#undefined` / `NaNd` in Tower overview for Gitea

Once the 500 was patched, every backlog row rendered `#undefined` and ages showed `NaNd` because the Gitea preset scripts piped raw `tea --output json` straight to the overview, which expects the GitHub-compatible shape declared in `forge-contracts.ts`.

Each of the four affected scripts now requests an explicit `--fields` list and normalizes via `jq`:

| `tea` field | normalized to |
|---|---|
| `index` (string) | `number` (int) |
| `created` | `createdAt` |
| `author` (flat string) | `author.login` |
| `labels` (CSV string or `""`) | `labels[].name` |
| `assignees` (CSV string or `""`) | `assignees[].login` |
| `description` | `body` |

- `recently-closed.sh`: maps `updated` → `closedAt` (Gitea has no `closed_at` field on list output; for issues edited after close this overestimates, acceptable for the 24h overview window)
- `recently-merged.sh`: filters `select(.merged == true)` (same predicate `scripts/forge/gitea/pr-exists.sh` already uses) and maps `updated` → `mergedAt`, `head.ref` → `headRefName`

`jq` is already a runtime dependency of the gitea preset (`pr-exists.sh`, `user-identity.sh` both use it) so this introduces no new tooling requirement.

## Test plan

- [x] Run unit tests — `pnpm exec vitest run src/__tests__/github.test.ts` → 55/55 pass (4 new regression cases)
- [x] Typecheck — `pnpm exec tsc --noEmit` clean
- [x] Validate jq filters offline with synthetic tea-shaped fixtures (empty-string labels, CSV labels, merged-vs-closed PRs) — output matches `IssueListItem` / `PrListItem` shapes in `forge-contracts.ts`
- [ ] **Forgejo round-trip** — verified by report reproducer; requires the original reporter or a Gitea instance for end-to-end Tower overview check
- [ ] CMAP review (will run next)

Fixes #749
Fixes #750