### PR TITLE
[Bugfix #773] Retry POST /api/launch during Tower startup race in E2E global-setup

### DIFF
--- a/codev/projects/bugfix-773-flaky-dashboard-e2e-global-set/status.yaml
+++ b/codev/projects/bugfix-773-flaky-dashboard-e2e-global-set/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-773
 title: flaky-dashboard-e2e-global-set
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-19T21:00:05.748Z'
-updated_at: '2026-05-22T01:34:02.344Z'
+updated_at: '2026-05-22T01:40:54.789Z'

--- a/codev/projects/bugfix-773-flaky-dashboard-e2e-global-set/status.yaml
+++ b/codev/projects/bugfix-773-flaky-dashboard-e2e-global-set/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-773
 title: flaky-dashboard-e2e-global-set
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-19T21:00:05.748Z'
-updated_at: '2026-05-19T21:00:05.749Z'
+updated_at: '2026-05-22T01:34:02.344Z'

--- a/codev/projects/bugfix-773-flaky-dashboard-e2e-global-set/status.yaml
+++ b/codev/projects/bugfix-773-flaky-dashboard-e2e-global-set/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-773
+title: flaky-dashboard-e2e-global-set
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-19T21:00:05.748Z'
+updated_at: '2026-05-19T21:00:05.749Z'

--- a/codev/projects/bugfix-773-flaky-dashboard-e2e-global-set/status.yaml
+++ b/codev/projects/bugfix-773-flaky-dashboard-e2e-global-set/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-773
 title: flaky-dashboard-e2e-global-set
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-19T21:00:05.748Z'
-updated_at: '2026-05-22T01:40:54.789Z'
+updated_at: '2026-05-22T01:45:18.648Z'

--- a/packages/codev/src/agent-farm/__tests__/bugfix-773-launch-retry.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-773-launch-retry.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Regression test for Bugfix #773: Flaky Dashboard E2E global-setup.
+ *
+ * Tower returns HTTP 400 with `error: "Tower is still starting up. Try again
+ * shortly."` while its async `_deps` initialization is in flight. The previous
+ * `global-setup.ts` issued POST /api/launch exactly once and treated any
+ * non-OK response as a benign "workspace may already be active" — so a cold
+ * Tower start raced the test harness, the workspace was never activated, and
+ * every terminal-dependent test timed out 30s later.
+ *
+ * The fix retries POST /api/launch while the response body contains the
+ * "Tower is still starting up" marker, with a bounded total budget. Other
+ * non-OK responses are still tolerated (no retry, no throw) so the existing
+ * "already active" pass-through is preserved.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { launchWorkspaceWithRetry } from './e2e/global-setup.js';
+
+const URL = 'http://localhost:4100/api/launch';
+const WORKSPACE = '/tmp/workspace';
+
+const transientResponse = () =>
+  new Response(
+    JSON.stringify({ success: false, error: 'Tower is still starting up. Try again shortly.' }),
+    { status: 400, headers: { 'Content-Type': 'application/json' } },
+  );
+
+const successResponse = () =>
+  new Response(JSON.stringify({ success: true }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const terminalFailureResponse = () =>
+  new Response(
+    JSON.stringify({ success: false, error: 'Path does not exist: /missing' }),
+    { status: 400, headers: { 'Content-Type': 'application/json' } },
+  );
+
+describe('bugfix #773: launchWorkspaceWithRetry', () => {
+  it('returns ok on the first successful response without retrying', async () => {
+    const fetchFn = vi.fn(async () => successResponse());
+
+    const result = await launchWorkspaceWithRetry(URL, WORKSPACE, { fetchFn });
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.attempts).toBe(1);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries while Tower reports "still starting up", then resolves on success', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(transientResponse())
+      .mockResolvedValueOnce(transientResponse())
+      .mockResolvedValueOnce(successResponse());
+
+    const result = await launchWorkspaceWithRetry(URL, WORKSPACE, {
+      fetchFn,
+      interval: 1,
+      timeout: 1_000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.attempts).toBe(3);
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('does NOT retry a non-transient 4xx — terminal failures fail fast', async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(terminalFailureResponse());
+
+    const result = await launchWorkspaceWithRetry(URL, WORKSPACE, {
+      fetchFn,
+      interval: 1,
+      timeout: 1_000,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(400);
+    expect(result.body).toContain('Path does not exist');
+    expect(result.attempts).toBe(1);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after the timeout if Tower never finishes starting', async () => {
+    // Each call returns a fresh Response — bodies are single-use streams.
+    const fetchFn = vi.fn(async () => transientResponse());
+
+    const result = await launchWorkspaceWithRetry(URL, WORKSPACE, {
+      fetchFn,
+      interval: 10,
+      timeout: 50,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(400);
+    expect(result.body).toContain('Tower is still starting up');
+    expect(result.attempts).toBeGreaterThanOrEqual(2);
+    // Sanity: bounded by the budget, not unbounded retries
+    expect(result.attempts).toBeLessThan(50);
+  });
+
+  it('sends POST /api/launch with the workspacePath in the JSON body', async () => {
+    const fetchFn = vi.fn(async () => successResponse());
+
+    await launchWorkspaceWithRetry(URL, WORKSPACE, { fetchFn });
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      URL,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ workspacePath: WORKSPACE }),
+      }),
+    );
+  });
+});

--- a/packages/codev/src/agent-farm/__tests__/e2e/global-setup.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/global-setup.ts
@@ -6,7 +6,8 @@
  * `.terminal-container` time out because the Terminal component never mounts.
  *
  * This setup:
- *   1. Activates the workspace via POST /api/launch
+ *   1. Activates the workspace via POST /api/launch (with retry on the
+ *      transient "Tower is still starting up" 400 — see bugfix #773)
  *   2. Polls GET /api/state until architect.terminalId is present
  *
  * In CI, set TOWER_ARCHITECT_CMD=bash so the architect terminal uses a plain
@@ -24,20 +25,80 @@ const WORKSPACE_PATH = resolve(__dirname, '../../../../../../');
 const ENCODED_PATH = Buffer.from(WORKSPACE_PATH).toString('base64url');
 const STATE_URL = `${TOWER_URL}/workspace/${ENCODED_PATH}/api/state`;
 
-export default async function globalSetup() {
-  // Step 1: Activate the workspace via POST /api/launch
-  const launchRes = await fetch(`${TOWER_URL}/api/launch`, {
-    method: 'POST',
-    body: JSON.stringify({ workspacePath: WORKSPACE_PATH }),
-    headers: { 'Content-Type': 'application/json' },
-  });
+/**
+ * Tower returns this exact error string while its async `_deps` initialization
+ * is still in progress (see `launchInstance` in tower-instances.ts). The HTTP
+ * layer maps it to 400, but it's a transient startup race, not a genuine
+ * launch failure — the client should retry until Tower is ready.
+ */
+const TOWER_STARTING_MARKER = 'Tower is still starting up';
 
-  const launchBody = await launchRes.text();
-  if (!launchRes.ok) {
-    // Workspace may already be active — only warn if it's a real failure
-    console.warn(`[global-setup] POST /api/launch returned ${launchRes.status}: ${launchBody}`);
+export interface LaunchResult {
+  ok: boolean;
+  status: number;
+  body: string;
+  attempts: number;
+}
+
+/**
+ * POST /api/launch with bounded retry on the transient "Tower is still
+ * starting up" 400. Other non-OK responses (genuinely-failing launches,
+ * an already-active workspace's odd responses, etc.) return immediately
+ * so callers can decide how to react.
+ *
+ * Exported for unit testing — see bugfix-773-launch-retry.test.ts.
+ */
+export async function launchWorkspaceWithRetry(
+  url: string,
+  workspacePath: string,
+  options: {
+    timeout?: number;
+    interval?: number;
+    fetchFn?: typeof fetch;
+  } = {},
+): Promise<LaunchResult> {
+  const timeout = options.timeout ?? 30_000;
+  const interval = options.interval ?? 500;
+  const fetchFn = options.fetchFn ?? fetch;
+  const start = Date.now();
+
+  let attempts = 0;
+  while (true) {
+    attempts++;
+    const res = await fetchFn(url, {
+      method: 'POST',
+      body: JSON.stringify({ workspacePath }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const body = await res.text();
+
+    // Success, or a terminal failure unrelated to the startup race → stop.
+    if (res.ok || !body.includes(TOWER_STARTING_MARKER)) {
+      return { ok: res.ok, status: res.status, body, attempts };
+    }
+
+    // Transient startup race. Retry until the budget is exhausted.
+    if (Date.now() - start + interval >= timeout) {
+      return { ok: false, status: res.status, body, attempts };
+    }
+    await new Promise((r) => setTimeout(r, interval));
+  }
+}
+
+export default async function globalSetup() {
+  // Step 1: Activate the workspace via POST /api/launch (with retry).
+  const launch = await launchWorkspaceWithRetry(`${TOWER_URL}/api/launch`, WORKSPACE_PATH);
+
+  if (!launch.ok) {
+    // Workspace may already be active, or launch genuinely failed — only
+    // warn here so the state poll below can confirm reality.
+    console.warn(
+      `[global-setup] POST /api/launch returned ${launch.status} after ${launch.attempts} attempt(s): ${launch.body}`,
+    );
   } else {
-    console.log(`[global-setup] Workspace activated: ${launchBody}`);
+    console.log(
+      `[global-setup] Workspace activated (${launch.attempts} attempt(s)): ${launch.body}`,
+    );
   }
 
   // Step 2: Poll for architect terminal readiness


### PR DESCRIPTION
## Summary

Playwright's E2E global-setup races against Tower's async `_deps` init: a single `POST /api/launch` issued before Tower is ready receives an HTTP 400 with `error: "Tower is still starting up. Try again shortly."`, which the previous code treated as a benign "workspace may already be active" — so the workspace was never activated and every terminal-dependent test timed out 30 s later. This PR retries on that specific transient signal.

Fixes #773

## Root Cause

`packages/codev/src/agent-farm/__tests__/e2e/global-setup.ts:29` issued `POST /api/launch` exactly once. When Tower's `_deps` wasn't initialized yet, `launchInstance` (`tower-instances.ts:317`) returned `{ success: false, error: 'Tower is still starting up. Try again shortly.' }`, and the route handler (`tower-routes.ts:1163`) mapped any `success: false` to HTTP 400. Global-setup's `if (!launchRes.ok)` branch only warned (under the assumption that a 400 meant "already active") and proceeded straight to the architect-terminal poll — which then timed out after 30 s because the workspace had never actually been activated. Failing run: https://github.com/cluesmith/codev/actions/runs/26087972908.

## Fix

Extracted `launchWorkspaceWithRetry` from `globalSetup` and added a bounded retry loop:

- Retries only while the response body contains the literal `"Tower is still starting up"` marker. Other non-OK responses fall through immediately, preserving the existing "already active" tolerance and failing fast on genuine errors (path-not-found, adopt-failure, etc.).
- Total budget: 30 s at 500 ms intervals — symmetric with the existing architect-terminal poll budget downstream.
- Logs the attempt count so future flakes are diagnosable from CI output.

No product code changed — this is a test-infra-only fix.

## Test Plan

- [x] Regression test added: `bugfix-773-launch-retry.test.ts` (5 tests, all green)
  - first-call success → no retry
  - transient `"Tower is still starting up"` → retries then succeeds
  - non-transient 4xx → fails fast on first attempt
  - timeout exhausted → gives up with the last status/body
  - request shape: POST + JSON body matches Tower contract
- [x] `pnpm build` passes
- [x] Full agent-farm test suite passes (80 files / 1775 tests, 13 pre-existing skips)
- [x] Net diff: 192 + / 12 − across 2 files — under the 300 LOC BUGFIX scope

## CMAP Review (3-way)

| Model  | Verdict | Confidence | Key Issues |
|--------|---------|------------|------------|
| Gemini | APPROVE | HIGH       | None       |
| Codex  | APPROVE | HIGH       | None       |
| Claude | APPROVE | HIGH       | None       |

All three reviewers confirmed the retry scope is correct (matches only the transient marker), the regression tests are deterministic and cover every branch (first-call success, transient-then-success, non-transient fail-fast, timeout exhaustion, request shape), and the change is well-bounded with no product code touched.