### PR TITLE
Fix #878: Point gemini consult lane at gemini-3.1-pro-preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,7 +281,7 @@ Use sequential numbering with descriptive names (no leading zeros):
 ## Multi-Agent Consultation
 
 **DEFAULT BEHAVIOR**: Consultation is ENABLED by default with:
-- **Gemini 3 Pro** (gemini-3-pro-preview) for deep analysis
+- **Gemini 3.1 Pro** (gemini-3.1-pro-preview) for deep analysis
 - **GPT-5.4 Codex** (gpt-5.4-codex) for coding and architecture perspective
 
 To disable: User must explicitly say "without multi-agent consultation"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,7 +281,7 @@ Use sequential numbering with descriptive names (no leading zeros):
 ## Multi-Agent Consultation
 
 **DEFAULT BEHAVIOR**: Consultation is ENABLED by default with:
-- **Gemini 3 Pro** (gemini-3-pro-preview) for deep analysis
+- **Gemini 3.1 Pro** (gemini-3.1-pro-preview) for deep analysis
 - **GPT-5.4 Codex** (gpt-5.4-codex) for coding and architecture perspective
 
 To disable: User must explicitly say "without multi-agent consultation"

--- a/codev/projects/bugfix-878-consult-gemini-lane-points-at-/status.yaml
+++ b/codev/projects/bugfix-878-consult-gemini-lane-points-at-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-878
 title: consult-gemini-lane-points-at-
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,5 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T05:34:36.124Z'
-updated_at: '2026-05-27T05:46:31.999Z'
+updated_at: '2026-05-27T05:52:30.741Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-878-consult-gemini-lane-points-at-/status.yaml
+++ b/codev/projects/bugfix-878-consult-gemini-lane-points-at-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-878
 title: consult-gemini-lane-points-at-
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T05:34:36.124Z'
-updated_at: '2026-05-27T05:34:36.125Z'
+updated_at: '2026-05-27T05:40:03.706Z'

--- a/codev/projects/bugfix-878-consult-gemini-lane-points-at-/status.yaml
+++ b/codev/projects/bugfix-878-consult-gemini-lane-points-at-/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-878
+title: consult-gemini-lane-points-at-
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-27T05:34:36.124Z'
+updated_at: '2026-05-27T05:34:36.125Z'

--- a/codev/projects/bugfix-878-consult-gemini-lane-points-at-/status.yaml
+++ b/codev/projects/bugfix-878-consult-gemini-lane-points-at-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-878
 title: consult-gemini-lane-points-at-
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T05:34:36.124Z'
-updated_at: '2026-05-27T05:40:03.706Z'
+updated_at: '2026-05-27T05:46:31.999Z'

--- a/codev/state/bugfix-878_thread.md
+++ b/codev/state/bugfix-878_thread.md
@@ -29,3 +29,22 @@ The discrepancy is likely due to different gemini-cli versions / model-rollout c
 4. Test fixture → update to `gemini-3.1-pro-preview` with new expected cost $14 (1M input × $2 + 1M output × $12)
 
 Size: ~10 LOC. Comfortably within BUGFIX scope.
+
+## Fix + PR phases — 2026-05-26
+
+Implemented the fix, ran the full test suite locally (3162 passed, 0 failed),
+opened PR #879, ran CMAP-3, and notified the architect.
+
+CMAP-3 verdicts (all APPROVE, no actionable issues raised):
+- gemini: APPROVE — "Correctly bumps retired Gemini 3 model to gemini-3.1-pro-preview"
+- codex: APPROVE — "Focused bugfix updates the Gemini consult model, pricing, docs, and regression coverage"
+- claude: APPROVE — "Clean, focused bugfix — model identifier updated in all active locations, pricing added, regression test guards against silent re-regression"
+
+Note for future readers: the initial 3-way CMAP (gemini/codex/claude) failed for codex and claude
+because `--issue 878` is required when multiple projects exist in the same worktree — the consult
+CLI errors with "Multiple projects found: ..." otherwise. Re-ran with `--issue 878 --output <path>`
+and all three returned APPROVE. The first gemini run actually succeeded because gemini's exit-code
+semantics print the review *and* report success even when consult's project-resolution failed; the
+APPROVE was for a *generic* (no diff) review, not the PR. The re-run with `--issue 878` was scoped
+to the PR diff and also returned APPROVE.
+

--- a/codev/state/bugfix-878_thread.md
+++ b/codev/state/bugfix-878_thread.md
@@ -1,0 +1,31 @@
+# bugfix-878 thread
+
+## Investigate phase — 2026-05-26
+
+### Issue summary
+`packages/codev/src/commands/consult/index.ts:38` hardcodes `gemini-3-pro-preview` which Google retired on 2026-03-09. Every gemini consult fast-fails in ~1.8s with an opaque `[object Object]` error.
+
+### Reproduction in my environment (2026-05-26)
+- `gemini --model gemini-3-pro-preview` → **WORKS** (returned "OK" in ~4s)
+- `gemini --model gemini-3-pro` → 404 `ModelNotFoundError`
+- `gemini --model gemini-3.1-pro-preview` → **WORKS** (returned "OK" in ~4s)
+- gemini-cli version: 0.38.2
+
+So the issue's initial reproduction did not reproduce locally, BUT the architect added a clarifying comment (2026-05-27) noting:
+> The proposed fix (`gemini-3-pro`) would also fail. Per Google's docs, Gemini 3 Pro Preview was shut down March 9, 2026. The current actively-supported Pro identifier is **`gemini-3.1-pro-preview`** (Gemini 3.1 Pro, released Feb 19, 2026).
+
+The discrepancy is likely due to different gemini-cli versions / model-rollout cohorts. The architect's recommendation matches my verification — `gemini-3.1-pro-preview` is the correct target.
+
+### Root cause
+- `packages/codev/src/commands/consult/index.ts:38` — hardcoded model identifier
+- `packages/codev/src/commands/consult/usage-extractor.ts:19` — no pricing entry for `gemini-3.1-pro`
+- `CLAUDE.md:284`, `AGENTS.md:284` — docs reference the retired identifier
+- `packages/codev/src/commands/consult/__tests__/metrics.test.ts:617` — test fixture uses retired identifier
+
+### Fix plan (per architect's updated acceptance criteria)
+1. `consult/index.ts:38` → `gemini-3.1-pro-preview`
+2. `usage-extractor.ts` pricing → add `'gemini-3.1-pro': { inputPer1M: 2.00, cachedInputPer1M: 0.50, outputPer1M: 12.00 }` (cached at 25% of input, consistent with other entries)
+3. `CLAUDE.md`, `AGENTS.md` → update to `Gemini 3.1 Pro (gemini-3.1-pro-preview)`
+4. Test fixture → update to `gemini-3.1-pro-preview` with new expected cost $14 (1M input × $2 + 1M output × $12)
+
+Size: ~10 LOC. Comfortably within BUGFIX scope.

--- a/packages/codev/src/commands/consult/__tests__/metrics.test.ts
+++ b/packages/codev/src/commands/consult/__tests__/metrics.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { MetricsDB, type MetricsRecord } from '../metrics.js';
 import { extractUsage, extractReviewText, type SDKResultLike } from '../usage-extractor.js';
+import { _MODEL_CONFIGS } from '../index.js';
 
 function makeTmpDir(): string {
   return mkdtempSync(join(tmpdir(), 'metrics-test-'));
@@ -609,12 +610,12 @@ describe('Gemini graceful fallback for malformed output', () => {
     expect(usage).toBeNull();
   });
 
-  it('extractUsage computes per-model cost correctly for Pro pricing', () => {
+  it('extractUsage computes per-model cost correctly for 3.1 Pro pricing', () => {
     const geminiOutput = JSON.stringify({
       response: 'Review',
       stats: {
         models: {
-          'gemini-3-pro-preview': {
+          'gemini-3.1-pro-preview': {
             tokens: { prompt: 1_000_000, candidates: 1_000_000, cached: 0 },
           },
         },
@@ -622,8 +623,16 @@ describe('Gemini graceful fallback for malformed output', () => {
     });
     const usage = extractUsage('gemini', geminiOutput);
     expect(usage).not.toBeNull();
-    // Pro pricing: 1M input * $1.25/1M + 1M output * $5.00/1M = $6.25
-    expect(usage!.costUsd).toBeCloseTo(6.25, 1);
+    // 3.1 Pro pricing: 1M input * $2.00/1M + 1M output * $12.00/1M = $14.00
+    expect(usage!.costUsd).toBeCloseTo(14.00, 1);
+  });
+
+  it('gemini lane points at a current Gemini 3.x model identifier (regression: #878)', () => {
+    // #878: gemini-3-pro-preview was retired by Google on 2026-03-09; every
+    // CMAP gemini-side fast-failed with an opaque error. Guard against the
+    // identifier silently regressing back to a retired model.
+    const modelArg = _MODEL_CONFIGS.gemini.args[_MODEL_CONFIGS.gemini.args.indexOf('--model') + 1];
+    expect(modelArg).toBe('gemini-3.1-pro-preview');
   });
 
   it('extractUsage computes per-model cost correctly for Flash pricing', () => {

--- a/packages/codev/src/commands/consult/index.ts
+++ b/packages/codev/src/commands/consult/index.ts
@@ -35,7 +35,7 @@ interface ModelConfig {
 }
 
 const MODEL_CONFIGS: Record<string, ModelConfig> = {
-  gemini: { cli: 'gemini', args: ['--model', 'gemini-3-pro-preview'], envVar: 'GEMINI_SYSTEM_MD' },
+  gemini: { cli: 'gemini', args: ['--model', 'gemini-3.1-pro-preview'], envVar: 'GEMINI_SYSTEM_MD' },
   hermes: { cli: 'hermes', args: ['chat', '-q'], envVar: null },
 };
 
@@ -1631,4 +1631,5 @@ export {
   buildPRQuery as _buildPRQuery,
   composePRQueryText as _composePRQueryText,
   computePersistentOutputPath as _computePersistentOutputPath,
+  MODEL_CONFIGS as _MODEL_CONFIGS,
 };

--- a/packages/codev/src/commands/consult/usage-extractor.ts
+++ b/packages/codev/src/commands/consult/usage-extractor.ts
@@ -16,6 +16,7 @@
 // Maps model name prefixes to pricing tiers.
 // Longer prefixes must appear before shorter ones (e.g., flash-lite before flash).
 const GEMINI_PRICING: Record<string, { inputPer1M: number; cachedInputPer1M: number; outputPer1M: number }> = {
+  'gemini-3.1-pro':  { inputPer1M: 2.00,  cachedInputPer1M: 0.50,   outputPer1M: 12.00 },
   'gemini-3-pro':    { inputPer1M: 1.25,  cachedInputPer1M: 0.315,  outputPer1M: 5.00 },
   'gemini-2.5-pro':  { inputPer1M: 1.25,  cachedInputPer1M: 0.315,  outputPer1M: 5.00 },
   'gemini-3-flash':  { inputPer1M: 0.15,  cachedInputPer1M: 0.0375, outputPer1M: 0.60 },


### PR DESCRIPTION
## Summary

Google retired `gemini-3-pro-preview` on 2026-03-09, so every CMAP gemini-side fast-fails in ~1.8s with an opaque `[object Object]` error (the gemini-cli's misformatted `ModelNotFoundError` dump). This PR bumps the consult lane to `gemini-3.1-pro-preview` — the current actively-supported Gemini 3.x Pro identifier.

Fixes #878

## Root Cause

`packages/codev/src/commands/consult/index.ts:38` hardcoded `gemini-3-pro-preview` when that was the current preview alias (Feb 2026). Google has since shut it down, and `gemini-3-pro` is not the active GA identifier either — the current target is `gemini-3.1-pro-preview` (Gemini 3.1 Pro, released Feb 19, 2026).

## Fix

- `consult/index.ts` — bump `--model` arg to `gemini-3.1-pro-preview`.
- `usage-extractor.ts` — add `gemini-3.1-pro` pricing tier (`$2.00/$12.00 per 1M`, cached at 25% of input). Placed before `gemini-3-pro` in the prefix-match table so the 3.1 variant resolves first.
- `CLAUDE.md` / `AGENTS.md` — update the Multi-Agent Consultation reference.
- `metrics.test.ts` — update the Pro pricing fixture to the new model and cost; add a focused regression test asserting that `MODEL_CONFIGS.gemini.args` points at `gemini-3.1-pro-preview` (the exact thing that regressed).
- Export `MODEL_CONFIGS` as `_MODEL_CONFIGS` for the regression test, matching the existing `_`-prefixed test-export pattern in `consult/index.ts`.

## Verification

- Smoke-tested locally: `gemini --model gemini-3.1-pro-preview --prompt "OK"` returns `OK` in ~4s. `consult -m gemini --prompt "OK"` returns a real response.
- `npx tsc` passes clean.
- Full test suite: 3162 passed, 13 skipped, 0 failed (vitest run).

## Test Plan

- [x] Regression test added (`metrics.test.ts` — guards against the model identifier silently regressing back to a retired model)
- [x] Build passes (`npx tsc` clean)
- [x] All tests pass (`vitest run` — 3162 passed)
- [x] Manual smoke: `consult -m gemini --prompt "OK?"` returns a real response, exit 0