### PR TITLE
[Bugfix #826] iter-7: Fix release blocker — LOCAL_SCHEMA CREATE INDEX vs migration order

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/bugfix-826-migration.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-826-migration.test.ts
@@ -151,9 +151,12 @@ describe('Bugfix #826 — Migration v11 (workspace-scoped architect schema)', ()
       localDb.exec(`
         DROP TABLE architect;
         ALTER TABLE architect_v11 RENAME TO architect;
-        CREATE INDEX IF NOT EXISTS idx_architect_workspace ON architect(workspace_path);
       `);
     }
+
+    // iter-7: create the index outside the alreadyMigrated guard so both
+    // upgrade and fresh paths converge. Mirrors production.
+    localDb.exec('CREATE INDEX IF NOT EXISTS idx_architect_workspace ON architect(workspace_path);');
 
     localDb.prepare('INSERT INTO _migrations (version) VALUES (11)').run();
   }
@@ -354,5 +357,118 @@ describe('Bugfix #826 — Migration v11 (workspace-scoped architect schema)', ()
 
     const v11Row = localDb.prepare('SELECT version FROM _migrations WHERE version = 11').get() as { version: number } | undefined;
     expect(v11Row?.version).toBe(11);
+  });
+
+  // ===========================================================================
+  // Bugfix #826 iter-7 — Upgrade-path schema-exec ordering
+  // ===========================================================================
+  //
+  // ensureLocalDatabase runs `db.exec(LOCAL_SCHEMA)` BEFORE migrations on every
+  // open. In iter-4 through iter-6, LOCAL_SCHEMA contained
+  // `CREATE INDEX idx_architect_workspace ON architect(workspace_path)`.
+  // On any existing pre-v11 install (every v3.1.1 user upgrading to v3.1.2),
+  // the architect table lacks the workspace_path column, so the CREATE INDEX
+  // threw 'no such column: workspace_path' and aborted ensureLocalDatabase
+  // before migration v11 could run — the schema stayed at v10 and every
+  // subsequent setArchitectByName call failed with the same error. Release
+  // blocker.
+  //
+  // Fix (iter-7): drop the CREATE INDEX from LOCAL_SCHEMA; create it inside
+  // migration v11's outer block, AFTER the alreadyMigrated inner-if. That
+  // way the index is created on both upgrade installs (after the migration
+  // body) and fresh installs (where LOCAL_SCHEMA already created the v11
+  // table shape and the inner block was a no-op).
+  //
+  // Sentinel: this test runs the production LOCAL_SCHEMA via db.exec against
+  // the v10 architect-table shape. Pre-iter-7 it would throw; post-iter-7 it
+  // must succeed.
+
+  describe('iter-7 release-blocker: LOCAL_SCHEMA must not reference workspace_path before migration', () => {
+    it('db.exec(LOCAL_SCHEMA) succeeds against a pre-v11 architect table', async () => {
+      // Build the v10 architect table shape (no workspace_path column).
+      buildPreV11Schema();
+      localDb.prepare(
+        "INSERT INTO architect (id, pid, port, cmd, started_at, terminal_id) VALUES ('main', 0, 0, 'claude', '2026-05-23T10:00:00Z', 't-main')"
+      ).run();
+
+      // Import the actual production LOCAL_SCHEMA and run it. Pre-iter-7
+      // this throws 'no such column: workspace_path' because the CREATE INDEX
+      // line in LOCAL_SCHEMA references a column that doesn't exist on the
+      // pre-v11 table.
+      const { LOCAL_SCHEMA } = await import('../db/schema.js');
+      expect(() => localDb.exec(LOCAL_SCHEMA)).not.toThrow();
+    });
+
+    it('runs the full pre-migration → LOCAL_SCHEMA → migrate sequence end-to-end (upgrade path)', async () => {
+      // Recreate the production upgrade sequence:
+      //   1. Existing v10 database (architect with no workspace_path).
+      //   2. db.exec(LOCAL_SCHEMA) on open — must not throw.
+      //   3. Migration v11 runs.
+      //   4. Architect table is migrated to v11 shape; index exists.
+      buildPreV11Schema();
+      localDb.prepare(
+        "INSERT INTO architect (id, pid, port, cmd, started_at, terminal_id) VALUES ('main', 0, 0, 'claude', '2026-05-23T10:00:00Z', 't-main')"
+      ).run();
+      globalDb.prepare(
+        "INSERT INTO terminal_sessions (id, workspace_path, type, role_id, pid) VALUES ('t-main', '/workspace/upgrade-user', 'architect', 'main', 1234)"
+      ).run();
+
+      const { LOCAL_SCHEMA } = await import('../db/schema.js');
+      localDb.exec(LOCAL_SCHEMA);
+      runV11Migration();
+
+      // Post-migration: workspace_path column present, row migrated, index exists.
+      const cols = localDb.prepare('PRAGMA table_info(architect)').all() as Array<{ name: string }>;
+      expect(cols.some(c => c.name === 'workspace_path')).toBe(true);
+
+      const rows = localDb.prepare('SELECT workspace_path, id FROM architect').all() as Array<{ workspace_path: string; id: string }>;
+      expect(rows).toEqual([{ workspace_path: '/workspace/upgrade-user', id: 'main' }]);
+
+      const indexes = localDb
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'architect'")
+        .all() as Array<{ name: string }>;
+      expect(indexes.map(i => i.name)).toContain('idx_architect_workspace');
+    });
+
+    it('fresh-install path: LOCAL_SCHEMA creates the v11 table, migration v11 creates the index', async () => {
+      // Fresh install: no pre-existing architect table at all. LOCAL_SCHEMA
+      // creates it with the v11 shape; the migration v11 inner block is a
+      // no-op (workspace_path column already present); the index gets
+      // created by the outer-block CREATE INDEX.
+      localDb.exec(`
+        CREATE TABLE IF NOT EXISTS _migrations (
+          version INTEGER PRIMARY KEY,
+          applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+      `);
+      // Pre-mark prior migrations as done — only v11 should run.
+      for (let v = 1; v <= 10; v++) {
+        localDb.prepare('INSERT INTO _migrations (version) VALUES (?)').run(v);
+      }
+      // Build the global terminal_sessions table so runV11Migration's ATTACH
+      // path doesn't throw — even with no rows, the table must exist.
+      globalDb.exec(`
+        CREATE TABLE IF NOT EXISTS terminal_sessions (
+          id TEXT PRIMARY KEY,
+          workspace_path TEXT NOT NULL,
+          type TEXT NOT NULL CHECK(type IN ('architect', 'builder', 'shell')),
+          role_id TEXT,
+          pid INTEGER
+        );
+      `);
+
+      const { LOCAL_SCHEMA } = await import('../db/schema.js');
+      localDb.exec(LOCAL_SCHEMA);
+
+      // At this point architect already has workspace_path (from LOCAL_SCHEMA).
+      // The migration's inner alreadyMigrated branch fires → skipped — but
+      // the outer-block CREATE INDEX must still run.
+      runV11Migration();
+
+      const indexes = localDb
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'architect'")
+        .all() as Array<{ name: string }>;
+      expect(indexes.map(i => i.name)).toContain('idx_architect_workspace');
+    });
   });
 });

--- a/packages/codev/src/agent-farm/db/index.ts
+++ b/packages/codev/src/agent-farm/db/index.ts
@@ -577,11 +577,21 @@ function ensureLocalDatabase(): Database.Database {
       db.exec(`
         DROP TABLE architect;
         ALTER TABLE architect_v11 RENAME TO architect;
-        CREATE INDEX IF NOT EXISTS idx_architect_workspace ON architect(workspace_path);
       `);
 
       console.log('[info] Migrated architect table: workspace-scoped rows (Bugfix #826)');
     }
+
+    // Bugfix #826 iter-7: create the workspace_path index here, OUTSIDE the
+    // alreadyMigrated guard. The index is NOT in LOCAL_SCHEMA because
+    // db.exec(LOCAL_SCHEMA) runs before migrations on every open — and on a
+    // pre-v11 install the architect table lacks workspace_path, so CREATE
+    // INDEX would throw 'no such column' and abort ensureLocalDatabase before
+    // v11 can run. Placing it here ensures the index is created on both
+    // upgrade installs (after the migration body) and fresh installs (where
+    // LOCAL_SCHEMA already created the v11 table shape and the inner block
+    // was skipped). `IF NOT EXISTS` makes the second-open case a no-op.
+    db.exec('CREATE INDEX IF NOT EXISTS idx_architect_workspace ON architect(workspace_path);');
 
     db.prepare('INSERT INTO _migrations (version) VALUES (11)').run();
   }

--- a/packages/codev/src/agent-farm/db/schema.ts
+++ b/packages/codev/src/agent-farm/db/schema.ts
@@ -19,6 +19,14 @@ CREATE TABLE IF NOT EXISTS _migrations (
 -- Bugfix #826: workspace_path scopes architect rows per workspace, eliminating
 -- the cross-workspace leak. Composite PK lets the same architect name (e.g.
 -- 'main') exist in multiple workspaces without collision.
+--
+-- Bugfix #826 iter-7: idx_architect_workspace is intentionally NOT created
+-- here. LOCAL_SCHEMA runs via db.exec() BEFORE migrations on every open. On
+-- pre-v11 installs the architect table doesn't yet have workspace_path, so a
+-- CREATE INDEX statement referencing that column would throw 'no such column'
+-- and abort ensureLocalDatabase before migration v11 can run — breaking every
+-- upgrade install. The index is created INSIDE migration v11 instead, where
+-- both fresh installs and upgrade installs converge on the same v11 shape.
 CREATE TABLE IF NOT EXISTS architect (
   workspace_path TEXT NOT NULL,
   id TEXT NOT NULL,
@@ -29,7 +37,6 @@ CREATE TABLE IF NOT EXISTS architect (
   terminal_id TEXT,
   PRIMARY KEY (workspace_path, id)
 );
-CREATE INDEX IF NOT EXISTS idx_architect_workspace ON architect(workspace_path);
 
 -- Builder sessions
 CREATE TABLE IF NOT EXISTS builders (


### PR DESCRIPTION
## Summary

Follow-up to merged PR #827 (Fixes #826) — fixes a release blocker discovered during local manazil verification: every v3.1.1 user's upgrade would have crashed at startup.

## Root cause

`ensureLocalDatabase` runs `db.exec(LOCAL_SCHEMA)` BEFORE migrations on every open. PR #827's `LOCAL_SCHEMA` contained:

```sql
CREATE INDEX IF NOT EXISTS idx_architect_workspace ON architect(workspace_path);
```

On any pre-v11 install, the `architect` table lacks the `workspace_path` column. The CREATE INDEX threw `no such column: workspace_path` and aborted `ensureLocalDatabase` before migration v11 could run. The schema stayed at v10 and every subsequent `setArchitectByName` call failed with the same error.

Architect caught it on the user's actual `codev/.agent-farm/state.db`:
> [WARN] Failed to persist architect verify-826-test to state.db: no such column: workspace_path

Fresh installs would have worked (LOCAL_SCHEMA's `CREATE TABLE` would have created the v11 shape from scratch) — but upgrade installs would not.

## Fix

1. **Drop the CREATE INDEX statement from `schema.ts` LOCAL_SCHEMA.**
2. **Add it to `db/index.ts` migration v11 block, OUTSIDE the inner `if (!alreadyMigrated)` guard but inside the outer `if (!v11)` guard.**
   - **Upgrade install**: inner block runs (architect → architect_v11 rename); then `CREATE INDEX IF NOT EXISTS` creates the index on the new table.
   - **Fresh install**: LOCAL_SCHEMA created the v11-shaped table; inner block is a no-op (workspace_path column already present); CREATE INDEX still runs in the outer block.
3. `IF NOT EXISTS` makes subsequent opens (after v11 is recorded in `_migrations`) a no-op.

## Tests

3 new in `bugfix-826-migration.test.ts`:

1. **`db.exec(LOCAL_SCHEMA)` against a pre-v11 architect table no longer throws.** Pre-iter-7 this test would have failed with `no such column`; it's the literal release-blocker repro.
2. **Full upgrade sequence**: v10 schema → LOCAL_SCHEMA → migrate. Asserts the table is migrated AND the index exists.
3. **Fresh-install path**: LOCAL_SCHEMA creates v11 shape → migration inner block skipped → CREATE INDEX still runs in the outer block. Asserts the index exists.

The existing migration tests didn't catch this because they set up the v10 schema directly in SQL and called the migration body — they never exercised LOCAL_SCHEMA's `db.exec` sequence, where the bug lived. Architect explicitly called out this test gap.

## Test results

- 1853 agent-farm unit tests pass.
- `pnpm exec tsc --noEmit` clean.

## Diff stat

3 files, +136 / -3.

## CMAP

Will run 3-way after PR creation per the BUGFIX protocol.