### PR TITLE
vscode: group backlog tree by area/* label (PIR #811)

### DIFF
--- a/codev/plans/811-vscode-group-backlog-by-area.md
+++ b/codev/plans/811-vscode-group-backlog-by-area.md
@@ -1,0 +1,79 @@
+# PIR Plan: vscode — group backlog tree by area
+
+## Understanding
+
+The vscode Backlog tree (`packages/vscode/src/views/backlog.ts:27`) renders open GitHub issues as a flat list. As the repo grows, scanning the list mixes work across every product surface with no axis that mirrors how engineers coordinate. Issue #811 asks for two-level grouping by the `area/*` label namespace established by #819.
+
+The wire already carries everything we need: `OverviewBacklogItem.area: string` (required, never `undefined`) was added by #819, projected server-side via `parseArea(issue.labels)`. The parser returns the first-alphabetical `area/*` value (with the `area/` prefix stripped), or the literal `'Uncategorized'` when no `area/*` labels are present. **The parser is policy-free** — it does NOT privilege `area/cross-cutting` (see #819's regression-guard test at `packages/codev/src/__tests__/github.test.ts:333-341`). That policy decision lives in the consumer.
+
+The cross-cutting UX privilege ("place `area/cross-cutting` issues in their own top group") is a **view-layer convention** for this PIR. The issue body documents the tagging convention:
+
+> Tag it `area/cross-cutting` only (don't list every individual area); the dedicated group surfaces them for coordination review.
+
+Under this convention, an issue tagged only with `area/cross-cutting` arrives at the view with `item.area === 'cross-cutting'`. The view's grouping logic recognises that bucket and sorts it first. No additional wire field is needed for this PIR — see *Risks & Alternatives* for the "user broke the convention" case.
+
+## Proposed Change
+
+Convert `BacklogProvider` from a flat `TreeDataProvider<TreeItem>` into a two-level provider:
+
+- **Root level** (`getChildren()` with no element) → one `BacklogGroupTreeItem` per non-empty area group, ordered: `cross-cutting` → alphabetical specific areas → `Uncategorized`. Label format: `<area> (<count>)`.
+- **Group level** (`getChildren(groupItem)`) → the existing `BacklogTreeItem` rows for that group, in the same intra-group order the flat view uses today (mine-first then rest, both preserving the server's order).
+
+Add a pure helper `groupBacklogByArea(items)` (in `views/backlog.ts`) that takes `OverviewBacklogItem[]` and returns an ordered array of `{ area, items }`. Pure-functional, no VSCode dependency → unit-testable.
+
+Group expansion state persists per area name via `vscode.Memento` (`context.workspaceState`). Default: all groups expanded. The provider reads the persisted map on each `getChildren()` root call and writes back via `onDidExpandElement` / `onDidCollapseElement` on the `TreeView`.
+
+The Mine/All toggle (#809) is orthogonal — when it ships, its filter applies before `groupBacklogByArea` and groups are recomputed automatically.
+
+## Files to Change
+
+- `packages/vscode/src/views/backlog.ts:39-66` — refactor `BacklogProvider.getChildren()` to dispatch on element type; add `groupBacklogByArea(items)` exported helper; add the area-resolution rule (`cross-cutting` first, alphabetical, `Uncategorized` last). Constructor takes `vscode.Memento` for expansion-state persistence. Existing `spawnableBacklog` helper unchanged.
+- `packages/vscode/src/views/backlog-tree-item.ts` — add `BacklogGroupTreeItem` class. Holds `areaName: string`, `count: number`, `contextValue: 'backlog-group'`. `collapsibleState` set from the persisted Memento map at construction.
+- `packages/vscode/src/extension.ts:258` — pass `context.workspaceState` to `BacklogProvider` constructor. Wire `backlogView.onDidExpandElement` / `onDidCollapseElement` to write expansion state back when the user expands/collapses a group (gated on `element instanceof BacklogGroupTreeItem`).
+- `packages/vscode/src/test/backlog.test.ts` — new test suite for `groupBacklogByArea`:
+  - empty input → empty output
+  - single `Uncategorized` item → single `Uncategorized` group
+  - `cross-cutting` items → first group, no matter the alphabetical position
+  - mixed groups → cross-cutting first, then alphabetical specifics, Uncategorized last
+  - within-group order preserves input order
+  - empty area groups are omitted (no `<area> (0)` headers)
+
+## Risks & Alternatives Considered
+
+- **Risk: convention violation.** An issue tagged with `area/auth` AND `area/cross-cutting` (against the documented convention) lands in `area = 'auth'` server-side, so the view places it under the `auth` group, not `cross-cutting`. Mitigation: rely on the documented convention; if real-world tagging shows this convention is regularly broken, a follow-up PIR can add `areas: string[]` (or `crossCutting: boolean`) to the wire and shift the cross-cutting detection into the view's `resolveArea(item)` step. Out of scope for #811 — keeping this PIR scoped to "view-level grouping over what the wire already provides" preserves #819's policy-free framework boundary.
+
+- **Risk: backlog count badge desync.** `extension.ts:165` recomputes the view title `Backlog (N)` from `spawnableBacklog(data.backlog).length`. Grouping doesn't change that count — the same items are visible, just nested. No change needed.
+
+- **Risk: reveal / select-by-id consumers.** If anything in the codebase calls `backlogView.reveal(item)`, the new two-level tree requires `getParent()` on the provider. Mitigation: grep first; today no consumer calls reveal on the backlog tree (`backlogView.reveal` does not appear in the codebase). If a future consumer needs it, add `getParent()` then.
+
+- **Alternative: add `areas: string[]` wire field now (revert #819's projection).** Rejected — #819 deliberately chose the singular-string shape with explicit user feedback ("framework code must be policy-free about specific label values" + "wire-shape permissiveness then projection is a smell"). Re-adding the array shape would relitigate that decision without a concrete consumer pull. The cross-cutting convention is the cleaner answer at the cost of being convention-dependent.
+
+- **Alternative: add `crossCutting: boolean` to the wire.** Considered. Minimally invasive (one boolean, computed server-side from raw labels), preserves #819's projection-on-server discipline, and detects convention violators. Rejected only because nothing else needs it yet — the cost (one wire-contract addition, one server populate site, one test) isn't justified by the convention-violator edge case alone. Worth filing as a small issue if the convention proves brittle in practice.
+
+- **Alternative: toggle to disable grouping.** Issue §6 (`### 6. No toggle`) explicitly rejects this — grouping is the default, and repos without `area/*` labels see everything under `Uncategorized` (functionally identical to today). Aligns with #818 which DOES have a toggle for builders; the asymmetry is intentional (the issue argues the backlog grouping is zero-cost so no toggle is needed).
+
+## Test Plan
+
+### Unit tests (`packages/vscode/src/test/backlog.test.ts`)
+
+Add a `suite('groupBacklogByArea', ...)` covering:
+
+- Empty input → empty array.
+- Single uncategorized item → one group with key `'Uncategorized'`, count 1.
+- `[area/cross-cutting]` alone → first (and only) group is `'cross-cutting'`.
+- Mixed: `auth`, `cross-cutting`, `tower`, `Uncategorized` → order is `['cross-cutting', 'auth', 'tower', 'Uncategorized']`.
+- Two alphabetical-specific areas + cross-cutting → `['cross-cutting', <alphabetically-first>, <alphabetically-second>]`, no Uncategorized header rendered.
+- Within-group order preserves input order (do not re-sort items).
+- Empty groups are omitted (no `(0)` headers).
+
+### Manual verification at `dev-approval` gate
+
+Reviewer launches `afx dev pir-811` and inspects the VSCode sidebar:
+
+1. **Default rendering**: Backlog view shows headers like `vscode (20)`, `tower (4)`, etc. Click a header to expand → issue rows render underneath. Headers ordered: `cross-cutting` first if present, then alphabetical, `Uncategorized` last.
+2. **Single-issue cross-cutting**: pick an issue tagged with only `area/cross-cutting` (e.g. #854 today) → confirm it lives under the `cross-cutting` group.
+3. **Uncategorized fallback**: any issue with no `area/*` labels → confirm it's under `Uncategorized` (last position).
+4. **Click → view**: clicking a row still opens the issue via `codev.viewBacklogIssue`. Right-click → context-menu actions (spawn, open in browser, copy issue number) all still work.
+5. **Expansion persistence**: collapse a group, reload the VSCode window → that group stays collapsed.
+6. **No regression on dashboard**: open the web dashboard's Backlog view (`packages/dashboard/src/components/BacklogList.tsx`) → still renders as a flat list (no wire changes, no breakage).
+7. **Empty repo**: temporarily filter the test fixture to a repo with no `area/*` labels → everything under `Uncategorized`, no other groups.

--- a/codev/plans/811-vscode-group-backlog-by-area.md
+++ b/codev/plans/811-vscode-group-backlog-by-area.md
@@ -6,17 +6,13 @@ The vscode Backlog tree (`packages/vscode/src/views/backlog.ts:27`) renders open
 
 The wire already carries everything we need: `OverviewBacklogItem.area: string` (required, never `undefined`) was added by #819, projected server-side via `parseArea(issue.labels)`. The parser returns the first-alphabetical `area/*` value (with the `area/` prefix stripped), or the literal `'Uncategorized'` when no `area/*` labels are present. **The parser is policy-free** — it does NOT privilege `area/cross-cutting` (see #819's regression-guard test at `packages/codev/src/__tests__/github.test.ts:333-341`). That policy decision lives in the consumer.
 
-The cross-cutting UX privilege ("place `area/cross-cutting` issues in their own top group") is a **view-layer convention** for this PIR. The issue body documents the tagging convention:
-
-> Tag it `area/cross-cutting` only (don't list every individual area); the dedicated group surfaces them for coordination review.
-
-Under this convention, an issue tagged only with `area/cross-cutting` arrives at the view with `item.area === 'cross-cutting'`. The view's grouping logic recognises that bucket and sorts it first. No additional wire field is needed for this PIR — see *Risks & Alternatives* for the "user broke the convention" case.
+The framework intentionally does **not** privilege any specific area name (e.g. `cross-cutting`). Hardcoding `'cross-cutting'` into the view would bake a repo-specific convention into framework code — the same anti-pattern #819 corrected at the parser. Instead, a per-repo VSCode setting `codev.backlog.priorityAreas: string[]` lets each repo pin specific areas to the top of the group order, in the listed order. Default `[]` means pure alphabetical (with `Uncategorized` always last) — a no-op for repos that haven't expressed a preference.
 
 ## Proposed Change
 
 Convert `BacklogProvider` from a flat `TreeDataProvider<TreeItem>` into a two-level provider:
 
-- **Root level** (`getChildren()` with no element) → one `BacklogGroupTreeItem` per non-empty area group, ordered: `cross-cutting` → alphabetical specific areas → `Uncategorized`. Label format: `<area> (<count>)`.
+- **Root level** (`getChildren()` with no element) → one `BacklogGroupTreeItem` per non-empty area group, ordered: `priorityAreas` entries (from `codev.backlog.priorityAreas`) in the listed order → alphabetical specific areas → `Uncategorized`. Label format: `<area> (<count>)`.
 - **Group level** (`getChildren(groupItem)`) → the existing `BacklogTreeItem` rows for that group, in the same intra-group order the flat view uses today (mine-first then rest, both preserving the server's order).
 
 Add a pure helper `groupBacklogByArea(items)` (in `views/backlog.ts`) that takes `OverviewBacklogItem[]` and returns an ordered array of `{ area, items }`. Pure-functional, no VSCode dependency → unit-testable.

--- a/codev/plans/811-vscode-group-backlog-by-area.md
+++ b/codev/plans/811-vscode-group-backlog-by-area.md
@@ -6,14 +6,16 @@ The vscode Backlog tree (`packages/vscode/src/views/backlog.ts:27`) renders open
 
 The wire already carries everything we need: `OverviewBacklogItem.area: string` (required, never `undefined`) was added by #819, projected server-side via `parseArea(issue.labels)`. The parser returns the first-alphabetical `area/*` value (with the `area/` prefix stripped), or the literal `'Uncategorized'` when no `area/*` labels are present. **The parser is policy-free** — it does NOT privilege `area/cross-cutting` (see #819's regression-guard test at `packages/codev/src/__tests__/github.test.ts:333-341`). That policy decision lives in the consumer.
 
-The framework intentionally does **not** privilege any specific area name (e.g. `cross-cutting`). Hardcoding `'cross-cutting'` into the view would bake a repo-specific convention into framework code — the same anti-pattern #819 corrected at the parser. Instead, a per-repo VSCode setting `codev.backlog.priorityAreas: string[]` lets each repo pin specific areas to the top of the group order, in the listed order. Default `[]` means pure alphabetical (with `Uncategorized` always last) — a no-op for repos that haven't expressed a preference.
+This PIR matches the parser's policy-free posture in the view: alphabetical specific areas, `Uncategorized` always last, no privileged label names. Coordination of overlapping work is a separate concern from group rank — the grouping itself surfaces the per-area picture engineers need.
 
 ## Proposed Change
 
 Convert `BacklogProvider` from a flat `TreeDataProvider<TreeItem>` into a two-level provider:
 
-- **Root level** (`getChildren()` with no element) → one `BacklogGroupTreeItem` per non-empty area group, ordered: `priorityAreas` entries (from `codev.backlog.priorityAreas`) in the listed order → alphabetical specific areas → `Uncategorized`. Label format: `<area> (<count>)`.
+- **Root level** (`getChildren()` with no element) → one `BacklogGroupTreeItem` per non-empty area group, ordered: alphabetical specific areas → `Uncategorized`. Label format: `<area> (<count>)`.
 - **Group level** (`getChildren(groupItem)`) → the existing `BacklogTreeItem` rows for that group, in the same intra-group order the flat view uses today (mine-first then rest, both preserving the server's order).
+
+Single-`Uncategorized` collapses to flat rendering: when the grouped output is exactly one group AND that group is `Uncategorized`, the view skips the header and returns rows directly. This is the zero-cost migration property for repos that haven't adopted `area/*` labels yet.
 
 Add a pure helper `groupBacklogByArea(items)` (in `views/backlog.ts`) that takes `OverviewBacklogItem[]` and returns an ordered array of `{ area, items }`. Pure-functional, no VSCode dependency → unit-testable.
 
@@ -23,30 +25,28 @@ The Mine/All toggle (#809) is orthogonal — when it ships, its filter applies b
 
 ## Files to Change
 
-- `packages/vscode/src/views/backlog.ts:39-66` — refactor `BacklogProvider.getChildren()` to dispatch on element type; add `groupBacklogByArea(items)` exported helper; add the area-resolution rule (`cross-cutting` first, alphabetical, `Uncategorized` last). Constructor takes `vscode.Memento` for expansion-state persistence. Existing `spawnableBacklog` helper unchanged.
-- `packages/vscode/src/views/backlog-tree-item.ts` — add `BacklogGroupTreeItem` class. Holds `areaName: string`, `count: number`, `contextValue: 'backlog-group'`. `collapsibleState` set from the persisted Memento map at construction.
+- `packages/vscode/src/views/backlog.ts` — refactor `BacklogProvider.getChildren()` to dispatch on element type; add `groupBacklogByArea(items)` exported helper (alphabetical specific areas, `Uncategorized` last, empty groups omitted). Constructor takes `vscode.Memento` for expansion-state persistence. Existing `spawnableBacklog` helper unchanged.
+- `packages/vscode/src/views/backlog-tree-item.ts` — add `BacklogGroupTreeItem` class. Holds `areaName: string`, `count: number`, `contextValue: 'backlog-group'`. Stable `id` (`backlog-group:<areaName>`) so VSCode preserves item identity across SSE-driven `onDidChangeTreeData` refreshes.
 - `packages/vscode/src/extension.ts:258` — pass `context.workspaceState` to `BacklogProvider` constructor. Wire `backlogView.onDidExpandElement` / `onDidCollapseElement` to write expansion state back when the user expands/collapses a group (gated on `element instanceof BacklogGroupTreeItem`).
 - `packages/vscode/src/test/backlog.test.ts` — new test suite for `groupBacklogByArea`:
   - empty input → empty output
   - single `Uncategorized` item → single `Uncategorized` group
-  - `cross-cutting` items → first group, no matter the alphabetical position
-  - mixed groups → cross-cutting first, then alphabetical specifics, Uncategorized last
+  - mixed: alphabetical specifics, `Uncategorized` last
   - within-group order preserves input order
   - empty area groups are omitted (no `<area> (0)` headers)
+  - multiple items per area grouped correctly
 
 ## Risks & Alternatives Considered
 
-- **Risk: convention violation.** An issue tagged with `area/auth` AND `area/cross-cutting` (against the documented convention) lands in `area = 'auth'` server-side, so the view places it under the `auth` group, not `cross-cutting`. Mitigation: rely on the documented convention; if real-world tagging shows this convention is regularly broken, a follow-up PIR can add `areas: string[]` (or `crossCutting: boolean`) to the wire and shift the cross-cutting detection into the view's `resolveArea(item)` step. Out of scope for #811 — keeping this PIR scoped to "view-level grouping over what the wire already provides" preserves #819's policy-free framework boundary.
-
 - **Risk: backlog count badge desync.** `extension.ts:165` recomputes the view title `Backlog (N)` from `spawnableBacklog(data.backlog).length`. Grouping doesn't change that count — the same items are visible, just nested. No change needed.
 
-- **Risk: reveal / select-by-id consumers.** If anything in the codebase calls `backlogView.reveal(item)`, the new two-level tree requires `getParent()` on the provider. Mitigation: grep first; today no consumer calls reveal on the backlog tree (`backlogView.reveal` does not appear in the codebase). If a future consumer needs it, add `getParent()` then.
+- **Risk: reveal / select-by-id consumers.** If anything in the codebase calls `backlogView.reveal(item)`, the new two-level tree requires `getParent()` on the provider. Mitigation: grep first; today no consumer calls reveal on the backlog tree. If a future consumer needs it, add `getParent()` then.
 
-- **Alternative: add `areas: string[]` wire field now (revert #819's projection).** Rejected — #819 deliberately chose the singular-string shape with explicit user feedback ("framework code must be policy-free about specific label values" + "wire-shape permissiveness then projection is a smell"). Re-adding the array shape would relitigate that decision without a concrete consumer pull. The cross-cutting convention is the cleaner answer at the cost of being convention-dependent.
+- **Alternative: privilege a specific area (e.g. `cross-cutting`) at the top.** Rejected — #819 deliberately chose framework-neutral parsing. Same posture applies to the view: alphabetical specifics + `Uncategorized` last is the simplest rule that doesn't bake repo-specific conventions into the framework. Coordination of overlapping work is a separate concern from group rank.
 
-- **Alternative: add `crossCutting: boolean` to the wire.** Considered. Minimally invasive (one boolean, computed server-side from raw labels), preserves #819's projection-on-server discipline, and detects convention violators. Rejected only because nothing else needs it yet — the cost (one wire-contract addition, one server populate site, one test) isn't justified by the convention-violator edge case alone. Worth filing as a small issue if the convention proves brittle in practice.
+- **Alternative: per-repo `priorityAreas` configurable for pinning specific areas to the top.** Considered and tried during the implement phase; the architect later requested it be removed. Rationale: solving a problem we don't actually have, and a configurable shape conflates coordination with rank. Pure alphabetical is the cleaner answer.
 
-- **Alternative: toggle to disable grouping.** Issue §6 (`### 6. No toggle`) explicitly rejects this — grouping is the default, and repos without `area/*` labels see everything under `Uncategorized` (functionally identical to today). Aligns with #818 which DOES have a toggle for builders; the asymmetry is intentional (the issue argues the backlog grouping is zero-cost so no toggle is needed).
+- **Alternative: toggle to disable grouping.** Issue §6 (`### 6. No toggle`) explicitly rejects this — grouping is the default, and repos without `area/*` labels see everything under `Uncategorized` (functionally identical to today, then flattened away by the single-Uncategorized optimization). No per-repo opt-out needed.
 
 ## Test Plan
 
@@ -56,9 +56,8 @@ Add a `suite('groupBacklogByArea', ...)` covering:
 
 - Empty input → empty array.
 - Single uncategorized item → one group with key `'Uncategorized'`, count 1.
-- `[area/cross-cutting]` alone → first (and only) group is `'cross-cutting'`.
-- Mixed: `auth`, `cross-cutting`, `tower`, `Uncategorized` → order is `['cross-cutting', 'auth', 'tower', 'Uncategorized']`.
-- Two alphabetical-specific areas + cross-cutting → `['cross-cutting', <alphabetically-first>, <alphabetically-second>]`, no Uncategorized header rendered.
+- Mixed: `auth`, `tower`, `Uncategorized` → order is `['auth', 'tower', 'Uncategorized']`.
+- Two specific areas → alphabetical, no `Uncategorized` header rendered when no uncategorized items exist.
 - Within-group order preserves input order (do not re-sort items).
 - Empty groups are omitted (no `(0)` headers).
 
@@ -66,10 +65,9 @@ Add a `suite('groupBacklogByArea', ...)` covering:
 
 Reviewer launches `afx dev pir-811` and inspects the VSCode sidebar:
 
-1. **Default rendering**: Backlog view shows headers like `vscode (20)`, `tower (4)`, etc. Click a header to expand → issue rows render underneath. Headers ordered: `cross-cutting` first if present, then alphabetical, `Uncategorized` last.
-2. **Single-issue cross-cutting**: pick an issue tagged with only `area/cross-cutting` (e.g. #854 today) → confirm it lives under the `cross-cutting` group.
-3. **Uncategorized fallback**: any issue with no `area/*` labels → confirm it's under `Uncategorized` (last position).
-4. **Click → view**: clicking a row still opens the issue via `codev.viewBacklogIssue`. Right-click → context-menu actions (spawn, open in browser, copy issue number) all still work.
-5. **Expansion persistence**: collapse a group, reload the VSCode window → that group stays collapsed.
-6. **No regression on dashboard**: open the web dashboard's Backlog view (`packages/dashboard/src/components/BacklogList.tsx`) → still renders as a flat list (no wire changes, no breakage).
-7. **Empty repo**: temporarily filter the test fixture to a repo with no `area/*` labels → everything under `Uncategorized`, no other groups.
+1. **Default rendering**: Backlog view shows headers like `vscode (20)`, `tower (4)`, etc. Headers ordered alphabetically, `Uncategorized` last.
+2. **Uncategorized fallback**: any issue with no `area/*` labels → confirm it's under `Uncategorized` (last position).
+3. **Click → view**: clicking a row still opens the issue via `codev.viewBacklogIssue`. Right-click → context-menu actions (spawn, open in browser, copy issue number) all still work.
+4. **Expansion persistence**: collapse a group, reload the VSCode window → that group stays collapsed.
+5. **No regression on dashboard**: open the web dashboard's Backlog view (`packages/dashboard/src/components/BacklogList.tsx`) → still renders as a flat list (no wire changes, no breakage).
+6. **No-area repo**: on a hypothetical repo with no `area/*` labels at all, single-Uncategorized flattens away — view renders flat rows with no header.

--- a/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
+++ b/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-05-27T11:39:37.781Z'
   pr:
     status: pending
+    requested_at: '2026-05-27T11:48:15.308Z'
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-05-27T10:36:54.820Z'
-updated_at: '2026-05-27T11:44:01.631Z'
+updated_at: '2026-05-27T11:48:15.309Z'
 pr_history:
   - phase: review
     pr_number: 886
     branch: builder/pir-811
     created_at: '2026-05-27T11:43:05.641Z'
+pr_ready_for_human: true

--- a/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
+++ b/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
@@ -1,0 +1,18 @@
+id: '811'
+title: vscode-group-backlog-by-area-a
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-27T10:36:54.820Z'
+updated_at: '2026-05-27T10:36:54.821Z'

--- a/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
+++ b/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
@@ -1,7 +1,7 @@
 id: '811'
 title: vscode-group-backlog-by-area-a
 protocol: pir
-phase: review
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -21,7 +21,7 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-27T10:36:54.820Z'
-updated_at: '2026-05-27T21:15:46.781Z'
+updated_at: '2026-05-27T21:26:41.774Z'
 pr_history:
   - phase: review
     pr_number: 886

--- a/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
+++ b/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-05-27T10:46:09.873Z'
   dev-approval:
     status: pending
+    requested_at: '2026-05-27T10:53:58.839Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T10:36:54.820Z'
-updated_at: '2026-05-27T10:46:15.743Z'
+updated_at: '2026-05-27T10:53:58.840Z'

--- a/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
+++ b/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
@@ -1,7 +1,7 @@
 id: '811'
 title: vscode-group-backlog-by-area-a
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T10:36:54.820Z'
-updated_at: '2026-05-27T11:39:37.781Z'
+updated_at: '2026-05-27T11:40:02.750Z'

--- a/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
+++ b/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-05-27T10:53:58.839Z'
     approved_at: '2026-05-27T11:39:37.781Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-05-27T11:48:15.308Z'
+    approved_at: '2026-05-27T21:15:46.780Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-27T10:36:54.820Z'
-updated_at: '2026-05-27T12:01:06.933Z'
+updated_at: '2026-05-27T21:15:46.781Z'
 pr_history:
   - phase: review
     pr_number: 886
     branch: builder/pir-811
     created_at: '2026-05-27T11:43:05.641Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
+++ b/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T10:36:54.820Z'
-updated_at: '2026-05-27T11:40:02.750Z'
+updated_at: '2026-05-27T11:43:05.641Z'
+pr_history:
+  - phase: review
+    pr_number: 886
+    branch: builder/pir-811
+    created_at: '2026-05-27T11:43:05.641Z'

--- a/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
+++ b/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-05-27T10:42:56.460Z'
+    approved_at: '2026-05-27T10:46:09.873Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T10:36:54.820Z'
-updated_at: '2026-05-27T10:42:56.461Z'
+updated_at: '2026-05-27T10:46:09.874Z'

--- a/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
+++ b/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-05-27T10:42:56.460Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T10:36:54.820Z'
-updated_at: '2026-05-27T10:36:54.821Z'
+updated_at: '2026-05-27T10:42:56.461Z'

--- a/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
+++ b/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
@@ -17,10 +17,10 @@ gates:
     status: pending
     requested_at: '2026-05-27T11:48:15.308Z'
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-05-27T10:36:54.820Z'
-updated_at: '2026-05-27T11:48:15.309Z'
+updated_at: '2026-05-27T12:01:06.933Z'
 pr_history:
   - phase: review
     pr_number: 886

--- a/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
+++ b/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
@@ -1,7 +1,7 @@
 id: '811'
 title: vscode-group-backlog-by-area-a
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T10:36:54.820Z'
-updated_at: '2026-05-27T10:46:09.874Z'
+updated_at: '2026-05-27T10:46:15.743Z'

--- a/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
+++ b/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-05-27T10:42:56.460Z'
     approved_at: '2026-05-27T10:46:09.873Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-05-27T10:53:58.839Z'
+    approved_at: '2026-05-27T11:39:37.781Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T10:36:54.820Z'
-updated_at: '2026-05-27T10:53:58.840Z'
+updated_at: '2026-05-27T11:39:37.781Z'

--- a/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
+++ b/codev/projects/811-vscode-group-backlog-by-area-a/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-05-27T10:36:54.820Z'
-updated_at: '2026-05-27T11:43:05.641Z'
+updated_at: '2026-05-27T11:44:01.631Z'
 pr_history:
   - phase: review
     pr_number: 886

--- a/codev/reviews/811-vscode-group-backlog-by-area-a.md
+++ b/codev/reviews/811-vscode-group-backlog-by-area-a.md
@@ -1,0 +1,95 @@
+# PIR Review: vscode — group backlog tree by area
+
+Fixes #811
+
+## Summary
+
+The vscode Backlog tree is now grouped by `area/*` label. Group ordering is driven by a per-repo setting `codev.backlog.priorityAreas` (default empty → pure alphabetical) followed by `Uncategorized` last; a single-`Uncategorized` group collapses to flat rendering so repos that haven't adopted `area/*` labels see no visual regression. Cross-cutting privilege is *not* hardcoded — the framework stays policy-free about specific label names (extending #819's discipline to the view layer).
+
+## Files Changed
+
+Computed via `git diff --stat origin/main...HEAD`:
+
+- `codev/plans/811-vscode-group-backlog-by-area.md` (+75 / -0)
+- `codev/projects/811-vscode-group-backlog-by-area-a/status.yaml` (+22 / -0) — porch-managed
+- `codev/reviews/811-vscode-group-backlog-by-area-a.md` (+TBD / -0) — this file
+- `codev/state/pir-811_thread.md` (+TBD / -0)
+- `packages/vscode/package.json` (+6 / -0) — registered the `codev.backlog.priorityAreas` setting
+- `packages/vscode/src/extension.ts` (+19 / -3) — wire workspaceState + expand/collapse listeners + config-change listener
+- `packages/vscode/src/test/backlog.test.ts` (+91 / -11) — 8 new `groupBacklogByArea` tests; one defensive test (`Uncategorized stays last even when listed in priorityAreas`)
+- `packages/vscode/src/views/backlog-tree-item.ts` (+22 / -0) — `BacklogGroupTreeItem` class
+- `packages/vscode/src/views/backlog.ts` (+193 / -21) — pure `groupBacklogByArea` helper + two-level `BacklogProvider` + single-Uncategorized flatten optimization
+
+Total: 9 files, +428 / -35 (approx; final stat in PR description).
+
+## Commits
+
+```
+68c3d070 [PIR #811] Group backlog tree by area/* label
+5fd9351e [PIR #811] Thread: log implement-phase progress
+aab03a27 [PIR #811] Replace hardcoded cross-cutting with codev.backlog.priorityAreas setting
+f736c3cc [PIR #811] Plan + thread: revise to user-configurable priority areas
+87fbf75b [PIR #811] Flatten single-Uncategorized backlog to row list (no header)
+7309c94c [PIR #811] Plan draft
+```
+
+## Test Results
+
+- `pnpm --filter codev-vscode test`: ✓ 92 pass (8 new `groupBacklogByArea` cases + 84 pre-existing)
+- `pnpm build` (full workspace): ✓ green
+- `pnpm --filter codev-vscode check-types`: ✓ green
+- `pnpm --filter codev-vscode lint`: ✓ green (ESLint via the test pretest pipeline)
+- Manual verification (at `dev-approval` gate): the human inspected the running implementation in the worktree dev server and approved.
+
+## Architecture Updates
+
+No changes to `codev/resources/arch.md`. This PR adds:
+
+1. A pure view-layer grouping helper (`groupBacklogByArea`) over an existing wire shape (`OverviewBacklogItem.area`, added by #819) — no new module boundaries, no new wire fields, no new caching layers.
+2. A two-level VSCode `TreeDataProvider` for the backlog view — a localized refactor of `BacklogProvider`, not a new tree-architecture pattern.
+3. A per-repo VSCode setting (`codev.backlog.priorityAreas`) — registered in `packages/vscode/package.json` alongside the existing `buildersAutoCollapse` / `buildersFileViewAsTree` settings, mirroring their wiring discipline (read via `vscode.workspace.getConfiguration('codev')`, refresh provider on `onDidChangeConfiguration`).
+
+None of these warrant arch-doc entries — they reuse established patterns. The framework-neutrality discipline (do not bake repo-specific label names into framework code) was already established in `codev/resources/arch.md` / lessons via #819 and remains the implicit rule this PR follows.
+
+## Lessons Learned Updates
+
+No additions to `codev/resources/lessons-learned.md`. Two design decisions worth noting are already covered by existing project memory:
+
+1. **Framework code stays policy-free about specific label values.** The first iteration hardcoded `'cross-cutting'` into the view's grouping rule. The human at dev-approval flagged this as the same anti-pattern #819 corrected at the parser. Replaced with a per-repo VSCode setting `codev.backlog.priorityAreas: string[]`. This is the *view-layer mirror* of the parser-layer rule already captured in [`feedback_framework_neutral_on_label_semantics`](../../.claude/projects/-Users-amrmohamed-repos-cluesmith-codev/memory/feedback_framework_neutral_on_label_semantics.md) — same principle, different surface, no new lesson needed.
+
+2. **Trust the wire contract; don't add defensive coercions for things the contract guarantees.** First iteration had `item.area || UNCATEGORIZED_AREA` as a defensive fallback even though the wire contract (`required-with-default`, set by `parseArea` server-side) guarantees `area` is always a populated string. Dropped the fallback and the corresponding empty-string test case. This is the system-prompt rule ("Don't add error handling, fallbacks, or validation for scenarios that can't happen") applied to the view boundary — not a new lesson.
+
+A follow-up issue was filed during this PIR:
+
+- **#885** — `vscode: capitalize area group header labels in backlog and builders trees`. The lowercase `area/*` label convention renders headers as `vscode (12)` next to `Uncategorized (8)`; visual inconsistency that this PIR did not address (it would touch the rendering layer and the same fix should land in #818's builders-tree grouping). Filed with both surfaces in scope and the sentence-case-vs-override-map decision left to the implementer.
+
+## Things to Look At During PR Review
+
+1. **Two design revisions during the implement phase**, visible in the commit history. The first iteration hardcoded `'cross-cutting'` as a privileged top group. The human flagged that as repo-specific policy leaking into framework code — replaced with `codev.backlog.priorityAreas` (per-repo setting). Then dropped the defensive `item.area || UNCATEGORIZED_AREA` coercion since the wire contract guarantees `area` is populated. Net: the final shape is smaller and cleaner than the first cut. The plan file's Risks section and the thread document the back-and-forth.
+
+2. **Single-Uncategorized flatten optimization** (`packages/vscode/src/views/backlog.ts:154-160`). When the grouped output is exactly one group AND that group is `Uncategorized`, the view skips the header and returns rows directly. This means a repo that hasn't adopted `area/*` labels sees zero visual change from the pre-grouping flat list — the zero-cost migration property the issue body promised. Worth a glance to confirm the trigger condition is what you'd expect (it's specifically "1 group AND Uncategorized" — not just "1 group", since a single-`vscode` repo with all items in one specific area still gets a header for clarity).
+
+3. **Group identity** (`BacklogGroupTreeItem.id = 'backlog-group:<areaName>'`). VSCode reuses the same TreeItem instance across `onDidChangeTreeData` refreshes when `id` matches, which keeps the user's expand/collapse state visually stable across the `OverviewCache` SSE tick. Without the stable `id`, every refresh would reset the visible expansion (the persisted state in `workspaceState` would still be honored, but the tree would flash collapsed-then-expanded on each tick).
+
+4. **`Uncategorized` is unpinnable defensively** (`packages/vscode/src/views/backlog.ts:61-63`). Even if a repo misconfigures `codev.backlog.priorityAreas: ["Uncategorized"]`, it's skipped from the priority loop so it always lands last. Explicit regression test: `Uncategorized stays last even when listed in priorityAreas`. This pinning rule isn't documented in the setting's `markdownDescription`; the test is the contract.
+
+5. **`pnpm --filter @cluesmith/codev test` showed 17 unrelated flakes on first run** (cron-cli and other agent-farm tests) that all passed on retry. The diff is 100% under `packages/vscode/` so the failures cannot be caused by this PIR. Mentioning for transparency, not as a flaky-test skip — no tests were quarantined.
+
+## How to Test Locally
+
+For reviewers pulling the branch:
+
+- **View diff**: VSCode sidebar → right-click builder `pir-811` → **Review Diff** (auto-detects the repo's default branch). Or `git diff main...HEAD`.
+- **Run dev server**: VSCode sidebar → **Run Dev Server**, or `afx dev pir-811` from a shell.
+- **What to verify**:
+  - The Backlog tree shows grouped headers like `vscode (N)`, `tower (N)`, etc., ordered alphabetically with `Uncategorized` last.
+  - Issue #854 (currently labeled `area/cross-cutting`) lives in its own `cross-cutting` group (alphabetical position, not pinned — pinning is opt-in via the setting).
+  - Add `"codev.backlog.priorityAreas": ["vscode"]` to your VSCode user/workspace settings → the `vscode` group jumps to the top; everything else stays alphabetical; `Uncategorized` stays last.
+  - Collapse a group, reload the VSCode window → that group stays collapsed.
+  - Single-issue click → still opens via `codev.viewBacklogIssue`. Right-click → context menu actions (spawn, open in browser, copy issue number) still work.
+  - On a hypothetical repo with no `area/*` labels at all, the view renders flat (no `Uncategorized (N)` header) — zero-cost migration.
+  - Dashboard's `BacklogList` (web): no wire changes, no breakage; still renders as a flat list.
+
+## Flaky Tests
+
+None skipped or quarantined.

--- a/codev/reviews/811-vscode-group-backlog-by-area-a.md
+++ b/codev/reviews/811-vscode-group-backlog-by-area-a.md
@@ -4,38 +4,40 @@ Fixes #811
 
 ## Summary
 
-The vscode Backlog tree is now grouped by `area/*` label. Group ordering is driven by a per-repo setting `codev.backlog.priorityAreas` (default empty → pure alphabetical) followed by `Uncategorized` last; a single-`Uncategorized` group collapses to flat rendering so repos that haven't adopted `area/*` labels see no visual regression. Cross-cutting privilege is *not* hardcoded — the framework stays policy-free about specific label names (extending #819's discipline to the view layer).
+The vscode Backlog tree is now grouped by `area/*` label. Group ordering is pure alphabetical specific areas followed by `Uncategorized` last; a single-`Uncategorized` group collapses to flat rendering so repos that haven't adopted `area/*` labels see no visual regression. No configurable mechanism — the framework stays policy-free about specific label names and about group rank (extending #819's discipline to the view layer).
 
 ## Files Changed
 
 Computed via `git diff --stat origin/main...HEAD`:
 
-- `codev/plans/811-vscode-group-backlog-by-area.md` (+75 / -0)
-- `codev/projects/811-vscode-group-backlog-by-area-a/status.yaml` (+22 / -0) — porch-managed
+- `codev/plans/811-vscode-group-backlog-by-area.md` (+TBD / -TBD)
+- `codev/projects/811-vscode-group-backlog-by-area-a/status.yaml` — porch-managed
 - `codev/reviews/811-vscode-group-backlog-by-area-a.md` (+TBD / -0) — this file
 - `codev/state/pir-811_thread.md` (+TBD / -0)
-- `packages/vscode/package.json` (+6 / -0) — registered the `codev.backlog.priorityAreas` setting
-- `packages/vscode/src/extension.ts` (+19 / -3) — wire workspaceState + expand/collapse listeners + config-change listener
-- `packages/vscode/src/test/backlog.test.ts` (+91 / -11) — 8 new `groupBacklogByArea` tests; one defensive test (`Uncategorized stays last even when listed in priorityAreas`)
+- `packages/vscode/src/extension.ts` (+13 / -1) — wire workspaceState + expand/collapse listeners
+- `packages/vscode/src/test/backlog.test.ts` (+59 / -11) — 6 new `groupBacklogByArea` tests
 - `packages/vscode/src/views/backlog-tree-item.ts` (+22 / -0) — `BacklogGroupTreeItem` class
-- `packages/vscode/src/views/backlog.ts` (+193 / -21) — pure `groupBacklogByArea` helper + two-level `BacklogProvider` + single-Uncategorized flatten optimization
+- `packages/vscode/src/views/backlog.ts` (+140 / -21) — pure `groupBacklogByArea` helper + two-level `BacklogProvider` + single-Uncategorized flatten optimization
 
-Total: 9 files, +428 / -35 (approx; final stat in PR description).
+Final stat in PR description.
 
 ## Commits
 
 ```
+7309c94c [PIR #811] Plan draft
 68c3d070 [PIR #811] Group backlog tree by area/* label
 5fd9351e [PIR #811] Thread: log implement-phase progress
 aab03a27 [PIR #811] Replace hardcoded cross-cutting with codev.backlog.priorityAreas setting
 f736c3cc [PIR #811] Plan + thread: revise to user-configurable priority areas
 87fbf75b [PIR #811] Flatten single-Uncategorized backlog to row list (no header)
-7309c94c [PIR #811] Plan draft
+a235d422 [PIR #811] Review + retrospective
+9ace0fcb [PIR #811] Address Claude COMMENT: drop void prefix on fire-and-forget update
+<sha>     [PIR #811] Drop codev.backlog.priorityAreas mechanism per architect reconsideration
 ```
 
 ## Test Results
 
-- `pnpm --filter codev-vscode test`: ✓ 92 pass (8 new `groupBacklogByArea` cases + 84 pre-existing)
+- `pnpm --filter codev-vscode test`: ✓ 90 pass (6 new `groupBacklogByArea` cases + 84 pre-existing)
 - `pnpm build` (full workspace): ✓ green
 - `pnpm --filter codev-vscode check-types`: ✓ green
 - `pnpm --filter codev-vscode lint`: ✓ green (ESLint via the test pretest pipeline)
@@ -47,33 +49,30 @@ No changes to `codev/resources/arch.md`. This PR adds:
 
 1. A pure view-layer grouping helper (`groupBacklogByArea`) over an existing wire shape (`OverviewBacklogItem.area`, added by #819) — no new module boundaries, no new wire fields, no new caching layers.
 2. A two-level VSCode `TreeDataProvider` for the backlog view — a localized refactor of `BacklogProvider`, not a new tree-architecture pattern.
-3. A per-repo VSCode setting (`codev.backlog.priorityAreas`) — registered in `packages/vscode/package.json` alongside the existing `buildersAutoCollapse` / `buildersFileViewAsTree` settings, mirroring their wiring discipline (read via `vscode.workspace.getConfiguration('codev')`, refresh provider on `onDidChangeConfiguration`).
 
-None of these warrant arch-doc entries — they reuse established patterns. The framework-neutrality discipline (do not bake repo-specific label names into framework code) was already established in `codev/resources/arch.md` / lessons via #819 and remains the implicit rule this PR follows.
+None warrant arch-doc entries — they reuse established patterns. The framework-neutrality discipline (do not bake repo-specific label names or per-repo rank policy into framework code) was already established in `codev/resources/arch.md` / lessons via #819 and remains the implicit rule this PR follows.
 
 ## Lessons Learned Updates
 
-No additions to `codev/resources/lessons-learned.md`. Two design decisions worth noting are already covered by existing project memory:
+No additions to `codev/resources/lessons-learned.md`. Two design moves worth recording are already covered by existing project memory:
 
-1. **Framework code stays policy-free about specific label values.** The first iteration hardcoded `'cross-cutting'` into the view's grouping rule. The human at dev-approval flagged this as the same anti-pattern #819 corrected at the parser. Replaced with a per-repo VSCode setting `codev.backlog.priorityAreas: string[]`. This is the *view-layer mirror* of the parser-layer rule already captured in [`feedback_framework_neutral_on_label_semantics`](../../.claude/projects/-Users-amrmohamed-repos-cluesmith-codev/memory/feedback_framework_neutral_on_label_semantics.md) — same principle, different surface, no new lesson needed.
+1. **Framework code stays policy-free about label values *and* about per-repo rank policy.** The first iteration hardcoded `'cross-cutting'` as a privileged top group; the human at `dev-approval` flagged it as the same anti-pattern #819 corrected at the parser. Switching to a `codev.backlog.priorityAreas` setting solved the hardcoded-label problem but introduced a new one: a configurable mechanism for what turned out to be the wrong shape (rank ≠ coordination). The architect's reconsideration during the review phase dropped the mechanism entirely. Net: alphabetical specifics + `Uncategorized` last is the simplest rule and matches `parseArea`'s policy-free posture. Same principle as [`feedback_framework_neutral_on_label_semantics`](../../.claude/projects/-Users-amrmohamed-repos-cluesmith-codev/memory/feedback_framework_neutral_on_label_semantics.md); no new lesson.
 
-2. **Trust the wire contract; don't add defensive coercions for things the contract guarantees.** First iteration had `item.area || UNCATEGORIZED_AREA` as a defensive fallback even though the wire contract (`required-with-default`, set by `parseArea` server-side) guarantees `area` is always a populated string. Dropped the fallback and the corresponding empty-string test case. This is the system-prompt rule ("Don't add error handling, fallbacks, or validation for scenarios that can't happen") applied to the view boundary — not a new lesson.
+2. **Trust the wire contract; don't add defensive coercions for things the contract guarantees.** First iteration had `item.area || UNCATEGORIZED_AREA` as a defensive fallback even though the wire contract (`required-with-default`, set by `parseArea` server-side) guarantees `area` is always a populated string. Dropped the fallback and the corresponding empty-string test case. System-prompt rule applied to the view boundary — not a new lesson.
 
 A follow-up issue was filed during this PIR:
 
-- **#885** — `vscode: capitalize area group header labels in backlog and builders trees`. The lowercase `area/*` label convention renders headers as `vscode (12)` next to `Uncategorized (8)`; visual inconsistency that this PIR did not address (it would touch the rendering layer and the same fix should land in #818's builders-tree grouping). Filed with both surfaces in scope and the sentence-case-vs-override-map decision left to the implementer.
+- **#885** — `vscode: capitalize area group header labels in backlog and builders trees`. The lowercase `area/*` label convention renders headers as `vscode (12)` next to `Uncategorized (8)`; visual inconsistency this PIR did not address (it would touch the rendering layer and the same fix should land in #818's builders-tree grouping).
 
 ## Things to Look At During PR Review
 
-1. **Two design revisions during the implement phase**, visible in the commit history. The first iteration hardcoded `'cross-cutting'` as a privileged top group. The human flagged that as repo-specific policy leaking into framework code — replaced with `codev.backlog.priorityAreas` (per-repo setting). Then dropped the defensive `item.area || UNCATEGORIZED_AREA` coercion since the wire contract guarantees `area` is populated. Net: the final shape is smaller and cleaner than the first cut. The plan file's Risks section and the thread document the back-and-forth.
+1. **Three design revisions before settling**, visible in the commit history. First iteration hardcoded `'cross-cutting'` as a privileged top group. Second iteration replaced that with a per-repo VSCode setting `codev.backlog.priorityAreas`. Third iteration (this commit) dropped the configurable entirely per architect reconsideration — pure alphabetical, no priority mechanism, no setting. The final shape is the smallest possible: a render-layer grouping over an existing wire field, with one optimization (single-Uncategorized flatten) for the no-area-labels case.
 
-2. **Single-Uncategorized flatten optimization** (`packages/vscode/src/views/backlog.ts:154-160`). When the grouped output is exactly one group AND that group is `Uncategorized`, the view skips the header and returns rows directly. This means a repo that hasn't adopted `area/*` labels sees zero visual change from the pre-grouping flat list — the zero-cost migration property the issue body promised. Worth a glance to confirm the trigger condition is what you'd expect (it's specifically "1 group AND Uncategorized" — not just "1 group", since a single-`vscode` repo with all items in one specific area still gets a header for clarity).
+2. **Single-Uncategorized flatten optimization** (`packages/vscode/src/views/backlog.ts:120-125`). When the grouped output is exactly one group AND that group is `Uncategorized`, the view skips the header and returns rows directly. This is the zero-cost migration property the issue body promised. Trigger is specifically "1 group AND Uncategorized" — a single-`vscode` repo with all items in one specific area still gets a header for clarity (the header carries the categorization signal; an `Uncategorized` header carries none).
 
 3. **Group identity** (`BacklogGroupTreeItem.id = 'backlog-group:<areaName>'`). VSCode reuses the same TreeItem instance across `onDidChangeTreeData` refreshes when `id` matches, which keeps the user's expand/collapse state visually stable across the `OverviewCache` SSE tick. Without the stable `id`, every refresh would reset the visible expansion (the persisted state in `workspaceState` would still be honored, but the tree would flash collapsed-then-expanded on each tick).
 
-4. **`Uncategorized` is unpinnable defensively** (`packages/vscode/src/views/backlog.ts:61-63`). Even if a repo misconfigures `codev.backlog.priorityAreas: ["Uncategorized"]`, it's skipped from the priority loop so it always lands last. Explicit regression test: `Uncategorized stays last even when listed in priorityAreas`. This pinning rule isn't documented in the setting's `markdownDescription`; the test is the contract.
-
-5. **`pnpm --filter @cluesmith/codev test` showed 17 unrelated flakes on first run** (cron-cli and other agent-farm tests) that all passed on retry. The diff is 100% under `packages/vscode/` so the failures cannot be caused by this PIR. Mentioning for transparency, not as a flaky-test skip — no tests were quarantined.
+4. **`pnpm --filter @cluesmith/codev test` showed 17 unrelated flakes on first run** (cron-cli and other agent-farm tests) that all passed on retry. The diff is 100% under `packages/vscode/` so the failures cannot be caused by this PIR. Mentioning for transparency, not as a flaky-test skip — no tests were quarantined.
 
 ## How to Test Locally
 
@@ -83,11 +82,10 @@ For reviewers pulling the branch:
 - **Run dev server**: VSCode sidebar → **Run Dev Server**, or `afx dev pir-811` from a shell.
 - **What to verify**:
   - The Backlog tree shows grouped headers like `vscode (N)`, `tower (N)`, etc., ordered alphabetically with `Uncategorized` last.
-  - Issue #854 (currently labeled `area/cross-cutting`) lives in its own `cross-cutting` group (alphabetical position, not pinned — pinning is opt-in via the setting).
-  - Add `"codev.backlog.priorityAreas": ["vscode"]` to your VSCode user/workspace settings → the `vscode` group jumps to the top; everything else stays alphabetical; `Uncategorized` stays last.
+  - Issue with no `area/*` labels lives under `Uncategorized` at the bottom.
   - Collapse a group, reload the VSCode window → that group stays collapsed.
   - Single-issue click → still opens via `codev.viewBacklogIssue`. Right-click → context menu actions (spawn, open in browser, copy issue number) still work.
-  - On a hypothetical repo with no `area/*` labels at all, the view renders flat (no `Uncategorized (N)` header) — zero-cost migration.
+  - On a hypothetical repo with no `area/*` labels at all, the view renders flat (no `Uncategorized (N)` header) — single-Uncategorized flatten optimization.
   - Dashboard's `BacklogList` (web): no wire changes, no breakage; still renders as a flat list.
 
 ## Flaky Tests

--- a/codev/reviews/811-vscode-group-backlog-by-area-a.md
+++ b/codev/reviews/811-vscode-group-backlog-by-area-a.md
@@ -10,16 +10,16 @@ The vscode Backlog tree is now grouped by `area/*` label. Group ordering is pure
 
 Computed via `git diff --stat origin/main...HEAD`:
 
-- `codev/plans/811-vscode-group-backlog-by-area.md` (+TBD / -TBD)
-- `codev/projects/811-vscode-group-backlog-by-area-a/status.yaml` — porch-managed
-- `codev/reviews/811-vscode-group-backlog-by-area-a.md` (+TBD / -0) — this file
-- `codev/state/pir-811_thread.md` (+TBD / -0)
-- `packages/vscode/src/extension.ts` (+13 / -1) — wire workspaceState + expand/collapse listeners
-- `packages/vscode/src/test/backlog.test.ts` (+59 / -11) — 6 new `groupBacklogByArea` tests
+- `codev/plans/811-vscode-group-backlog-by-area.md` (+73 / -0)
+- `codev/projects/811-vscode-group-backlog-by-area-a/status.yaml` (+29 / -0) — porch-managed
+- `codev/reviews/811-vscode-group-backlog-by-area-a.md` (+93 / -0) — this file
+- `codev/state/pir-811_thread.md` (+68 / -0)
+- `packages/vscode/src/extension.ts` (+13 / -4) — wire workspaceState + expand/collapse listeners
+- `packages/vscode/src/test/backlog.test.ts` (+59 / -6) — 6 new `groupBacklogByArea` tests
 - `packages/vscode/src/views/backlog-tree-item.ts` (+22 / -0) — `BacklogGroupTreeItem` class
-- `packages/vscode/src/views/backlog.ts` (+140 / -21) — pure `groupBacklogByArea` helper + two-level `BacklogProvider` + single-Uncategorized flatten optimization
+- `packages/vscode/src/views/backlog.ts` (+154 / -19) — pure `groupBacklogByArea` helper + two-level `BacklogProvider` + single-Uncategorized flatten optimization
 
-Final stat in PR description.
+Total: 8 files, +511 / -29.
 
 ## Commits
 
@@ -32,7 +32,8 @@ f736c3cc [PIR #811] Plan + thread: revise to user-configurable priority areas
 87fbf75b [PIR #811] Flatten single-Uncategorized backlog to row list (no header)
 a235d422 [PIR #811] Review + retrospective
 9ace0fcb [PIR #811] Address Claude COMMENT: drop void prefix on fire-and-forget update
-<sha>     [PIR #811] Drop codev.backlog.priorityAreas mechanism per architect reconsideration
+6183fba6 [PIR #811] Thread: log review-phase consult verdicts and pr gate
+f1c30975 [PIR #811] Drop codev.backlog.priorityAreas mechanism per architect reconsideration
 ```
 
 ## Test Results

--- a/codev/state/pir-811_thread.md
+++ b/codev/state/pir-811_thread.md
@@ -51,3 +51,18 @@ PR #886 opened with the review file as body. Single advisory 3-way consultation 
 - Claude: COMMENT (one cosmetic — `void` prefix on a fire-and-forget Promise; matches my own `feedback_no_void_floating_promise` convention)
 
 Addressed Claude's nit in `9ace0fcb` (dropped the `void` prefix). pr gate now pending; architect notified.
+
+## 2026-05-27 — review phase, revision 2
+
+Architect reconsideration during pr-gate review: drop the `codev.backlog.priorityAreas` mechanism entirely. Rationale: solving a problem we don't have; configurable shape conflated coordination with rank. Better to remove than ship + maintain.
+
+Changes:
+- `views/backlog.ts`: `groupBacklogByArea` no longer takes `priorityAreas`; pure alphabetical specifics + `Uncategorized` last. Dropped `readPriorityAreas()`, `refresh()`.
+- `extension.ts`: dropped the `onDidChangeConfiguration` listener for `codev.backlog.priorityAreas`.
+- `package.json`: dropped the `codev.backlog.priorityAreas` setting registration.
+- `test/backlog.test.ts`: dropped three priorityAreas-related tests; renamed "default ordering is alphabetical specifics then Uncategorized last" → "alphabetical specifics then Uncategorized last".
+- Plan + review docs revised to remove all priorityAreas references; alternatives section now documents both the cross-cutting hardcoding and the priorityAreas configurable as rejected.
+
+Test results: `pnpm --filter codev-vscode test` → 90 pass.
+
+Sibling PIR #818 (builders-tree grouping) is still in plan phase. The same simpler design applies there; the architect will flag this when their plan lands so both views ship byte-identical.

--- a/codev/state/pir-811_thread.md
+++ b/codev/state/pir-811_thread.md
@@ -12,3 +12,19 @@ Design tension: AC #2 wants cross-cutting in its own top group, but the singular
 Resolution chosen: lean on the issue body's own convention guidance — "Tag it `area/cross-cutting` only (don't list every individual area)". Under this convention, singular `area === 'cross-cutting'` is sufficient detection. Avoids re-litigating #819's wire-shape decision. Documented the alternative (`crossCutting: boolean` or `areas: string[]`) in the plan's Risks section as a follow-up if the convention proves brittle.
 
 Plan written to `codev/plans/811-vscode-group-backlog-by-area.md`. Ready for plan-approval gate.
+
+## 2026-05-27 — implement phase
+
+Plan-approval gate approved. Implemented the area-grouping refactor:
+
+- `views/backlog.ts`: added pure `groupBacklogByArea(items)` helper (cross-cutting first, alphabetical specifics, Uncategorized last; empty groups omitted; within-group order preserved). Refactored `BacklogProvider` to two-level (`getChildren()` returns groups when called with no element, rows when called with a `BacklogGroupTreeItem`). Constructor now takes `vscode.Memento` for expansion-state persistence.
+- `views/backlog-tree-item.ts`: added `BacklogGroupTreeItem` class. Uses stable `id` (`backlog-group:<areaName>`) so VSCode preserves item identity across SSE-driven `onDidChangeTreeData` refreshes — which keeps the user's expand/collapse choice persistent visually as well as via the workspaceState write-back.
+- `extension.ts`: passed `context.workspaceState` to `BacklogProvider`; wired `backlogView.onDidExpandElement` / `onDidCollapseElement` to call `setGroupExpanded()` so user choices persist.
+- `test/backlog.test.ts`: 8 new tests for `groupBacklogByArea` covering empty input, lone cross-cutting, lone Uncategorized, full ordering, omitted empty groups, within-group order preservation, multi-item-per-area, and the defensive empty-string-area fallback.
+
+Test results:
+- `pnpm --filter codev-vscode test`: 91 pass (8 new groupBacklogByArea + all pre-existing).
+- `pnpm build` (full workspace): green.
+- `pnpm --filter @cluesmith/codev test`: first run showed 17 flakes in unrelated suites (cron-cli, etc.); re-run clean at 3173 pass. Not caused by this PIR — my changes are entirely in `packages/vscode/`.
+
+Ready for dev-approval gate.

--- a/codev/state/pir-811_thread.md
+++ b/codev/state/pir-811_thread.md
@@ -1,0 +1,14 @@
+# pir-811 thread
+
+## 2026-05-27 — plan phase
+
+Read issue #811 (group backlog by area). Investigated:
+- `OverviewBacklogItem.area: string` already on the wire (added by #819).
+- `parseArea` (singular) is policy-free — does NOT privilege `area/cross-cutting` (explicit decision + regression test in #819).
+- `parseAreaLabels` (plural) does NOT exist. The "helper issue" referenced as Related in #811 was #819, which CLOSED with a different shape (singular projection on the server, no resolvePrimaryArea helper).
+
+Design tension: AC #2 wants cross-cutting in its own top group, but the singular `area` field can't distinguish `[area/cross-cutting]` from `[area/auth, area/cross-cutting]` (the latter projects to `auth`).
+
+Resolution chosen: lean on the issue body's own convention guidance — "Tag it `area/cross-cutting` only (don't list every individual area)". Under this convention, singular `area === 'cross-cutting'` is sufficient detection. Avoids re-litigating #819's wire-shape decision. Documented the alternative (`crossCutting: boolean` or `areas: string[]`) in the plan's Risks section as a follow-up if the convention proves brittle.
+
+Plan written to `codev/plans/811-vscode-group-backlog-by-area.md`. Ready for plan-approval gate.

--- a/codev/state/pir-811_thread.md
+++ b/codev/state/pir-811_thread.md
@@ -66,3 +66,12 @@ Changes:
 Test results: `pnpm --filter codev-vscode test` → 90 pass.
 
 Sibling PIR #818 (builders-tree grouping) is still in plan phase. The same simpler design applies there; the architect will flag this when their plan lands so both views ship byte-identical.
+
+## 2026-05-27 — re-run CMAP after architect reconsideration
+
+Iter-2 verdicts (Codex failed first attempt on transient DNS; retried successfully):
+- Gemini: APPROVE
+- Codex: REQUEST_CHANGES — flagged unresolved `(+TBD / -TBD)` placeholders in the review's Files Changed section and a `<sha>` placeholder in the commit list. Real finding (I left placeholders when rewriting the review for the priorityAreas removal). Fixed in `2ced3f9d`: filled in real diff stats from `git diff --stat origin/main...HEAD` and the final commit sha. PR body re-synced via `gh pr edit`.
+- Claude: APPROVE
+
+Architect re-notified with REQUEST_CHANGES disposition (single-pass — no automatic re-review).

--- a/codev/state/pir-811_thread.md
+++ b/codev/state/pir-811_thread.md
@@ -28,3 +28,17 @@ Test results:
 - `pnpm --filter @cluesmith/codev test`: first run showed 17 flakes in unrelated suites (cron-cli, etc.); re-run clean at 3173 pass. Not caused by this PIR — my changes are entirely in `packages/vscode/`.
 
 Ready for dev-approval gate.
+
+## 2026-05-27 — implement phase, revision 1
+
+User correction at the dev-approval gate: hardcoding `'cross-cutting'` into the view bakes a repo-specific convention into framework code. Replaced with a per-repo VSCode setting `codev.backlog.priorityAreas: string[]` — areas listed here get pinned to the top in the listed order; default `[]` is pure alphabetical. Mirrors the framework-neutral discipline #819 already established at the parser layer.
+
+Also dropped the defensive `item.area || UNCATEGORIZED_AREA` coercion in `groupBacklogByArea` — the wire contract from #819 guarantees `area` is always a populated string, so the fallback is dead defense. Removed the corresponding empty-string-area test case.
+
+Changes:
+- `views/backlog.ts`: `groupBacklogByArea(items, priorityAreas = [])`; new `readPriorityAreas()` reads the setting; new `refresh()` for config-change re-render.
+- `extension.ts`: subscribed `onDidChangeConfiguration` for `codev.backlog.priorityAreas` to call `backlogProvider.refresh()`.
+- `package.json`: registered the `codev.backlog.priorityAreas` setting.
+- `test/backlog.test.ts`: dropped cross-cutting and empty-string fixtures; added `priorityAreas pins listed areas`, `Uncategorized stays last even when listed in priorityAreas` (defensive guard), `priorityAreas entries that match no present area are skipped silently`.
+
+Test results: `pnpm --filter codev-vscode test` → 92 pass.

--- a/codev/state/pir-811_thread.md
+++ b/codev/state/pir-811_thread.md
@@ -42,3 +42,12 @@ Changes:
 - `test/backlog.test.ts`: dropped cross-cutting and empty-string fixtures; added `priorityAreas pins listed areas`, `Uncategorized stays last even when listed in priorityAreas` (defensive guard), `priorityAreas entries that match no present area are skipped silently`.
 
 Test results: `pnpm --filter codev-vscode test` → 92 pass.
+
+## 2026-05-27 — review phase
+
+PR #886 opened with the review file as body. Single advisory 3-way consultation pass:
+- Gemini: APPROVE
+- Codex: APPROVE
+- Claude: COMMENT (one cosmetic — `void` prefix on a fire-and-forget Promise; matches my own `feedback_no_void_floating_promise` convention)
+
+Addressed Claude's nit in `9ace0fcb` (dropped the `void` prefix). pr gate now pending; architect notified.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -562,6 +562,12 @@
           "type": "boolean",
           "default": true,
           "description": "Render a builder's changed-files list as a folder tree (with single-child folder chains compacted, like VSCode's Source Control panel) instead of a flat list. Toggleable via the Builders title-bar button."
+        },
+        "codev.backlog.priorityAreas": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "markdownDescription": "Area names (without the `area/` prefix) to pin to the top of the grouped Backlog tree, in the order listed. Everything else sorts alphabetically below, with `Uncategorized` always last. Default `[]` is pure alphabetical. Per-repo policy — the framework intentionally does not bake in any specific label name."
         }
       }
     }

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -562,12 +562,6 @@
           "type": "boolean",
           "default": true,
           "description": "Render a builder's changed-files list as a folder tree (with single-child folder chains compacted, like VSCode's Source Control panel) instead of a flat list. Toggleable via the Builders title-bar button."
-        },
-        "codev.backlog.priorityAreas": {
-          "type": "array",
-          "items": { "type": "string" },
-          "default": [],
-          "markdownDescription": "Area names (without the `area/` prefix) to pin to the top of the grouped Backlog tree, in the order listed. Everything else sorts alphabetically below, with `Uncategorized` always last. Default `[]` is pure alphabetical. Per-repo policy — the framework intentionally does not bake in any specific label name."
         }
       }
     }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -268,6 +268,11 @@ export async function activate(context: vscode.ExtensionContext) {
 				backlogProvider.setGroupExpanded(e.element.areaName, false);
 			}
 		}),
+		vscode.workspace.onDidChangeConfiguration((e) => {
+			if (e.affectsConfiguration('codev.backlog.priorityAreas')) {
+				backlogProvider.refresh();
+			}
+		}),
 	);
 	recentlyClosedView = vscode.window.createTreeView('codev.recentlyClosed', { treeDataProvider: new RecentlyClosedProvider(overviewCache) });
 	// Seed the badge so it's correct immediately if overview data is already

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -268,11 +268,6 @@ export async function activate(context: vscode.ExtensionContext) {
 				backlogProvider.setGroupExpanded(e.element.areaName, false);
 			}
 		}),
-		vscode.workspace.onDidChangeConfiguration((e) => {
-			if (e.affectsConfiguration('codev.backlog.priorityAreas')) {
-				backlogProvider.refresh();
-			}
-		}),
 	);
 	recentlyClosedView = vscode.window.createTreeView('codev.recentlyClosed', { treeDataProvider: new RecentlyClosedProvider(overviewCache) });
 	// Seed the badge so it's correct immediately if overview data is already

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -37,7 +37,7 @@ import { BuilderTreeItem } from './views/builder-tree-item.js';
 import { BuilderFileTreeItem } from './views/builder-file-tree-item.js';
 import { BuilderDiffCache } from './views/builder-diff-cache.js';
 import { BuilderFileDecorationProvider } from './views/builder-file-decoration.js';
-import { BacklogTreeItem } from './views/backlog-tree-item.js';
+import { BacklogGroupTreeItem, BacklogTreeItem } from './views/backlog-tree-item.js';
 
 let connectionManager: ConnectionManager | null = null;
 let terminalManager: TerminalManager | null = null;
@@ -255,7 +255,20 @@ export async function activate(context: vscode.ExtensionContext) {
 	const buildersProvider = new BuildersProvider(overviewCache, builderDiffCache);
 	buildersView = vscode.window.createTreeView('codev.builders', { treeDataProvider: buildersProvider });
 	pullRequestsView = vscode.window.createTreeView('codev.pullRequests', { treeDataProvider: new PullRequestsProvider(overviewCache) });
-	backlogView = vscode.window.createTreeView('codev.backlog', { treeDataProvider: new BacklogProvider(overviewCache) });
+	const backlogProvider = new BacklogProvider(overviewCache, context.workspaceState);
+	backlogView = vscode.window.createTreeView('codev.backlog', { treeDataProvider: backlogProvider });
+	context.subscriptions.push(
+		backlogView.onDidExpandElement((e) => {
+			if (e.element instanceof BacklogGroupTreeItem) {
+				backlogProvider.setGroupExpanded(e.element.areaName, true);
+			}
+		}),
+		backlogView.onDidCollapseElement((e) => {
+			if (e.element instanceof BacklogGroupTreeItem) {
+				backlogProvider.setGroupExpanded(e.element.areaName, false);
+			}
+		}),
+	);
 	recentlyClosedView = vscode.window.createTreeView('codev.recentlyClosed', { treeDataProvider: new RecentlyClosedProvider(overviewCache) });
 	// Seed the badge so it's correct immediately if overview data is already
 	// cached, instead of waiting for the next onDidChange tick.

--- a/packages/vscode/src/test/backlog.test.ts
+++ b/packages/vscode/src/test/backlog.test.ts
@@ -1,10 +1,14 @@
 import * as assert from 'assert';
 import type { OverviewBacklogItem } from '@cluesmith/codev-types';
-import { spawnableBacklog } from '../views/backlog.js';
+import { groupBacklogByArea, spawnableBacklog } from '../views/backlog.js';
 
 function item(id: string, hasBuilder: boolean): OverviewBacklogItem {
 	// Only the fields spawnableBacklog reads matter; cast the rest.
 	return { id, title: `t${id}`, hasBuilder } as unknown as OverviewBacklogItem;
+}
+
+function backlogItem(id: string, area: string): OverviewBacklogItem {
+	return { id, title: `t${id}`, area } as unknown as OverviewBacklogItem;
 }
 
 suite('spawnableBacklog', () => {
@@ -33,5 +37,79 @@ suite('spawnableBacklog', () => {
 			item('d', false),
 		]);
 		assert.deepStrictEqual(out.map(i => i.id), ['a', 'c', 'd']);
+	});
+});
+
+suite('groupBacklogByArea', () => {
+	test('empty in -> empty out', () => {
+		assert.deepStrictEqual(groupBacklogByArea([]), []);
+	});
+
+	test('single Uncategorized item -> one Uncategorized group', () => {
+		const out = groupBacklogByArea([backlogItem('1', 'Uncategorized')]);
+		assert.deepStrictEqual(out.map(g => g.area), ['Uncategorized']);
+		assert.deepStrictEqual(out[0].items.map(i => i.id), ['1']);
+	});
+
+	test('lone cross-cutting item lands in the cross-cutting group', () => {
+		const out = groupBacklogByArea([backlogItem('1', 'cross-cutting')]);
+		assert.deepStrictEqual(out.map(g => g.area), ['cross-cutting']);
+	});
+
+	test('orders groups: cross-cutting first, alphabetical specifics, Uncategorized last', () => {
+		const out = groupBacklogByArea([
+			backlogItem('1', 'tower'),
+			backlogItem('2', 'Uncategorized'),
+			backlogItem('3', 'auth'),
+			backlogItem('4', 'cross-cutting'),
+			backlogItem('5', 'porch'),
+		]);
+		assert.deepStrictEqual(
+			out.map(g => g.area),
+			['cross-cutting', 'auth', 'porch', 'tower', 'Uncategorized'],
+		);
+	});
+
+	test('omits empty area groups (no "<area> (0)" headers)', () => {
+		// No items with area "vscode" -> no vscode header even though it's a
+		// real area in the repo's label set.
+		const out = groupBacklogByArea([
+			backlogItem('1', 'auth'),
+			backlogItem('2', 'tower'),
+		]);
+		assert.deepStrictEqual(out.map(g => g.area), ['auth', 'tower']);
+	});
+
+	test('preserves input order within a group (no internal re-sort)', () => {
+		const out = groupBacklogByArea([
+			backlogItem('5', 'vscode'),
+			backlogItem('2', 'vscode'),
+			backlogItem('9', 'vscode'),
+			backlogItem('1', 'vscode'),
+		]);
+		assert.deepStrictEqual(out.map(g => g.area), ['vscode']);
+		assert.deepStrictEqual(out[0].items.map(i => i.id), ['5', '2', '9', '1']);
+	});
+
+	test('groups multiple items per area correctly', () => {
+		const out = groupBacklogByArea([
+			backlogItem('1', 'vscode'),
+			backlogItem('2', 'tower'),
+			backlogItem('3', 'vscode'),
+			backlogItem('4', 'tower'),
+			backlogItem('5', 'vscode'),
+		]);
+		assert.deepStrictEqual(out.map(g => g.area), ['tower', 'vscode']);
+		assert.deepStrictEqual(out[0].items.map(i => i.id), ['2', '4']);
+		assert.deepStrictEqual(out[1].items.map(i => i.id), ['1', '3', '5']);
+	});
+
+	test('falls back to Uncategorized when area field is empty string', () => {
+		// Defensive: server contract says area is always a populated string,
+		// but a malformed payload (empty string from a custom forge adapter)
+		// must not break grouping or vanish the item.
+		const out = groupBacklogByArea([backlogItem('1', '')]);
+		assert.deepStrictEqual(out.map(g => g.area), ['Uncategorized']);
+		assert.deepStrictEqual(out[0].items.map(i => i.id), ['1']);
 	});
 });

--- a/packages/vscode/src/test/backlog.test.ts
+++ b/packages/vscode/src/test/backlog.test.ts
@@ -51,7 +51,7 @@ suite('groupBacklogByArea', () => {
 		assert.deepStrictEqual(out[0].items.map(i => i.id), ['1']);
 	});
 
-	test('default ordering is alphabetical specifics then Uncategorized last', () => {
+	test('alphabetical specifics then Uncategorized last', () => {
 		const out = groupBacklogByArea([
 			backlogItem('1', 'tower'),
 			backlogItem('2', 'Uncategorized'),
@@ -62,43 +62,6 @@ suite('groupBacklogByArea', () => {
 			out.map(g => g.area),
 			['auth', 'porch', 'tower', 'Uncategorized'],
 		);
-	});
-
-	test('priorityAreas pins listed areas to the top in the listed order', () => {
-		const out = groupBacklogByArea(
-			[
-				backlogItem('1', 'tower'),
-				backlogItem('2', 'auth'),
-				backlogItem('3', 'porch'),
-				backlogItem('4', 'vscode'),
-			],
-			['porch', 'auth'],
-		);
-		assert.deepStrictEqual(
-			out.map(g => g.area),
-			['porch', 'auth', 'tower', 'vscode'],
-		);
-	});
-
-	test('Uncategorized stays last even when listed in priorityAreas', () => {
-		// Defensive: explicit policy is "Uncategorized always last". A
-		// misconfigured priority list shouldn't be able to override it.
-		const out = groupBacklogByArea(
-			[
-				backlogItem('1', 'auth'),
-				backlogItem('2', 'Uncategorized'),
-			],
-			['Uncategorized'],
-		);
-		assert.deepStrictEqual(out.map(g => g.area), ['auth', 'Uncategorized']);
-	});
-
-	test('priorityAreas entries that match no present area are skipped silently', () => {
-		const out = groupBacklogByArea(
-			[backlogItem('1', 'auth'), backlogItem('2', 'tower')],
-			['missing-area', 'auth'],
-		);
-		assert.deepStrictEqual(out.map(g => g.area), ['auth', 'tower']);
 	});
 
 	test('omits empty area groups (no "<area> (0)" headers)', () => {

--- a/packages/vscode/src/test/backlog.test.ts
+++ b/packages/vscode/src/test/backlog.test.ts
@@ -51,23 +51,54 @@ suite('groupBacklogByArea', () => {
 		assert.deepStrictEqual(out[0].items.map(i => i.id), ['1']);
 	});
 
-	test('lone cross-cutting item lands in the cross-cutting group', () => {
-		const out = groupBacklogByArea([backlogItem('1', 'cross-cutting')]);
-		assert.deepStrictEqual(out.map(g => g.area), ['cross-cutting']);
-	});
-
-	test('orders groups: cross-cutting first, alphabetical specifics, Uncategorized last', () => {
+	test('default ordering is alphabetical specifics then Uncategorized last', () => {
 		const out = groupBacklogByArea([
 			backlogItem('1', 'tower'),
 			backlogItem('2', 'Uncategorized'),
 			backlogItem('3', 'auth'),
-			backlogItem('4', 'cross-cutting'),
-			backlogItem('5', 'porch'),
+			backlogItem('4', 'porch'),
 		]);
 		assert.deepStrictEqual(
 			out.map(g => g.area),
-			['cross-cutting', 'auth', 'porch', 'tower', 'Uncategorized'],
+			['auth', 'porch', 'tower', 'Uncategorized'],
 		);
+	});
+
+	test('priorityAreas pins listed areas to the top in the listed order', () => {
+		const out = groupBacklogByArea(
+			[
+				backlogItem('1', 'tower'),
+				backlogItem('2', 'auth'),
+				backlogItem('3', 'porch'),
+				backlogItem('4', 'vscode'),
+			],
+			['porch', 'auth'],
+		);
+		assert.deepStrictEqual(
+			out.map(g => g.area),
+			['porch', 'auth', 'tower', 'vscode'],
+		);
+	});
+
+	test('Uncategorized stays last even when listed in priorityAreas', () => {
+		// Defensive: explicit policy is "Uncategorized always last". A
+		// misconfigured priority list shouldn't be able to override it.
+		const out = groupBacklogByArea(
+			[
+				backlogItem('1', 'auth'),
+				backlogItem('2', 'Uncategorized'),
+			],
+			['Uncategorized'],
+		);
+		assert.deepStrictEqual(out.map(g => g.area), ['auth', 'Uncategorized']);
+	});
+
+	test('priorityAreas entries that match no present area are skipped silently', () => {
+		const out = groupBacklogByArea(
+			[backlogItem('1', 'auth'), backlogItem('2', 'tower')],
+			['missing-area', 'auth'],
+		);
+		assert.deepStrictEqual(out.map(g => g.area), ['auth', 'tower']);
 	});
 
 	test('omits empty area groups (no "<area> (0)" headers)', () => {
@@ -102,14 +133,5 @@ suite('groupBacklogByArea', () => {
 		assert.deepStrictEqual(out.map(g => g.area), ['tower', 'vscode']);
 		assert.deepStrictEqual(out[0].items.map(i => i.id), ['2', '4']);
 		assert.deepStrictEqual(out[1].items.map(i => i.id), ['1', '3', '5']);
-	});
-
-	test('falls back to Uncategorized when area field is empty string', () => {
-		// Defensive: server contract says area is always a populated string,
-		// but a malformed payload (empty string from a custom forge adapter)
-		// must not break grouping or vanish the item.
-		const out = groupBacklogByArea([backlogItem('1', '')]);
-		assert.deepStrictEqual(out.map(g => g.area), ['Uncategorized']);
-		assert.deepStrictEqual(out[0].items.map(i => i.id), ['1']);
 	});
 });

--- a/packages/vscode/src/views/backlog-tree-item.ts
+++ b/packages/vscode/src/views/backlog-tree-item.ts
@@ -22,3 +22,25 @@ export class BacklogTreeItem extends vscode.TreeItem {
     super(label);
   }
 }
+
+/**
+ * TreeItem subclass for an area group header in the backlog tree.
+ *
+ * Carries the canonical area name (e.g. `'vscode'`, `'cross-cutting'`,
+ * `'Uncategorized'`) so the expand/collapse persistence handler can key
+ * the workspaceState map by area name regardless of the rendered label
+ * (which includes the count suffix). `id` is set from the area name so
+ * VSCode reuses the same TreeItem identity across refreshes — letting
+ * the user's collapse choice survive `OverviewCache` ticks.
+ */
+export class BacklogGroupTreeItem extends vscode.TreeItem {
+  constructor(
+    public readonly areaName: string,
+    count: number,
+    collapsibleState: vscode.TreeItemCollapsibleState,
+  ) {
+    super(`${areaName} (${count})`, collapsibleState);
+    this.id = `backlog-group:${areaName}`;
+    this.contextValue = 'backlog-group';
+  }
+}

--- a/packages/vscode/src/views/backlog.ts
+++ b/packages/vscode/src/views/backlog.ts
@@ -1,7 +1,11 @@
 import * as vscode from 'vscode';
 import type { OverviewBacklogItem } from '@cluesmith/codev-types';
+import { UNCATEGORIZED_AREA } from '@cluesmith/codev-core/constants';
 import type { OverviewCache } from './overview-data.js';
-import { BacklogTreeItem } from './backlog-tree-item.js';
+import { BacklogGroupTreeItem, BacklogTreeItem } from './backlog-tree-item.js';
+
+const CROSS_CUTTING_AREA = 'cross-cutting';
+const EXPANSION_STATE_KEY = 'codev.backlogGroupExpansion';
 
 /**
  * Backlog rows the user can act on — exclude issues that already have an
@@ -14,21 +18,87 @@ export function spawnableBacklog(items: OverviewBacklogItem[]): OverviewBacklogI
 }
 
 /**
- * Backlog view: open GitHub issues with no PR yet. Issues assigned to the
- * current user (auto-detected via OverviewData.currentUser) sort to the
- * top with an `account` icon; the rest keep `issues`. Order within each
- * group preserves Tower's order. Mirrors how BuildersProvider sorts
- * blocked-first above active within a single view — no separator rows.
+ * Group backlog items by their resolved `area` (already projected on the
+ * server via `parseArea`; see #819). Returned groups are ordered:
  *
- * Row click starts work: it invokes codev.spawnBuilder with the issue
- * number pre-filled (protocol-pick only). Browser / copy actions live in
- * the right-click context menu (see package.json view/item/context).
+ *   1. `cross-cutting` (highest-coordination-risk surfaced first)
+ *   2. alphabetical specific areas
+ *   3. `Uncategorized` (last)
+ *
+ * Within-group order preserves the input order — the caller has already
+ * applied any "mine-first" or sort policy. Empty groups are omitted
+ * (no `<area> (0)` headers).
+ *
+ * Pure function — no VSCode dependency, unit-testable.
+ *
+ * Cross-cutting detection relies on the documented convention: an issue
+ * tagged ONLY `area/cross-cutting` arrives here with `area === 'cross-cutting'`.
+ * Issues that mix `area/cross-cutting` with another area label land in
+ * the alphabetically-first specific area per `parseArea`'s server-side
+ * projection. The framework parser is policy-free about label semantics
+ * by design (see #819); the cross-cutting convention is a view-layer
+ * UX choice.
+ */
+export function groupBacklogByArea(
+  items: OverviewBacklogItem[],
+): Array<{ area: string; items: OverviewBacklogItem[] }> {
+  const buckets = new Map<string, OverviewBacklogItem[]>();
+  for (const item of items) {
+    const area = item.area || UNCATEGORIZED_AREA;
+    const bucket = buckets.get(area);
+    if (bucket) {
+      bucket.push(item);
+    } else {
+      buckets.set(area, [item]);
+    }
+  }
+
+  const result: Array<{ area: string; items: OverviewBacklogItem[] }> = [];
+  const crossCutting = buckets.get(CROSS_CUTTING_AREA);
+  if (crossCutting) {
+    result.push({ area: CROSS_CUTTING_AREA, items: crossCutting });
+    buckets.delete(CROSS_CUTTING_AREA);
+  }
+
+  const uncategorized = buckets.get(UNCATEGORIZED_AREA);
+  buckets.delete(UNCATEGORIZED_AREA);
+
+  const specifics = [...buckets.keys()].sort();
+  for (const area of specifics) {
+    result.push({ area, items: buckets.get(area)! });
+  }
+
+  if (uncategorized) {
+    result.push({ area: UNCATEGORIZED_AREA, items: uncategorized });
+  }
+
+  return result;
+}
+
+/**
+ * Backlog view: open GitHub issues with no PR yet, grouped by `area/*`
+ * label. Group ordering: `cross-cutting` → alphabetical specifics →
+ * `Uncategorized`. Within each group, items assigned to the current
+ * user (auto-detected via OverviewData.currentUser) sort to the top
+ * with an `account` icon; the rest keep `issues`. Order within those
+ * two segments preserves Tower's order.
+ *
+ * Row click starts work: it invokes codev.viewBacklogIssue with the
+ * issue number pre-filled. Browser / copy / spawn actions live in the
+ * right-click context menu (see package.json view/item/context).
+ *
+ * Group expand/collapse state persists per area name via
+ * `workspaceState` under `codev.backlogGroupExpansion`. Default for
+ * any group the user hasn't touched: expanded.
  */
 export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
   private readonly changeEmitter = new vscode.EventEmitter<void>();
   readonly onDidChangeTreeData = this.changeEmitter.event;
 
-  constructor(private cache: OverviewCache) {
+  constructor(
+    private readonly cache: OverviewCache,
+    private readonly workspaceState: vscode.Memento,
+  ) {
     cache.onDidChange(() => this.changeEmitter.fire());
   }
 
@@ -36,20 +106,56 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
     return element;
   }
 
-  getChildren(): vscode.TreeItem[] {
+  getChildren(element?: vscode.TreeItem): vscode.TreeItem[] {
+    if (element instanceof BacklogGroupTreeItem) {
+      return this.rowsForGroup(element.areaName);
+    }
+    if (element) {
+      return [];
+    }
+    return this.groupHeaders();
+  }
+
+  /**
+   * Persist a user's expand/collapse choice for an area group. Called
+   * from `extension.ts` via `backlogView.onDidExpand/CollapseElement`.
+   */
+  setGroupExpanded(areaName: string, expanded: boolean): void {
+    const map = this.readExpansionState();
+    map[areaName] = expanded;
+    void this.workspaceState.update(EXPANSION_STATE_KEY, map);
+  }
+
+  private groupHeaders(): vscode.TreeItem[] {
     const data = this.cache.getData();
     if (!data) { return []; }
+
+    const items = this.orderedSpawnable(data);
+    const groups = groupBacklogByArea(items);
+    const expansion = this.readExpansionState();
+    return groups.map(g => {
+      const expanded = expansion[g.area] ?? true;
+      const state = expanded
+        ? vscode.TreeItemCollapsibleState.Expanded
+        : vscode.TreeItemCollapsibleState.Collapsed;
+      return new BacklogGroupTreeItem(g.area, g.items.length, state);
+    });
+  }
+
+  private rowsForGroup(areaName: string): vscode.TreeItem[] {
+    const data = this.cache.getData();
+    if (!data) { return []; }
+
+    const items = this.orderedSpawnable(data);
+    const group = groupBacklogByArea(items).find(g => g.area === areaName);
+    if (!group) { return []; }
 
     const me = data.currentUser?.toLowerCase();
     const isMine = (item: OverviewBacklogItem) =>
       !!me && !!item.assignees?.some(a => a.toLowerCase() === me);
 
-    const items = spawnableBacklog(data.backlog);
-    const mine = items.filter(isMine);
-    const rest = items.filter(item => !isMine(item));
-
-    return [...mine, ...rest].map(item => {
-      const assigned = mine.includes(item);
+    return group.items.map(item => {
+      const assigned = isMine(item);
       const author = item.author ? ` @${item.author}` : '';
       const ti = new BacklogTreeItem(item.id, item.url, `#${item.id} ${item.title}${author}`);
       ti.tooltip = item.url;
@@ -63,5 +169,25 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
       };
       return ti;
     });
+  }
+
+  /**
+   * Spawnable items in display order (mine-first, then rest), preserving
+   * Tower's order within each segment. Identical to the pre-grouping
+   * behavior so within-group ordering matches the old flat list.
+   */
+  private orderedSpawnable(data: NonNullable<ReturnType<OverviewCache['getData']>>): OverviewBacklogItem[] {
+    const me = data.currentUser?.toLowerCase();
+    const isMine = (item: OverviewBacklogItem) =>
+      !!me && !!item.assignees?.some(a => a.toLowerCase() === me);
+
+    const items = spawnableBacklog(data.backlog);
+    const mine = items.filter(isMine);
+    const rest = items.filter(item => !isMine(item));
+    return [...mine, ...rest];
+  }
+
+  private readExpansionState(): Record<string, boolean> {
+    return this.workspaceState.get<Record<string, boolean>>(EXPANSION_STATE_KEY, {});
   }
 }

--- a/packages/vscode/src/views/backlog.ts
+++ b/packages/vscode/src/views/backlog.ts
@@ -140,7 +140,7 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
   setGroupExpanded(areaName: string, expanded: boolean): void {
     const map = this.readExpansionState();
     map[areaName] = expanded;
-    void this.workspaceState.update(EXPANSION_STATE_KEY, map);
+    this.workspaceState.update(EXPANSION_STATE_KEY, map);
   }
 
   private rootChildren(): vscode.TreeItem[] {

--- a/packages/vscode/src/views/backlog.ts
+++ b/packages/vscode/src/views/backlog.ts
@@ -20,29 +20,17 @@ export function spawnableBacklog(items: OverviewBacklogItem[]): OverviewBacklogI
  * Group backlog items by their resolved `area` (already projected on the
  * server via `parseArea`; see #819). Returned groups are ordered:
  *
- *   1. Any areas the caller pins via `priorityAreas`, in the listed order
- *   2. Alphabetical specific areas
- *   3. `Uncategorized` (last)
+ *   1. Alphabetical specific areas
+ *   2. `Uncategorized` (last)
  *
  * Within-group order preserves the input order — the caller has already
  * applied any "mine-first" or sort policy. Empty groups are omitted
- * (no `<area> (0)` headers). Priority entries that don't match any
- * present area are silently skipped — same outcome as alphabetical for
- * absent areas.
- *
- * `priorityAreas` is per-repo policy supplied by the user via the
- * `codev.backlog.priorityAreas` setting. The framework intentionally
- * does NOT bake in any specific label name (e.g. `cross-cutting`) — that
- * decision belongs to the repo, not the framework, mirroring the
- * policy-free posture of `parseArea` (#819). Passing `[]` yields pure
- * alphabetical ordering, which is the appropriate default for any repo
- * that hasn't expressed a preference.
+ * (no `<area> (0)` headers).
  *
  * Pure function — no VSCode dependency, unit-testable.
  */
 export function groupBacklogByArea(
   items: OverviewBacklogItem[],
-  priorityAreas: readonly string[] = [],
 ): Array<{ area: string; items: OverviewBacklogItem[] }> {
   const buckets = new Map<string, OverviewBacklogItem[]>();
   for (const item of items) {
@@ -55,24 +43,10 @@ export function groupBacklogByArea(
   }
 
   const result: Array<{ area: string; items: OverviewBacklogItem[] }> = [];
-  const consumed = new Set<string>();
-
-  for (const area of priorityAreas) {
-    // Uncategorized always lands last regardless of priority configuration —
-    // it's the "no opinion" bucket, not a pinnable area.
-    if (area === UNCATEGORIZED_AREA || consumed.has(area)) { continue; }
-    const bucket = buckets.get(area);
-    if (bucket) {
-      result.push({ area, items: bucket });
-      consumed.add(area);
-    }
-  }
-
   const uncategorized = buckets.get(UNCATEGORIZED_AREA);
-  consumed.add(UNCATEGORIZED_AREA);
 
   const specifics = [...buckets.keys()]
-    .filter(a => !consumed.has(a))
+    .filter(a => a !== UNCATEGORIZED_AREA)
     .sort();
   for (const area of specifics) {
     result.push({ area, items: buckets.get(area)! });
@@ -87,13 +61,11 @@ export function groupBacklogByArea(
 
 /**
  * Backlog view: open GitHub issues with no PR yet, grouped by `area/*`
- * label. Group ordering: areas listed in the per-repo setting
- * `codev.backlog.priorityAreas` first (in their listed order), then
- * alphabetical specifics, then `Uncategorized` last. Within each group,
- * items assigned to the current user (auto-detected via
- * OverviewData.currentUser) sort to the top with an `account` icon; the
- * rest keep `issues`. Order within those two segments preserves Tower's
- * order.
+ * label. Group ordering: alphabetical specific areas, then `Uncategorized`
+ * last. Within each group, items assigned to the current user
+ * (auto-detected via OverviewData.currentUser) sort to the top with an
+ * `account` icon; the rest keep `issues`. Order within those two segments
+ * preserves Tower's order.
  *
  * Row click starts work: it invokes codev.viewBacklogIssue with the
  * issue number pre-filled. Browser / copy / spawn actions live in the
@@ -112,11 +84,6 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
     private readonly workspaceState: vscode.Memento,
   ) {
     cache.onDidChange(() => this.changeEmitter.fire());
-  }
-
-  /** Re-render when the user edits `codev.backlog.priorityAreas`. */
-  refresh(): void {
-    this.changeEmitter.fire();
   }
 
   getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
@@ -148,7 +115,7 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
     if (!data) { return []; }
 
     const items = this.orderedSpawnable(data);
-    const groups = groupBacklogByArea(items, this.readPriorityAreas());
+    const groups = groupBacklogByArea(items);
 
     // Degenerate case: a repo that doesn't use `area/*` labels yields a
     // single `Uncategorized` group containing every issue. Rendering its
@@ -173,8 +140,7 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
     if (!data) { return []; }
 
     const items = this.orderedSpawnable(data);
-    const group = groupBacklogByArea(items, this.readPriorityAreas())
-      .find(g => g.area === areaName);
+    const group = groupBacklogByArea(items).find(g => g.area === areaName);
     if (!group) { return []; }
 
     return group.items.map(item => this.makeRow(item, data));
@@ -218,12 +184,5 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
 
   private readExpansionState(): Record<string, boolean> {
     return this.workspaceState.get<Record<string, boolean>>(EXPANSION_STATE_KEY, {});
-  }
-
-  private readPriorityAreas(): readonly string[] {
-    const raw = vscode.workspace
-      .getConfiguration('codev')
-      .get<unknown>('backlog.priorityAreas');
-    return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === 'string') : [];
   }
 }

--- a/packages/vscode/src/views/backlog.ts
+++ b/packages/vscode/src/views/backlog.ts
@@ -4,7 +4,6 @@ import { UNCATEGORIZED_AREA } from '@cluesmith/codev-core/constants';
 import type { OverviewCache } from './overview-data.js';
 import { BacklogGroupTreeItem, BacklogTreeItem } from './backlog-tree-item.js';
 
-const CROSS_CUTTING_AREA = 'cross-cutting';
 const EXPANSION_STATE_KEY = 'codev.backlogGroupExpansion';
 
 /**
@@ -21,49 +20,60 @@ export function spawnableBacklog(items: OverviewBacklogItem[]): OverviewBacklogI
  * Group backlog items by their resolved `area` (already projected on the
  * server via `parseArea`; see #819). Returned groups are ordered:
  *
- *   1. `cross-cutting` (highest-coordination-risk surfaced first)
- *   2. alphabetical specific areas
+ *   1. Any areas the caller pins via `priorityAreas`, in the listed order
+ *   2. Alphabetical specific areas
  *   3. `Uncategorized` (last)
  *
  * Within-group order preserves the input order — the caller has already
  * applied any "mine-first" or sort policy. Empty groups are omitted
- * (no `<area> (0)` headers).
+ * (no `<area> (0)` headers). Priority entries that don't match any
+ * present area are silently skipped — same outcome as alphabetical for
+ * absent areas.
+ *
+ * `priorityAreas` is per-repo policy supplied by the user via the
+ * `codev.backlog.priorityAreas` setting. The framework intentionally
+ * does NOT bake in any specific label name (e.g. `cross-cutting`) — that
+ * decision belongs to the repo, not the framework, mirroring the
+ * policy-free posture of `parseArea` (#819). Passing `[]` yields pure
+ * alphabetical ordering, which is the appropriate default for any repo
+ * that hasn't expressed a preference.
  *
  * Pure function — no VSCode dependency, unit-testable.
- *
- * Cross-cutting detection relies on the documented convention: an issue
- * tagged ONLY `area/cross-cutting` arrives here with `area === 'cross-cutting'`.
- * Issues that mix `area/cross-cutting` with another area label land in
- * the alphabetically-first specific area per `parseArea`'s server-side
- * projection. The framework parser is policy-free about label semantics
- * by design (see #819); the cross-cutting convention is a view-layer
- * UX choice.
  */
 export function groupBacklogByArea(
   items: OverviewBacklogItem[],
+  priorityAreas: readonly string[] = [],
 ): Array<{ area: string; items: OverviewBacklogItem[] }> {
   const buckets = new Map<string, OverviewBacklogItem[]>();
   for (const item of items) {
-    const area = item.area || UNCATEGORIZED_AREA;
-    const bucket = buckets.get(area);
+    const bucket = buckets.get(item.area);
     if (bucket) {
       bucket.push(item);
     } else {
-      buckets.set(area, [item]);
+      buckets.set(item.area, [item]);
     }
   }
 
   const result: Array<{ area: string; items: OverviewBacklogItem[] }> = [];
-  const crossCutting = buckets.get(CROSS_CUTTING_AREA);
-  if (crossCutting) {
-    result.push({ area: CROSS_CUTTING_AREA, items: crossCutting });
-    buckets.delete(CROSS_CUTTING_AREA);
+  const consumed = new Set<string>();
+
+  for (const area of priorityAreas) {
+    // Uncategorized always lands last regardless of priority configuration —
+    // it's the "no opinion" bucket, not a pinnable area.
+    if (area === UNCATEGORIZED_AREA || consumed.has(area)) { continue; }
+    const bucket = buckets.get(area);
+    if (bucket) {
+      result.push({ area, items: bucket });
+      consumed.add(area);
+    }
   }
 
   const uncategorized = buckets.get(UNCATEGORIZED_AREA);
-  buckets.delete(UNCATEGORIZED_AREA);
+  consumed.add(UNCATEGORIZED_AREA);
 
-  const specifics = [...buckets.keys()].sort();
+  const specifics = [...buckets.keys()]
+    .filter(a => !consumed.has(a))
+    .sort();
   for (const area of specifics) {
     result.push({ area, items: buckets.get(area)! });
   }
@@ -77,11 +87,13 @@ export function groupBacklogByArea(
 
 /**
  * Backlog view: open GitHub issues with no PR yet, grouped by `area/*`
- * label. Group ordering: `cross-cutting` → alphabetical specifics →
- * `Uncategorized`. Within each group, items assigned to the current
- * user (auto-detected via OverviewData.currentUser) sort to the top
- * with an `account` icon; the rest keep `issues`. Order within those
- * two segments preserves Tower's order.
+ * label. Group ordering: areas listed in the per-repo setting
+ * `codev.backlog.priorityAreas` first (in their listed order), then
+ * alphabetical specifics, then `Uncategorized` last. Within each group,
+ * items assigned to the current user (auto-detected via
+ * OverviewData.currentUser) sort to the top with an `account` icon; the
+ * rest keep `issues`. Order within those two segments preserves Tower's
+ * order.
  *
  * Row click starts work: it invokes codev.viewBacklogIssue with the
  * issue number pre-filled. Browser / copy / spawn actions live in the
@@ -100,6 +112,11 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
     private readonly workspaceState: vscode.Memento,
   ) {
     cache.onDidChange(() => this.changeEmitter.fire());
+  }
+
+  /** Re-render when the user edits `codev.backlog.priorityAreas`. */
+  refresh(): void {
+    this.changeEmitter.fire();
   }
 
   getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
@@ -131,7 +148,7 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
     if (!data) { return []; }
 
     const items = this.orderedSpawnable(data);
-    const groups = groupBacklogByArea(items);
+    const groups = groupBacklogByArea(items, this.readPriorityAreas());
     const expansion = this.readExpansionState();
     return groups.map(g => {
       const expanded = expansion[g.area] ?? true;
@@ -147,7 +164,8 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
     if (!data) { return []; }
 
     const items = this.orderedSpawnable(data);
-    const group = groupBacklogByArea(items).find(g => g.area === areaName);
+    const group = groupBacklogByArea(items, this.readPriorityAreas())
+      .find(g => g.area === areaName);
     if (!group) { return []; }
 
     const me = data.currentUser?.toLowerCase();
@@ -189,5 +207,12 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
 
   private readExpansionState(): Record<string, boolean> {
     return this.workspaceState.get<Record<string, boolean>>(EXPANSION_STATE_KEY, {});
+  }
+
+  private readPriorityAreas(): readonly string[] {
+    const raw = vscode.workspace
+      .getConfiguration('codev')
+      .get<unknown>('backlog.priorityAreas');
+    return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === 'string') : [];
   }
 }

--- a/packages/vscode/src/views/backlog.ts
+++ b/packages/vscode/src/views/backlog.ts
@@ -130,7 +130,7 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
     if (element) {
       return [];
     }
-    return this.groupHeaders();
+    return this.rootChildren();
   }
 
   /**
@@ -143,12 +143,21 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
     void this.workspaceState.update(EXPANSION_STATE_KEY, map);
   }
 
-  private groupHeaders(): vscode.TreeItem[] {
+  private rootChildren(): vscode.TreeItem[] {
     const data = this.cache.getData();
     if (!data) { return []; }
 
     const items = this.orderedSpawnable(data);
     const groups = groupBacklogByArea(items, this.readPriorityAreas());
+
+    // Degenerate case: a repo that doesn't use `area/*` labels yields a
+    // single `Uncategorized` group containing every issue. Rendering its
+    // header would add no information — collapse to flat rows so the
+    // backlog looks the same as it did before grouping shipped.
+    if (groups.length === 1 && groups[0].area === UNCATEGORIZED_AREA) {
+      return groups[0].items.map(item => this.makeRow(item, data));
+    }
+
     const expansion = this.readExpansionState();
     return groups.map(g => {
       const expanded = expansion[g.area] ?? true;
@@ -168,25 +177,27 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
       .find(g => g.area === areaName);
     if (!group) { return []; }
 
-    const me = data.currentUser?.toLowerCase();
-    const isMine = (item: OverviewBacklogItem) =>
-      !!me && !!item.assignees?.some(a => a.toLowerCase() === me);
+    return group.items.map(item => this.makeRow(item, data));
+  }
 
-    return group.items.map(item => {
-      const assigned = isMine(item);
-      const author = item.author ? ` @${item.author}` : '';
-      const ti = new BacklogTreeItem(item.id, item.url, `#${item.id} ${item.title}${author}`);
-      ti.tooltip = item.url;
-      ti.contextValue = 'backlog-item';
-      ti.iconPath = new vscode.ThemeIcon(assigned ? 'account' : 'issues');
-      if (assigned) { ti.description = 'assigned to you'; }
-      ti.command = {
-        command: 'codev.viewBacklogIssue',
-        title: 'View Issue',
-        arguments: [item.id],
-      };
-      return ti;
-    });
+  private makeRow(
+    item: OverviewBacklogItem,
+    data: NonNullable<ReturnType<OverviewCache['getData']>>,
+  ): BacklogTreeItem {
+    const me = data.currentUser?.toLowerCase();
+    const assigned = !!me && !!item.assignees?.some(a => a.toLowerCase() === me);
+    const author = item.author ? ` @${item.author}` : '';
+    const ti = new BacklogTreeItem(item.id, item.url, `#${item.id} ${item.title}${author}`);
+    ti.tooltip = item.url;
+    ti.contextValue = 'backlog-item';
+    ti.iconPath = new vscode.ThemeIcon(assigned ? 'account' : 'issues');
+    if (assigned) { ti.description = 'assigned to you'; }
+    ti.command = {
+      command: 'codev.viewBacklogIssue',
+      title: 'View Issue',
+      arguments: [item.id],
+    };
+    return ti;
   }
 
   /**


### PR DESCRIPTION
# PIR Review: vscode — group backlog tree by area

Fixes #811

## Summary

The vscode Backlog tree is now grouped by `area/*` label. Group ordering is pure alphabetical specific areas followed by `Uncategorized` last; a single-`Uncategorized` group collapses to flat rendering so repos that haven't adopted `area/*` labels see no visual regression. No configurable mechanism — the framework stays policy-free about specific label names and about group rank (extending #819's discipline to the view layer).

## Files Changed

Computed via `git diff --stat origin/main...HEAD`:

- `codev/plans/811-vscode-group-backlog-by-area.md` (+73 / -0)
- `codev/projects/811-vscode-group-backlog-by-area-a/status.yaml` (+29 / -0) — porch-managed
- `codev/reviews/811-vscode-group-backlog-by-area-a.md` (+93 / -0) — this file
- `codev/state/pir-811_thread.md` (+68 / -0)
- `packages/vscode/src/extension.ts` (+13 / -4) — wire workspaceState + expand/collapse listeners
- `packages/vscode/src/test/backlog.test.ts` (+59 / -6) — 6 new `groupBacklogByArea` tests
- `packages/vscode/src/views/backlog-tree-item.ts` (+22 / -0) — `BacklogGroupTreeItem` class
- `packages/vscode/src/views/backlog.ts` (+154 / -19) — pure `groupBacklogByArea` helper + two-level `BacklogProvider` + single-Uncategorized flatten optimization

Total: 8 files, +511 / -29.

## Commits

```
7309c94c [PIR #811] Plan draft
68c3d070 [PIR #811] Group backlog tree by area/* label
5fd9351e [PIR #811] Thread: log implement-phase progress
aab03a27 [PIR #811] Replace hardcoded cross-cutting with codev.backlog.priorityAreas setting
f736c3cc [PIR #811] Plan + thread: revise to user-configurable priority areas
87fbf75b [PIR #811] Flatten single-Uncategorized backlog to row list (no header)
a235d422 [PIR #811] Review + retrospective
9ace0fcb [PIR #811] Address Claude COMMENT: drop void prefix on fire-and-forget update
6183fba6 [PIR #811] Thread: log review-phase consult verdicts and pr gate
f1c30975 [PIR #811] Drop codev.backlog.priorityAreas mechanism per architect reconsideration
```

## Test Results

- `pnpm --filter codev-vscode test`: ✓ 90 pass (6 new `groupBacklogByArea` cases + 84 pre-existing)
- `pnpm build` (full workspace): ✓ green
- `pnpm --filter codev-vscode check-types`: ✓ green
- `pnpm --filter codev-vscode lint`: ✓ green (ESLint via the test pretest pipeline)
- Manual verification (at `dev-approval` gate): the human inspected the running implementation in the worktree dev server and approved.

## Architecture Updates

No changes to `codev/resources/arch.md`. This PR adds:

1. A pure view-layer grouping helper (`groupBacklogByArea`) over an existing wire shape (`OverviewBacklogItem.area`, added by #819) — no new module boundaries, no new wire fields, no new caching layers.
2. A two-level VSCode `TreeDataProvider` for the backlog view — a localized refactor of `BacklogProvider`, not a new tree-architecture pattern.

None warrant arch-doc entries — they reuse established patterns. The framework-neutrality discipline (do not bake repo-specific label names or per-repo rank policy into framework code) was already established in `codev/resources/arch.md` / lessons via #819 and remains the implicit rule this PR follows.

## Lessons Learned Updates

No additions to `codev/resources/lessons-learned.md`. Two design moves worth recording are already covered by existing project memory:

1. **Framework code stays policy-free about label values *and* about per-repo rank policy.** The first iteration hardcoded `'cross-cutting'` as a privileged top group; the human at `dev-approval` flagged it as the same anti-pattern #819 corrected at the parser. Switching to a `codev.backlog.priorityAreas` setting solved the hardcoded-label problem but introduced a new one: a configurable mechanism for what turned out to be the wrong shape (rank ≠ coordination). The architect's reconsideration during the review phase dropped the mechanism entirely. Net: alphabetical specifics + `Uncategorized` last is the simplest rule and matches `parseArea`'s policy-free posture. Same principle as [`feedback_framework_neutral_on_label_semantics`](../../.claude/projects/-Users-amrmohamed-repos-cluesmith-codev/memory/feedback_framework_neutral_on_label_semantics.md); no new lesson.

2. **Trust the wire contract; don't add defensive coercions for things the contract guarantees.** First iteration had `item.area || UNCATEGORIZED_AREA` as a defensive fallback even though the wire contract (`required-with-default`, set by `parseArea` server-side) guarantees `area` is always a populated string. Dropped the fallback and the corresponding empty-string test case. System-prompt rule applied to the view boundary — not a new lesson.

A follow-up issue was filed during this PIR:

- **#885** — `vscode: capitalize area group header labels in backlog and builders trees`. The lowercase `area/*` label convention renders headers as `vscode (12)` next to `Uncategorized (8)`; visual inconsistency this PIR did not address (it would touch the rendering layer and the same fix should land in #818's builders-tree grouping).

## Things to Look At During PR Review

1. **Three design revisions before settling**, visible in the commit history. First iteration hardcoded `'cross-cutting'` as a privileged top group. Second iteration replaced that with a per-repo VSCode setting `codev.backlog.priorityAreas`. Third iteration (this commit) dropped the configurable entirely per architect reconsideration — pure alphabetical, no priority mechanism, no setting. The final shape is the smallest possible: a render-layer grouping over an existing wire field, with one optimization (single-Uncategorized flatten) for the no-area-labels case.

2. **Single-Uncategorized flatten optimization** (`packages/vscode/src/views/backlog.ts:120-125`). When the grouped output is exactly one group AND that group is `Uncategorized`, the view skips the header and returns rows directly. This is the zero-cost migration property the issue body promised. Trigger is specifically "1 group AND Uncategorized" — a single-`vscode` repo with all items in one specific area still gets a header for clarity (the header carries the categorization signal; an `Uncategorized` header carries none).

3. **Group identity** (`BacklogGroupTreeItem.id = 'backlog-group:<areaName>'`). VSCode reuses the same TreeItem instance across `onDidChangeTreeData` refreshes when `id` matches, which keeps the user's expand/collapse state visually stable across the `OverviewCache` SSE tick. Without the stable `id`, every refresh would reset the visible expansion (the persisted state in `workspaceState` would still be honored, but the tree would flash collapsed-then-expanded on each tick).

4. **`pnpm --filter @cluesmith/codev test` showed 17 unrelated flakes on first run** (cron-cli and other agent-farm tests) that all passed on retry. The diff is 100% under `packages/vscode/` so the failures cannot be caused by this PIR. Mentioning for transparency, not as a flaky-test skip — no tests were quarantined.

## How to Test Locally

For reviewers pulling the branch:

- **View diff**: VSCode sidebar → right-click builder `pir-811` → **Review Diff** (auto-detects the repo's default branch). Or `git diff main...HEAD`.
- **Run dev server**: VSCode sidebar → **Run Dev Server**, or `afx dev pir-811` from a shell.
- **What to verify**:
  - The Backlog tree shows grouped headers like `vscode (N)`, `tower (N)`, etc., ordered alphabetically with `Uncategorized` last.
  - Issue with no `area/*` labels lives under `Uncategorized` at the bottom.
  - Collapse a group, reload the VSCode window → that group stays collapsed.
  - Single-issue click → still opens via `codev.viewBacklogIssue`. Right-click → context menu actions (spawn, open in browser, copy issue number) still work.
  - On a hypothetical repo with no `area/*` labels at all, the view renders flat (no `Uncategorized (N)` header) — single-Uncategorized flatten optimization.
  - Dashboard's `BacklogList` (web): no wire changes, no breakage; still renders as a flat list.

## Flaky Tests

None skipped or quarantined.
