### PR TITLE
feat(vscode): idle-waiting builders, sidebar polish, and PIR default-branch fix (#777 Layer 2)

### DIFF
--- a/codev-skeleton/protocols/pir/builder-prompt.md
+++ b/codev-skeleton/protocols/pir/builder-prompt.md
@@ -82,7 +82,7 @@ If you encounter **pre-existing flaky tests** (intermittent failures unrelated t
 If your Claude session crashes mid-flow, Tower's `while true` loop will relaunch you with the same prompt. On startup:
 
 1. Run `porch next {{project_id}}` to learn what phase you're in
-2. If `gate_pending`: read the latest plan file (plan-approval) or `git diff main` (dev-approval) plus any new GitHub issue comments; check `afx send` queue. Decide whether to revise or just announce you're back.
+2. If `gate_pending`: read the latest plan file (plan-approval) or `git diff "$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || echo main)"` (dev-approval) plus any new GitHub issue comments; check `afx send` queue. Decide whether to revise or just announce you're back.
 3. Otherwise: pick up where you left off
 
 ## Getting Started

--- a/codev-skeleton/protocols/pir/consult-types/pr-review.md
+++ b/codev-skeleton/protocols/pir/consult-types/pr-review.md
@@ -22,7 +22,7 @@ You are performing the 3-way review of a PIR protocol PR. The builder has implem
    - Any `// REVIEW:` markers that weren't addressed?
 
 4. **Branch Hygiene**
-   - Is the branch up to date with main? (If not, suggest a rebase.)
+   - Is the branch up to date with the default branch? (If not, suggest a rebase. The default branch is whatever `git symbolic-ref --short refs/remotes/origin/HEAD` reports — typically `main`, but may be `dev`, `ci`, etc.)
    - Are commits atomic and well-described?
    - Is the change diff a reasonable size for the issue scope?
 

--- a/codev-skeleton/protocols/pir/prompts/implement.md
+++ b/codev-skeleton/protocols/pir/prompts/implement.md
@@ -17,12 +17,18 @@ Implement the approved plan, write tests, and pause at the `dev-approval` gate s
 
 Run `porch next {{project_id}}`. If the response is `gate_pending` on `dev-approval`, the code is already written and you're awaiting review. In that case:
 
-1. Check for feedback:
-   - `git diff main` — has the reviewer made any direct edits to your code?
+1. Resolve your repo's default branch (falls back to `main` if `origin/HEAD` isn't set):
+
+   ```bash
+   DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || echo main)
+   ```
+
+2. Check for feedback:
+   - `git diff "$DEFAULT_BRANCH"` — has the reviewer made any direct edits to your code?
    - `gh issue view {{issue.number}} --comments`
    - `afx send` queue messages
-2. If feedback requires code changes: make them, re-run build + tests, recommit.
-3. If feedback is a discussion question: respond and stay in the session.
+3. If feedback requires code changes: make them, re-run build + tests, recommit.
+4. If feedback is a discussion question: respond and stay in the session.
 
 Otherwise (`tasks` response — first run), continue below.
 
@@ -107,7 +113,7 @@ When the gate goes pending, output a short prose summary in the pane to orient t
 
 > **What changed**: 2–3 sentence summary.
 >
-> **Files**: `git diff --stat main` style list — paths and +/-.
+> **Files**: `git diff --stat "$DEFAULT_BRANCH"` style list — paths and +/-. (Resolve `$DEFAULT_BRANCH` once per session: `DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || echo main)`.)
 >
 > **Test results**: `npm run build` ✓, `npm test` ✓ (X tests, Y new).
 >
@@ -133,7 +139,7 @@ Then **stay in the interactive session**. Do not exit. Wait for the user's next 
 - **Don't write `codev/reviews/<id>-<slug>.md` in this phase** — it's the next phase's artifact, with a different shape (retrospective with arch + lessons updates)
 - Don't add features not in the plan — scope creep is a `BLOCKED` signal, not a free expansion
 - Don't run `porch approve` yourself
-- Don't push to main — only to your builder branch
+- Don't push to the default branch — only to your builder branch
 - Don't squash commits — let the merge commit preserve history
 - Don't use `git add .` or `git add -A`
 - Don't open the PR yet — that's the `review` phase

--- a/codev-skeleton/protocols/pir/prompts/review.md
+++ b/codev-skeleton/protocols/pir/prompts/review.md
@@ -38,7 +38,7 @@ Fixes #{{issue.number}}
 
 ## Files Changed
 
-Output of `git diff --stat main`, formatted as a list:
+Output of `git diff --stat "$DEFAULT_BRANCH"`, formatted as a list (resolve once: `DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || echo main)`):
 
 - `path/to/file.ts` (+12 / -3)
 - `path/to/new-file.ts` (+45 / -0)
@@ -239,15 +239,19 @@ Together with the `--pr` record from step 4a and the `--merged` record from step
 - **Don't merge before the `pr` gate is approved.** A consultation APPROVE verdict is NOT merge authorization. User-in-pane prose ("looks good", "lgtm", "merge it") is NOT merge authorization. The *only* signal that authorizes `gh pr merge` is porch reporting `gate_status: approved` for the `pr` gate (which only the user can do, via Cmd+K G or `porch approve` from a non-Claude shell). If `porch next` doesn't show the gate as approved, you wait.
 - Don't skip porch's PR/merge records (steps 4a, 9). The `--pr` record (step 4a) lets the gate-pending state link to the actual PR; the `--merged` record (step 9) closes the lifecycle in porch state. Skipping either leaves `history:` empty and downstream tooling blind.
 - Don't run `porch approve` for any gate yourself
-- Don't push to main — only merge via PR
+- Don't push to the default branch — only merge via PR
 - Don't skip the Architecture Updates / Lessons Learned sections — porch checks enforce their presence (the section must exist; explaining "no changes needed" in one line is fine)
 - **Don't run `consult` commands yourself** — porch handles consultations via the `verify` block. Manually invoking `consult` causes the consultation to run twice.
 - **Don't fix, skip, or quarantine pre-existing failures unrelated to your change.** Porch's `checks` for this phase are narrow *structural* gates (`pr_exists`, review-section presence) — a green gate does **not** certify the wider build/test suite. If the broader suite surfaces failures your diff did not cause, they are out of scope: note them in the review's Lessons Learned / Things to Look At and proceed. Touching another team's tests to make an unrelated red go green is scope creep, not diligence.
 
 ## Handling Problems
 
-**If the PR cannot be created (e.g., merge conflicts with main):**
-- Rebase on main: `git fetch origin main && git rebase origin/main`
+**If the PR cannot be created (e.g., merge conflicts with the default branch):**
+- Rebase on the default branch:
+  ```bash
+  DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || echo main)
+  git fetch origin "$DEFAULT_BRANCH" && git rebase "origin/$DEFAULT_BRANCH"
+  ```
 - Resolve conflicts (do NOT use destructive shortcuts)
 - Force-push with lease: `git push --force-with-lease`
 - Re-run `gh pr create`

--- a/codev/protocols/pir/builder-prompt.md
+++ b/codev/protocols/pir/builder-prompt.md
@@ -82,7 +82,7 @@ If you encounter **pre-existing flaky tests** (intermittent failures unrelated t
 If your Claude session crashes mid-flow, Tower's `while true` loop will relaunch you with the same prompt. On startup:
 
 1. Run `porch next {{project_id}}` to learn what phase you're in
-2. If `gate_pending`: read the latest plan file (plan-approval) or `git diff main` (dev-approval) plus any new GitHub issue comments; check `afx send` queue. Decide whether to revise or just announce you're back.
+2. If `gate_pending`: read the latest plan file (plan-approval) or `git diff "$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || echo main)"` (dev-approval) plus any new GitHub issue comments; check `afx send` queue. Decide whether to revise or just announce you're back.
 3. Otherwise: pick up where you left off
 
 ## Getting Started

--- a/codev/protocols/pir/consult-types/pr-review.md
+++ b/codev/protocols/pir/consult-types/pr-review.md
@@ -22,7 +22,7 @@ You are performing the 3-way review of a PIR protocol PR. The builder has implem
    - Any `// REVIEW:` markers that weren't addressed?
 
 4. **Branch Hygiene**
-   - Is the branch up to date with main? (If not, suggest a rebase.)
+   - Is the branch up to date with the default branch? (If not, suggest a rebase. The default branch is whatever `git symbolic-ref --short refs/remotes/origin/HEAD` reports — typically `main`, but may be `dev`, `ci`, etc.)
    - Are commits atomic and well-described?
    - Is the change diff a reasonable size for the issue scope?
 

--- a/codev/protocols/pir/prompts/implement.md
+++ b/codev/protocols/pir/prompts/implement.md
@@ -17,12 +17,18 @@ Implement the approved plan, write tests, and pause at the `dev-approval` gate s
 
 Run `porch next {{project_id}}`. If the response is `gate_pending` on `dev-approval`, the code is already written and you're awaiting review. In that case:
 
-1. Check for feedback:
-   - `git diff main` — has the reviewer made any direct edits to your code?
+1. Resolve your repo's default branch (falls back to `main` if `origin/HEAD` isn't set):
+
+   ```bash
+   DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || echo main)
+   ```
+
+2. Check for feedback:
+   - `git diff "$DEFAULT_BRANCH"` — has the reviewer made any direct edits to your code?
    - `gh issue view {{issue.number}} --comments`
    - `afx send` queue messages
-2. If feedback requires code changes: make them, re-run build + tests, recommit.
-3. If feedback is a discussion question: respond and stay in the session.
+3. If feedback requires code changes: make them, re-run build + tests, recommit.
+4. If feedback is a discussion question: respond and stay in the session.
 
 Otherwise (`tasks` response — first run), continue below.
 
@@ -107,7 +113,7 @@ When the gate goes pending, output a short prose summary in the pane to orient t
 
 > **What changed**: 2–3 sentence summary.
 >
-> **Files**: `git diff --stat main` style list — paths and +/-.
+> **Files**: `git diff --stat "$DEFAULT_BRANCH"` style list — paths and +/-. (Resolve `$DEFAULT_BRANCH` once per session: `DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || echo main)`.)
 >
 > **Test results**: `npm run build` ✓, `npm test` ✓ (X tests, Y new).
 >
@@ -133,7 +139,7 @@ Then **stay in the interactive session**. Do not exit. Wait for the user's next 
 - **Don't write `codev/reviews/<id>-<slug>.md` in this phase** — it's the next phase's artifact, with a different shape (retrospective with arch + lessons updates)
 - Don't add features not in the plan — scope creep is a `BLOCKED` signal, not a free expansion
 - Don't run `porch approve` yourself
-- Don't push to main — only to your builder branch
+- Don't push to the default branch — only to your builder branch
 - Don't squash commits — let the merge commit preserve history
 - Don't use `git add .` or `git add -A`
 - Don't open the PR yet — that's the `review` phase

--- a/codev/protocols/pir/prompts/review.md
+++ b/codev/protocols/pir/prompts/review.md
@@ -38,7 +38,7 @@ Fixes #{{issue.number}}
 
 ## Files Changed
 
-Output of `git diff --stat main`, formatted as a list:
+Output of `git diff --stat "$DEFAULT_BRANCH"`, formatted as a list (resolve once: `DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || echo main)`):
 
 - `path/to/file.ts` (+12 / -3)
 - `path/to/new-file.ts` (+45 / -0)
@@ -239,15 +239,19 @@ Together with the `--pr` record from step 4a and the `--merged` record from step
 - **Don't merge before the `pr` gate is approved.** A consultation APPROVE verdict is NOT merge authorization. User-in-pane prose ("looks good", "lgtm", "merge it") is NOT merge authorization. The *only* signal that authorizes `gh pr merge` is porch reporting `gate_status: approved` for the `pr` gate (which only the user can do, via Cmd+K G or `porch approve` from a non-Claude shell). If `porch next` doesn't show the gate as approved, you wait.
 - Don't skip porch's PR/merge records (steps 4a, 9). The `--pr` record (step 4a) lets the gate-pending state link to the actual PR; the `--merged` record (step 9) closes the lifecycle in porch state. Skipping either leaves `history:` empty and downstream tooling blind.
 - Don't run `porch approve` for any gate yourself
-- Don't push to main — only merge via PR
+- Don't push to the default branch — only merge via PR
 - Don't skip the Architecture Updates / Lessons Learned sections — porch checks enforce their presence (the section must exist; explaining "no changes needed" in one line is fine)
 - **Don't run `consult` commands yourself** — porch handles consultations via the `verify` block. Manually invoking `consult` causes the consultation to run twice.
 - **Don't fix, skip, or quarantine pre-existing failures unrelated to your change.** Porch's `checks` for this phase are narrow *structural* gates (`pr_exists`, review-section presence) — a green gate does **not** certify the wider build/test suite. If the broader suite surfaces failures your diff did not cause, they are out of scope: note them in the review's Lessons Learned / Things to Look At and proceed. Touching another team's tests to make an unrelated red go green is scope creep, not diligence.
 
 ## Handling Problems
 
-**If the PR cannot be created (e.g., merge conflicts with main):**
-- Rebase on main: `git fetch origin main && git rebase origin/main`
+**If the PR cannot be created (e.g., merge conflicts with the default branch):**
+- Rebase on the default branch:
+  ```bash
+  DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || echo main)
+  git fetch origin "$DEFAULT_BRANCH" && git rebase "origin/$DEFAULT_BRANCH"
+  ```
 - Resolve conflicts (do NOT use destructive shortcuts)
 - Force-push with lease: `git push --force-with-lease`
 - Re-run `gh pr create`

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -40,6 +40,15 @@ export interface BuilderOverview {
   mode: 'strict' | 'soft';
   gates: Record<string, string>;
   worktreePath: string;
+  /**
+   * Canonical role identifier (e.g. `builder-pir-1423`) derived from the
+   * worktree basename via `worktreeNameToRoleId`. The bridge between
+   * filesystem-discovered builders and the runtime terminal registry's
+   * `entry.builders: Map<roleId, ptySessionId>`. `null` if the worktree
+   * name doesn't match any known protocol pattern (soft-mode builders
+   * with arbitrary names).
+   */
+  roleId: string | null;
   protocol: string;
   planPhases: PlanPhase[];
   progress: number;
@@ -54,6 +63,14 @@ export interface BuilderOverview {
   blockedSince: string | null;
   startedAt: string | null;
   idleMs: number;
+  /**
+   * Wall-clock ISO timestamp of the last DATA frame Tower received from
+   * this builder's shellper (`null` when no live session). The UI uses
+   * it to detect builders silent past a threshold — likely waiting for
+   * non-gate human input. Filled by `handleOverview` after this object
+   * is constructed (the parser leaves it `null`).
+   */
+  lastDataAt: string | null;
 }
 
 export interface PROverview {
@@ -543,6 +560,10 @@ export function discoverBuilders(workspaceRoot: string): BuilderOverview[] {
 
     const worktreePath = path.join(buildersDir, entry.name);
     const projectId = extractProjectIdFromWorktreeName(entry.name);
+    // Compute the canonical roleId once per worktree — used both as a
+    // filter key (against entry.builders.keys()) and as the bridge to
+    // PtySession at request time, so callers don't re-run the regex.
+    const roleId = worktreeNameToRoleId(entry.name);
 
     if (!projectId) {
       // No ID extracted (task-*, worktree-*) → soft mode
@@ -554,6 +575,7 @@ export function discoverBuilders(workspaceRoot: string): BuilderOverview[] {
         mode: 'soft',
         gates: {},
         worktreePath,
+        roleId,
         protocol: '',
         planPhases: [],
         progress: 0,
@@ -562,6 +584,7 @@ export function discoverBuilders(workspaceRoot: string): BuilderOverview[] {
         blockedSince: null,
         startedAt: null,
         idleMs: 0,
+        lastDataAt: null,
       });
       continue;
     }
@@ -606,6 +629,7 @@ export function discoverBuilders(workspaceRoot: string): BuilderOverview[] {
             mode: 'strict',
             gates: parsed.gates,
             worktreePath,
+            roleId,
             protocol: parsed.protocol,
             planPhases: parsed.planPhases,
             progress: calculateProgress(parsed, workspaceRoot),
@@ -614,6 +638,7 @@ export function discoverBuilders(workspaceRoot: string): BuilderOverview[] {
             blockedSince: detectBlockedSince(parsed),
             startedAt: parsed.startedAt || null,
             idleMs: computeIdleMs(parsed),
+            lastDataAt: null,
           });
           found = true;
           break;
@@ -635,6 +660,7 @@ export function discoverBuilders(workspaceRoot: string): BuilderOverview[] {
         mode: 'soft',
         gates: {},
         worktreePath,
+        roleId,
         protocol: '',
         planPhases: [],
         progress: 0,
@@ -643,6 +669,7 @@ export function discoverBuilders(workspaceRoot: string): BuilderOverview[] {
         blockedSince: null,
         startedAt: null,
         idleMs: 0,
+        lastDataAt: null,
       });
     }
   }
@@ -743,10 +770,8 @@ export class OverviewCache {
     // 1. Discover builders from .builders/ directory, then filter to live sessions
     let builders = discoverBuilders(workspaceRoot);
     if (activeBuilderRoleIds) {
-      builders = builders.filter(b => {
-        const roleId = worktreeNameToRoleId(path.basename(b.worktreePath));
-        return roleId !== null && activeBuilderRoleIds.has(roleId);
-      });
+      // roleId is precomputed by discoverBuilders — no regex per call.
+      builders = builders.filter(b => b.roleId !== null && activeBuilderRoleIds.has(b.roleId));
     }
 
     // Enrich issueId from DB issue_number — protocol-agnostic (fixes #664)

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -145,7 +145,7 @@ const ROUTES: Record<string, RouteEntry> = {
   'POST /api/terminals':  (req, res, _url, ctx) => handleTerminalCreate(req, res, ctx),
   'GET /api/terminals':   (_req, res) => handleTerminalList(res),
   'GET /api/status':      (_req, res) => handleStatus(res),
-  'GET /api/overview':    (_req, res, url) => handleOverview(res, url),
+  'GET /api/overview':    (_req, res, url, ctx) => handleOverview(res, url, undefined, ctx),
   'GET /api/issue':       (_req, res, url) => handleIssueView(res, url),
   'GET /api/analytics':   (_req, res, url) => handleAnalytics(res, url),
   'POST /api/overview/refresh': (_req, res, _url, ctx) => handleOverviewRefresh(res, ctx),
@@ -737,7 +737,7 @@ async function handleStatus(res: http.ServerResponse): Promise<void> {
   res.end(JSON.stringify({ instances }));
 }
 
-async function handleOverview(res: http.ServerResponse, url: URL, workspaceOverride?: string): Promise<void> {
+async function handleOverview(res: http.ServerResponse, url: URL, workspaceOverride?: string, ctx?: RouteContext): Promise<void> {
   // Accept workspace from: explicit override (workspace-scoped route), ?workspace= param, or first known path.
   let workspaceRoot = workspaceOverride || url.searchParams.get('workspace');
 
@@ -764,6 +764,27 @@ async function handleOverview(res: http.ServerResponse, url: URL, workspaceOverr
   }
 
   const data = await overviewCache.getOverview(workspaceRoot, activeBuilderRoleIds);
+
+  // Enrich each builder with `lastDataAt` — the wall-clock time Tower
+  // last received a DATA frame from that builder's shellper. The UI uses
+  // this to flag builders silent past a threshold as "waiting for input"
+  // (separate from formal porch gates, which `blocked` already covers).
+  //
+  // Pattern mirrors /api/state's builder loop (around line 1572): iterate
+  // `entry.builders` (Map<roleId, PtySession ID>), look up the session,
+  // do the work. Discovery already stamps `roleId` on each builder, so
+  // matching the runtime registry back to the discovery list is a single
+  // `find`. Builders with no attached session keep `lastDataAt = null`
+  // (the discover-time default).
+  const terminalManager = getTerminalManager();
+  for (const [builderId, terminalId] of entry.builders) {
+    const ptySession = terminalManager.getSession(terminalId);
+    if (!ptySession) { continue; }
+    const builder = data.builders.find(b => b.roleId === builderId.toLowerCase());
+    if (!builder) { continue; }
+    builder.lastDataAt = new Date(ptySession.lastDataAt).toISOString();
+  }
+
   res.writeHead(200, { 'Content-Type': 'application/json' });
   res.end(JSON.stringify(data));
 }
@@ -1422,7 +1443,7 @@ async function handleWorkspaceRoutes(
 
     // GET /api/overview - Work view overview data (Spec 0126 Phase 4)
     if (req.method === 'GET' && apiPath === 'overview') {
-      return handleOverview(res, url, workspacePath);
+      return handleOverview(res, url, workspacePath, ctx);
     }
 
     // POST /api/overview/refresh - Invalidate overview cache (Spec 0126 Phase 4)

--- a/packages/codev/src/terminal/pty-session.ts
+++ b/packages/codev/src/terminal/pty-session.ts
@@ -121,6 +121,11 @@ export class PtySession extends EventEmitter {
     this.shellperClient = client;
     this.shellperPid = shellperPid;
     this._shellperSessionId = shellperSessionId ?? null;
+    // Hydrate Spec 467's lastDataAt from the shellper's own tracker if
+    // it has a value (WELCOME-side hydration carries genuine activity
+    // history across Tower restart). The data-frame subscription below
+    // keeps it bumped going forward via onPtyData.
+    this._lastDataAt = client.lastDataAt;
 
     // Ensure log directory exists
     if (this.diskLogEnabled) {
@@ -200,6 +205,7 @@ export class PtySession extends EventEmitter {
   get shellperSessionId(): string | null {
     return this._shellperSessionId;
   }
+
 
   /**
    * Whether this session should suppress exit cleanup because the process

--- a/packages/codev/src/terminal/shellper-client.ts
+++ b/packages/codev/src/terminal/shellper-client.ts
@@ -45,12 +45,38 @@ export interface IShellperClient extends EventEmitter {
   getReplayData(): Buffer | null;
   waitForReplay(timeoutMs?: number): Promise<Buffer>;
   readonly connected: boolean;
+  /**
+   * Epoch (ms) of the last PTY byte the shellper has seen.
+   * Hydrated from the shellper's own tracker on WELCOME, then bumped on
+   * every DATA frame. Falls back to construct time only if the shellper
+   * is an older one that doesn't send the field.
+   */
+  readonly lastDataAt: number;
 }
 
 export class ShellperClient extends EventEmitter implements IShellperClient {
   private socket: net.Socket | null = null;
   private _connected = false;
   private replayData: Buffer | null = null;
+  // Wall-clock epoch (ms) of the last PTY byte the shellper has seen.
+  //
+  // Lifecycle:
+  //   - Construct: initialised to `Date.now()` (a sane fallback for the
+  //     window before WELCOME arrives, plus the path for legacy shellpers
+  //     that don't yet send the field).
+  //   - WELCOME handshake: overwritten with the shellper's own
+  //     `lastDataAt` if present. This is the critical step — the
+  //     shellper process survives Tower restart and keeps tracking, so
+  //     hydrating from its value here gives Tower a reading that's
+  //     accurate from the moment of connect, with no 5-minute warm-up
+  //     window after a Tower restart against a long-silent builder.
+  //   - DATA frame: bumped to `Date.now()` on every byte burst (the
+  //     in-memory live update path; matches what the shellper does on
+  //     its side).
+  // PtySession reads this once at attachShellper to hydrate Spec 467's
+  // own `lastDataAt`; from there, PtySession owns the read side and
+  // /api/overview enrichment uses ptySession.lastDataAt.
+  private _lastDataAt: number = Date.now();
 
   constructor(
     private readonly socketPath: string,
@@ -72,6 +98,16 @@ export class ShellperClient extends EventEmitter implements IShellperClient {
 
   get connected(): boolean {
     return this._connected;
+  }
+
+  /**
+   * Epoch (ms) of the last DATA frame received from the shellper. Updated
+   * on every data frame; initialised to construction time so a fresh
+   * client is treated as "just heard from" rather than stale. Used by
+   * PtySession at attach time to hydrate Spec 467's own lastDataAt.
+   */
+  get lastDataAt(): number {
+    return this._lastDataAt;
   }
 
   /**
@@ -153,6 +189,14 @@ export class ShellperClient extends EventEmitter implements IShellperClient {
 
               handshakeResolved = true;
               this._connected = true;
+              // Hydrate lastDataAt from the shellper's own tracker if it
+              // sent one. Old shellpers omit the field (it's optional in
+              // the protocol) — leave the construct-time fallback in
+              // place for those. New shellpers send the genuine last-PTY
+              // moment, including across Tower restarts.
+              if (typeof welcome.lastDataAt === 'number') {
+                this._lastDataAt = welcome.lastDataAt;
+              }
               // Replay any buffered frames received before WELCOME
               for (const buffered of preWelcomeBuffer) {
                 this.handleFrame(buffered);
@@ -183,6 +227,7 @@ export class ShellperClient extends EventEmitter implements IShellperClient {
 
     switch (frame.type) {
       case FrameType.DATA:
+        this._lastDataAt = Date.now();
         this.emit('data', frame.payload);
         break;
       case FrameType.EXIT: {

--- a/packages/codev/src/terminal/shellper-process.ts
+++ b/packages/codev/src/terminal/shellper-process.ts
@@ -79,6 +79,12 @@ export class ShellperProcess extends EventEmitter {
   private cols = DEFAULT_COLS;
   private rows = DEFAULT_ROWS;
   private startTime: number = Date.now();
+  // Wall-clock epoch (ms) of the last PTY byte received. Sent in every
+  // WELCOME so Tower (which loses its own in-memory tracker on restart)
+  // can hydrate to the genuine last-activity moment instead of treating
+  // reconnect as fresh activity. Initialised to startTime so a brand-new
+  // shellper that has emitted nothing yet still reports a sane value.
+  private lastDataAt: number = Date.now();
   private exited = false;
 
   constructor(
@@ -135,6 +141,7 @@ export class ShellperProcess extends EventEmitter {
 
       const buf = Buffer.from(data, 'utf-8');
       this.replayBuffer.append(buf);
+      this.lastDataAt = Date.now();
 
       this.broadcast(encodeData(buf));
     });
@@ -357,6 +364,7 @@ export class ShellperProcess extends EventEmitter {
       cols: this.cols,
       rows: this.rows,
       startTime: this.startTime,
+      lastDataAt: this.lastDataAt,
     });
     socket.write(welcome);
     this.log(`WELCOME sent: pid=${pid}, version=${PROTOCOL_VERSION}`);

--- a/packages/codev/src/terminal/shellper-protocol.ts
+++ b/packages/codev/src/terminal/shellper-protocol.ts
@@ -71,6 +71,18 @@ export interface WelcomeMessage {
   cols: number;
   rows: number;
   startTime: number;
+  /**
+   * Epoch (ms) of the most recent PTY byte the shellper has seen.
+   *
+   * Optional for backward compatibility: a Tower talking to an older
+   * shellper that doesn't send the field treats it as missing and falls
+   * back to construct-time `Date.now()`. The new shellper sends it on
+   * every WELCOME, including reconnects — so Tower hydrates its own
+   * `lastDataAt` to the genuine last-activity moment across Tower
+   * restarts (which discard the in-memory value but leave the shellper
+   * process running and still tracking).
+   */
+  lastDataAt?: number;
 }
 
 export interface SpawnMessage {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,10 @@
     "./agent-names": {
       "types": "./dist/agent-names.d.ts",
       "default": "./dist/agent-names.js"
+    },
+    "./builder-helpers": {
+      "types": "./dist/builder-helpers.d.ts",
+      "default": "./dist/builder-helpers.js"
     }
   },
   "files": [

--- a/packages/core/src/builder-helpers.ts
+++ b/packages/core/src/builder-helpers.ts
@@ -1,0 +1,35 @@
+import type { OverviewBuilder } from '@cluesmith/codev-types';
+
+/**
+ * Threshold (ms) for treating a builder as "idle, likely waiting on input".
+ *
+ * If Tower last received output from the builder's shellper longer than this
+ * ago — and the builder isn't blocked at a gate or completed — it's likely
+ * paused at a clarifying question. 5 minutes is conservative enough that
+ * legitimate long agent "thinking" pauses rarely false-positive, but short
+ * enough that a real wait surfaces while the user is still on-task.
+ *
+ * Lives here (not in `@cluesmith/codev-types`) because it's *application
+ * policy* — the UI rule for interpreting `lastDataAt`. The types
+ * package describes the wire contract; this constant decides what the
+ * VSCode extension and the web dashboard *do* with it. Co-locating both
+ * surfaces' threshold here prevents silent UI drift where one says
+ * "waiting" and the other says "active" for the same builder.
+ */
+export const IDLE_WAITING_THRESHOLD_MS = 5 * 60 * 1000;
+
+/**
+ * True iff the builder is silent past `IDLE_WAITING_THRESHOLD_MS` while
+ * still being able to make progress (not blocked at a gate, not
+ * completed/verified, and Tower has a `lastDataAt` timestamp for it).
+ *
+ * Canonical predicate for the third "needs me" state alongside `blocked`.
+ * UI surfaces should call this rather than reimplementing the threshold
+ * check.
+ */
+export function isIdleWaiting(b: OverviewBuilder, now: number = Date.now()): boolean {
+  if (b.blocked) { return false; }
+  if (b.phase === 'complete' || b.phase === 'verified') { return false; }
+  if (!b.lastDataAt) { return false; }
+  return now - new Date(b.lastDataAt).getTime() > IDLE_WAITING_THRESHOLD_MS;
+}

--- a/packages/dashboard/src/components/BuilderCard.tsx
+++ b/packages/dashboard/src/components/BuilderCard.tsx
@@ -1,3 +1,4 @@
+import { isIdleWaiting } from '@cluesmith/codev-core/builder-helpers';
 import type { OverviewBuilder } from '../lib/api.js';
 
 interface BuilderCardProps {
@@ -7,6 +8,7 @@ interface BuilderCardProps {
 
 function stateLabel(builder: OverviewBuilder): string {
   if (builder.blocked) return `Blocked: ${builder.blocked}`;
+  if (isIdleWaiting(builder)) return 'Waiting on input';
   if (builder.mode === 'soft') return 'running';
   if (!builder.phase) return 'starting';
   const phases = builder.planPhases;
@@ -40,21 +42,28 @@ export function BuilderCard({ builder, onOpen }: BuilderCardProps) {
   const displayId = builder.issueId ? `#${builder.issueId}` : builder.id;
   const displayTitle = builder.issueTitle || builder.id;
   const isBlocked = builder.blocked !== null && builder.blocked !== '';
+  const isWaiting = !isBlocked && isIdleWaiting(builder);
   const pct = Math.min(100, Math.max(0, Math.round(builder.progress ?? 0)));
 
+  // Reuse the blocked visual treatment for waiting rows in v1 — both are
+  // "needs me" states. Splitting CSS into a distinct `--waiting` modifier
+  // is a follow-up refinement once we see how the signal behaves in practice.
+  const rowMod = isBlocked ? ' builder-row--blocked' : isWaiting ? ' builder-row--waiting' : '';
+  const fillMod = isBlocked ? ' progress-fill--blocked' : isWaiting ? ' progress-fill--waiting' : '';
+
   return (
-    <tr className={`builder-row${isBlocked ? ' builder-row--blocked' : ''}`}>
+    <tr className={`builder-row${rowMod}`}>
       <td className="builder-col-id">{displayId}</td>
       <td className="builder-col-title">{displayTitle}</td>
       <td className="builder-col-state">
-        <span className={isBlocked ? 'builder-state-blocked' : 'builder-state-active'}>
+        <span className={isBlocked || isWaiting ? 'builder-state-blocked' : 'builder-state-active'}>
           {stateLabel(builder)}
         </span>
       </td>
       <td className="builder-col-progress">
         <div className="progress-bar">
           <div
-            className={`progress-fill${isBlocked ? ' progress-fill--blocked' : ''}`}
+            className={`progress-fill${fillMod}`}
             style={{ width: `${pct}%` }}
           />
         </div>

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -105,6 +105,14 @@ export interface OverviewBuilder {
   mode: 'strict' | 'soft';
   gates: Record<string, string>;
   worktreePath: string;
+  /**
+   * Canonical role identifier (e.g. `builder-pir-1423`) derived from the
+   * worktree basename. Stable across requests for a given builder while
+   * its worktree exists, and the key by which Tower's runtime terminal
+   * registry indexes the live session. `null` for soft-mode builders
+   * whose worktree name doesn't match a known protocol pattern.
+   */
+  roleId: string | null;
   protocol: string;
   planPhases: Array<{ id: string; title: string; status: string }>;
   progress: number;
@@ -119,6 +127,14 @@ export interface OverviewBuilder {
   blockedSince: string | null;
   startedAt: string | null;
   idleMs: number;
+  /**
+   * Wall-clock ISO timestamp of the last DATA frame Tower received from
+   * this builder's shellper, or `null` when no live session exists.
+   * Clients use it to flag builders that have been silent for a threshold
+   * — likely waiting for non-gate human input. Distinct from `idleMs`,
+   * which sums time spent at formal porch gates.
+   */
+  lastDataAt: string | null;
 }
 
 export interface OverviewPR {

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 What's changed in the Codev VS Code extension, version by version, written for the developers who use it.
 
+## [Unreleased]
+
+### What's new
+
+- **Count badge on the Codev activity-bar icon.** The sidebar icon now carries a numeric badge for builders that need your attention.
+- **Builders waiting silently for input now surface as "waiting on input."** A builder whose terminal has been idle for more than 5 minutes, and isn't blocked at a gate or finished, gets a chat-bubble icon in the Builders tree and an `N waiting` segment in the status bar.
+- **Single-click a builder row to expand its file list.** Clicking a builder row now opens its terminal *and* expands the file list underneath — previously the expand chevron was a separate click.
+- **Send a backlog issue to the architect inline.** Each backlog row has a new inline button that pastes the issue's `#<id>` reference straight into the architect input, no copy-paste step.
+- **Issue markdown previews update live.** Leave an issue preview open and it refreshes in place when the underlying issue changes (new comment, label edit, etc.) instead of going stale.
+
 ## [3.0.7] - 2026-05-20
 
 ### What's new

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 What's changed in the Codev VS Code extension, version by version, written for the developers who use it.
 
-## [Unreleased]
+## [3.0.7] - 2026-05-20
 
 ### What's new
 

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -31,8 +31,8 @@ Bring Codev's Agent Farm into VS Code — monitor builders, open terminals, appr
 
 ```
 +------------+----------------+----------------+
-| Codev      | Architect      | [#42] [#43]    |
-| (sidebar)  | (terminal)     | Builder #42    |
+| Codev      | Architect      | [42] [43]      |
+| (sidebar)  | (terminal)     | Builder 42     |
 |            |                | (terminal)     |
 | - Workspace|                |                |
 | - Builders | Left editor    | Right editor   |
@@ -42,6 +42,8 @@ Bring Codev's Agent Farm into VS Code — monitor builders, open terminals, appr
 | - Team     |                |                |
 | - Status   |                |                |
 +------------+----------------+----------------+
+| Bottom panel: dev server (when running)      |
++----------------------------------------------+
 ```
 
 ## Commands

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -252,7 +252,7 @@
         },
         {
           "command": "codev.openBuilderById",
-          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder)-/",
+          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder|awaiting-builder)-/",
           "group": "1_primary@1"
         },
         {
@@ -262,37 +262,37 @@
         },
         {
           "command": "codev.viewPlanFile",
-          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder)-pir$/",
+          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder|awaiting-builder)-pir$/",
           "group": "1_primary@3"
         },
         {
           "command": "codev.viewDiff",
-          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder)-/",
+          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder|awaiting-builder)-/",
           "group": "2_worktree@0"
         },
         {
           "command": "codev.openWorktreeWindow",
-          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder)-/",
+          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder|awaiting-builder)-/",
           "group": "2_worktree@1"
         },
         {
           "command": "codev.openWorktreeFolder",
-          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder)-/",
+          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder|awaiting-builder)-/",
           "group": "2_worktree@2"
         },
         {
           "command": "codev.runWorktreeSetup",
-          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder)-/",
+          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder|awaiting-builder)-/",
           "group": "3_dev@1"
         },
         {
           "command": "codev.runWorktreeDev",
-          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder)-/",
+          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder|awaiting-builder)-/",
           "group": "3_dev@2"
         },
         {
           "command": "codev.stopWorktreeDev",
-          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder)-/",
+          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder|awaiting-builder)-/",
           "group": "3_dev@3"
         },
         {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -178,6 +178,11 @@
         "title": "Codev: View Issue"
       },
       {
+        "command": "codev.referenceIssueInArchitect",
+        "title": "Codev: Reference Issue in Architect",
+        "icon": "$(mention)"
+      },
+      {
         "command": "codev.openBacklogIssue",
         "title": "Codev: Open Issue in Browser"
       },
@@ -208,6 +213,10 @@
         },
         {
           "command": "codev.viewBacklogIssue",
+          "when": "false"
+        },
+        {
+          "command": "codev.referenceIssueInArchitect",
           "when": "false"
         },
         {
@@ -295,6 +304,11 @@
           "command": "codev.stopWorkspaceDev",
           "when": "view == codev.workspace && viewItem == workspace-dev-stop",
           "group": "1_primary@1"
+        },
+        {
+          "command": "codev.referenceIssueInArchitect",
+          "when": "view == codev.backlog && viewItem == backlog-item",
+          "group": "inline@1"
         },
         {
           "command": "codev.viewBacklogIssue",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -520,8 +520,8 @@
     "lint": "eslint src",
     "test": "vscode-test",
     "vsix": "vsce package --no-dependencies",
-    "vscode:publish": "vsce publish --no-dependencies",
-    "vscode:publish:pre": "vsce publish --no-dependencies --pre-release"
+    "vscode:publish": "sh scripts/publish.sh",
+    "vscode:publish:pre": "sh scripts/publish.sh --pre-release"
   },
   "dependencies": {
     "@cluesmith/codev-core": "workspace:*",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -158,6 +158,10 @@
         "title": "Codev: Open Builder Terminal"
       },
       {
+        "command": "codev.openBuilderRow",
+        "title": "Codev: Open Builder Terminal (and expand row)"
+      },
+      {
         "command": "codev.openWorktreeFolder",
         "title": "Codev: Open Worktree Folder"
       },
@@ -196,6 +200,10 @@
       "commandPalette": [
         {
           "command": "codev.openBuilderById",
+          "when": "false"
+        },
+        {
+          "command": "codev.openBuilderRow",
           "when": "false"
         },
         {

--- a/packages/vscode/scripts/publish.sh
+++ b/packages/vscode/scripts/publish.sh
@@ -3,8 +3,10 @@
 # .vsix — keeps VS Code Marketplace and Open VSX byte-identical.
 #
 # Usage:
-#   scripts/publish-vscode.sh                # stable, both registries
-#   scripts/publish-vscode.sh --pre-release  # pre-release channel, both registries
+#   pnpm vscode:publish        # stable, both registries
+#   pnpm vscode:publish:pre    # pre-release channel, both registries
+#
+# (Or invoke directly: `sh packages/vscode/scripts/publish.sh [--pre-release]`.)
 #
 # Auth:
 #   VSCE_PAT  — VS Code Marketplace token, or run `vsce login cluesmith` once
@@ -24,7 +26,11 @@
 
 set -e
 
-cd packages/vscode
+# Resolve to the package root (one level up from this scripts/ dir) regardless
+# of cwd, so direct invocation from anywhere works too — not just the
+# `pnpm vscode:publish` wrapper.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/.."
 
 PRE=""
 if [ "$1" = "--pre-release" ]; then
@@ -57,4 +63,6 @@ echo "▶ publishing to Open VSX..."
 ovsx publish $PRE "$VSIX"
 
 echo ""
-echo "✓ Published $VSIX to Marketplace + Open VSX"
+echo "✓ Published $VSIX to:"
+echo "  • VS Code Marketplace: https://marketplace.visualstudio.com/items?itemName=cluesmith.codev-vscode"
+echo "  • Open VSX:            https://open-vsx.org/extension/cluesmith/codev-vscode"

--- a/packages/vscode/src/commands/view-issue.ts
+++ b/packages/vscode/src/commands/view-issue.ts
@@ -11,20 +11,46 @@
  * A TextDocumentContentProvider scheme is read-only by construction, so
  * there's no editable scratch buffer left behind (unlike opening an
  * untitled document).
+ *
+ * Refresh model: each `set` updates the cached markdown and fires
+ * `onDidChange`, so re-click refreshes immediately. For passive updates
+ * while a preview is open, activate subscribes to `OverviewCache.onDidChange`
+ * (the existing sidebar-poll + SSE heartbeat) and re-fetches every issue
+ * still in the cache. The cache is bounded *exactly* by what's open:
+ * `onDidCloseTextDocument` drops entries when their preview tab is
+ * closed and VSCode unloads the underlying TextDocument. A leading-edge
+ * 30s throttle absorbs SSE bursts; the dedup'ing `set` absorbs no-op
+ * refetches.
  */
 
 import * as vscode from 'vscode';
 import type { IssueView } from '@cluesmith/codev-types';
 import type { ConnectionManager } from '../connection-manager.js';
+import type { OverviewCache } from '../views/overview-data.js';
 
 const SCHEME = 'codev-issue';
+const REFRESH_THROTTLE_MS = 30_000;
 
 class IssueContentProvider implements vscode.TextDocumentContentProvider {
   private readonly contents = new Map<string, string>();
+  private readonly _onDidChange = new vscode.EventEmitter<vscode.Uri>();
+  readonly onDidChange = this._onDidChange.event;
 
-  /** Key is the issue id; value is the rendered markdown. */
-  set(issueId: string, markdown: string): void {
+  /**
+   * Stash rendered markdown for `issueId`. Returns true iff the content
+   * actually changed (dedup) — `onDidChange` only fires on real changes
+   * so identical refetches don't churn the preview.
+   */
+  set(issueId: string, markdown: string): boolean {
+    if (this.contents.get(issueId) === markdown) { return false; }
     this.contents.set(issueId, markdown);
+    this._onDidChange.fire(vscode.Uri.parse(`${SCHEME}:${issueId}.md`));
+    return true;
+  }
+
+  /** Drop a cached entry — called when its preview's TextDocument closes. */
+  forget(issueId: string): void {
+    this.contents.delete(issueId);
   }
 
   provideTextDocumentContent(uri: vscode.Uri): string {
@@ -32,14 +58,22 @@ class IssueContentProvider implements vscode.TextDocumentContentProvider {
     const issueId = uri.path.replace(/\.md$/, '');
     return this.contents.get(issueId) ?? `# Issue #${issueId}\n\n_Content unavailable._`;
   }
+
+  /** Issue ids whose previews are currently open. */
+  knownIssueIds(): string[] {
+    return [...this.contents.keys()];
+  }
+
+  dispose(): void {
+    this._onDidChange.dispose();
+  }
 }
 
 const provider = new IssueContentProvider();
 
-export function activateIssueView(context: vscode.ExtensionContext): void {
-  context.subscriptions.push(
-    vscode.workspace.registerTextDocumentContentProvider(SCHEME, provider),
-  );
+function issueIdFromUri(uri: vscode.Uri): string | undefined {
+  if (uri.scheme !== SCHEME) { return undefined; }
+  return uri.path.replace(/\.md$/, '');
 }
 
 function renderIssue(issueId: string, issue: IssueView): string {
@@ -59,6 +93,48 @@ function renderIssue(issueId: string, issue: IssueView): string {
   }
 
   return lines.join('\n');
+}
+
+export function activateIssueView(
+  context: vscode.ExtensionContext,
+  connectionManager: ConnectionManager,
+  overviewCache: OverviewCache,
+): void {
+  // Re-fetch every open preview on each heartbeat from overviewCache —
+  // that emitter already coalesces the 60s sidebar poll with Tower's SSE
+  // events. SSE bursts (frequent during builder activity) are absorbed
+  // by the leading-edge throttle.
+  let lastRefreshAt = 0;
+  const refreshTracked = async (): Promise<void> => {
+    const now = Date.now();
+    if (now - lastRefreshAt < REFRESH_THROTTLE_MS) { return; }
+    lastRefreshAt = now;
+    const client = connectionManager.getClient();
+    const workspacePath = connectionManager.getWorkspacePath();
+    if (!client || !workspacePath || connectionManager.getState() !== 'connected') { return; }
+    for (const issueId of provider.knownIssueIds()) {
+      try {
+        const issue = await client.getIssue(issueId, workspacePath);
+        if (issue) { provider.set(issueId, renderIssue(issueId, issue)); }
+      } catch {
+        // Benign — keep the last good content; next tick may succeed.
+      }
+    }
+  };
+
+  context.subscriptions.push(
+    vscode.workspace.registerTextDocumentContentProvider(SCHEME, provider),
+    // Drop cache entries when the markdown preview tab closes (and VSCode
+    // therefore unloads the underlying codev-issue: TextDocument). Keeps
+    // the cache shaped to exactly what's currently visible — refresh loop
+    // never iterates closed previews.
+    vscode.workspace.onDidCloseTextDocument((doc) => {
+      const issueId = issueIdFromUri(doc.uri);
+      if (issueId) { provider.forget(issueId); }
+    }),
+    overviewCache.onDidChange(refreshTracked),
+    { dispose: () => provider.dispose() },
+  );
 }
 
 export async function viewBacklogIssue(

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -157,6 +157,27 @@ export async function activate(context: vscode.ExtensionContext) {
 		if (recentlyClosedView) { recentlyClosedView.title = withCount('Recently Closed', data?.recentlyClosed.length); }
 	};
 
+	// Activity-bar badge — paint the blocked-builder count on the Codev icon.
+	// Mirrors the status-bar bell pattern (only surfaced when > 0). VSCode has
+	// no container-level badge API; per-view `TreeView.badge` bubbles up to the
+	// activity-bar icon when the sidebar is hidden, so badging `buildersView`
+	// is how we paint the icon.
+	const updateActivityBadge = () => {
+		if (!buildersView) { return; }
+		const data = overviewCache.getData();
+		const blockedCount = (connectionManager?.getState() === 'connected' && data)
+			? data.builders.filter(b => b.blocked).length
+			: 0;
+		buildersView.badge = blockedCount > 0
+			? {
+				value: blockedCount,
+				tooltip: blockedCount === 1
+					? '1 builder blocked at a human-approval gate'
+					: `${blockedCount} builders blocked at human-approval gates`,
+			}
+			: undefined;
+	};
+
 	// Close builder/dev terminal tabs when their builder disappears from Tower
 	// state. Covers cleanup triggered from the VSCode "Cleanup Builder" command,
 	// `afx cleanup` on the CLI, or any other removal path — otherwise Tower
@@ -200,6 +221,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		updateStatusBarCounts();
 		pruneClosedBuilderTerminals();
 		updateListViewTitles();
+		updateActivityBadge();
 	});
 
 	// Shared across the Builders tree (second-level changed files) and the
@@ -216,6 +238,9 @@ export async function activate(context: vscode.ExtensionContext) {
 	pullRequestsView = vscode.window.createTreeView('codev.pullRequests', { treeDataProvider: new PullRequestsProvider(overviewCache) });
 	backlogView = vscode.window.createTreeView('codev.backlog', { treeDataProvider: new BacklogProvider(overviewCache) });
 	recentlyClosedView = vscode.window.createTreeView('codev.recentlyClosed', { treeDataProvider: new RecentlyClosedProvider(overviewCache) });
+	// Seed the badge so it's correct immediately if overview data is already
+	// cached, instead of waiting for the next onDidChange tick.
+	updateActivityBadge();
 	const teamProvider = new TeamProvider(connectionManager);
 	context.subscriptions.push(
 		buildersView,

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -24,7 +24,7 @@ import { activateReviewDecorations } from './review-decorations.js';
 import { activateReviewComments } from './comments/plan-review.js';
 import { BuilderSpawnHandler } from './builder-spawn-handler.js';
 import { BuilderTerminalLinkProvider } from './terminal-link-provider.js';
-import { BuildersProvider } from './views/builders.js';
+import { BuildersProvider, isIdleWaiting } from './views/builders.js';
 import { PullRequestsProvider } from './views/pull-requests.js';
 import { BacklogProvider, spawnableBacklog } from './views/backlog.js';
 import { RecentlyClosedProvider } from './views/recently-closed.js';
@@ -127,16 +127,23 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.window.onDidChangeActiveTerminal(syncTerminalFocusContext));
 	syncTerminalFocusContext(); // seed initial state
 
-	// Update status bar with builder/gate counts
+	// Update status bar with builder + needs-attention counts.
+	// Two "needs me" signals: blocked (formal gate) and idle-waiting
+	// (PTY silent past threshold, likely paused at a non-gate question
+	// — see isIdleWaiting in views/builders.ts). Each is shown only
+	// when > 0, with its own icon.
 	const updateStatusBarCounts = () => {
 		if (!statusBarItem || connectionManager?.getState() !== 'connected') { return; }
 		const data = overviewCache.getData();
 		if (!data) { return; }
 		const builderCount = data.builders.length;
+		const now = Date.now();
 		const blockedCount = data.builders.filter(b => b.blocked).length;
-		statusBarItem.text = blockedCount > 0
-			? `$(server) Codev: ${builderCount} builders · $(bell) ${blockedCount} blocked`
-			: `$(server) Codev: ${builderCount} builders`;
+		const idleCount = data.builders.filter(b => isIdleWaiting(b, now)).length;
+		let text = `$(server) Codev: ${builderCount} builders`;
+		if (blockedCount > 0) { text += ` · $(bell) ${blockedCount} blocked`; }
+		if (idleCount > 0) { text += ` · $(comment-discussion) ${idleCount} waiting`; }
+		statusBarItem.text = text;
 	};
 
 	// List views show their item count in the title: "Builders (3)".
@@ -157,25 +164,34 @@ export async function activate(context: vscode.ExtensionContext) {
 		if (recentlyClosedView) { recentlyClosedView.title = withCount('Recently Closed', data?.recentlyClosed.length); }
 	};
 
-	// Activity-bar badge — paint the blocked-builder count on the Codev icon.
-	// Mirrors the status-bar bell pattern (only surfaced when > 0). VSCode has
-	// no container-level badge API; per-view `TreeView.badge` bubbles up to the
-	// activity-bar icon when the sidebar is hidden, so badging `buildersView`
-	// is how we paint the icon.
+	// Activity-bar badge — paint the "needs me" count on the Codev icon.
+	// Combines both signals: blocked (formal gate) + idle-waiting (PTY
+	// silent past threshold). VSCode has no container-level badge API;
+	// per-view `TreeView.badge` bubbles up to the activity-bar icon
+	// when the sidebar is hidden, so badging `buildersView` is how
+	// we paint the icon. Badge only set when there's at least one
+	// item needing the user.
 	const updateActivityBadge = () => {
 		if (!buildersView) { return; }
 		const data = overviewCache.getData();
-		const blockedCount = (connectionManager?.getState() === 'connected' && data)
-			? data.builders.filter(b => b.blocked).length
-			: 0;
-		buildersView.badge = blockedCount > 0
-			? {
-				value: blockedCount,
-				tooltip: blockedCount === 1
-					? '1 builder blocked at a human-approval gate'
-					: `${blockedCount} builders blocked at human-approval gates`,
-			}
-			: undefined;
+		if (connectionManager?.getState() !== 'connected' || !data) {
+			buildersView.badge = undefined;
+			return;
+		}
+		const now = Date.now();
+		const blockedCount = data.builders.filter(b => b.blocked).length;
+		const idleCount = data.builders.filter(b => isIdleWaiting(b, now)).length;
+		const total = blockedCount + idleCount;
+		if (total === 0) {
+			buildersView.badge = undefined;
+			return;
+		}
+		const tooltip = (blockedCount > 0 && idleCount > 0)
+			? `${blockedCount} blocked, ${idleCount} waiting on input`
+			: blockedCount > 0
+				? (blockedCount === 1 ? '1 builder blocked at a human-approval gate' : `${blockedCount} builders blocked at human-approval gates`)
+				: (idleCount === 1 ? '1 builder waiting on input' : `${idleCount} builders waiting on input`);
+		buildersView.badge = { value: total, tooltip };
 	};
 
 	// Close builder/dev terminal tabs when their builder disappears from Tower

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -524,7 +524,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// Read-only `codev-issue:` content provider backing the "View Issue"
 	// backlog action — renders issue body + comments as markdown preview.
-	activateIssueView(context);
+	// Reuses overviewCache's existing 60s + SSE heartbeat to passively
+	// refresh open previews; no new timer.
+	activateIssueView(context, connectionManager, overviewCache);
 
 	// Read-only `codev-diff:` content provider backing the "View Diff"
 	// builder action — serves base-branch blob content for the diff editor

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -450,6 +450,18 @@ export async function activate(context: vscode.ExtensionContext) {
 		}),
 		vscode.commands.registerCommand('codev.viewBacklogIssue', (arg: vscode.TreeItem | string | undefined) =>
 			viewBacklogIssue(connectionManager!, extractIssueId(arg))),
+		vscode.commands.registerCommand('codev.referenceIssueInArchitect', async (arg: vscode.TreeItem | string | undefined) => {
+			// Inline-button action on a backlog row: open + focus the architect
+			// terminal, then type `#<id> ` into its prompt without submitting,
+			// so the user can keep typing their context before hitting Enter.
+			const issueId = extractIssueId(arg);
+			if (!issueId) { return; }
+			await vscode.commands.executeCommand('codev.openArchitectTerminal');
+			const ok = terminalManager?.injectArchitectText(`#${issueId} `);
+			if (!ok) {
+				vscode.window.showWarningMessage('Codev: Architect terminal not available');
+			}
+		}),
 		vscode.commands.registerCommand('codev.sendMessage', () => sendMessage(connectionManager!)),
 		vscode.commands.registerCommand('codev.approveGate', (arg: vscode.TreeItem | string | undefined, options?: { skipConfirmation?: boolean }) =>
 			approveGate(connectionManager!, overviewCache, extractBuilderId(arg), options)),

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -24,7 +24,8 @@ import { activateReviewDecorations } from './review-decorations.js';
 import { activateReviewComments } from './comments/plan-review.js';
 import { BuilderSpawnHandler } from './builder-spawn-handler.js';
 import { BuilderTerminalLinkProvider } from './terminal-link-provider.js';
-import { BuildersProvider, isIdleWaiting } from './views/builders.js';
+import { isIdleWaiting } from '@cluesmith/codev-core/builder-helpers';
+import { BuildersProvider } from './views/builders.js';
 import { PullRequestsProvider } from './views/pull-requests.js';
 import { BacklogProvider, spawnableBacklog } from './views/backlog.js';
 import { RecentlyClosedProvider } from './views/recently-closed.js';
@@ -130,8 +131,8 @@ export async function activate(context: vscode.ExtensionContext) {
 	// Update status bar with builder + needs-attention counts.
 	// Two "needs me" signals: blocked (formal gate) and idle-waiting
 	// (PTY silent past threshold, likely paused at a non-gate question
-	// — see isIdleWaiting in views/builders.ts). Each is shown only
-	// when > 0, with its own icon.
+	// — see isIdleWaiting in @cluesmith/codev-core/builder-helpers).
+	// Each is shown only when > 0, with its own icon.
 	const updateStatusBarCounts = () => {
 		if (!statusBarItem || connectionManager?.getState() !== 'connected') { return; }
 		const data = overviewCache.getData();

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -421,6 +421,20 @@ export async function activate(context: vscode.ExtensionContext) {
 			if (!roleOrId) { return; }
 			await terminalManager?.openBuilderByRoleOrId(roleOrId, true);
 		}),
+		vscode.commands.registerCommand('codev.openBuilderRow', async (item: unknown) => {
+			// Builder-row single-click does BOTH: opens the terminal and expands
+			// the row (the file list). Expansion is via reveal(expand:true) which
+			// fires onDidExpandElement — the accordion handler picks that up and
+			// collapses peers when the setting is on. focus:false keeps the
+			// terminal focused, not the tree.
+			if (!(item instanceof BuilderTreeItem)) { return; }
+			await terminalManager?.openBuilderByRoleOrId(item.builderId, true);
+			try {
+				await buildersView!.reveal(item, { expand: true, select: false, focus: false });
+			} catch {
+				// Benign if the row is no longer present (e.g. mid-cleanup).
+			}
+		}),
 		vscode.commands.registerCommand('codev.spawnBuilder', (arg: vscode.TreeItem | string | undefined) =>
 			spawnBuilder(extractIssueId(arg))),
 		vscode.commands.registerCommand('codev.openBacklogIssue', (arg: vscode.TreeItem | undefined) => {

--- a/packages/vscode/src/terminal-manager.ts
+++ b/packages/vscode/src/terminal-manager.ts
@@ -102,6 +102,25 @@ export class TerminalManager {
   }
 
   /**
+   * Type `text` into the architect terminal's input *without* a trailing
+   * newline (no submit). Returns false if the architect terminal isn't
+   * registered in this window — callers should ensure it's open first (via
+   * `codev.openArchitectTerminal`) before injecting.
+   *
+   * `sendText(text, false)` flows through the Pseudoterminal's `handleInput`
+   * exactly like a user keystroke; visibility/focus of the tab is not
+   * required, but we `.show()` so the user can see what they queued and
+   * keep typing.
+   */
+  injectArchitectText(text: string): boolean {
+    const entry = this.terminals.get('architect');
+    if (!entry) { return false; }
+    entry.terminal.show();
+    entry.terminal.sendText(text, false);
+    return true;
+  }
+
+  /**
    * Open a builder terminal. If a terminal already exists for this builder
    * but points at a different (stale) Tower session, dispose it before
    * opening a new one — happens when a builder is re-spawned and Tower

--- a/packages/vscode/src/test/builders.test.ts
+++ b/packages/vscode/src/test/builders.test.ts
@@ -1,0 +1,108 @@
+import * as assert from 'assert';
+import type { OverviewBuilder } from '@cluesmith/codev-types';
+import { isIdleWaiting, orderForDisplay } from '../views/builders.js';
+
+const FIVE_MIN_MS = 5 * 60 * 1000;
+const NOW = 1_700_000_000_000;
+
+function builder(
+  id: string,
+  opts: {
+    blocked?: boolean;
+    blockedSince?: string;
+    phase?: string;
+    lastDataAt?: string | null;
+  } = {},
+): OverviewBuilder {
+  return {
+    id,
+    blocked: opts.blocked ? 'gate-x' : null,
+    blockedSince: opts.blockedSince ?? null,
+    phase: opts.phase ?? 'implement',
+    lastDataAt: opts.lastDataAt === undefined ? null : opts.lastDataAt,
+  } as unknown as OverviewBuilder;
+}
+
+const iso = (ms: number) => new Date(ms).toISOString();
+
+suite('isIdleWaiting', () => {
+	test('false when builder is blocked', () => {
+		const b = builder('b', { blocked: true, lastDataAt: iso(NOW - 10 * 60_000) });
+		assert.strictEqual(isIdleWaiting(b, NOW), false);
+	});
+
+	test('false when no lastDataAt timestamp (no live session)', () => {
+		assert.strictEqual(isIdleWaiting(builder('a'), NOW), false);
+	});
+
+	test('false when phase is complete', () => {
+		const b = builder('a', { phase: 'complete', lastDataAt: iso(NOW - 10 * 60_000) });
+		assert.strictEqual(isIdleWaiting(b, NOW), false);
+	});
+
+	test('false when phase is verified', () => {
+		const b = builder('a', { phase: 'verified', lastDataAt: iso(NOW - 10 * 60_000) });
+		assert.strictEqual(isIdleWaiting(b, NOW), false);
+	});
+
+	test('false when last activity is fresher than the threshold', () => {
+		const b = builder('a', { lastDataAt: iso(NOW - (FIVE_MIN_MS - 1000)) });
+		assert.strictEqual(isIdleWaiting(b, NOW), false);
+	});
+
+	test('false right at the threshold (>, not >=)', () => {
+		const b = builder('a', { lastDataAt: iso(NOW - FIVE_MIN_MS) });
+		assert.strictEqual(isIdleWaiting(b, NOW), false);
+	});
+
+	test('true past the threshold', () => {
+		const b = builder('a', { lastDataAt: iso(NOW - (FIVE_MIN_MS + 1)) });
+		assert.strictEqual(isIdleWaiting(b, NOW), true);
+	});
+});
+
+suite('orderForDisplay', () => {
+	test('three buckets in order: blocked, then idle-waiting, then active', () => {
+		const active = builder('a-active', { lastDataAt: iso(NOW - 1000) }); // fresh
+		const idle = builder('i-idle', { lastDataAt: iso(NOW - 10 * 60_000) }); // stale
+		const blockd = builder('b-blocked', { blocked: true, blockedSince: iso(NOW - 60_000) });
+		const out = orderForDisplay([active, idle, blockd], NOW);
+		assert.deepStrictEqual(out.map(x => x.id), ['b-blocked', 'i-idle', 'a-active']);
+	});
+
+	test('blocked sorted by blockedSince ascending (longest-waiting first)', () => {
+		const newer = builder('new', { blocked: true, blockedSince: iso(NOW - 60_000) });
+		const older = builder('old', { blocked: true, blockedSince: iso(NOW - 3600_000) });
+		const out = orderForDisplay([newer, older], NOW);
+		assert.deepStrictEqual(out.map(x => x.id), ['old', 'new']);
+	});
+
+	test('blocked takes precedence over idle: blocked+stale goes in blocked bucket', () => {
+		const both = builder('both', { blocked: true, blockedSince: iso(NOW - 60_000), lastDataAt: iso(NOW - 10 * 60_000) });
+		const idle = builder('idle', { lastDataAt: iso(NOW - 10 * 60_000) });
+		const active = builder('active');
+		const out = orderForDisplay([active, idle, both], NOW);
+		assert.deepStrictEqual(out.map(x => x.id), ['both', 'idle', 'active']);
+	});
+
+	test('builders with null lastDataAt go to active (not idle)', () => {
+		const idle = builder('idle', { lastDataAt: iso(NOW - 10 * 60_000) });
+		const noActivity = builder('no-activity'); // lastDataAt: null
+		const out = orderForDisplay([idle, noActivity], NOW);
+		assert.deepStrictEqual(out.map(x => x.id), ['idle', 'no-activity']);
+	});
+
+	test('empty input -> empty output', () => {
+		assert.deepStrictEqual(orderForDisplay([], NOW), []);
+	});
+
+	test('does not drop any builders (count is preserved)', () => {
+		const bs = [
+			builder('a'),
+			builder('b', { lastDataAt: iso(NOW - 10 * 60_000) }),
+			builder('c', { blocked: true, blockedSince: iso(NOW - 60_000) }),
+			builder('d', { phase: 'complete', lastDataAt: iso(NOW - 10 * 60_000) }),
+		];
+		assert.strictEqual(orderForDisplay(bs, NOW).length, bs.length);
+	});
+});

--- a/packages/vscode/src/test/builders.test.ts
+++ b/packages/vscode/src/test/builders.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import type { OverviewBuilder } from '@cluesmith/codev-types';
-import { isIdleWaiting, orderForDisplay } from '../views/builders.js';
+import { isIdleWaiting } from '@cluesmith/codev-core/builder-helpers';
+import { orderForDisplay } from '../views/builders.js';
 
 const FIVE_MIN_MS = 5 * 60 * 1000;
 const NOW = 1_700_000_000_000;

--- a/packages/vscode/src/views/builders.ts
+++ b/packages/vscode/src/views/builders.ts
@@ -1,23 +1,35 @@
 import * as vscode from 'vscode';
 import type { OverviewBuilder } from '@cluesmith/codev-types';
+import { isIdleWaiting } from '@cluesmith/codev-core/builder-helpers';
 import type { OverviewCache } from './overview-data.js';
 import { BuilderTreeItem } from './builder-tree-item.js';
 import { BuilderFileTreeItem } from './builder-file-tree-item.js';
 import type { BuilderDiffCache } from './builder-diff-cache.js';
 
+// `isIdleWaiting` (and its 5-minute threshold) lives in @cluesmith/codev-core
+// so the dashboard reads the same predicate. Re-export here so downstream
+// users of this view module (and the unit tests under test/) keep a single
+// import path; the canonical source is core.
+export { isIdleWaiting };
+
 /**
- * Order builders for the Builders tree: blocked first with the longest-
- * waiting at the top, then active builders in overview order. Builders
- * with no recorded `blockedSince` sort last within the blocked group
- * (we don't pretend to know their wait time).
+ * Order builders for the Builders tree: three buckets, top-down.
+ *  1. **blocked** (formal gate awaiting approval) — longest-waiting first.
+ *  2. **idle waiting** (`isIdleWaiting`) — agent silent past the threshold,
+ *      likely paused at a clarifying question.
+ *  3. **active** — everything else; overview order.
+ * Blocked rows with no `blockedSince` sort last within the blocked group
+ * (we don't pretend to know their wait time). Idle-waiting and active
+ * rows preserve Tower's source order within each bucket.
  */
-function orderForDisplay(builders: OverviewBuilder[]): OverviewBuilder[] {
+export function orderForDisplay(builders: OverviewBuilder[], now: number = Date.now()): OverviewBuilder[] {
   const ms = (iso: string | null) => iso ? new Date(iso).getTime() : Infinity;
   const blocked = builders
     .filter(b => b.blocked)
     .sort((a, b) => ms(a.blockedSince) - ms(b.blockedSince));
-  const active = builders.filter(b => !b.blocked);
-  return [...blocked, ...active];
+  const idleWaiting = builders.filter(b => !b.blocked && isIdleWaiting(b, now));
+  const active = builders.filter(b => !b.blocked && !isIdleWaiting(b, now));
+  return [...blocked, ...idleWaiting, ...active];
 }
 
 /**
@@ -62,11 +74,16 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
     const data = this.cache.getData();
     if (!data) { return []; }
 
-    return orderForDisplay(data.builders).map(b => {
+    const now = Date.now();
+    return orderForDisplay(data.builders, now).map(b => {
       const isBlocked = !!b.blocked;
+      const isIdle = !isBlocked && isIdleWaiting(b, now);
       const waitTime = isBlocked && b.blockedSince ? ` [${timeSince(b.blockedSince)}]` : '';
+      const idleTime = isIdle && b.lastDataAt ? ` [${timeSince(b.lastDataAt)} silent]` : '';
       const phaseLabel = isBlocked
         ? `blocked on ${b.blocked}${waitTime}`
+        : isIdle
+        ? `waiting on input${idleTime}`
         : `[${b.phase}]`;
       const item = new BuilderTreeItem(b.id, `#${b.issueId ?? b.id} ${b.issueTitle ?? ''} ${phaseLabel}`);
       // Stable id (not the churning label) so VSCode persists expansion across
@@ -78,16 +95,20 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
       // toggles the file list.
       item.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
       item.tooltip = `Protocol: ${b.protocol} | Mode: ${b.mode} | Progress: ${b.progress}%`;
-      // contextValue encodes both blocked-state and protocol so menus can
-      // scope by either (e.g., inline Approve only on blocked-builder-*).
+      // contextValue encodes the row's state-family + protocol so menus can
+      // scope by either (Approve Gate inline only on blocked-builder-*;
+      // everything else applies to all three families).
       item.contextValue = isBlocked
         ? `blocked-builder-${b.protocol || 'unknown'}`
+        : isIdle
+        ? `awaiting-builder-${b.protocol || 'unknown'}`
         : `builder-${b.protocol || 'unknown'}`;
-      // 'circle-filled' (a solid status dot, like VSCode's running-process /
-      // port indicators) reads as "this is live" — unlike 'play', which
-      // looks like a button you press to start it.
+      // Three icons for three states: bell (gate), comment-discussion
+      // (silent, likely waiting on a question), circle-filled (live/active).
       item.iconPath = isBlocked
         ? new vscode.ThemeIcon('bell', new vscode.ThemeColor('notificationsWarningIcon.foreground'))
+        : isIdle
+        ? new vscode.ThemeIcon('comment-discussion', new vscode.ThemeColor('notificationsInfoIcon.foreground'))
         : new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('testing.iconPassed'));
       // The row click runs `codev.openBuilderRow` — a wrapper that opens the
       // builder terminal AND expands the row (so single-click matches what

--- a/packages/vscode/src/views/builders.ts
+++ b/packages/vscode/src/views/builders.ts
@@ -6,12 +6,6 @@ import { BuilderTreeItem } from './builder-tree-item.js';
 import { BuilderFileTreeItem } from './builder-file-tree-item.js';
 import type { BuilderDiffCache } from './builder-diff-cache.js';
 
-// `isIdleWaiting` (and its 5-minute threshold) lives in @cluesmith/codev-core
-// so the dashboard reads the same predicate. Re-export here so downstream
-// users of this view module (and the unit tests under test/) keep a single
-// import path; the canonical source is core.
-export { isIdleWaiting };
-
 /**
  * Order builders for the Builders tree: three buckets, top-down.
  *  1. **blocked** (formal gate awaiting approval) — longest-waiting first.

--- a/packages/vscode/src/views/builders.ts
+++ b/packages/vscode/src/views/builders.ts
@@ -89,10 +89,16 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
       item.iconPath = isBlocked
         ? new vscode.ThemeIcon('bell', new vscode.ThemeColor('notificationsWarningIcon.foreground'))
         : new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('testing.iconPassed'));
+      // The row click runs `codev.openBuilderRow` — a wrapper that opens the
+      // builder terminal AND expands the row (so single-click matches what
+      // most users expect). Pass the item itself so the handler can call
+      // `buildersView.reveal(...)` against this row. Other callers
+      // (terminal-link clicks, etc.) still use `codev.openBuilderById`
+      // directly with just the id and don't trigger expansion.
       item.command = {
-        command: 'codev.openBuilderById',
+        command: 'codev.openBuilderRow',
         title: 'Open Builder Terminal',
-        arguments: [b.id],
+        arguments: [item],
       };
       return item;
     });


### PR DESCRIPTION
A grab-bag of VSCode-extension polish around the Builders view, plus a PIR-protocol fix that addresses Layer 2 (PIR slice) of #777.

## What's new in the extension

- **Count badge on the Codev activity-bar icon.** Builders needing your attention (blocked at a gate or idle waiting on input) contribute to a numeric badge on the sidebar icon — visible from anywhere in VSCode without opening the sidebar.
- **Builders waiting silently for input now surface as \"waiting on input.\"** A builder whose terminal has been idle for > 5 min and isn't blocked or finished gets a chat-bubble icon in the Builders tree and an \`N waiting\` segment in the status bar. Catches the case of an agent quietly waiting on a clarifying question; distinct from being blocked at a formal porch gate.
- **Single-click a builder row to expand its file list.** Clicking opens the terminal *and* expands the file list underneath; the chevron is no longer a separate click.
- **Send a backlog issue to the architect inline.** Each backlog row has an inline button that pastes the issue's \`#<id>\` reference into the architect input.
- **Issue markdown previews update live** while open — they refresh in place when the underlying issue changes (new comment, label edit, etc.).

## Preview
<img width="932" height="763" alt="image" src="https://github.com/user-attachments/assets/e163de0b-4476-445e-adc6-3c0b2939e7d0" />


## Fixed

- **#777 Layer 2 (PIR slice).** PIR builder/reviewer prompts no longer hardcode \`main\` as the integration branch. The eight PIR-specific sites (builder-prompt.md, prompts/implement.md, prompts/review.md, consult-types/pr-review.md — plus the matching \`codev-skeleton/protocols/pir/\` copies) now resolve the default branch dynamically via the in-tree resolver pattern from \`view-diff.ts:262-271\`:

  \`\`\`
  \$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || echo main)
  \`\`\`

  Behaviour-preserving on \`main\`-default repos; correct on \`dev\`/\`ci\`/\`master\`-default ones (which is exactly where #777 surfaced). Layer 1 (the consult harness CLI), Layer 2 of the other protocols, Layer 3 (test infrastructure), and the optional porch-side prompt substitution mechanism remain tracked on #777.

## Internal / chore

- Dropped a transitional \`isIdleWaiting\` re-export in \`views/builders.ts\`; consumers import from \`@cluesmith/codev-core/builder-helpers\` directly.
- \`pnpm vscode:publish\` now publishes to both the VS Code Marketplace and Open VSX in one command.
- README layout diagram tidied.

## Verification

- types + core build clean.
- vscode compile (\`tsc --noEmit\` + lint + esbuild) clean.
- vscode mocha tests: **67 passing** (13 new for the idle-waiting predicate + ordering).
- codev vitest: **2974 passing, 13 skipped.**
- dashboard \`tsc -b\` clean.
- Manual end-to-end: idle-waiting verified on a non-\`main\`-default consumer repo — \`/api/overview\` now populates \`lastDataAt\` correctly, the icon flips to chat-bubble after the threshold.

## Branch notes

Branch was renamed from \`feat/vscode-updates-2\` mid-development as the scope grew to include PIR work.

Closes the PIR slice of #777; remaining layers tracked there.