### PR TITLE
[Bugfix #870] Wire up max_iterations as safety ceiling; treat COMMENT and REQUEST_CHANGES asymmetrically

### DIFF
--- a/codev-skeleton/protocols/aspir/protocol.json
+++ b/codev-skeleton/protocols/aspir/protocol.json
@@ -23,7 +23,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 1,
+      "max_iterations": 8,
       "on_complete": {
         "commit": true,
         "push": true
@@ -44,7 +44,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 1,
+      "max_iterations": 8,
       "on_complete": {
         "commit": true,
         "push": true
@@ -70,7 +70,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 1,
+      "max_iterations": 8,
       "on_complete": {
         "commit": true,
         "push": true
@@ -107,7 +107,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 1,
+      "max_iterations": 8,
       "on_complete": {
         "commit": true,
         "push": true
@@ -160,7 +160,7 @@
   },
   "defaults": {
     "mode": "strict",
-    "max_iterations": 1,
+    "max_iterations": 8,
     "verify": {
       "models": ["gemini", "codex", "claude"],
       "parallel": true

--- a/codev-skeleton/protocols/spir/protocol.json
+++ b/codev-skeleton/protocols/spir/protocol.json
@@ -24,7 +24,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 1,
+      "max_iterations": 8,
       "on_complete": {
         "commit": true,
         "push": true
@@ -46,7 +46,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 1,
+      "max_iterations": 8,
       "on_complete": {
         "commit": true,
         "push": true
@@ -73,7 +73,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 1,
+      "max_iterations": 8,
       "on_complete": {
         "commit": true,
         "push": true
@@ -110,7 +110,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 1,
+      "max_iterations": 8,
       "on_complete": {
         "commit": true,
         "push": true
@@ -163,7 +163,7 @@
   },
   "defaults": {
     "mode": "strict",
-    "max_iterations": 1,
+    "max_iterations": 8,
     "verify": {
       "models": ["gemini", "codex", "claude"],
       "parallel": true

--- a/codev/projects/bugfix-870-porch-max-iterations-enforceme/status.yaml
+++ b/codev/projects/bugfix-870-porch-max-iterations-enforceme/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-870
 title: porch-max-iterations-enforceme
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-26T18:04:27.519Z'
-updated_at: '2026-05-26T18:23:25.932Z'
+updated_at: '2026-05-26T18:23:56.560Z'

--- a/codev/projects/bugfix-870-porch-max-iterations-enforceme/status.yaml
+++ b/codev/projects/bugfix-870-porch-max-iterations-enforceme/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-870
 title: porch-max-iterations-enforceme
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-26T18:04:27.519Z'
-updated_at: '2026-05-26T18:04:27.520Z'
+updated_at: '2026-05-26T18:23:25.932Z'

--- a/codev/projects/bugfix-870-porch-max-iterations-enforceme/status.yaml
+++ b/codev/projects/bugfix-870-porch-max-iterations-enforceme/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-870
+title: porch-max-iterations-enforceme
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-26T18:04:27.519Z'
+updated_at: '2026-05-26T18:04:27.520Z'

--- a/codev/protocols/aspir/protocol.json
+++ b/codev/protocols/aspir/protocol.json
@@ -23,7 +23,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 1,
+      "max_iterations": 8,
       "on_complete": {
         "commit": true,
         "push": true
@@ -44,7 +44,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 1,
+      "max_iterations": 8,
       "on_complete": {
         "commit": true,
         "push": true
@@ -70,7 +70,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 1,
+      "max_iterations": 8,
       "on_complete": {
         "commit": true,
         "push": true
@@ -107,7 +107,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 1,
+      "max_iterations": 8,
       "on_complete": {
         "commit": true,
         "push": true
@@ -160,7 +160,7 @@
   },
   "defaults": {
     "mode": "strict",
-    "max_iterations": 1,
+    "max_iterations": 8,
     "verify": {
       "models": ["gemini", "codex", "claude"],
       "parallel": true

--- a/codev/protocols/spir/protocol.json
+++ b/codev/protocols/spir/protocol.json
@@ -24,7 +24,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 1,
+      "max_iterations": 8,
       "on_complete": {
         "commit": true,
         "push": true
@@ -46,7 +46,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 1,
+      "max_iterations": 8,
       "on_complete": {
         "commit": true,
         "push": true
@@ -73,7 +73,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 1,
+      "max_iterations": 8,
       "on_complete": {
         "commit": true,
         "push": true
@@ -110,7 +110,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 1,
+      "max_iterations": 8,
       "on_complete": {
         "commit": true,
         "push": true
@@ -163,7 +163,7 @@
   },
   "defaults": {
     "mode": "strict",
-    "max_iterations": 1,
+    "max_iterations": 8,
     "verify": {
       "models": ["gemini", "codex", "claude"],
       "parallel": true

--- a/codev/state/bugfix-870_thread.md
+++ b/codev/state/bugfix-870_thread.md
@@ -1,0 +1,41 @@
+# bugfix-870 thread
+
+## Phase: investigate (2026-05-26)
+
+Picking up issue #870: `getMaxIterations()` is dead code; porch ignores per-phase `max_iterations`.
+
+Confirmed via grep — the only references in `packages/codev/src/`:
+- `protocol.ts:228` — default parsing
+- `protocol.ts:403` — definition (no other callers)
+- `next.ts:617` — phantom comment that says "this MUST come before the max_iterations safety valve" but the safety valve doesn't exist
+
+The verdict-handling flow in `next.ts:587-650` reaches the "no rebuttal yet — emit write rebuttal task" path on every iteration. There's no cap.
+
+Design question for architect (from issue): Option A (cap at 1, force-advance) vs Option B (raise default to 2 + wire up). Reporter prefers Option B.
+
+Plan: implement the wiring (Option B). The default-value bump is a single-line config decision; the wiring is the same in either option. I'll set the default to 2 in `protocol.ts:228` AND wire up the force-advance.
+
+## 18:08 — Architect scope redirect
+
+Reporter retracted the per-N-cap framing. New policy:
+- ADVANCE on all-APPROVE-or-COMMENT (already handled by `allApprove` in verdict.ts:57)
+- RE-ITER on any REQUEST_CHANGES, no normal-flow cap
+- SAFETY CEILING via `getMaxIterations` (default 8), invoked only when REQUEST_CHANGES persists for many rounds
+
+Current behavior verification:
+- `getMaxIterations` is dead code (zero callers — confirmed)
+- The rebuttal-exists branch at next.ts:594-614 currently *advances* the phase regardless of remaining REQUEST_CHANGES. That's the OPPOSITE of re-iter.
+- I cannot find any code that increments `state.iteration`. The cycle the reporter observed must have come from some other mechanism (architect re-running consult manually, or a different fork).
+
+Implementation plan:
+1. Rewrite the rebuttal-exists branch in next.ts: record reviews → check max_iterations safety ceiling → either force-advance (with audit trail) or re-iter (increment iteration, build_complete=false).
+2. Add `force_advanced` audit field to ProjectState type.
+3. Bump SPIR/ASPIR `max_iterations: 1 → 8` per phase to enable normal-flow re-iter.
+4. Leave PIR at `max_iterations: 1` — its docs explicitly require single-pass advisory; the new safety ceiling makes that semantic correct (force-advances immediately on iter=1 REQUEST_CHANGES).
+5. Bump default in protocol.ts:228 from `?? 1 → ?? 8`.
+6. Replace phantom comment at next.ts:617-618 with comment that describes live code.
+7. Tests: (a) all-APPROVE-or-COMMENT → advance; (b) REQUEST_CHANGES + rebuttal → re-iter; (c) iter==ceiling + REQUEST_CHANGES → force-advance with audit trail.
+
+## 18:10 — Scope note on PR voice
+
+Architect: keep PR description, commit messages, code comments GENERIC. No external-adopter workspace names, no project IDs, no business-logic specifics. Issue body and reframe comment are already scrubbed — mirror that.

--- a/codev/state/bugfix-870_thread.md
+++ b/codev/state/bugfix-870_thread.md
@@ -39,3 +39,22 @@ Implementation plan:
 ## 18:10 — Scope note on PR voice
 
 Architect: keep PR description, commit messages, code comments GENERIC. No external-adopter workspace names, no project IDs, no business-logic specifics. Issue body and reframe comment are already scrubbed — mirror that.
+
+## 18:23 — Implementation complete
+
+Code committed (abc06392), thread committed (5486e108), pushed to origin/builder/bugfix-870. PR #871 created. Diff: 237 LOC, 8 files. Full test suite: 3141 passed, 0 failed, 13 skipped (unrelated). Porch suite isolated: 319 passed.
+
+## 18:30 — CMAP unanimous APPROVE
+
+3-way `consult --protocol bugfix --type pr` (with `--project-id bugfix-870` to disambiguate the worktree's projects dir):
+
+- Gemini → APPROVE / HIGH / no issues
+- Codex → APPROVE / HIGH / no issues
+- Claude → APPROVE / HIGH / no issues (also flagged that the existing rebuttal-advance test still works because the test fixture's `max_iterations: 1` puts iter=1 at the ceiling → force-advance path, same observable `gate_pending` outcome)
+
+All reviews saved to `codev/projects/bugfix-870-porch-max-iterations-enforceme/`. PR body updated with CMAP summary table.
+
+## Open items
+
+- Architect approval needed before merge.
+- One minor lift the architect may want to consider for follow-up: PIR docs (`prompts/review.md`, `consult-types/pr-review.md`) describe `max_iterations: 1` as the canonical lever for "single advisory pass" — that wording is still correct in spirit, but the mechanical force-advance + audit-trail trace it now produces could be mentioned in the PIR docs so a future reader knows what to look for. Out of scope for this BUGFIX.

--- a/packages/codev/src/commands/porch/__tests__/next.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/next.test.ts
@@ -467,6 +467,120 @@ describe('porch next', () => {
   });
 
   // --------------------------------------------------------------------------
+  // Issue #870 — asymmetric COMMENT vs REQUEST_CHANGES policy
+  // --------------------------------------------------------------------------
+
+  it('advances when reviewers return only COMMENT verdicts (no REQUEST_CHANGES)', async () => {
+    // Asymmetric policy: COMMENT is not a change-request, so any combination
+    // of APPROVE and COMMENT (with no REQUEST_CHANGES) must advance directly,
+    // not emit a rebuttal task.
+    const state = makeState({ build_complete: true });
+    setupState(testDir, state);
+
+    const projectDir = getProjectDir(testDir, '0001', 'test-feature');
+    fs.mkdirSync(projectDir, { recursive: true });
+
+    const approveContent = `Review text that is long enough to pass the minimum length threshold for parsing.\n\n---\nVERDICT: APPROVE\n---`;
+    const commentContent = `Review text that is long enough to pass the minimum length threshold for parsing.\n\n---\nVERDICT: COMMENT\n---`;
+
+    fs.writeFileSync(path.join(projectDir, '0001-specify-iter1-gemini.txt'), approveContent);
+    fs.writeFileSync(path.join(projectDir, '0001-specify-iter1-codex.txt'), commentContent);
+    fs.writeFileSync(path.join(projectDir, '0001-specify-iter1-claude.txt'), commentContent);
+
+    const result = await next(testDir, '0001');
+
+    expect(result.status).toBe('gate_pending');
+    expect(result.gate).toBe('spec-approval');
+    // No rebuttal task should have been emitted
+    expect(result.tasks![0].subject).not.toContain('Write rebuttal');
+  });
+
+  it('re-iters when rebuttal exists and iteration is below the safety ceiling', async () => {
+    // Set up a protocol with max_iterations: 5 so iter=2 is well below the ceiling.
+    const reIterProtocol = JSON.parse(JSON.stringify(spirProtocol));
+    reIterProtocol.phases.find((p: { id: string }) => p.id === 'specify').max_iterations = 5;
+    setupProtocol(testDir, 'spir', reIterProtocol);
+
+    const state = makeState({ build_complete: true, iteration: 2 });
+    setupState(testDir, state);
+
+    const projectDir = getProjectDir(testDir, '0001', 'test-feature');
+    fs.mkdirSync(projectDir, { recursive: true });
+
+    const approveContent = `Review text that is long enough to pass the minimum length threshold for parsing.\n\n---\nVERDICT: APPROVE\n---`;
+    const rcContent = `Review text that is long enough to pass the minimum length threshold for parsing.\n\n---\nVERDICT: REQUEST_CHANGES\n---`;
+    fs.writeFileSync(path.join(projectDir, '0001-specify-iter2-gemini.txt'), approveContent);
+    fs.writeFileSync(path.join(projectDir, '0001-specify-iter2-codex.txt'), rcContent);
+    fs.writeFileSync(path.join(projectDir, '0001-specify-iter2-claude.txt'), approveContent);
+    fs.writeFileSync(
+      path.join(projectDir, '0001-specify-iter2-rebuttals.md'),
+      '## Rebuttal\n\nAddressing codex feedback...'
+    );
+
+    const result = await next(testDir, '0001');
+
+    // Re-iter: porch should now emit a fresh build task (iter=3)
+    expect(result.status).toBe('tasks');
+    expect(result.iteration).toBe(3);
+    expect(result.tasks![0].subject).toContain('Specify');
+    expect(result.tasks![0].subject).toContain('iteration');
+
+    // State on disk reflects the increment and reset build_complete
+    const statusPath = getStatusPath(testDir, '0001', 'test-feature');
+    const persisted = JSON.parse(JSON.stringify(
+      // status.yaml uses YAML; just match the salient fields
+      { content: fs.readFileSync(statusPath, 'utf-8') }
+    ));
+    expect(persisted.content).toContain('iteration: 3');
+    expect(persisted.content).toContain('build_complete: false');
+    // No force_advanced field should have been written
+    expect(persisted.content).not.toContain('force_advanced:');
+  });
+
+  it('force-advances with audit trail when REQUEST_CHANGES persists at the safety ceiling', async () => {
+    // Set up a protocol with max_iterations: 2 so iter=2 IS the ceiling.
+    const ceilingProtocol = JSON.parse(JSON.stringify(spirProtocol));
+    ceilingProtocol.phases.find((p: { id: string }) => p.id === 'specify').max_iterations = 2;
+    setupProtocol(testDir, 'spir', ceilingProtocol);
+
+    const state = makeState({ build_complete: true, iteration: 2 });
+    setupState(testDir, state);
+
+    const projectDir = getProjectDir(testDir, '0001', 'test-feature');
+    fs.mkdirSync(projectDir, { recursive: true });
+
+    const approveContent = `Review text that is long enough to pass the minimum length threshold for parsing.\n\n---\nVERDICT: APPROVE\n---`;
+    const rcContent = `Review text that is long enough to pass the minimum length threshold for parsing.\n\n---\nVERDICT: REQUEST_CHANGES\n---`;
+    fs.writeFileSync(path.join(projectDir, '0001-specify-iter2-gemini.txt'), approveContent);
+    fs.writeFileSync(path.join(projectDir, '0001-specify-iter2-codex.txt'), rcContent);
+    fs.writeFileSync(path.join(projectDir, '0001-specify-iter2-claude.txt'), approveContent);
+    fs.writeFileSync(
+      path.join(projectDir, '0001-specify-iter2-rebuttals.md'),
+      '## Rebuttal\n\nThe outstanding feedback is unactionable.'
+    );
+
+    const result = await next(testDir, '0001');
+
+    // Force-advance still passes through handleVerifyApproved → gate request
+    expect(result.status).toBe('gate_pending');
+    expect(result.gate).toBe('spec-approval');
+    // Ceiling notice prepended to the gate task description
+    expect(result.tasks![0].description).toContain('FORCE-ADVANCE');
+    expect(result.tasks![0].description).toContain('safety ceiling = 2');
+    expect(result.tasks![0].description).toContain('0001-specify-iter2-rebuttals.md');
+
+    // Audit trail on status.yaml
+    const statusPath = getStatusPath(testDir, '0001', 'test-feature');
+    const persisted = fs.readFileSync(statusPath, 'utf-8');
+    expect(persisted).toContain('force_advanced:');
+    expect(persisted).toContain('max_iterations: 2');
+    expect(persisted).toContain('rebuttal_file: 0001-specify-iter2-rebuttals.md');
+
+    // Rebuttal file is preserved on disk
+    expect(fs.existsSync(path.join(projectDir, '0001-specify-iter2-rebuttals.md'))).toBe(true);
+  });
+
+  // --------------------------------------------------------------------------
   // Rebuttal advancement — advances when rebuttal file exists
   // --------------------------------------------------------------------------
 

--- a/packages/codev/src/commands/porch/next.ts
+++ b/packages/codev/src/commands/porch/next.ts
@@ -24,6 +24,7 @@ import {
   getVerifyConfig,
   getOnCompleteConfig,
   getPhaseChecks,
+  getMaxIterations,
 } from './protocol.js';
 import {
   extractPlanPhases,
@@ -590,10 +591,14 @@ async function handleBuildVerify(
       return await handleVerifyApproved(workspaceRoot, projectId, state, protocol, statusPath, reviews);
     }
 
-    // Some request changes — check for rebuttal file first
+    // At least one reviewer returned REQUEST_CHANGES (allApprove above
+    // already advanced when verdicts were all APPROVE-or-COMMENT, per
+    // verdict.ts:57). Policy: re-iter on any REQUEST_CHANGES with no
+    // count limit in normal flow; getMaxIterations is consulted only as
+    // a safety ceiling for runaway prevention. See issue #870.
     const rebuttalFile = findRebuttalFile(workspaceRoot, state, state.iteration);
     if (rebuttalFile) {
-      // Rebuttal exists — record reviews in history and advance (no second consultation)
+      // Record reviews in history for audit trail.
       const currentPhase = state.current_plan_phase || undefined;
       const existingRecord = state.history.find(
         h => h.iteration === state.iteration &&
@@ -609,13 +614,58 @@ async function handleBuildVerify(
           reviews,
         });
       }
-      await writeStateAndCommit(statusPath, state, `chore(porch): ${state.id} ${state.phase} review-recorded`);
-      return await handleVerifyApproved(workspaceRoot, projectId, state, protocol, statusPath, reviews);
+
+      const maxIterations = getMaxIterations(protocol, state.phase);
+
+      // Safety ceiling: force-advance only when REQUEST_CHANGES has
+      // recurred for many rounds. The latest rebuttal file is preserved
+      // on disk as audit trail; the force_advanced record on state
+      // points reviewers at it.
+      if (state.iteration >= maxIterations) {
+        state.force_advanced = {
+          phase: state.current_plan_phase || state.phase,
+          iteration: state.iteration,
+          max_iterations: maxIterations,
+          rebuttal_file: path.basename(rebuttalFile),
+          at: new Date().toISOString(),
+        };
+        await writeStateAndCommit(
+          statusPath,
+          state,
+          `chore(porch): ${state.id} ${state.phase} force-advance (safety ceiling reached at iter ${state.iteration})`,
+        );
+        const response = await handleVerifyApproved(workspaceRoot, projectId, state, protocol, statusPath, reviews);
+        // Prepend the force-advance notice to whatever the approval path emitted.
+        const ceilingNotice =
+          `⚠️ FORCE-ADVANCE: REQUEST_CHANGES persisted for ${state.iteration} iterations ` +
+          `(safety ceiling = ${maxIterations}). Latest rebuttal preserved as audit trail: ${path.basename(rebuttalFile)}. ` +
+          `Reviewer verdicts on iter ${state.iteration}:\n${formatVerdicts(reviews)}`;
+        if (response.tasks && response.tasks.length > 0) {
+          response.tasks[0] = {
+            ...response.tasks[0],
+            description: `${ceilingNotice}\n\n---\n\n${response.tasks[0].description}`,
+          };
+        }
+        return response;
+      }
+
+      // Normal flow: re-iter. Increment iteration and clear build_complete
+      // so the next porch-next emits a fresh build task. The rebuttal
+      // file (still on disk at the previous iteration) is incorporated
+      // as context by buildPhasePrompt when iteration > 1.
+      state.iteration += 1;
+      state.build_complete = false;
+      await writeStateAndCommit(
+        statusPath,
+        state,
+        `chore(porch): ${state.id} ${state.phase} re-iter (iter ${state.iteration})`,
+      );
+      return next(workspaceRoot, projectId);
     }
 
-    // No rebuttal yet — emit "write rebuttal" task (do NOT increment iteration)
-    // This MUST come before the max_iterations safety valve so the builder
-    // gets a chance to write a rebuttal before force-advance kicks in.
+    // No rebuttal yet — emit "write rebuttal" task (do NOT increment iteration).
+    // Rebuttals are required even when we will re-iter; they record the
+    // builder's response to feedback and become part of the audit trail.
     const reviewInfo = reviews.map(r => {
       const phase = state.current_plan_phase || state.phase;
       const fileName = `${state.id}-${phase}-iter${state.iteration}-${r.model}.txt`;

--- a/packages/codev/src/commands/porch/protocol.ts
+++ b/packages/codev/src/commands/porch/protocol.ts
@@ -225,7 +225,7 @@ function normalizePhase(p: unknown): ProtocolPhase {
     type: phase.type as 'once' | 'per_plan_phase' | 'build_verify' | undefined,
     build,
     verify,
-    max_iterations: (phase.max_iterations as number) ?? 1,
+    max_iterations: (phase.max_iterations as number) ?? 8,
     on_complete,
     gate: gateName,
     checks: checks.length > 0 ? checks : undefined,
@@ -398,11 +398,15 @@ export function getVerifyConfig(protocol: Protocol, phaseId: string): VerifyConf
 }
 
 /**
- * Get max iterations for a build_verify phase
+ * Get the safety-ceiling for build_verify iterations on a phase.
+ *
+ * Re-iter on REQUEST_CHANGES is uncapped in normal flow; this ceiling
+ * fires only as runaway-prevention when REQUEST_CHANGES persists for
+ * many rounds. See next.ts handleBuildVerify for force-advance behavior.
  */
 export function getMaxIterations(protocol: Protocol, phaseId: string): number {
   const phase = getPhaseConfig(protocol, phaseId);
-  return phase?.max_iterations ?? 1;
+  return phase?.max_iterations ?? 8;
 }
 
 /**

--- a/packages/codev/src/commands/porch/types.ts
+++ b/packages/codev/src/commands/porch/types.ts
@@ -43,7 +43,7 @@ export interface ProtocolPhase {
   type?: 'once' | 'per_plan_phase' | 'build_verify';
   build?: BuildConfig;           // Build config (for build_verify phases)
   verify?: VerifyConfig;         // Verify config (for build_verify phases)
-  max_iterations?: number;       // Max build-verify iterations (default: 1)
+  max_iterations?: number;       // Safety ceiling for build-verify iterations (default: 8). Re-iter on REQUEST_CHANGES is uncapped in normal flow; this only fires when REQUEST_CHANGES persists for many rounds.
   on_complete?: OnCompleteConfig; // Actions after successful verify
   gate?: string;                 // Gate name that blocks after this phase
   checks?: string[];             // Check names to run (keys into protocol.checks)
@@ -164,6 +164,13 @@ export interface ProjectState {
     merged?: boolean;
     merged_at?: string;
   }>;
+  force_advanced?: {                       // Set when safety-ceiling force-advance fires (issue #870)
+    phase: string;                         // Protocol phase or plan phase the force-advance occurred in
+    iteration: number;                     // Iteration at which the ceiling was reached
+    max_iterations: number;                // Configured safety ceiling that was hit
+    rebuttal_file: string;                 // Basename of the latest rebuttal file preserved as audit trail
+    at: string;                            // ISO timestamp
+  };
   started_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
Fixes #870

## Root cause

`getMaxIterations()` in `packages/codev/src/commands/porch/protocol.ts:403` was exported but had zero callers — porch ignored the configured per-phase cap on every verdict-handling decision. The rebuttal-exists branch in `next.ts` also unconditionally advanced the phase even when reviewers had returned `REQUEST_CHANGES`, so the rebuttal cycle was effectively one-shot. The phantom comment at `next.ts:617-618` referencing a "max_iterations safety valve" pointed at code that had never landed.

## Fix

Adopts the asymmetric policy proposed on the issue. `COMMENT` is a non-blocking note, not a change-request:

- **ADVANCE** on no `REQUEST_CHANGES` (all `APPROVE`-or-`COMMENT`). Already handled by `allApprove()` in `verdict.ts:57` (`COMMENT` was already counted as approve); this PR adds an explicit regression test for the asymmetry so future refactors do not silently regress it.
- **RE-ITER** on any `REQUEST_CHANGES` — no count limit in normal flow. The rebuttal-exists branch now increments `state.iteration` and clears `build_complete` so the next `porch next` emits a fresh build task carrying the previous reviews + rebuttal as context.
- **SAFETY CEILING** via `getMaxIterations()`. When `state.iteration >= max_iterations` and `REQUEST_CHANGES` persists, porch force-advances, records a `force_advanced` audit entry on `status.yaml`, and prepends a clear notice to the next task's description. The latest rebuttal file is preserved on disk as the audit trail.

The natural-experiment data cited on the issue (21 review iterations classified post-hoc) showed iteration-count is a poor signal — `52%` of iters caught real bugs, `24%` were `COMMENT`-cycling. A per-iter cap missed bugs that surfaced at iter-3, iter-4. The new policy keeps re-iter responsive to verdicts (which DO carry signal) and reserves `max_iterations` for runaway prevention only.

## Defaults

- Default safety ceiling in protocol parsing bumped from `1` → `8` (`protocol.ts:228`).
- SPIR and ASPIR per-phase `max_iterations` bumped from `1` → `8` so build-verify cycles can re-iter on `REQUEST_CHANGES`.
- PIR left at `max_iterations: 1` — its documented "single advisory pass" semantic is now mechanically enforced (`REQUEST_CHANGES` on iter 1 hits the ceiling and force-advances). BUGFIX/AIR are unaffected (their PR consultations are `once`-type phases, not `build_verify`).

## Behavioral diff vs. before this PR

| Scenario | Before | After |
|---|---|---|
| All `APPROVE` | Advance | Advance |
| Mix of `APPROVE` + `COMMENT` | Advance | Advance |
| Any `REQUEST_CHANGES`, no rebuttal yet | Emit "write rebuttal" task | Emit "write rebuttal" task (unchanged) |
| `REQUEST_CHANGES` + rebuttal, `iter < ceiling` | Advance (one-shot) | Re-iter (increment, rebuild with context) |
| `REQUEST_CHANGES` + rebuttal, `iter >= ceiling` | Advance silently | Force-advance + `force_advanced` audit + ceiling notice |

## Test Plan

- [x] Existing `next.test.ts` rebuttal/advance tests still pass (max=1 protocol → iter=1 hits ceiling, force-advance path lands at same gate_pending response as before).
- [x] New test: `advances when reviewers return only COMMENT verdicts (no REQUEST_CHANGES)` — asymmetric policy explicit.
- [x] New test: `re-iters when rebuttal exists and iteration is below the safety ceiling` — confirms iter increments, build_complete cleared, no force_advanced.
- [x] New test: `force-advances with audit trail when REQUEST_CHANGES persists at the safety ceiling` — confirms force_advanced state field, ceiling notice on task, rebuttal preserved on disk.
- [x] Full porch test suite passes (319 tests).
- [x] Full codev test suite passes (3141 tests, 0 failures, 13 unrelated skips).

## CMAP Review

3-way consultation (Gemini, Codex, Claude) via `consult --protocol bugfix --type pr`:

| Reviewer | Verdict | Confidence | Key Issues |
|---|---|---|---|
| Gemini | APPROVE | HIGH | None |
| Codex | APPROVE | HIGH | None |
| Claude | APPROVE | HIGH | None |

Reviewers independently confirmed: (a) the fix correctly wires up the previously dead `getMaxIterations` as a safety ceiling, (b) the asymmetric COMMENT vs REQUEST_CHANGES policy matches the superseding policy from the issue's follow-up comment, (c) regression tests cover all three code paths (advance, re-iter, force-advance), (d) scope is tight, no debug code, no stray TODOs, (e) the existing rebuttal-advance test still passes because the test fixture's `max_iterations: 1` puts iter=1 at the ceiling, producing the same `gate_pending` outcome through the new force-advance path. Reviews saved to `codev/projects/bugfix-870-porch-max-iterations-enforceme/`.