### PR TITLE
Fix #848: probe afx (not removed af) in verify-install.mjs

### DIFF
--- a/codev/projects/bugfix-848-ci-verify-install-script-still/status.yaml
+++ b/codev/projects/bugfix-848-ci-verify-install-script-still/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-848
 title: ci-verify-install-script-still
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-25T05:00:55.907Z'
-updated_at: '2026-05-25T05:00:55.908Z'
+updated_at: '2026-05-25T05:02:26.388Z'

--- a/codev/projects/bugfix-848-ci-verify-install-script-still/status.yaml
+++ b/codev/projects/bugfix-848-ci-verify-install-script-still/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-848
+title: ci-verify-install-script-still
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-25T05:00:55.907Z'
+updated_at: '2026-05-25T05:00:55.908Z'

--- a/codev/projects/bugfix-848-ci-verify-install-script-still/status.yaml
+++ b/codev/projects/bugfix-848-ci-verify-install-script-still/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-848
 title: ci-verify-install-script-still
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-25T05:00:55.907Z'
-updated_at: '2026-05-25T05:02:26.388Z'
+updated_at: '2026-05-25T05:05:15.219Z'

--- a/codev/projects/bugfix-848-ci-verify-install-script-still/status.yaml
+++ b/codev/projects/bugfix-848-ci-verify-install-script-still/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-848
 title: ci-verify-install-script-still
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-25T05:00:55.907Z'
-updated_at: '2026-05-25T05:05:15.219Z'
+updated_at: '2026-05-25T05:08:04.561Z'

--- a/codev/state/bugfix-848_thread.md
+++ b/codev/state/bugfix-848_thread.md
@@ -1,0 +1,19 @@
+# bugfix-848 thread
+
+## Investigation
+
+Issue #848: `verify-install.mjs` still probes the removed `af` bin (CI red since #847 merged), and it has never probed `afx` either.
+
+- Confirmed root cause: `packages/codev/scripts/verify-install.mjs:35` lists `'af'` but not `'afx'`.
+- Confirmed no other references to `'af'` remain under `.github/` or `packages/codev/scripts/` via `grep -rn "'af'"`.
+- `packages/codev/package.json` bin map has `afx` (not `af`), so probing `afx` is the right replacement.
+
+## Fix
+
+Single-line change: `['codev', 'af', 'porch', 'consult']` → `['codev', 'afx', 'porch', 'consult']`.
+
+No regression test is added: the script is itself the CI verification test. Changing the list IS the regression guard — the post-install workflow on `main` will fail again immediately if the bin list ever drifts from the bin map.
+
+## Next
+
+Run porch done → 3-way review → PR.

--- a/codev/state/bugfix-848_thread.md
+++ b/codev/state/bugfix-848_thread.md
@@ -14,6 +14,8 @@ Single-line change: `['codev', 'af', 'porch', 'consult']` → `['codev', 'afx', 
 
 No regression test is added: the script is itself the CI verification test. Changing the list IS the regression guard — the post-install workflow on `main` will fail again immediately if the bin list ever drifts from the bin map.
 
-## Next
+## PR
 
-Run porch done → 3-way review → PR.
+PR #851 created. 3-way CMAP all APPROVE (gemini, codex, claude), HIGH confidence each. All three flagged the same out-of-scope observation: `verify-install.mjs` still doesn't probe `team` or `generate-image` (also in the bin map). Not addressed here — out of scope per the issue's "Re-adding af as a bin is out of scope" framing, which sets the precedent that the script's allowlist scope changes belong to a separate ticket.
+
+Protocol complete from the builder side. Awaiting architect merge.

--- a/packages/codev/scripts/verify-install.mjs
+++ b/packages/codev/scripts/verify-install.mjs
@@ -32,7 +32,7 @@ try {
   console.log(`Installing ${targets.join(', ')} into ${prefix}...`);
   execSync(`npm install -g --prefix "${prefix}" ${quoted}`, { stdio: 'inherit' });
 
-  const bins = ['codev', 'af', 'porch', 'consult'];
+  const bins = ['codev', 'afx', 'porch', 'consult'];
   for (const bin of bins) {
     try {
       execSync(`"${join(prefix, 'bin', bin)}" --help`, { stdio: 'pipe' });


### PR DESCRIPTION
## Summary

The post-install CI verification script (`packages/codev/scripts/verify-install.mjs`) still listed the deprecated `af` bin that PR #847 removed from the package's bin map. The `Tests` workflow on `main` went red immediately after #847 merged (exit code 127 — command not found). Replace `'af'` with `'afx'` so the script verifies the canonical agent-farm entrypoint, which the script had never actually covered before.

Fixes #848

## Root Cause

PR #847 dropped `af` from `packages/codev/package.json`'s bin map but didn't update the parallel allowlist in `scripts/verify-install.mjs:35`. The iter-2 cleanup updated the e2e test (`install.e2e.test.ts` asserts `AF_BIN` does not exist) but missed this post-install CI script. As a side effect, the original script also never probed `afx` at all — it had been verifying the deprecated alias and not the canonical entrypoint.

## Fix

One-character payload change:

```diff
-  const bins = ['codev', 'af', 'porch', 'consult'];
+  const bins = ['codev', 'afx', 'porch', 'consult'];
```

No other `'af'` references remain under `.github/` or `packages/codev/scripts/` (grep clean per the acceptance criteria).

## Test Plan

No dedicated unit test is added — `verify-install.mjs` *is* the test. It runs in the `Package Install Verification` job of `.github/workflows/test.yml` against a packed tarball after every push to `main`. The next post-merge run is the regression check; if the bin list ever drifts from `package.json`'s bin map again, that workflow turns red immediately. The existing `install.e2e.test.ts` already asserts `AF_BIN` does not exist and `AFX_BIN` does, covering the source-level contract.

- [x] `verify-install.mjs` probes `afx` instead of `af`
- [x] No other workflow or script references the removed `af` bin
- [x] Local `pnpm --filter @cluesmith/codev test` passes
- [x] Local `pnpm --filter @cluesmith/codev build` passes
- [ ] Post-merge `Tests` workflow on `main` goes green