### PR TITLE
Fix #799: use custom scheme for builder changed-file resourceUri

### DIFF
--- a/codev/projects/bugfix-799-vscode-builder-changed-file-ro/status.yaml
+++ b/codev/projects/bugfix-799-vscode-builder-changed-file-ro/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-799
 title: vscode-builder-changed-file-ro
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-26T05:44:41.621Z'
-updated_at: '2026-05-26T05:48:07.915Z'
+updated_at: '2026-05-26T05:54:09.628Z'

--- a/codev/projects/bugfix-799-vscode-builder-changed-file-ro/status.yaml
+++ b/codev/projects/bugfix-799-vscode-builder-changed-file-ro/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-799
 title: vscode-builder-changed-file-ro
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-26T05:44:41.621Z'
-updated_at: '2026-05-26T05:54:09.628Z'
+updated_at: '2026-05-26T05:55:36.805Z'

--- a/codev/projects/bugfix-799-vscode-builder-changed-file-ro/status.yaml
+++ b/codev/projects/bugfix-799-vscode-builder-changed-file-ro/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-799
+title: vscode-builder-changed-file-ro
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-26T05:44:41.621Z'
+updated_at: '2026-05-26T05:44:41.622Z'

--- a/codev/projects/bugfix-799-vscode-builder-changed-file-ro/status.yaml
+++ b/codev/projects/bugfix-799-vscode-builder-changed-file-ro/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-799
 title: vscode-builder-changed-file-ro
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-26T05:44:41.621Z'
-updated_at: '2026-05-26T05:44:41.622Z'
+updated_at: '2026-05-26T05:48:07.915Z'

--- a/codev/state/bugfix-799_thread.md
+++ b/codev/state/bugfix-799_thread.md
@@ -1,0 +1,45 @@
+# bugfix-799 thread
+
+## Investigate
+
+Issue #799: changed-file rows in Builders view render grey instead of SCM colors.
+
+Root cause confirmed from code reading (the issue body already nailed it; verifying touch points):
+
+- `packages/vscode/src/views/builder-file-tree-item.ts:49` sets `resourceUri = vscode.Uri.file(path.join(worktreePath, rel))`.
+- `resourceUri.scheme === 'file'` makes the row eligible for VSCode's global decoration providers — including the built-in Git decorator, which sees the path as gitignored (it lives under `.builders/<id>/…`) and tints the label with `gitDecoration.ignoredResourceForeground` (grey).
+- Our `BuilderFileDecorationProvider` supplies the `A`/`M`/`D` badge but loses the color tint to Git in the decoration merge.
+
+Only `BuilderFileTreeItem.resourceUri` is ever constructed; nothing else reads `resourceUri` on that class. The `codev.openBuilderFileDiff` handler uses `arg.plan`/`arg.worktreePath`/`arg.baseRef` — not the resourceUri — so changing the scheme doesn't break diff opening. No context-menu entries are wired to scheme === 'file' for `builder-file` rows.
+
+## Plan for fix
+
+Switch the scheme to a custom one (`codev-builder-diff`), so the built-in Git decorator skips the URI. Same `fsPath` (and same basename) ⇒ the file-type icon still resolves.
+
+Touch points:
+
+1. `builder-file-tree-item.ts` — construct the URI via `vscode.Uri.file(...).with({ scheme: BUILDER_FILE_SCHEME })`. Export the helper + scheme so the cache can match.
+2. `builder-diff-cache.ts` — `syncDecorations` must fire the `onDidChangeFileDecorations` event with URIs that match what the tree items carry (same scheme), or VSCode won't re-query our provider for those rows. Switch the map keying to `uri.toString()` so lookups are unambiguous across schemes.
+3. Add regression test asserting the resourceUri scheme is NOT `file`.
+
+Touch size estimate: ~40 LOC. Well within BUGFIX scope.
+
+## Fix
+
+Implemented:
+
+1. **`packages/vscode/src/views/builder-file-tree-item.ts`** — added `BUILDER_FILE_SCHEME = 'codev-builder-diff'` constant and `builderFileResourceUri(worktreePath, rel)` factory. `BuilderFileTreeItem.resourceUri` now uses the helper. The scheme is intentionally not registered as a TextDocumentContentProvider — these URIs are decoration-only markers; the diff is opened via the existing `codev.openBuilderFileDiff` command which builds explicit left/right URIs (the `codev-diff:` content scheme owned by `commands/view-diff.ts` is unchanged).
+2. **`packages/vscode/src/views/builder-diff-cache.ts`** — `syncDecorations` constructs URIs via the same helper so the URI fired through `onDidChangeFileDecorations` matches the one VSCode sees on the tree row (otherwise the cached decoration would go stale on file-list changes). Keying switched from `uri.fsPath` to `uri.toString()` for unambiguous matching across schemes.
+3. **`packages/vscode/src/test/builder-file-tree-item.test.ts`** — 5 regression tests: scheme is non-`file`, scheme matches `BUILDER_FILE_SCHEME`, `decorationFor()` returns the recorded status for the helper-built URI, plain `file:` URI of the same path returns `undefined` (proves the scheme separation), and the change-event URI carries the custom scheme.
+
+Diff size: ~70 LOC (incl. tests + comments). Well within BUGFIX scope.
+
+## Verification
+
+- `pnpm exec tsc --noEmit` → clean
+- `pnpm lint` → clean
+- `pnpm test:unit` (vitest) → 34/34 passing
+- `pnpm test` (vscode-test, Electron) → 83/83 passing, includes the 5 new cases
+
+I have not been able to visually verify the rendered tree colors (no VSCode UI session in the worktree). The fix is mechanical and the issue body diagnosed it precisely; a reviewer running the dev build can confirm by spawning a builder and inspecting the Builders view.
+

--- a/packages/vscode/src/test/builder-file-tree-item.test.ts
+++ b/packages/vscode/src/test/builder-file-tree-item.test.ts
@@ -1,0 +1,116 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import {
+  BUILDER_FILE_SCHEME,
+  BuilderFileTreeItem,
+  builderFileResourceUri,
+} from '../views/builder-file-tree-item.js';
+import { BuilderDiffCache, type BuilderFileChange } from '../views/builder-diff-cache.js';
+import {
+  planResources,
+  type ChangeEntry,
+  type ChangeStatus,
+  type ResourcePlan,
+} from '../commands/view-diff.js';
+
+/**
+ * Regression tests for #799: the changed-file rows under each builder in
+ * the Builders view were rendering with grey filenames because VSCode's
+ * built-in Git FileDecorationProvider was firing on the `file:` URIs
+ * (which point into gitignored `.builders/<id>/…`) and tinting the label
+ * with `gitDecoration.ignoredResourceForeground`, winning the color merge
+ * over our `BuilderFileDecorationProvider`. The fix is to use a custom
+ * scheme on `resourceUri` so the built-in Git decorator skips these rows.
+ */
+
+const WT = '/repo/.builders/0042';
+
+function makeFileChange(path: string, status: ChangeStatus = 'M'): BuilderFileChange {
+  const change: ChangeEntry = { status, oldPath: null, path };
+  const [plan] = planResources([change], new Set<string>());
+  return { change, plan: plan as ResourcePlan };
+}
+
+suite('builderFileResourceUri', () => {
+  test('returns a non-file scheme so the built-in Git decorator skips it', () => {
+    const uri = builderFileResourceUri(WT, 'src/a.ts');
+    // The whole point of the fix — Git only decorates `file:` URIs.
+    assert.notStrictEqual(uri.scheme, 'file');
+    assert.strictEqual(uri.scheme, BUILDER_FILE_SCHEME);
+  });
+
+  test('preserves the worktree-relative fs path (so the file-type icon resolves by basename)', () => {
+    const uri = builderFileResourceUri(WT, 'src/components/Foo.tsx');
+    // basename drives the icon — it must come through unchanged.
+    assert.ok(uri.path.endsWith('/src/components/Foo.tsx'), `path = ${uri.path}`);
+  });
+});
+
+suite('BuilderFileTreeItem (#799)', () => {
+  test('resourceUri uses the custom scheme, not file:', () => {
+    const item = new BuilderFileTreeItem(
+      '0042',
+      WT,
+      'main',
+      { status: 'M', oldPath: null, path: 'src/a.ts' },
+      planResources([{ status: 'M', oldPath: null, path: 'src/a.ts' }], new Set<string>())[0]!,
+    );
+    assert.ok(item.resourceUri, 'resourceUri must be set');
+    assert.strictEqual(item.resourceUri!.scheme, BUILDER_FILE_SCHEME);
+    assert.notStrictEqual(item.resourceUri!.scheme, 'file');
+  });
+});
+
+suite('BuilderDiffCache decorations (#799)', () => {
+  test('decorationFor returns the status for a URI built via the same helper', () => {
+    const cache = new BuilderDiffCache();
+    try {
+      // Internal accessor — exercises the path the real getDiff flow takes.
+      const change = makeFileChange('src/a.ts', 'A');
+      const result = { baseRef: 'main', files: [change] };
+      (cache as unknown as { syncDecorations: (id: string, wt: string, r: typeof result) => void })
+        .syncDecorations('0042', WT, result);
+
+      const uri = builderFileResourceUri(WT, 'src/a.ts');
+      assert.strictEqual(cache.decorationFor(uri), 'A');
+    } finally {
+      cache.dispose();
+    }
+  });
+
+  test('decorationFor returns undefined for a plain file: URI of the same path', () => {
+    // If a stray `file:` URI for the same path slipped into the tree,
+    // we wouldn't decorate it — that's by design under the new scheme.
+    const cache = new BuilderDiffCache();
+    try {
+      const change = makeFileChange('src/a.ts', 'M');
+      (cache as unknown as { syncDecorations: (id: string, wt: string, r: { baseRef: string; files: BuilderFileChange[] }) => void })
+        .syncDecorations('0042', WT, { baseRef: 'main', files: [change] });
+
+      const fileUri = vscode.Uri.file(`${WT}/src/a.ts`);
+      assert.strictEqual(cache.decorationFor(fileUri), undefined);
+    } finally {
+      cache.dispose();
+    }
+  });
+
+  test('onDidChangeDecorations fires URIs with the custom scheme (so VSCode re-queries tree rows)', async () => {
+    const cache = new BuilderDiffCache();
+    try {
+      const fired: vscode.Uri[] = [];
+      const sub = cache.onDidChangeDecorations(uris => fired.push(...uris));
+      try {
+        const change = makeFileChange('src/a.ts', 'A');
+        (cache as unknown as { syncDecorations: (id: string, wt: string, r: { baseRef: string; files: BuilderFileChange[] }) => void })
+          .syncDecorations('0042', WT, { baseRef: 'main', files: [change] });
+
+        assert.strictEqual(fired.length, 1, `expected 1 URI fired, got ${fired.length}`);
+        assert.strictEqual(fired[0]!.scheme, BUILDER_FILE_SCHEME);
+      } finally {
+        sub.dispose();
+      }
+    } finally {
+      cache.dispose();
+    }
+  });
+});

--- a/packages/vscode/src/views/builder-diff-cache.ts
+++ b/packages/vscode/src/views/builder-diff-cache.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import * as path from 'node:path';
 import {
   getBuilderChanges,
   planResources,
@@ -7,6 +6,7 @@ import {
   type ChangeStatus,
   type ResourcePlan,
 } from '../commands/view-diff.js';
+import { builderFileResourceUri } from './builder-file-tree-item.js';
 
 /**
  * A changed file paired with its diff plan. `planResources` maps
@@ -28,7 +28,7 @@ export interface BuilderDiffResult {
 
 /**
  * TTL cache around `getBuilderChanges` keyed by builder id, plus a global
- * `fsPath → git status` registry that backs the SCM-style file decorations
+ * `uri → git status` registry that backs the SCM-style file decorations
  * (colored status letter on each changed-file row).
  *
  * Why the TTL: VSCode re-queries an *expanded* tree node's children on
@@ -40,10 +40,10 @@ export interface BuilderDiffResult {
 export class BuilderDiffCache {
   private readonly cache = new Map<string, { ts: number; result: BuilderDiffResult }>();
 
-  /** fsPath → status for every file currently shown across builders. */
+  /** uri.toString() → status for every file currently shown across builders. */
   private readonly decorations = new Map<string, ChangeStatus>();
-  /** builderId → the fsPaths it contributed, so a recompute can replace them. */
-  private readonly builderPaths = new Map<string, string[]>();
+  /** builderId → the URIs it contributed, so a recompute can replace them. */
+  private readonly builderUris = new Map<string, vscode.Uri[]>();
 
   private readonly _onDidChangeDecorations = new vscode.EventEmitter<vscode.Uri[]>();
   /** Fires the affected file URIs whenever the decoration map changes. */
@@ -53,7 +53,7 @@ export class BuilderDiffCache {
 
   /** Status for a file URI, or undefined if it isn't a tracked change. */
   decorationFor(uri: vscode.Uri): ChangeStatus | undefined {
-    return this.decorations.get(uri.fsPath);
+    return this.decorations.get(uri.toString());
   }
 
   async getDiff(builderId: string, worktreePath: string): Promise<BuilderDiffResult> {
@@ -92,22 +92,34 @@ export class BuilderDiffCache {
   /**
    * Replace this builder's contribution to the decoration map and notify
    * listeners of every affected URI (old ∪ new) so VSCode re-queries them.
+   *
+   * URIs are constructed via the same helper `BuilderFileTreeItem` uses,
+   * so the scheme/path match exactly — VSCode keys decoration cache
+   * entries by the full URI, not by fsPath, so a scheme mismatch would
+   * leave stale decorations on screen after a file list change.
    */
   private syncDecorations(builderId: string, worktreePath: string, result: BuilderDiffResult): void {
-    const oldPaths = this.builderPaths.get(builderId) ?? [];
-    for (const p of oldPaths) { this.decorations.delete(p); }
+    const oldUris = this.builderUris.get(builderId) ?? [];
+    for (const u of oldUris) { this.decorations.delete(u.toString()); }
 
-    const newPaths: string[] = [];
+    const newUris: vscode.Uri[] = [];
     for (const f of result.files) {
-      const fsPath = vscode.Uri.file(path.join(worktreePath, f.change.path)).fsPath;
-      this.decorations.set(fsPath, f.change.status);
-      newPaths.push(fsPath);
+      const uri = builderFileResourceUri(worktreePath, f.change.path);
+      this.decorations.set(uri.toString(), f.change.status);
+      newUris.push(uri);
     }
-    this.builderPaths.set(builderId, newPaths);
+    this.builderUris.set(builderId, newUris);
 
-    const affected = [...new Set([...oldPaths, ...newPaths])];
+    const seen = new Set<string>();
+    const affected: vscode.Uri[] = [];
+    for (const u of [...oldUris, ...newUris]) {
+      const key = u.toString();
+      if (seen.has(key)) { continue; }
+      seen.add(key);
+      affected.push(u);
+    }
     if (affected.length > 0) {
-      this._onDidChangeDecorations.fire(affected.map(p => vscode.Uri.file(p)));
+      this._onDidChangeDecorations.fire(affected);
     }
   }
 

--- a/packages/vscode/src/views/builder-file-tree-item.ts
+++ b/packages/vscode/src/views/builder-file-tree-item.ts
@@ -17,6 +17,33 @@ import type { ChangeEntry, ChangeStatus, ResourcePlan } from '../commands/view-d
  * Used by views/builders.ts.
  */
 
+/**
+ * Scheme for builder changed-file `resourceUri`s. Deliberately NOT `file:`
+ * so VSCode's built-in Git FileDecorationProvider — which fires for every
+ * `file:` URI rendered in the editor — does not also decorate these rows.
+ * With a `file:` URI, Git sees the gitignored `.builders/<id>/…` path and
+ * tints the label with `gitDecoration.ignoredResourceForeground` (grey),
+ * winning the color merge over our SCM-style status colors (#799). The
+ * file-type icon still resolves because `IFileIconTheme` keys off
+ * basename, not scheme.
+ *
+ * No TextDocumentContentProvider is registered for this scheme — these
+ * URIs are markers for the tree row only; the diff is opened via
+ * `codev.openBuilderFileDiff`, which builds explicit left/right URIs.
+ */
+export const BUILDER_FILE_SCHEME = 'codev-builder-diff';
+
+/**
+ * Build the `resourceUri` for a builder changed-file row. Used by both
+ * `BuilderFileTreeItem` (the tree item shown to the user) and
+ * `BuilderDiffCache` (when firing decoration-change events) so the two
+ * URIs match exactly — VSCode keys decoration cache entries by URI, so a
+ * mismatch would leave stale decorations on screen.
+ */
+export function builderFileResourceUri(worktreePath: string, rel: string): vscode.Uri {
+  return vscode.Uri.file(path.join(worktreePath, rel)).with({ scheme: BUILDER_FILE_SCHEME });
+}
+
 const STATUS_LABEL: Record<ChangeStatus, string> = {
   A: 'Added',
   D: 'Deleted',
@@ -45,8 +72,10 @@ export class BuilderFileTreeItem extends vscode.TreeItem {
         ? `${dirLabel ? dirLabel + '  ' : ''}↤ ${change.oldPath}`
         : dirLabel;
 
-    // resourceUri → native file-type icon + the decoration-provider badge.
-    this.resourceUri = vscode.Uri.file(path.join(worktreePath, rel));
+    // resourceUri → native file-type icon + our decoration-provider badge.
+    // Custom scheme keeps the built-in Git decorator from firing on the
+    // gitignored worktree path and tinting the label grey (#799).
+    this.resourceUri = builderFileResourceUri(worktreePath, rel);
     this.tooltip = `${STATUS_LABEL[change.status] ?? 'Changed'} · ${rel}`;
     this.contextValue = 'builder-file';
     this.command = {


### PR DESCRIPTION
## Summary

- Switches `BuilderFileTreeItem.resourceUri` from `file:` to a custom `codev-builder-diff:` scheme so VSCode's built-in Git FileDecorationProvider stops firing on these rows and overriding our SCM-style colors with `gitDecoration.ignoredResourceForeground` (grey).
- Adds a shared `builderFileResourceUri(worktreePath, rel)` helper used by both `BuilderFileTreeItem` and `BuilderDiffCache.syncDecorations`, and switches the decoration map's keying to `uri.toString()` so the URI fired through `onDidChangeFileDecorations` matches what the tree row carries.
- Adds 5 regression cases (`src/test/builder-file-tree-item.test.ts`) covering the scheme, the decoration lookup, and the change event.

Fixes #799.

## Why custom scheme

VSCode's `IDecorationService` is global — every registered `FileDecorationProvider` is queried for every `file:` URI rendered anywhere in the editor. For our changed-file rows pointing into gitignored `.builders/<id>/…`, the built-in Git decorator wins the color merge (it contributes no badge, so ours stays — but its `ignoredResourceForeground` tint clobbers our status color). Using a non-`file:` scheme is the canonical workaround: `IFileIconTheme` keys off basename so the file-type icon still resolves, and Git's decorator only acts on `scheme === 'file'`.

No `TextDocumentContentProvider` is registered for the new scheme — these URIs are markers for the tree row only. The diff is opened via the existing `codev.openBuilderFileDiff` command, which builds explicit left/right URIs and is unaffected by the scheme change.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm lint` clean
- [x] `pnpm test:unit` (vitest) → 34/34 passing
- [x] `pnpm test` (vscode-test) → 83/83 passing, includes the 5 new cases
- [ ] Visual confirmation in a running VSCode session: spawn a builder, expand it in the Builders view, verify Added rows render green / Modified yellow / Deleted red in list-mode and tree-mode