### PR TITLE
Fix #839: Prefix review-comment commands with "Codev:"

### DIFF
--- a/codev/projects/bugfix-839-review-comment-commands-missin/status.yaml
+++ b/codev/projects/bugfix-839-review-comment-commands-missin/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-839
 title: review-comment-commands-missin
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-26T05:44:32.129Z'
-updated_at: '2026-05-26T05:48:15.926Z'
+updated_at: '2026-05-26T05:51:41.231Z'

--- a/codev/projects/bugfix-839-review-comment-commands-missin/status.yaml
+++ b/codev/projects/bugfix-839-review-comment-commands-missin/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-839
+title: review-comment-commands-missin
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-26T05:44:32.129Z'
+updated_at: '2026-05-26T05:44:32.129Z'

--- a/codev/projects/bugfix-839-review-comment-commands-missin/status.yaml
+++ b/codev/projects/bugfix-839-review-comment-commands-missin/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-839
 title: review-comment-commands-missin
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-26T05:44:32.129Z'
-updated_at: '2026-05-26T05:44:32.129Z'
+updated_at: '2026-05-26T05:45:35.500Z'

--- a/codev/projects/bugfix-839-review-comment-commands-missin/status.yaml
+++ b/codev/projects/bugfix-839-review-comment-commands-missin/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-839
 title: review-comment-commands-missin
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-26T05:44:32.129Z'
-updated_at: '2026-05-26T05:45:35.500Z'
+updated_at: '2026-05-26T05:48:15.926Z'

--- a/codev/state/bugfix-839_thread.md
+++ b/codev/state/bugfix-839_thread.md
@@ -18,3 +18,15 @@ Fix: title-case to match the rest of the command set:
 Net diff: 2 lines.
 
 No regression test possible/needed — this is a static `package.json` manifest entry surfaced by VS Code's marketplace UI. There is no runtime path to assert against; the only "test" is reading the JSON. Will note this in the review.
+
+## PR
+
+PR #864 opened. Build + tests green via porch checks.
+
+## CMAP (iter 1)
+
+- gemini: APPROVE — HIGH confidence
+- codex:  APPROVE — "Scoped manifest fix matches the issue and leaves all 40 contributed command titles consistently prefixed with `Codev:`."
+- claude: APPROVE — "Minimal, correct fix — two command titles prefixed to match convention; all 40 commands verified consistent; no test needed for static manifest entries."
+
+3/3 APPROVE. Notifying architect.

--- a/codev/state/bugfix-839_thread.md
+++ b/codev/state/bugfix-839_thread.md
@@ -1,0 +1,20 @@
+# bugfix-839 thread
+
+## Investigate
+
+Issue #839: two `contributes.commands` entries in `packages/vscode/package.json` are missing the `Codev:` prefix that every other command uses.
+
+Located the two entries at `packages/vscode/package.json:213-220`:
+
+- `codev.submitReviewComment` → `"Submit review comment"`
+- `codev.deleteReviewComment` → `"Delete review comment"`
+
+Grep for these strings across `packages/vscode/` finds them only in `package.json` — no other code/docs reference the title text, so renaming is safe (commands are referenced by their internal id, not the title).
+
+Fix: title-case to match the rest of the command set:
+- `Codev: Submit Review Comment`
+- `Codev: Delete Review Comment`
+
+Net diff: 2 lines.
+
+No regression test possible/needed — this is a static `package.json` manifest entry surfaced by VS Code's marketplace UI. There is no runtime path to assert against; the only "test" is reading the JSON. Will note this in the review.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -211,12 +211,12 @@
       },
       {
         "command": "codev.submitReviewComment",
-        "title": "Submit review comment",
+        "title": "Codev: Submit Review Comment",
         "enablement": "!commentIsEmpty"
       },
       {
         "command": "codev.deleteReviewComment",
-        "title": "Delete review comment",
+        "title": "Codev: Delete Review Comment",
         "icon": "$(trash)"
       }
     ],


### PR DESCRIPTION
## Summary

Two entries in `packages/vscode/package.json#contributes.commands` were missing the `Codev:` prefix that every other command in the extension uses. On the VS Code Feature Contributions tab they appeared as if they came from a different extension. This PR renames the two titles to match the existing title-cased convention (`Codev: Open Builder Terminal`, `Codev: Approve Gate`, …).

Fixes #839

## Root Cause

`codev.submitReviewComment` and `codev.deleteReviewComment` were declared with titles `"Submit review comment"` and `"Delete review comment"`. Both are hidden from the Command Palette via `menus.commandPalette { when: false }` (they target the comment-thread gutter), but the Feature Contributions tab lists every declared command regardless — exposing the inconsistency.

## Fix

`packages/vscode/package.json`:

- `codev.submitReviewComment`: `"Submit review comment"` → `"Codev: Submit Review Comment"`
- `codev.deleteReviewComment`: `"Delete review comment"` → `"Codev: Delete Review Comment"`

Audited all 40 `contributes.commands` entries — every entry now starts with `Codev:`. No other files reference these title strings (commands are wired up by `command` id, not title).

## Test Plan

- [x] Build passes (`pnpm build`)
- [x] All tests pass (porch checks green)
- [x] Audited every `contributes.commands` entry — all 40 now `Codev:`-prefixed
- [ ] No regression test: the change is a static manifest entry surfaced by VS Code's marketplace UI; there is no runtime code path to assert against. The static audit above is the equivalent check.