### PR TITLE
Fix #880: gitignore .architect-role.md and add update-time backfill

### DIFF
--- a/codev/projects/bugfix-880-scaffold-architect-role-md-mis/status.yaml
+++ b/codev/projects/bugfix-880-scaffold-architect-role-md-mis/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-880
 title: scaffold-architect-role-md-mis
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T10:34:30.369Z'
-updated_at: '2026-05-27T10:36:16.200Z'
+updated_at: '2026-05-27T10:45:40.810Z'

--- a/codev/projects/bugfix-880-scaffold-architect-role-md-mis/status.yaml
+++ b/codev/projects/bugfix-880-scaffold-architect-role-md-mis/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-880
 title: scaffold-architect-role-md-mis
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T10:34:30.369Z'
-updated_at: '2026-05-27T10:34:30.369Z'
+updated_at: '2026-05-27T10:36:16.200Z'

--- a/codev/projects/bugfix-880-scaffold-architect-role-md-mis/status.yaml
+++ b/codev/projects/bugfix-880-scaffold-architect-role-md-mis/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-880
+title: scaffold-architect-role-md-mis
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-27T10:34:30.369Z'
+updated_at: '2026-05-27T10:34:30.369Z'

--- a/codev/projects/bugfix-880-scaffold-architect-role-md-mis/status.yaml
+++ b/codev/projects/bugfix-880-scaffold-architect-role-md-mis/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-880
 title: scaffold-architect-role-md-mis
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,5 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T10:34:30.369Z'
-updated_at: '2026-05-27T10:45:40.810Z'
+updated_at: '2026-05-27T10:55:12.011Z'
+pr_ready_for_human: true

--- a/codev/state/bugfix-880_thread.md
+++ b/codev/state/bugfix-880_thread.md
@@ -1,0 +1,46 @@
+# bugfix-880 thread
+
+## Investigate (2026-05-27)
+
+**Issue**: `.architect-role.md` is missing from `CODEV_GITIGNORE_ENTRIES` in `packages/codev/src/lib/scaffold.ts:12`. Result: every fresh `codev init`/`codev adopt` produces a dirty git status the first time the architect spawns (Tower writes `.architect-role.md` at workspace root via `tower-utils.ts:184`).
+
+**Root cause confirmed** by reading:
+- `packages/codev/src/lib/scaffold.ts:12` — `CODEV_GITIGNORE_ENTRIES` lists `.agent-farm/`, `.consult/`, `codev/.update-hashes.json`, `.builders/` but not `.architect-role.md`.
+- `packages/codev/src/commands/update.ts` — confirmed zero gitignore handling; existing projects can't self-heal.
+- `packages/codev/src/agent-farm/servers/tower-utils.ts:184` — confirms architect spawn writes `.architect-role.md` to workspace root.
+
+**Scope**: 2-part fix per issue spec.
+1. Part 1: add `.architect-role.md` to `CODEV_GITIGNORE_ENTRIES`.
+2. Part 2: add `backfillGitignore(targetDir, entries)` helper + wire into `codev update`.
+
+**Fixable in BUGFIX scope**: yes, well under 300 LOC.
+
+## Fix (2026-05-27)
+
+Implemented per the issue spec:
+
+**Part 1** — `packages/codev/src/lib/scaffold.ts`: added `.architect-role.md` to `CODEV_GITIGNORE_ENTRIES`. Covers fresh `codev init` (via `FULL_GITIGNORE_CONTENT`) and `codev adopt` (direct append).
+
+**Part 2** — added `backfillGitignore(targetDir, block, options)` in `scaffold.ts`:
+- Parses the managed block to extract pattern lines (ignoring comments and blanks).
+- Compares with the existing `.gitignore` on a trimmed line-equality basis (avoids false-positive substring matches like `.agent-farm/x` matching `.agent-farm/`).
+- Idempotent: no-op when all entries already present.
+- Append-only: never deletes, reorders, or duplicates existing lines.
+- Returns `{ added, alreadyPresent, skipped }`. `skipped: true` when no `.gitignore` exists at all (creation belongs to init/adopt).
+- Supports `dryRun` and an injectable `today` (for deterministic header in tests).
+- Appended block carries header: `# Codev (added by codev update YYYY-MM-DD)`.
+
+Wired into `packages/codev/src/commands/update.ts`:
+- Called at the end of the framework-refresh section.
+- Result surfaced via `UpdateResult.gitignoreAdded` / `gitignoreSkipped`.
+- Summary line: `gitignore: added <N> entries` or `gitignore: up to date` or `.gitignore: not present, skipped`.
+- Honors `dryRun`.
+
+## Tests (2026-05-27)
+
+- `scaffold.test.ts`: new `backfillGitignore` describe block (6 cases) — appends under dated header, idempotent, preserves custom user entries, skips silently when no gitignore, respects dry-run, no duplicates on repeated invocation. Plus regression tests on `createGitignore`, `CODEV_GITIGNORE_ENTRIES`.
+- `init.test.ts`, `adopt.test.ts`: extended existing assertions to verify `.architect-role.md` lands in fresh project gitignore.
+- `update.test.ts`: new `gitignore backfill (issue #880)` describe (4 cases) — backfills stale gitignore, respects dry-run, skips absent gitignore, idempotent across two updates.
+
+Full suite (`vitest run --exclude '**/e2e/**'`): **3185 passed | 13 skipped (3198)**. `tsc` clean. `porch check` passes both build and tests.
+

--- a/codev/state/bugfix-880_thread.md
+++ b/codev/state/bugfix-880_thread.md
@@ -44,3 +44,20 @@ Wired into `packages/codev/src/commands/update.ts`:
 
 Full suite (`vitest run --exclude '**/e2e/**'`): **3185 passed | 13 skipped (3198)**. `tsc` clean. `porch check` passes both build and tests.
 
+## PR + CMAP (2026-05-27)
+
+PR #881 opened against `main`.
+
+CMAP verdicts:
+- gemini: **APPROVE**
+- codex: **REQUEST_CHANGES** — legitimate gap: `updateGitignore()` short-circuited on `.agent-farm/` as a sentinel, so `codev adopt` on a project that already had a partial Codev block (e.g. `.agent-farm/` ignored but not yet `.architect-role.md`) would skip without backfilling. Bug not fully closed via the adopt path alone — required user to know they needed to also run `codev update`.
+- claude: **APPROVE**
+
+## Iteration: address codex feedback (2026-05-27)
+
+Replaced the `.agent-farm/` sentinel short-circuit in `updateGitignore()` with a delegation to `backfillGitignore()`. Result: adopt now does line-level backfill against existing `.gitignore` files — partial Codev blocks self-heal, no duplicates, existing user entries untouched. The `alreadyPresent: true` return value now means *all* managed entries are present, not just `.agent-farm/`.
+
+Updated the existing `scaffold.test.ts` "should not duplicate entries if already present" — it was encoding the buggy short-circuit (only `.agent-farm/` present, expected `alreadyPresent: true`). Replaced with a test that loads the *full* `CODEV_GITIGNORE_ENTRIES` block and expects `alreadyPresent: true`. Added new regression tests in both `scaffold.test.ts` and `adopt.test.ts` for the partial-block scenario.
+
+Full suite still green: **3179 passed | 21 skipped (3200)** (two new tests; skip count fluctuates with conditional-skip tests). `tsc` clean.
+

--- a/packages/codev/src/__tests__/adopt.test.ts
+++ b/packages/codev/src/__tests__/adopt.test.ts
@@ -129,6 +129,8 @@ describe('adopt command', () => {
       const gitignore = fs.readFileSync(path.join(projectDir, '.gitignore'), 'utf-8');
       expect(gitignore).toContain('node_modules/');
       expect(gitignore).toContain('.agent-farm/');
+      // Regression for issue #880
+      expect(gitignore).toContain('.architect-role.md');
     });
 
     it('should create .gitignore if it does not exist', async () => {
@@ -143,6 +145,8 @@ describe('adopt command', () => {
       expect(fs.existsSync(path.join(projectDir, '.gitignore'))).toBe(true);
       const gitignore = fs.readFileSync(path.join(projectDir, '.gitignore'), 'utf-8');
       expect(gitignore).toContain('.agent-farm/');
+      // Regression for issue #880
+      expect(gitignore).toContain('.architect-role.md');
     });
   });
 

--- a/packages/codev/src/__tests__/adopt.test.ts
+++ b/packages/codev/src/__tests__/adopt.test.ts
@@ -148,6 +148,29 @@ describe('adopt command', () => {
       // Regression for issue #880
       expect(gitignore).toContain('.architect-role.md');
     });
+
+    // Regression for issue #880: adopt must self-heal a partial Codev block.
+    // Earlier behavior short-circuited on a `.agent-farm/` sentinel and left
+    // newer entries (like `.architect-role.md`) missing.
+    it('should backfill .architect-role.md when partial Codev block already present (issue #880)', async () => {
+      const projectDir = path.join(testBaseDir, 'partial-gitignore');
+      fs.mkdirSync(projectDir, { recursive: true });
+
+      fs.writeFileSync(
+        path.join(projectDir, '.gitignore'),
+        'node_modules/\n.agent-farm/\n.consult/\n.builders/\n'
+      );
+
+      process.chdir(projectDir);
+
+      const { adopt } = await import('../commands/adopt.js');
+      await adopt({ yes: true });
+
+      const gitignore = fs.readFileSync(path.join(projectDir, '.gitignore'), 'utf-8');
+      expect(gitignore).toContain('.architect-role.md');
+      expect(gitignore).toContain('node_modules/');
+      expect((gitignore.match(/\.agent-farm\//g) || []).length).toBe(1);
+    });
   });
 
   describe('conflict detection', () => {

--- a/packages/codev/src/__tests__/init.test.ts
+++ b/packages/codev/src/__tests__/init.test.ts
@@ -144,6 +144,8 @@ describe('init command', () => {
         expect(gitignore).toContain('.agent-farm/');
         expect(gitignore).toContain('.consult/');
         expect(gitignore).toContain('.builders/');
+        // Regression for issue #880
+        expect(gitignore).toContain('.architect-role.md');
       } finally {
         process.chdir(originalCwd);
       }

--- a/packages/codev/src/__tests__/scaffold.test.ts
+++ b/packages/codev/src/__tests__/scaffold.test.ts
@@ -15,6 +15,7 @@ import {
   copyRootFiles,
   createGitignore,
   updateGitignore,
+  backfillGitignore,
   CODEV_GITIGNORE_ENTRIES,
 } from '../lib/scaffold.js';
 
@@ -285,6 +286,17 @@ describe('Scaffold Utilities', () => {
       expect(content).toContain('.consult/');
       expect(content).toContain('.builders/');
     });
+
+    // Regression for issue #880: .architect-role.md must be ignored from day one
+    it('should include .architect-role.md (issue #880)', () => {
+      const targetDir = path.join(tempDir, 'project');
+      fs.mkdirSync(targetDir, { recursive: true });
+
+      createGitignore(targetDir);
+
+      const content = fs.readFileSync(path.join(targetDir, '.gitignore'), 'utf-8');
+      expect(content).toContain('.architect-role.md');
+    });
   });
 
   describe('updateGitignore', () => {
@@ -328,6 +340,117 @@ describe('Scaffold Utilities', () => {
       expect(CODEV_GITIGNORE_ENTRIES).toContain('.agent-farm/');
       expect(CODEV_GITIGNORE_ENTRIES).toContain('.consult/');
       expect(CODEV_GITIGNORE_ENTRIES).toContain('.builders/');
+    });
+
+    // Regression for issue #880
+    it('should contain .architect-role.md (issue #880)', () => {
+      expect(CODEV_GITIGNORE_ENTRIES).toContain('.architect-role.md');
+    });
+  });
+
+  describe('backfillGitignore (issue #880)', () => {
+    it('appends missing entries under a dated Codev header', () => {
+      const targetDir = path.join(tempDir, 'project');
+      fs.mkdirSync(targetDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(targetDir, '.gitignore'),
+        '# Codev\n.agent-farm/\n.consult/\ncodev/.update-hashes.json\n.builders/\n'
+      );
+
+      const result = backfillGitignore(targetDir, CODEV_GITIGNORE_ENTRIES, { today: new Date('2026-05-27') });
+
+      expect(result.skipped).toBe(false);
+      expect(result.added).toEqual(['.architect-role.md']);
+      expect(result.alreadyPresent).toEqual(
+        expect.arrayContaining(['.agent-farm/', '.consult/', 'codev/.update-hashes.json', '.builders/'])
+      );
+
+      const content = fs.readFileSync(path.join(targetDir, '.gitignore'), 'utf-8');
+      expect(content).toContain('# Codev (added by codev update 2026-05-27)');
+      expect(content).toContain('.architect-role.md');
+    });
+
+    it('is idempotent — second run after a clean state is a no-op', () => {
+      const targetDir = path.join(tempDir, 'project');
+      fs.mkdirSync(targetDir, { recursive: true });
+      fs.writeFileSync(path.join(targetDir, '.gitignore'), CODEV_GITIGNORE_ENTRIES);
+
+      const result = backfillGitignore(targetDir, CODEV_GITIGNORE_ENTRIES);
+
+      expect(result.added).toEqual([]);
+      expect(result.alreadyPresent.length).toBeGreaterThan(0);
+
+      const contentAfter = fs.readFileSync(path.join(targetDir, '.gitignore'), 'utf-8');
+      expect(contentAfter).toBe(CODEV_GITIGNORE_ENTRIES);
+    });
+
+    it('preserves custom user entries verbatim', () => {
+      const targetDir = path.join(tempDir, 'project');
+      fs.mkdirSync(targetDir, { recursive: true });
+      const userGitignore = [
+        '# my project',
+        'node_modules/',
+        'dist/',
+        '.env.local',
+        '',
+        '# Codev',
+        '.agent-farm/',
+        '.consult/',
+        'codev/.update-hashes.json',
+        '.builders/',
+        '',
+      ].join('\n');
+      fs.writeFileSync(path.join(targetDir, '.gitignore'), userGitignore);
+
+      backfillGitignore(targetDir, CODEV_GITIGNORE_ENTRIES, { today: new Date('2026-05-27') });
+
+      const content = fs.readFileSync(path.join(targetDir, '.gitignore'), 'utf-8');
+      expect(content.startsWith(userGitignore)).toBe(true);
+      expect(content).toContain('.architect-role.md');
+      // Custom entries untouched
+      expect(content).toContain('# my project');
+      expect(content).toContain('.env.local');
+    });
+
+    it('skips silently when no .gitignore exists', () => {
+      const targetDir = path.join(tempDir, 'project');
+      fs.mkdirSync(targetDir, { recursive: true });
+
+      const result = backfillGitignore(targetDir, CODEV_GITIGNORE_ENTRIES);
+
+      expect(result.skipped).toBe(true);
+      expect(result.added).toEqual([]);
+      expect(fs.existsSync(path.join(targetDir, '.gitignore'))).toBe(false);
+    });
+
+    it('does not write in dry-run mode', () => {
+      const targetDir = path.join(tempDir, 'project');
+      fs.mkdirSync(targetDir, { recursive: true });
+      const original = '# Codev\n.agent-farm/\n.consult/\ncodev/.update-hashes.json\n.builders/\n';
+      fs.writeFileSync(path.join(targetDir, '.gitignore'), original);
+
+      const result = backfillGitignore(targetDir, CODEV_GITIGNORE_ENTRIES, { dryRun: true });
+
+      expect(result.added).toEqual(['.architect-role.md']);
+      expect(fs.readFileSync(path.join(targetDir, '.gitignore'), 'utf-8')).toBe(original);
+    });
+
+    it('does not duplicate when invoked twice in a row', () => {
+      const targetDir = path.join(tempDir, 'project');
+      fs.mkdirSync(targetDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(targetDir, '.gitignore'),
+        '# Codev\n.agent-farm/\n.consult/\ncodev/.update-hashes.json\n.builders/\n'
+      );
+
+      backfillGitignore(targetDir, CODEV_GITIGNORE_ENTRIES, { today: new Date('2026-05-27') });
+      const afterFirst = fs.readFileSync(path.join(targetDir, '.gitignore'), 'utf-8');
+      backfillGitignore(targetDir, CODEV_GITIGNORE_ENTRIES, { today: new Date('2026-05-28') });
+      const afterSecond = fs.readFileSync(path.join(targetDir, '.gitignore'), 'utf-8');
+
+      expect(afterFirst).toBe(afterSecond);
+      // Only one occurrence of .architect-role.md
+      expect(afterSecond.match(/\.architect-role\.md/g) || []).toHaveLength(1);
     });
   });
 

--- a/packages/codev/src/__tests__/scaffold.test.ts
+++ b/packages/codev/src/__tests__/scaffold.test.ts
@@ -313,15 +313,40 @@ describe('Scaffold Utilities', () => {
       expect(content).toContain('.agent-farm/');
     });
 
-    it('should not duplicate entries if already present', () => {
+    it('should report alreadyPresent when the full block is already present', () => {
       const targetDir = path.join(tempDir, 'project');
       fs.mkdirSync(targetDir, { recursive: true });
-      fs.writeFileSync(path.join(targetDir, '.gitignore'), '.agent-farm/\n');
+      fs.writeFileSync(path.join(targetDir, '.gitignore'), CODEV_GITIGNORE_ENTRIES);
 
       const result = updateGitignore(targetDir);
 
       expect(result.updated).toBe(false);
       expect(result.alreadyPresent).toBe(true);
+    });
+
+    // Regression for issue #880: adopt against a partial Codev block must self-heal.
+    // Previously, updateGitignore short-circuited on a `.agent-farm/` sentinel, which
+    // meant projects that ignored `.agent-farm/` but lacked `.architect-role.md` were
+    // left unhealed.
+    it('should backfill missing entries when block is partial (issue #880)', () => {
+      const targetDir = path.join(tempDir, 'project');
+      fs.mkdirSync(targetDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(targetDir, '.gitignore'),
+        'node_modules/\n.agent-farm/\n.consult/\n'
+      );
+
+      const result = updateGitignore(targetDir);
+
+      expect(result.updated).toBe(true);
+      expect(result.alreadyPresent).toBe(false);
+      const content = fs.readFileSync(path.join(targetDir, '.gitignore'), 'utf-8');
+      expect(content).toContain('.architect-role.md');
+      expect(content).toContain('.builders/');
+      // Existing entries preserved, no duplicates
+      expect(content).toContain('node_modules/');
+      expect((content.match(/\.agent-farm\//g) || []).length).toBe(1);
+      expect((content.match(/\.consult\//g) || []).length).toBe(1);
     });
 
     it('should create .gitignore if it does not exist', () => {

--- a/packages/codev/src/__tests__/update.test.ts
+++ b/packages/codev/src/__tests__/update.test.ts
@@ -466,6 +466,88 @@ describe('update command', () => {
     });
   });
 
+  describe('gitignore backfill (issue #880)', () => {
+    it('appends .architect-role.md to a stale .gitignore on update', async () => {
+      const projectDir = path.join(testBaseDir, 'gitignore-backfill');
+      fs.mkdirSync(path.join(projectDir, 'codev'), { recursive: true });
+
+      const staleGitignore = [
+        'node_modules/',
+        '',
+        '# Codev',
+        '.agent-farm/',
+        '.consult/',
+        'codev/.update-hashes.json',
+        '.builders/',
+        '',
+      ].join('\n');
+      fs.writeFileSync(path.join(projectDir, '.gitignore'), staleGitignore);
+
+      process.chdir(projectDir);
+
+      const { update } = await import('../commands/update.js');
+      const result = await update({ agent: true });
+
+      expect(result.error).toBeUndefined();
+      expect(result.gitignoreAdded).toEqual(['.architect-role.md']);
+
+      const content = fs.readFileSync(path.join(projectDir, '.gitignore'), 'utf-8');
+      expect(content).toContain('.architect-role.md');
+      // User entries preserved
+      expect(content).toContain('node_modules/');
+    });
+
+    it('does not write to .gitignore in dry-run', async () => {
+      const projectDir = path.join(testBaseDir, 'gitignore-dryrun');
+      fs.mkdirSync(path.join(projectDir, 'codev'), { recursive: true });
+
+      const stale = '# Codev\n.agent-farm/\n.consult/\ncodev/.update-hashes.json\n.builders/\n';
+      fs.writeFileSync(path.join(projectDir, '.gitignore'), stale);
+
+      process.chdir(projectDir);
+
+      const { update } = await import('../commands/update.js');
+      const result = await update({ agent: true, dryRun: true });
+
+      expect(result.gitignoreAdded).toEqual(['.architect-role.md']);
+      expect(fs.readFileSync(path.join(projectDir, '.gitignore'), 'utf-8')).toBe(stale);
+    });
+
+    it('skips silently when .gitignore is absent', async () => {
+      const projectDir = path.join(testBaseDir, 'gitignore-absent');
+      fs.mkdirSync(path.join(projectDir, 'codev'), { recursive: true });
+
+      process.chdir(projectDir);
+
+      const { update } = await import('../commands/update.js');
+      const result = await update({ agent: true });
+
+      expect(result.gitignoreSkipped).toBe(true);
+      expect(result.gitignoreAdded).toEqual([]);
+      expect(fs.existsSync(path.join(projectDir, '.gitignore'))).toBe(false);
+    });
+
+    it('is idempotent — second update is a no-op for the gitignore', async () => {
+      const projectDir = path.join(testBaseDir, 'gitignore-idempotent');
+      fs.mkdirSync(path.join(projectDir, 'codev'), { recursive: true });
+
+      const stale = '# Codev\n.agent-farm/\n.consult/\ncodev/.update-hashes.json\n.builders/\n';
+      fs.writeFileSync(path.join(projectDir, '.gitignore'), stale);
+
+      process.chdir(projectDir);
+
+      const { update } = await import('../commands/update.js');
+      await update({ agent: true });
+      const afterFirst = fs.readFileSync(path.join(projectDir, '.gitignore'), 'utf-8');
+
+      const result = await update({ agent: true });
+      const afterSecond = fs.readFileSync(path.join(projectDir, '.gitignore'), 'utf-8');
+
+      expect(result.gitignoreAdded).toEqual([]);
+      expect(afterFirst).toBe(afterSecond);
+    });
+  });
+
   describe('hash store management', () => {
     it('should preserve existing hashes after update', async () => {
       const projectDir = path.join(testBaseDir, 'hash-preserve');

--- a/packages/codev/src/commands/update.ts
+++ b/packages/codev/src/commands/update.ts
@@ -22,7 +22,12 @@ import {
   hashFile,
   loadHashStore,
 } from '../lib/templates.js';
-import { copySkills, copyRootFiles } from '../lib/scaffold.js';
+import {
+  copySkills,
+  copyRootFiles,
+  backfillGitignore,
+  CODEV_GITIGNORE_ENTRIES,
+} from '../lib/scaffold.js';
 
 export interface UpdateOptions {
   dryRun?: boolean;
@@ -45,6 +50,8 @@ export interface UpdateResult {
   migrated?: boolean;
   cleanedFiles?: string[];
   preservedFiles?: string[];
+  gitignoreAdded?: string[];
+  gitignoreSkipped?: boolean;
   error?: string;
 }
 
@@ -241,6 +248,19 @@ export async function update(options: UpdateOptions = {}): Promise<UpdateResult>
       }
     }
 
+    // Backfill .gitignore with any missing Codev entries
+    const gitignoreResult = backfillGitignore(targetDir, CODEV_GITIGNORE_ENTRIES, { dryRun });
+    result.gitignoreAdded = gitignoreResult.added;
+    result.gitignoreSkipped = gitignoreResult.skipped;
+    if (gitignoreResult.skipped) {
+      log(chalk.dim('  .gitignore: not present, skipped'));
+    } else if (gitignoreResult.added.length > 0) {
+      const verb = dryRun ? 'would add' : 'added';
+      log(chalk.green(`  + (gitignore) ${verb} ${gitignoreResult.added.length} entries: ${gitignoreResult.added.join(', ')}`));
+    } else {
+      log(chalk.dim('  .gitignore: up to date'));
+    }
+
     // Summary
     log('');
     log(chalk.bold('Summary:'));
@@ -257,8 +277,19 @@ export async function update(options: UpdateOptions = {}): Promise<UpdateResult>
     if (result.rootConflicts.length > 0) {
       log(chalk.yellow(`  ! ${result.rootConflicts.length} conflicts`));
     }
+    if (result.gitignoreAdded && result.gitignoreAdded.length > 0) {
+      log(chalk.green(`  gitignore: added ${result.gitignoreAdded.length} entries`));
+    } else if (!result.gitignoreSkipped) {
+      log(chalk.dim('  gitignore: up to date'));
+    }
 
-    if (!result.migrated && result.newFiles.length === 0 && result.updated.length === 0 && result.rootConflicts.length === 0) {
+    if (
+      !result.migrated &&
+      result.newFiles.length === 0 &&
+      result.updated.length === 0 &&
+      result.rootConflicts.length === 0 &&
+      (!result.gitignoreAdded || result.gitignoreAdded.length === 0)
+    ) {
       log(chalk.dim('  Already up to date!'));
     }
 

--- a/packages/codev/src/lib/scaffold.ts
+++ b/packages/codev/src/lib/scaffold.ts
@@ -14,6 +14,7 @@ export const CODEV_GITIGNORE_ENTRIES = `# Codev
 .consult/
 codev/.update-hashes.json
 .builders/
+.architect-role.md
 `;
 
 /**
@@ -250,6 +251,79 @@ export function updateGitignore(targetDir: string): UpdateGitignoreResult {
 
   fs.appendFileSync(gitignorePath, '\n' + CODEV_GITIGNORE_ENTRIES);
   return { updated: true, created: false, alreadyPresent: false };
+}
+
+interface BackfillGitignoreOptions {
+  dryRun?: boolean;
+  today?: Date;
+}
+
+export interface BackfillGitignoreResult {
+  added: string[];
+  alreadyPresent: string[];
+  skipped: boolean;
+}
+
+/**
+ * Parse a gitignore block into the list of pattern lines (excluding comments and blanks).
+ */
+function parseEntryLines(block: string): string[] {
+  return block
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0 && !line.startsWith('#'));
+}
+
+/**
+ * Backfill missing entries into an existing .gitignore.
+ *
+ * Append-only: never deletes, reorders, or duplicates existing lines.
+ * Idempotent: a second invocation after a clean run is a no-op.
+ * Missing entries are appended together under a dated `# Codev (added by codev update ...)`
+ * header so the user can see where they came from.
+ *
+ * If no .gitignore exists, returns { skipped: true } without creating one
+ * (creation belongs to init/adopt).
+ */
+export function backfillGitignore(
+  targetDir: string,
+  block: string,
+  options: BackfillGitignoreOptions = {}
+): BackfillGitignoreResult {
+  const { dryRun = false, today = new Date() } = options;
+  const gitignorePath = path.join(targetDir, '.gitignore');
+
+  if (!fs.existsSync(gitignorePath)) {
+    return { added: [], alreadyPresent: [], skipped: true };
+  }
+
+  const entries = parseEntryLines(block);
+  const existing = fs.readFileSync(gitignorePath, 'utf-8');
+  const existingLines = new Set(
+    existing.split('\n').map(line => line.trim()).filter(line => line.length > 0)
+  );
+
+  const added: string[] = [];
+  const alreadyPresent: string[] = [];
+
+  for (const entry of entries) {
+    if (existingLines.has(entry)) {
+      alreadyPresent.push(entry);
+    } else {
+      added.push(entry);
+    }
+  }
+
+  if (added.length === 0 || dryRun) {
+    return { added, alreadyPresent, skipped: false };
+  }
+
+  const isoDate = today.toISOString().slice(0, 10);
+  const trailingNewline = existing.endsWith('\n') ? '' : '\n';
+  const appended = `${trailingNewline}\n# Codev (added by codev update ${isoDate})\n${added.join('\n')}\n`;
+  fs.appendFileSync(gitignorePath, appended);
+
+  return { added, alreadyPresent, skipped: false };
 }
 
 interface CreateProjectsDirOptions {

--- a/packages/codev/src/lib/scaffold.ts
+++ b/packages/codev/src/lib/scaffold.ts
@@ -234,7 +234,13 @@ interface UpdateGitignoreResult {
 }
 
 /**
- * Update existing .gitignore or create if not exists (for adopt)
+ * Update existing .gitignore or create if not exists (for adopt).
+ *
+ * If .gitignore is absent, creates it with the full managed block.
+ * Otherwise, performs a line-level backfill — appends only the entries that
+ * are missing. This means adopt is self-healing against partial Codev blocks
+ * (e.g. a project that ignored `.agent-farm/` but not later additions like
+ * `.architect-role.md`).
  */
 export function updateGitignore(targetDir: string): UpdateGitignoreResult {
   const gitignorePath = path.join(targetDir, '.gitignore');
@@ -244,12 +250,10 @@ export function updateGitignore(targetDir: string): UpdateGitignoreResult {
     return { updated: false, created: true, alreadyPresent: false };
   }
 
-  const existing = fs.readFileSync(gitignorePath, 'utf-8');
-  if (existing.includes('.agent-farm/')) {
+  const result = backfillGitignore(targetDir, CODEV_GITIGNORE_ENTRIES);
+  if (result.added.length === 0) {
     return { updated: false, created: false, alreadyPresent: true };
   }
-
-  fs.appendFileSync(gitignorePath, '\n' + CODEV_GITIGNORE_ENTRIES);
   return { updated: true, created: false, alreadyPresent: false };
 }
 


### PR DESCRIPTION
## Summary

Every fresh `codev init` / `codev adopt` left a dirty git status the first time the architect spawned — Tower writes `.architect-role.md` to the workspace root, but the file was missing from `CODEV_GITIGNORE_ENTRIES`. This PR plugs the day-one gap and adds an update-time backfill so existing Codev projects also self-heal.

Fixes #880

## Root Cause

`packages/codev/src/lib/scaffold.ts` declared the codev-managed gitignore block but omitted `.architect-role.md`. Sibling builder-runtime files (`.builder-role.md`, etc.) lived under `.builders/<id>/` and were covered transitively, but `.architect-role.md` lives at workspace root with no ignored ancestor. `codev update` had no gitignore handling at all, so existing projects had no upgrade path either.

## Fix

**Part 1 — fresh projects**: one-line addition to `CODEV_GITIGNORE_ENTRIES`. Propagates through `FULL_GITIGNORE_CONTENT` (init) and the direct append (adopt).

**Part 2 — existing projects**: new `backfillGitignore(targetDir, block, options)` in `scaffold.ts`, wired into `codev update`.

- Append-only line-level merge — never deletes, reorders, or duplicates.
- Idempotent: a second invocation after a clean state is a no-op.
- Compares on trimmed line equality (avoids false-positive substring matches).
- Missing entries are appended together under `# Codev (added by codev update YYYY-MM-DD)` so the user can see where they came from.
- Skips silently if no `.gitignore` exists — creation belongs to init/adopt.
- Honors `--dry-run`.
- Result surfaced on `UpdateResult` as `gitignoreAdded` / `gitignoreSkipped`; summary line printed in both interactive and agent modes.

Per the issue scope decision, the helper is gitignore-specific (not generalized to a managed-block primitive) — no second use case yet, no premature abstraction.

## Test Plan

- [x] Regression tests added (`scaffold.test.ts` `backfillGitignore` block: append, idempotency, custom-entry preservation, dry-run, skip-when-absent, no-duplicates)
- [x] `init.test.ts` and `adopt.test.ts` assert `.architect-role.md` appears in fresh project gitignores
- [x] `update.test.ts` integration tests for backfill (stale gitignore, dry-run, absent gitignore, idempotent across two updates)
- [x] `tsc` clean
- [x] Full test suite: **3185 passed | 13 skipped (3198)**
- [x] `porch check` passes both build and tests