### PR TITLE
[Bugfix #844] Gate NeedsAttention PR rows on porch pr-gate

### DIFF
--- a/codev/projects/bugfix-844-needs-attention-surfaces-prs-b/status.yaml
+++ b/codev/projects/bugfix-844-needs-attention-surfaces-prs-b/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-844
 title: needs-attention-surfaces-prs-b
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-24T16:21:04.768Z'
-updated_at: '2026-05-24T16:26:51.392Z'
+updated_at: '2026-05-24T16:29:06.638Z'

--- a/codev/projects/bugfix-844-needs-attention-surfaces-prs-b/status.yaml
+++ b/codev/projects/bugfix-844-needs-attention-surfaces-prs-b/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-844
 title: needs-attention-surfaces-prs-b
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-24T16:21:04.768Z'
-updated_at: '2026-05-24T16:29:06.638Z'
+updated_at: '2026-05-24T16:41:14.995Z'

--- a/codev/projects/bugfix-844-needs-attention-surfaces-prs-b/status.yaml
+++ b/codev/projects/bugfix-844-needs-attention-surfaces-prs-b/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-844
 title: needs-attention-surfaces-prs-b
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-24T16:21:04.768Z'
-updated_at: '2026-05-24T16:21:04.768Z'
+updated_at: '2026-05-24T16:26:51.392Z'

--- a/codev/projects/bugfix-844-needs-attention-surfaces-prs-b/status.yaml
+++ b/codev/projects/bugfix-844-needs-attention-surfaces-prs-b/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-844
+title: needs-attention-surfaces-prs-b
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-24T16:21:04.768Z'
+updated_at: '2026-05-24T16:21:04.768Z'

--- a/codev/state/bugfix-844_thread.md
+++ b/codev/state/bugfix-844_thread.md
@@ -23,3 +23,20 @@ Three scenarios from acceptance criteria:
 - PR with builder still in `review` phase (blocked == null or some other label) → excluded.
 - PR with builder at `pr` gate (blocked == 'PR review') → included.
 - PR with no associated builder + `reviewStatus === 'REVIEW_REQUIRED'` → included; same but APPROVED → excluded.
+
+## PR-845 — CMAP iter-1
+
+- **Codex**: APPROVE / HIGH. Focused, addresses root cause, solid regression coverage.
+- **Claude**: APPROVE / HIGH. Clean, well-scoped. Flagged `waitingSince` as non-blocking observation.
+- **Gemini**: REQUEST_CHANGES / HIGH. Three points:
+  1. `waitingSince` should use `blockedSince` (not `pr.createdAt`) so the wait-time chip reflects "human became bottleneck" not "PR was opened."
+  2. Unconditional `continue` for pr-gate builders hides them entirely if their PR is missing from `prs` (cache miss, pagination). Only skip when the PR was actually emitted.
+  3. `gateKindClass` needs a `'PR review'` case for the fallback row from (2).
+
+## iter-2 (7ec0fc9c) — addressed all three Gemini points
+
+- `prGateSince: Map<issueId, blockedSince>` replaces `prGateIssueIds: Set<issueId>`.
+- New `emittedPrGateIssueIds: Set<string>` tracks PRs actually emitted; builder loop only dedupes when present.
+- `gateKindClass` gets `'PR review' → 'attention-kind--pr'`.
+- 3 new regression tests; 9/9 pass; full codev build passes.
+- Net diff: 254 LOC (well under the 300 BUGFIX threshold).

--- a/codev/state/bugfix-844_thread.md
+++ b/codev/state/bugfix-844_thread.md
@@ -1,0 +1,25 @@
+# bugfix-844 thread
+
+## Investigation
+
+**Bug**: Needs Attention list surfaces PRs the moment they're created — before CMAP reviews finish — instead of waiting until the builder reaches the porch `pr` gate (the actual "human, please review/merge" signal).
+
+**Root cause confirmed**: `NeedsAttentionList.tsx:42-56` iterates every open PR from `overview.pendingPRs` and emits an attention row unconditionally. There is no cross-reference against builder gate state.
+
+**Signal available**:
+- `OverviewPR.linkedIssue` is already plumbed through (`api.ts:177-185`, populated in `overview.ts:840-849` via `parseLinkedIssue`).
+- `OverviewBuilder.blocked === 'PR review'` is the human-readable label for a builder waiting at the `pr` gate (mapped in `overview.ts:GATE_LABELS`, `'pr': 'PR review'`).
+
+## Approach
+
+In `buildItems`:
+1. Build `prGateIssueIds` = `Set` of `issueId` values where `builder.blocked === 'PR review'`.
+2. PR loop: include a PR if EITHER (a) its `linkedIssue` is in `prGateIssueIds`, OR (b) it has no associated builder *and* `reviewStatus === 'REVIEW_REQUIRED'` (handles human-authored / externally opened PRs — these have no porch gate to wait on).
+3. Keep the `continue` for `blocked === 'PR review'` in the builders loop — without it, a builder at the pr gate would be emitted twice (once by the PR loop, once by the gate loop). The issue text suggested dropping it but that creates duplicates; I'll explain in PR.
+
+## Test plan
+
+Three scenarios from acceptance criteria:
+- PR with builder still in `review` phase (blocked == null or some other label) → excluded.
+- PR with builder at `pr` gate (blocked == 'PR review') → included.
+- PR with no associated builder + `reviewStatus === 'REVIEW_REQUIRED'` → included; same but APPROVED → excluded.

--- a/packages/dashboard/__tests__/NeedsAttentionList.test.tsx
+++ b/packages/dashboard/__tests__/NeedsAttentionList.test.tsx
@@ -117,4 +117,60 @@ describe('NeedsAttentionList buildItems — PR gating (issue #844)', () => {
 
     expect(items.find(i => i.key === 'pr-300')).toBeUndefined();
   });
+
+  it('uses the builder blockedSince (not pr.createdAt) as waitingSince for affiliated PRs', () => {
+    const createdAt = new Date('2026-01-01T00:00:00Z').toISOString();
+    const blockedSince = new Date('2026-01-05T12:00:00Z').toISOString();
+    const prs = [makePR({ id: '400', linkedIssue: '42', createdAt })];
+    const builders = [
+      makeBuilder({ issueId: '42', blocked: 'PR review', blockedGate: 'pr', blockedSince }),
+    ];
+
+    const items = buildItems(prs, builders);
+    const pr = items.find(i => i.key === 'pr-400');
+
+    expect(pr).toBeDefined();
+    expect(pr!.waitingSince).toBe(blockedSince);
+  });
+
+  it('still surfaces a builder stuck at the pr gate when its PR is missing from prs', () => {
+    // Defensive: if a builder is at the pr gate but its PR didn't appear in
+    // `prs` (cache miss / pagination / API error), do NOT silently drop the
+    // builder from Needs Attention.
+    const prs: OverviewPR[] = [];
+    const blockedSince = new Date('2026-01-05T12:00:00Z').toISOString();
+    const builders = [
+      makeBuilder({
+        id: 'bugfix-42',
+        issueId: '42',
+        blocked: 'PR review',
+        blockedGate: 'pr',
+        blockedSince,
+      }),
+    ];
+
+    const items = buildItems(prs, builders);
+
+    expect(items.find(i => i.key === 'gate-bugfix-42')).toBeDefined();
+  });
+
+  it('does NOT double-emit when both the PR and the builder are present', () => {
+    // Regression guard for the dedupe invariant after the missing-PR fallback
+    // was added: when the PR IS emitted, the builder loop must skip.
+    const prs = [makePR({ id: '500', linkedIssue: '42' })];
+    const builders = [
+      makeBuilder({
+        id: 'bugfix-42',
+        issueId: '42',
+        blocked: 'PR review',
+        blockedGate: 'pr',
+        blockedSince: new Date('2026-01-02T00:00:00Z').toISOString(),
+      }),
+    ];
+
+    const items = buildItems(prs, builders);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].key).toBe('pr-500');
+  });
 });

--- a/packages/dashboard/__tests__/NeedsAttentionList.test.tsx
+++ b/packages/dashboard/__tests__/NeedsAttentionList.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { buildItems } from '../src/components/NeedsAttentionList.js';
+import type { OverviewPR, OverviewBuilder } from '../src/lib/api.js';
+
+function makePR(overrides: Partial<OverviewPR> = {}): OverviewPR {
+  return {
+    id: '100',
+    title: 'PR title',
+    url: 'https://github.com/org/repo/pull/100',
+    reviewStatus: 'REVIEW_REQUIRED',
+    linkedIssue: '42',
+    createdAt: new Date('2026-01-01T00:00:00Z').toISOString(),
+    ...overrides,
+  };
+}
+
+function makeBuilder(overrides: Partial<OverviewBuilder> = {}): OverviewBuilder {
+  return {
+    id: 'bugfix-42',
+    issueId: '42',
+    issueTitle: 'Issue 42',
+    phase: 'review',
+    mode: 'strict',
+    gates: {},
+    worktreePath: '/path',
+    roleId: 'builder-bugfix-42',
+    protocol: 'bugfix',
+    planPhases: [],
+    progress: 0.5,
+    blocked: null,
+    blockedGate: null,
+    blockedSince: null,
+    startedAt: null,
+    idleMs: 0,
+    lastDataAt: null,
+    spawnedByArchitect: 'main',
+    ...overrides,
+  };
+}
+
+describe('NeedsAttentionList buildItems — PR gating (issue #844)', () => {
+  it('excludes a PR whose builder is still in CMAP review (not yet at pr gate)', () => {
+    const prs = [makePR({ id: '100', linkedIssue: '42' })];
+    const builders = [makeBuilder({ issueId: '42', blocked: null })];
+
+    const items = buildItems(prs, builders);
+
+    expect(items.find(i => i.key === 'pr-100')).toBeUndefined();
+  });
+
+  it('includes a PR once the builder reaches the pr gate', () => {
+    const prs = [makePR({ id: '100', linkedIssue: '42' })];
+    const builders = [
+      makeBuilder({
+        issueId: '42',
+        blocked: 'PR review',
+        blockedGate: 'pr',
+        blockedSince: new Date('2026-01-02T00:00:00Z').toISOString(),
+      }),
+    ];
+
+    const items = buildItems(prs, builders);
+
+    expect(items.find(i => i.key === 'pr-100')).toBeDefined();
+  });
+
+  it('emits the PR exactly once when builder is at the pr gate (no dedupe double-count)', () => {
+    const prs = [makePR({ id: '100', linkedIssue: '42' })];
+    const builders = [
+      makeBuilder({
+        issueId: '42',
+        blocked: 'PR review',
+        blockedGate: 'pr',
+        blockedSince: new Date('2026-01-02T00:00:00Z').toISOString(),
+      }),
+    ];
+
+    const items = buildItems(prs, builders);
+
+    expect(items.filter(i => i.issueOrPR === '#100')).toHaveLength(1);
+  });
+
+  it('surfaces a human-authored PR (no matching builder) only when reviewStatus is REVIEW_REQUIRED', () => {
+    const required = makePR({ id: '200', linkedIssue: null, reviewStatus: 'REVIEW_REQUIRED' });
+    const approved = makePR({ id: '201', linkedIssue: null, reviewStatus: 'APPROVED' });
+
+    const items = buildItems([required, approved], []);
+
+    expect(items.find(i => i.key === 'pr-200')).toBeDefined();
+    expect(items.find(i => i.key === 'pr-201')).toBeUndefined();
+  });
+
+  it('still surfaces other gate-pending builders (spec/plan/dev review)', () => {
+    const prs: OverviewPR[] = [];
+    const builders = [
+      makeBuilder({
+        id: 'spir-99',
+        issueId: '99',
+        blocked: 'spec review',
+        blockedGate: 'spec-approval',
+        blockedSince: new Date('2026-01-02T00:00:00Z').toISOString(),
+      }),
+    ];
+
+    const items = buildItems(prs, builders);
+
+    expect(items.find(i => i.key === 'gate-spir-99')).toBeDefined();
+  });
+
+  it('treats a PR whose linkedIssue does not match any builder as unaffiliated', () => {
+    // PR claims to link issue 42, but no builder is tracking issue 42 — treat
+    // it the same as a human-authored PR (surface only if reviewStatus needs it).
+    const prs = [makePR({ id: '300', linkedIssue: '42', reviewStatus: 'APPROVED' })];
+    const builders: OverviewBuilder[] = [];
+
+    const items = buildItems(prs, builders);
+
+    expect(items.find(i => i.key === 'pr-300')).toBeUndefined();
+  });
+});

--- a/packages/dashboard/src/components/NeedsAttentionList.tsx
+++ b/packages/dashboard/src/components/NeedsAttentionList.tsx
@@ -25,6 +25,7 @@ function gateKindClass(blocked: string): string {
     case 'spec review': return 'attention-kind--spec';
     case 'plan review': return 'attention-kind--plan';
     case 'code review': return 'attention-kind--code-review';
+    case 'PR review': return 'attention-kind--pr';
     default: return 'attention-kind--plan';
   }
 }
@@ -46,31 +47,43 @@ export function buildItems(prs: OverviewPR[], builders: OverviewBuilder[]): Atte
   // and reaches the porch `pr` gate. Surfacing PRs before that means the
   // reviewer arrives ahead of the AI review comments. Cross-reference each
   // PR against the builder's gate state via `linkedIssue` → `issueId`.
-  const prGateIssueIds = new Set<string>();
+  // Track blockedSince per pr-gate builder so the waiting-time chip measures
+  // "how long since the human became the bottleneck," not "how long since the
+  // PR was opened while CMAP was still running."
+  const prGateSince = new Map<string, string>();
   const builderIssueIds = new Set<string>();
   for (const b of builders) {
     if (b.issueId) {
       builderIssueIds.add(b.issueId);
-      if (b.blocked === 'PR review') prGateIssueIds.add(b.issueId);
+      if (b.blocked === 'PR review' && b.blockedSince) {
+        prGateSince.set(b.issueId, b.blockedSince);
+      }
     }
   }
 
+  // Track which pr-gate builders had their PR successfully emitted. If a
+  // builder is at the pr gate but its PR is missing from `prs` (cache delay,
+  // pagination, transient API failure), the builder loop below still surfaces
+  // it so a real human-action signal isn't silently dropped.
+  const emittedPrGateIssueIds = new Set<string>();
+
   for (const pr of prs) {
     const hasBuilder = pr.linkedIssue !== null && builderIssueIds.has(pr.linkedIssue);
-    const builderAtPrGate = pr.linkedIssue !== null && prGateIssueIds.has(pr.linkedIssue);
+    const gateSince = pr.linkedIssue !== null ? prGateSince.get(pr.linkedIssue) : undefined;
     // Human-authored / externally opened PRs have no porch gate to wait on —
     // fall back to GitHub's reviewDecision and only surface when a review is
     // actually outstanding.
     const unaffiliatedNeedsReview = !hasBuilder && pr.reviewStatus === 'REVIEW_REQUIRED';
-    if (!builderAtPrGate && !unaffiliatedNeedsReview) continue;
+    if (!gateSince && !unaffiliatedNeedsReview) continue;
 
+    if (gateSince && pr.linkedIssue) emittedPrGateIssueIds.add(pr.linkedIssue);
     items.push({
       key: `pr-${pr.id}`,
       issueOrPR: `#${pr.id}`,
       title: pr.title,
       kind: 'PR review',
       kindClass: 'attention-kind--pr',
-      waitingSince: pr.createdAt,
+      waitingSince: gateSince || pr.createdAt,
       url: pr.url,
     });
   }
@@ -78,9 +91,11 @@ export function buildItems(prs: OverviewPR[], builders: OverviewBuilder[]): Atte
   // Builders blocked on gate approvals
   for (const b of builders) {
     if (!b.blocked || !b.blockedSince) continue;
-    // Skip "PR review" — those are emitted by the PR loop above. Without this
-    // skip, builders at the pr gate would be counted twice (once per loop).
-    if (b.blocked === 'PR review') continue;
+    // Skip pr-gate builders only when their PR was actually emitted above.
+    // Without this guard the same builder would be double-counted; with an
+    // unconditional skip a stuck builder whose PR is missing from `prs`
+    // would disappear entirely.
+    if (b.blocked === 'PR review' && b.issueId && emittedPrGateIssueIds.has(b.issueId)) continue;
     const label = b.issueId ? `#${b.issueId}` : b.id;
     items.push({
       key: `gate-${b.id}`,

--- a/packages/dashboard/src/components/NeedsAttentionList.tsx
+++ b/packages/dashboard/src/components/NeedsAttentionList.tsx
@@ -39,11 +39,31 @@ function timeAgo(dateStr: string): string {
   return `${days}d`;
 }
 
-function buildItems(prs: OverviewPR[], builders: OverviewBuilder[]): AttentionItem[] {
+export function buildItems(prs: OverviewPR[], builders: OverviewBuilder[]): AttentionItem[] {
   const items: AttentionItem[] = [];
 
-  // PRs needing review
+  // A PR is genuinely waiting on a human only after the builder finishes CMAP
+  // and reaches the porch `pr` gate. Surfacing PRs before that means the
+  // reviewer arrives ahead of the AI review comments. Cross-reference each
+  // PR against the builder's gate state via `linkedIssue` → `issueId`.
+  const prGateIssueIds = new Set<string>();
+  const builderIssueIds = new Set<string>();
+  for (const b of builders) {
+    if (b.issueId) {
+      builderIssueIds.add(b.issueId);
+      if (b.blocked === 'PR review') prGateIssueIds.add(b.issueId);
+    }
+  }
+
   for (const pr of prs) {
+    const hasBuilder = pr.linkedIssue !== null && builderIssueIds.has(pr.linkedIssue);
+    const builderAtPrGate = pr.linkedIssue !== null && prGateIssueIds.has(pr.linkedIssue);
+    // Human-authored / externally opened PRs have no porch gate to wait on —
+    // fall back to GitHub's reviewDecision and only surface when a review is
+    // actually outstanding.
+    const unaffiliatedNeedsReview = !hasBuilder && pr.reviewStatus === 'REVIEW_REQUIRED';
+    if (!builderAtPrGate && !unaffiliatedNeedsReview) continue;
+
     items.push({
       key: `pr-${pr.id}`,
       issueOrPR: `#${pr.id}`,
@@ -58,7 +78,8 @@ function buildItems(prs: OverviewPR[], builders: OverviewBuilder[]): AttentionIt
   // Builders blocked on gate approvals
   for (const b of builders) {
     if (!b.blocked || !b.blockedSince) continue;
-    // Skip "PR review" — those are already covered by the PRs list
+    // Skip "PR review" — those are emitted by the PR loop above. Without this
+    // skip, builders at the pr gate would be counted twice (once per loop).
     if (b.blocked === 'PR review') continue;
     const label = b.issueId ? `#${b.issueId}` : b.id;
     items.push({


### PR DESCRIPTION
## Summary
Fixes #844

## Root Cause
`packages/dashboard/src/components/NeedsAttentionList.tsx:42-56` iterated every open PR from `overview.pendingPRs` and emitted an attention row unconditionally. There was no cross-reference against the builder's porch gate state, so a PR appeared in **Needs Attention** the moment it was created — *before* the automated CMAP reviews (Gemini / Codex / Claude) had run. Reviewers arrived ahead of the AI review comments.

## Fix
`buildItems` now consults `OverviewBuilder.blocked` / `blockedSince` to decide whether a PR is genuinely waiting on a human:

1. Build `prGateSince` = `Map<issueId, blockedSince>` for builders with `blocked === 'PR review'` (the human-readable label for the porch `pr` gate, mapped in `overview.ts:GATE_LABELS`).
2. For each PR, include it iff EITHER:
   - its `linkedIssue` matches a pr-gate builder (`prGateSince.has(...)`), OR
   - it has no associated builder AND `reviewStatus === 'REVIEW_REQUIRED'` (the human-authored / externally opened case — no porch gate to wait on, so fall back to GitHub's `reviewDecision`).
3. `waitingSince` uses the builder's `blockedSince` for affiliated PRs (the "human became bottleneck" moment), falling back to `pr.createdAt` for unaffiliated PRs.
4. Track `emittedPrGateIssueIds`; the builder loop only dedupes pr-gate builders whose PR was actually emitted. This protects against a stuck builder disappearing if its PR is missing from `prs` (cache miss, pagination, transient API failure).
5. `gateKindClass` gains a `'PR review' → 'attention-kind--pr'` case so the builder-loop fallback row from (4) renders with the same PR styling.

The `linkedIssue` plumbing already existed on `OverviewPR` (populated by `parseLinkedIssue` in `overview.ts`); no API/types change was needed.

### Note on issue suggestion
The issue suggested dropping the `continue` at line 62, but doing so would create duplicate rows (one from the PR loop, one from the builder loop) for the same builder. Kept the skip and conditioned it on the emitted-set so a missing PR doesn't silently hide the gate signal.

## Test Plan
- [x] 9 unit tests covering acceptance criteria + waitingSince + missing-PR fallback + dedupe
- [x] Local tests pass: `pnpm test NeedsAttentionList` → 9/9 passed
- [x] `porch check` passes (build + tests)

### Test scenarios covered
- PR with builder still in CMAP (`blocked === null`) → **excluded** ✓
- PR with builder at `pr` gate → **included** ✓
- PR with builder at `pr` gate → emitted exactly once (dedupe holds) ✓
- Human-authored PR (no builder) + `REVIEW_REQUIRED` → **included** ✓
- Human-authored PR (no builder) + `APPROVED` → **excluded** ✓
- Other gate-pending builders (spec/plan/dev review) still surface ✓
- PR with stale `linkedIssue` (no matching builder) treated as unaffiliated ✓
- Affiliated PR `waitingSince === builder.blockedSince` (not `pr.createdAt`) ✓
- Builder at pr-gate with missing PR still surfaces via builder loop ✓
- Dedupe still holds when both PR and builder are present ✓

## CMAP Review (PR-845, 3-way)

| Model  | Verdict          | Confidence | Notes |
|--------|------------------|------------|-------|
| Codex  | APPROVE          | HIGH       | "Focused, addresses root cause, solid regression coverage." |
| Claude | APPROVE          | HIGH       | "Clean, well-scoped." Flagged `waitingSince` as a non-blocking observation. |
| Gemini | REQUEST_CHANGES  | HIGH       | Three points: `waitingSince` semantics, invisible stuck builders, missing `gateKindClass` case. |

All three of Gemini's points addressed in iter-2 commit `7ec0fc9c`.