### PR TITLE
vscode: group builders tree by area, extract shared grouping primitives (PIR #818)

### DIFF
--- a/codev/plans/818-vscode-group-builders-in-the-t.md
+++ b/codev/plans/818-vscode-group-builders-in-the-t.md
@@ -1,4 +1,4 @@
-# PIR Plan: Group Builders Tree by Area (mirror #811)
+# PIR Plan: Group Builders Tree by Area (mirror #811, dedup primitives)
 
 ## Understanding
 
@@ -6,190 +6,328 @@ The VSCode `Codev: Builders` tree (`packages/vscode/src/views/builders.ts:89`) i
 
 The design has converged to a deliberately simpler shape than #818's original framing:
 
-- **Pure alphabetical group ordering, `Uncategorized` last** — no `cross-cutting` privilege, no priority-areas knob, no configurable preference. Framework-neutrality discipline from #819 (the parser is policy-free; UI ordering matches).
+- **Pure alphabetical group ordering, `Uncategorized` last** — no `cross-cutting` privilege, no priority-areas knob, no configurable preference. Framework-neutrality discipline from #819.
 - **No toggle** — grouping is the only mode. Single-`Uncategorized` flatten optimization (below) makes "off" unnecessary for repos that don't use `area/*` labels.
-- **Single-`Uncategorized` flatten** — when the only group is `Uncategorized` (no `area/*` labels in the repo at all), render builder rows directly at root with no group header. Zero visual regression for unlabeled repos.
-- **Per-area expand/collapse state persists via `workspaceState`** — same key shape as backlog's `codev.backlogGroupExpansion`, here `codev.buildersGroupExpansion`. Default for an untouched area: expanded.
+- **Single-`Uncategorized` flatten** — when the only group is `Uncategorized`, render builder rows directly at root with no group header. Zero visual regression for unlabeled repos.
+- **Per-area expand/collapse state persists via `workspaceState`**, paired with backlog's `codev.backlogGroupExpansion`.
+
+### Scope choice: refactor first, then add the consumer
+
+Adding Builders as a second consumer of an inlined-once-helper pattern would commit ~67 LOC of structural duplication across 5 surfaces (helper, TreeItem class, flatten predicate, expansion store, wiring). The cheapest moment to extract is *the moment the second consumer lands* — before drift starts. This plan therefore:
+
+1. Extracts three primitives shared by both views,
+2. Migrates the already-shipped backlog code onto them (mechanical),
+3. Wires the new Builders consumer onto the same primitives.
+
+The acceptance criterion "Rule structurally identical to #811's" becomes literally true (same function call, same class), not merely-prose-identical.
 
 ### Wire-field note
 
-Revised #818 still references `OverviewBuilder.areas[]` (plural) in prose, but #886 actually ships against `OverviewBuilder.area: string` (single, projected via `parseArea` — first-alphabetical wins). `views/backlog.ts:37` reads `item.area`. I'll mirror that — `b.area` — so both views consume the same field. If the architect prefers re-introducing the plural shape, that's a wire change against #819, not this view.
+Revised #818 body says `OverviewBuilder.areas[]` (plural) in places, but #886 actually ships against `OverviewBuilder.area: string` (single, projected via `parseArea` — first-alphabetical wins). `views/backlog.ts:37` reads `item.area`. I'll mirror that. If the architect prefers re-introducing the plural shape, that's a wire change against #819, not this view.
 
 ## Proposed Change
 
-Mirror PR #886's three pieces in `views/backlog.ts` + `views/backlog-tree-item.ts` + `test/backlog.test.ts` onto the Builders side.
+### 1. Extract three shared primitives
 
-### 1. `groupBuildersByArea` pure helper
-
-In `packages/vscode/src/views/builders.ts`, structurally identical to `groupBacklogByArea` (`views/backlog.ts:32-60`):
+#### 1a. `packages/core/src/area-grouping.ts` (new) — generic `groupByArea`
 
 ```ts
-export function groupBuildersByArea(
-  builders: OverviewBuilder[],
-): Array<{ area: string; builders: OverviewBuilder[] }> {
-  const buckets = new Map<string, OverviewBuilder[]>();
-  for (const b of builders) {
-    const bucket = buckets.get(b.area);
-    if (bucket) bucket.push(b);
-    else buckets.set(b.area, [b]);
+import { UNCATEGORIZED_AREA } from './constants.js';
+
+/**
+ * Bucket items by their resolved area, returning groups in canonical
+ * Codev order: alphabetical specific areas first, then `Uncategorized`
+ * last. Within each group, the input order is preserved (the caller
+ * has already applied any sort policy — display-order for builders,
+ * mine-first for backlog).
+ *
+ * Pure, generic over the item type. Both `views/backlog.ts` and
+ * `views/builders.ts` consume this directly; future consumers
+ * (dashboard equivalents, etc.) reuse the same function.
+ */
+export function groupByArea<T>(
+  items: T[],
+  getArea: (item: T) => string,
+): Array<{ area: string; items: T[] }> {
+  const buckets = new Map<string, T[]>();
+  for (const item of items) {
+    const area = getArea(item);
+    const bucket = buckets.get(area);
+    if (bucket) bucket.push(item);
+    else buckets.set(area, [item]);
   }
 
-  const result: Array<{ area: string; builders: OverviewBuilder[] }> = [];
+  const result: Array<{ area: string; items: T[] }> = [];
   const uncategorized = buckets.get(UNCATEGORIZED_AREA);
   const specifics = [...buckets.keys()].filter(a => a !== UNCATEGORIZED_AREA).sort();
-  for (const area of specifics) result.push({ area, builders: buckets.get(area)! });
-  if (uncategorized) result.push({ area: UNCATEGORIZED_AREA, builders: uncategorized });
+  for (const area of specifics) result.push({ area, items: buckets.get(area)! });
+  if (uncategorized) result.push({ area: UNCATEGORIZED_AREA, items: uncategorized });
   return result;
 }
 ```
 
-Pure, VSCode-free, unit-testable. Caller passes builders in display order (i.e. `orderForDisplay()` output) so within-group order is preserved by Map insertion.
+Re-exported from the core barrel.
 
-### 2. `BuilderGroupTreeItem` class
+Tests in `packages/core/src/__tests__/area-grouping.test.ts` cover: empty input, single Uncategorized item, alphabetical specifics + Uncategorized last, omits empty groups, preserves input order within a group, multiple items per area. Adapted from the existing `suite('groupBacklogByArea')` in `test/backlog.test.ts:43-100` — same behavioural invariants, now generic.
 
-In `packages/vscode/src/views/builder-tree-item.ts` (alongside `BuilderTreeItem`), structurally identical to `BacklogGroupTreeItem` (`views/backlog-tree-item.ts:36-46`):
+#### 1b. `packages/vscode/src/views/area-group-tree-item.ts` (new) — base class
 
 ```ts
-export class BuilderGroupTreeItem extends vscode.TreeItem {
+import * as vscode from 'vscode';
+
+export type AreaGroupKind = 'backlog' | 'builder';
+
+/**
+ * Shared base for area-group header rows in the Backlog and Builders
+ * trees. The `kind` discriminator drives both the stable `id` prefix
+ * (so VSCode persists per-group expansion across cache ticks) and the
+ * `contextValue` (so per-view context menus can scope cleanly).
+ *
+ * Concrete subclasses (`BacklogGroupTreeItem`, `BuilderGroupTreeItem`)
+ * are thin tags around this base — they exist to preserve `instanceof`
+ * discrimination in `extension.ts`'s per-view onDidExpand/Collapse
+ * handlers, where each view must persist only its own groups.
+ */
+export class AreaGroupTreeItem extends vscode.TreeItem {
   constructor(
     public readonly areaName: string,
+    public readonly kind: AreaGroupKind,
     count: number,
     collapsibleState: vscode.TreeItemCollapsibleState,
   ) {
     super(`${areaName} (${count})`, collapsibleState);
-    this.id = `builder-group:${areaName}`;
-    this.contextValue = 'builder-group';
+    this.id = `${kind}-group:${areaName}`;
+    this.contextValue = `${kind}-group`;
   }
 }
 ```
 
-Stable `id` keyed off area name → VSCode reuses TreeItem identity across `OverviewCache` ticks → the user's collapse choice survives every refresh. `contextValue = 'builder-group'` lets us hang future per-group context menus off it without retrofitting selectors.
+Thin subclasses:
 
-### 3. Two-level `BuildersProvider`
+```ts
+// backlog-tree-item.ts
+export class BacklogGroupTreeItem extends AreaGroupTreeItem {
+  constructor(areaName: string, count: number, state: vscode.TreeItemCollapsibleState) {
+    super(areaName, 'backlog', count, state);
+  }
+}
 
-Restructure `BuildersProvider` in `views/builders.ts` to mirror `BacklogProvider`'s shape (`views/backlog.ts:78-188`):
+// builder-tree-item.ts
+export class BuilderGroupTreeItem extends AreaGroupTreeItem {
+  constructor(areaName: string, count: number, state: vscode.TreeItemCollapsibleState) {
+    super(areaName, 'builder', count, state);
+  }
+}
+```
 
-- **Constructor gains a `workspaceState: vscode.Memento` parameter** for persistence. Existing call site (`extension.ts:255`) becomes `new BuildersProvider(overviewCache, builderDiffCache, context.workspaceState)`.
-- **`getChildren(element?)`**: branch on element type.
-  - `BuilderTreeItem` → file children (unchanged: `fileChildren(builderId)`)
-  - `BuilderFolderTreeItem` → folder children (unchanged)
-  - `BuilderFileTreeItem` → `[]` (unchanged)
-  - `BuilderGroupTreeItem` → builder rows for that area (new — `rowsForGroup(areaName)`)
-  - `undefined` (root) → group rows OR flattened builder rows (new — `rootChildren()`)
-- **`rootChildren()`**: compute ordered builders once, group via `groupBuildersByArea`, apply single-`Uncategorized` flatten:
+Existing callers (`new BacklogGroupTreeItem(area, count, state)`) keep the same constructor signature — no migration churn at call sites.
 
+#### 1c. `packages/vscode/src/views/area-group-expansion.ts` (new) — store + wiring helper
+
+```ts
+import * as vscode from 'vscode';
+import { AreaGroupTreeItem } from './area-group-tree-item.js';
+
+/**
+ * Per-area expand/collapse state, persisted in `workspaceState`. One
+ * instance per view (each view scopes its own key, e.g.
+ * `codev.backlogGroupExpansion` / `codev.buildersGroupExpansion`),
+ * so users can collapse a `vscode` group in Builders without affecting
+ * the same group in Backlog.
+ */
+export class AreaGroupExpansionStore {
+  constructor(
+    private readonly workspaceState: vscode.Memento,
+    private readonly storageKey: string,
+  ) {}
+
+  read(): Record<string, boolean> {
+    return this.workspaceState.get<Record<string, boolean>>(this.storageKey, {});
+  }
+
+  set(areaName: string, expanded: boolean): void {
+    const map = this.read();
+    map[areaName] = expanded;
+    this.workspaceState.update(this.storageKey, map);
+  }
+}
+
+/**
+ * Wire a TreeView's expand/collapse events into an
+ * AreaGroupExpansionStore. The `GroupClass` parameter is the
+ * view-specific subclass (`BacklogGroupTreeItem` or
+ * `BuilderGroupTreeItem`); the `instanceof` check ensures each store
+ * only records events from its own view's groups, even though both
+ * views ultimately produce `AreaGroupTreeItem`-derived rows.
+ */
+export function wireAreaGroupExpansion(
+  view: vscode.TreeView<vscode.TreeItem>,
+  GroupClass: new (...args: never[]) => AreaGroupTreeItem,
+  store: AreaGroupExpansionStore,
+): vscode.Disposable[] {
+  return [
+    view.onDidExpandElement((e) => {
+      if (e.element instanceof GroupClass) store.set(e.element.areaName, true);
+    }),
+    view.onDidCollapseElement((e) => {
+      if (e.element instanceof GroupClass) store.set(e.element.areaName, false);
+    }),
+  ];
+}
+```
+
+### 2. Migrate `views/backlog.ts` onto the shared primitives
+
+Mechanical replacement (`views/backlog.ts:32-60, 107-111, 185-187`):
+
+- Drop inline `groupBacklogByArea` — replace with `groupByArea(items, i => i.area)` at the one call site.
+- Drop inline `setGroupExpanded` / `readExpansionState` / `EXPANSION_STATE_KEY` — replace with `private readonly expansion = new AreaGroupExpansionStore(workspaceState, 'codev.backlogGroupExpansion')`. Replace `setGroupExpanded` callers with `this.expansion.set(...)`; replace `readExpansionState` callers with `this.expansion.read()`.
+- `BacklogGroupTreeItem` body shrinks to the thin subclass shown above.
+
+Net: `views/backlog.ts` loses ~45 LOC; `backlog-tree-item.ts` loses ~7 LOC. Behaviour byte-identical.
+
+`packages/vscode/src/test/backlog.test.ts`: drop the `suite('groupBacklogByArea')` block (lines 43-100). The same invariants are tested in `packages/core/src/__tests__/area-grouping.test.ts` against the generic. `suite('spawnableBacklog')` stays.
+
+### 3. Apply to `views/builders.ts` (this issue's primary deliverable)
+
+`BuildersProvider` gains the two-level shape mirroring `BacklogProvider` after migration:
+
+- **Constructor**: `(overviewCache, builderDiffCache, workspaceState)`. The new `workspaceState` field constructs `private readonly expansion = new AreaGroupExpansionStore(workspaceState, 'codev.buildersGroupExpansion')`.
+- **`getChildren(element?)`**: existing branches for `BuilderTreeItem` / `BuilderFolderTreeItem` / `BuilderFileTreeItem` are unchanged. New branches:
+  - `BuilderGroupTreeItem` → `rowsForGroup(areaName)`
+  - root → `rootChildren()`
+- **`rootChildren()`**:
   ```ts
   const ordered = orderForDisplay(data.builders, now);
-  const groups = groupBuildersByArea(ordered);
+  const groups = groupByArea(ordered, b => b.area);
   if (groups.length === 1 && groups[0].area === UNCATEGORIZED_AREA) {
-    return groups[0].builders.map(b => this.makeBuilderRow(b, now));
+    return groups[0].items.map(b => this.makeBuilderRow(b, now));
   }
-  const expansion = this.readExpansionState();
-  return groups.map(g => new BuilderGroupTreeItem(g.area, g.builders.length,
+  const expansion = this.expansion.read();
+  return groups.map(g => new BuilderGroupTreeItem(
+    g.area,
+    g.items.length,
     (expansion[g.area] ?? true) ? vscode.TreeItemCollapsibleState.Expanded
-                                 : vscode.TreeItemCollapsibleState.Collapsed));
+                                : vscode.TreeItemCollapsibleState.Collapsed,
+  ));
   ```
+- **`rowsForGroup(areaName)`**: recompute `orderForDisplay` → `groupByArea` → find matching group → `map(makeBuilderRow)`. Matches backlog's `orderedSpawnable` recompute pattern (`backlog.ts:113-147`).
+- **`makeBuilderRow(b, now)`**: extract today's per-builder rendering (`builders.ts:89-136`) into a single helper. No behaviour change.
+- **`getParent`** — see §4.
 
-- **`rowsForGroup(areaName)`**: recompute the same ordered+grouped result and return the matching group's builder rows, each built via the same `makeBuilderRow` helper used by the flatten branch.
-- **`makeBuilderRow(b, now)`**: extract today's per-builder rendering (`builders.ts:89-136`) into a single helper so flatten + grouped paths share it byte-for-byte. No behavior change.
-- **`setGroupExpanded(areaName, expanded)`**: persistence method, identical to `BacklogProvider.setGroupExpanded` (`views/backlog.ts:107-111`).
-- **`readExpansionState()`**: read the `EXPANSION_STATE_KEY = 'codev.buildersGroupExpansion'` map from `workspaceState`, defaulting to `{}`.
+`BuilderGroupTreeItem` is added in `views/builder-tree-item.ts` (thin subclass of `AreaGroupTreeItem`, as shown in §1b).
 
-### 4. `getParent` for accordion `reveal()`
+### 4. `getParent` for accordion `reveal()` (Builders-only divergence)
 
-This is the **one** divergence from backlog: the Builders accordion (`extension.ts:310`) calls `buildersView.reveal(builderItem, { expand: 3 })`. With groups inserted, `reveal` needs a real parent chain — today's `getParent(): undefined` will break the accordion in grouping mode.
+The Builders accordion (`extension.ts:310`) calls `buildersView.reveal(builderItem, { expand: 3 })`. With groups inserted, `reveal` needs a real parent chain — today's `getParent(): undefined` breaks the accordion in grouping mode.
 
-Solution: maintain a `Map<builderId, BuilderGroupTreeItem>` populated by `rootChildren()` whenever it returns groups (i.e. multi-group case). `getParent(BuilderTreeItem)` returns the cached group; `getParent` for everything else (and in the single-`Uncategorized` flatten case, where builders are root) returns `undefined`. Clean and minimal.
+Solution: a `Map<builderId, BuilderGroupTreeItem>` populated by `rootChildren()` whenever it returns groups (multi-group case). `getParent(BuilderTreeItem)` returns the cached group; `getParent` for everything else (and in single-`Uncategorized` flatten, where builders are root again) returns `undefined`. Backlog has no equivalent need (no accordion on backlog rows) — this stays a Builders-only concern.
 
 ### 5. Wire `onDidExpand/CollapseElement` in `extension.ts`
 
-Mirror the backlog wiring (`extension.ts:261-271`) immediately after creating `buildersView`:
+After migration, the existing backlog wiring (`extension.ts:261-271`) becomes:
 
 ```ts
-context.subscriptions.push(
-  buildersView.onDidExpandElement((e) => {
-    if (e.element instanceof BuilderGroupTreeItem) {
-      buildersProvider.setGroupExpanded(e.element.areaName, true);
-    }
-  }),
-  buildersView.onDidCollapseElement((e) => {
-    if (e.element instanceof BuilderGroupTreeItem) {
-      buildersProvider.setGroupExpanded(e.element.areaName, false);
-    }
-  }),
-);
+context.subscriptions.push(...wireAreaGroupExpansion(
+  backlogView, BacklogGroupTreeItem, backlogProvider.expansion,
+));
+```
+
+(Or the provider exposes the store via a getter — minor API call.)
+
+Add immediately after `buildersView` creation:
+
+```ts
+context.subscriptions.push(...wireAreaGroupExpansion(
+  buildersView, BuilderGroupTreeItem, buildersProvider.expansion,
+));
 ```
 
 Existing `buildersView.onDidExpandElement` accordion handler (line 297) is untouched — its `instanceof BuilderTreeItem` guard already ignores group rows.
 
-### 6. Tests
+### 6. Single-Uncategorized flatten: kept per-provider (deliberate)
 
-`packages/vscode/src/test/builders.test.ts` gains a `suite('groupBuildersByArea')` mirroring `suite('groupBacklogByArea')` from `test/backlog.test.ts:43-100`. Same test cases adapted to the builders shape:
+Both providers carry the 6-LOC flatten predicate inline (`backlog.ts:124-126` and the equivalent in builders' `rootChildren`). Not extracted because the predicate's body calls a view-specific row-builder (`makeRow(item)` for backlog, `makeBuilderRow(b, now)` for builders). Extracting it cleanly would require an abstract provider with generics — disproportionate complexity for 6 LOC. Accepted as the residual duplication after the three extractions above.
 
-- empty in → empty out
-- single Uncategorized builder → one Uncategorized group
-- alphabetical specifics then Uncategorized last
-- omits empty area groups (no `<area> (0)` headers)
-- preserves input order within a group (no internal re-sort) — this is the within-group `orderForDisplay()` preservation
-- groups multiple builders per area correctly
-
-### 7. Out of scope (preserve issue's contract)
+### 7. Out of scope
 
 - Configurable priority-areas mechanism
 - Hardcoded `area/cross-cutting` or any area-name privilege
 - Toggle to disable grouping
 - Grouping by `type:*` / `priority:*` / any non-area axis
-- Duplicating a builder under multiple area groups (single primary area derived from `parseArea`)
+- Duplicating a builder under multiple area groups
 - Per-builder user-pickable primary area override
-- Dashboard equivalent (no existing dashboard consumer of `builder.area` — separate change)
+- Dashboard equivalent (no existing dashboard consumer of `builder.area` — but the `groupByArea` extraction is the future hook)
+- Header capitalization (`vscode` → `Vscode`) — tracked separately in #885
+- Abstract `AreaGroupedProvider` base class — would extract the single-Uncategorized flatten too; rejected as over-engineering for 6 LOC of remainder
 
 ## Files to Change
 
-- `packages/vscode/src/views/builders.ts` — add `groupBuildersByArea` pure helper; restructure `BuildersProvider` into two-level form with `rootChildren` / `rowsForGroup` / `makeBuilderRow` / `setGroupExpanded` / `readExpansionState` (mirror `BacklogProvider`); add `getParent` with group-cache map; widen constructor to accept `workspaceState: vscode.Memento`; import `UNCATEGORIZED_AREA` from `@cluesmith/codev-core/constants`.
-- `packages/vscode/src/views/builder-tree-item.ts` — add `BuilderGroupTreeItem` class (mirror `BacklogGroupTreeItem` in `backlog-tree-item.ts:36-46`).
-- `packages/vscode/src/extension.ts:255` — update `new BuildersProvider(...)` call to pass `context.workspaceState`; add `buildersView.onDidExpand/CollapseElement` subscriptions that call `buildersProvider.setGroupExpanded` for `BuilderGroupTreeItem` (mirror lines 261-271); import `BuilderGroupTreeItem`.
-- `packages/vscode/src/test/builders.test.ts` — add `suite('groupBuildersByArea')` with the six test cases mirrored from `backlog.test.ts`.
-- **No changes** to `packages/core/`, `packages/types/`, `packages/codev/`, `packages/vscode/package.json`. No new settings, no new commands, no new menu entries.
+### New
+- `packages/core/src/area-grouping.ts` — generic `groupByArea<T>(items, getArea)`.
+- `packages/core/src/__tests__/area-grouping.test.ts` — six tests adapted from `test/backlog.test.ts`'s `groupBacklogByArea` suite.
+- `packages/vscode/src/views/area-group-tree-item.ts` — base `AreaGroupTreeItem` with `kind: 'backlog' | 'builder'` discriminator.
+- `packages/vscode/src/views/area-group-expansion.ts` — `AreaGroupExpansionStore` class + `wireAreaGroupExpansion` helper.
+
+### Modified — refactor (touches backlog)
+- `packages/core/src/index.ts` (or barrel) — re-export `groupByArea`.
+- `packages/vscode/src/views/backlog.ts` — drop inline `groupBacklogByArea` and inline expansion-state plumbing; consume `groupByArea` + `AreaGroupExpansionStore`.
+- `packages/vscode/src/views/backlog-tree-item.ts` — `BacklogGroupTreeItem` becomes a thin subclass of `AreaGroupTreeItem` (~4 LOC).
+- `packages/vscode/src/extension.ts:261-271` — replace inline `onDidExpand/CollapseElement` wiring with `wireAreaGroupExpansion(backlogView, BacklogGroupTreeItem, backlogProvider.expansion)`.
+- `packages/vscode/src/test/backlog.test.ts` — drop `suite('groupBacklogByArea')` (covered now in core). `suite('spawnableBacklog')` stays.
+
+### Modified — new consumer (the original #818 goal)
+- `packages/vscode/src/views/builders.ts` — two-level `BuildersProvider`; consume `groupByArea` + `AreaGroupExpansionStore`; add `getParent` with group-cache; widen constructor to take `workspaceState: vscode.Memento`; extract `makeBuilderRow` from existing per-row rendering.
+- `packages/vscode/src/views/builder-tree-item.ts` — add `BuilderGroupTreeItem` thin subclass.
+- `packages/vscode/src/extension.ts:255` — pass `context.workspaceState` to `new BuildersProvider(...)`; add `wireAreaGroupExpansion(buildersView, BuilderGroupTreeItem, buildersProvider.expansion)`.
+- `packages/vscode/src/test/builders.test.ts` — no new grouping-specific tests (covered by `area-grouping.test.ts` in core). Existing `orderForDisplay` and `isIdleWaiting` suites untouched.
+
+### Not touched
+- `packages/types/`, `packages/codev/` — no wire changes. `OverviewBuilder.area` and `OverviewBacklogItem.area` already populated by #819.
+- `packages/vscode/package.json` — no new settings, commands, or menu entries.
 
 ## Risks & Alternatives Considered
 
 ### Risks
 
-- **Accordion `reveal()` regression in grouping mode** — addressed by the `getParent` + `Map<builderId, BuilderGroupTreeItem>` mechanism. Validated manually at the `dev-approval` gate (expand a builder; verify others auto-collapse across groups).
-- **`workspaceState` key collision** — `codev.buildersGroupExpansion` is namespaced under `codev.` and is distinct from `codev.backlogGroupExpansion`. No collision.
-- **Single-`Uncategorized` flatten makes `getParent` semantics differ between modes** — handled: the group cache is empty in flatten mode, so `getParent(builderItem)` returns `undefined` (today's behavior); accordion works unchanged.
-- **`orderForDisplay()` only runs once** — root render computes `ordered` then groups it; `rowsForGroup` recomputes the same pipeline so within-group order matches. Slightly wasteful (two `orderForDisplay` calls per refresh) but matches the backlog's `orderedSpawnable` pattern (`backlog.ts:113-147`) — caching across calls would diverge from the reference.
+- **Refactor scope on a shipped #886.** Touching `views/backlog.ts` / `backlog-tree-item.ts` / `test/backlog.test.ts` in the same PR as the Builders change. Mitigation: the refactor is mechanical (drop-in replacement of inlined-once code with a shared call); behaviour preserved by the test suite (which moves but tests the same invariants); reviewer can read the backlog diff as a no-op-by-construction.
+- **Accordion `reveal()` regression in grouping mode.** Addressed by the `getParent` + per-render group-cache map. Manually validated at the `dev-approval` gate.
+- **`AreaGroupTreeItem`'s shared base means `instanceof AreaGroupTreeItem` would match both views' groups.** Mitigated by the thin subclasses + `instanceof BacklogGroupTreeItem` / `instanceof BuilderGroupTreeItem` discriminators in `wireAreaGroupExpansion`. Each store sees only its own view's events.
+- **`workspaceState` key collision.** `codev.backlogGroupExpansion` (existing) and `codev.buildersGroupExpansion` (new) are distinct, namespaced under `codev.`. No collision.
+- **Single-Uncategorized flatten makes `getParent` semantics differ between modes** in Builders. Handled — group-cache is empty in flatten mode → `getParent(builderItem)` returns `undefined` (today's behaviour) → accordion works unchanged on that branch.
 
 ### Alternatives Considered
 
-- **Keep the toggle from v1 of this plan.** Rejected per architect's revised directive: #886 didn't ship one and the design discipline is "no configurable knob unless there's a real demand".
-- **Extract `groupByArea` to `@cluesmith/codev-core` as a shared helper.** Rejected to match #886's actually-shipped shape exactly — backlog inlined its helper in `views/backlog.ts`, so builders does the same. If/when a third consumer needs it (dashboard), extraction is a one-line refactor.
-- **Use `OverviewBuilder.areas[]` (plural) as the issue body still suggests.** Rejected — `#886` ships against the single `.area` projection from `parseArea`. Wire alignment matters more than copying the issue's prose verbatim.
+- **Skip the refactor; mirror #886 inline (v2 of this plan).** Rejected per user direction: the second consumer is the natural extraction moment.
+- **Extract only `groupByArea` (the largest single block); leave TreeItem + expansion-store duplicated.** Rejected as half-measure — the TreeItem and expansion-store extractions are each cheaper than the helper extraction and remove drift risk on the parts most likely to evolve (per-group context menus, expansion-state keys).
+- **Extract an abstract `AreaGroupedProvider` base** that hosts `rootChildren` / `rowsForGroup` / single-Uncategorized flatten with a generic row factory. Rejected — saves 6 LOC at the cost of generics over (item type, row type, group subclass), which would obscure the providers more than the duplication costs. Re-evaluate if a third consumer lands.
+- **Use `OverviewBuilder.areas[]` (plural) per revised issue prose.** Rejected — #886 ships against single `.area`; matching wire-shape consistency wins over copying the issue's prose verbatim.
 
 ## Test Plan
 
-### Unit (CI + local `pnpm test --filter @cluesmith/codev-vscode`)
+### Unit (CI + local `pnpm test`)
 
-Six tests in `suite('groupBuildersByArea')`:
-
-1. empty in → empty out
-2. single Uncategorized builder → one `Uncategorized` group
-3. mixed inputs → alphabetical specifics then `Uncategorized` last
-4. omits empty area groups (no `<area> (0)` headers)
-5. preserves input order within a group (no internal re-sort) — confirms within-group ordering relies on caller-supplied order (i.e. `orderForDisplay()` semantics flow through unchanged)
-6. groups multiple builders per area correctly
+- `packages/core/src/__tests__/area-grouping.test.ts` — six tests covering `groupByArea<T>`:
+  1. empty in → empty out
+  2. single Uncategorized item → one Uncategorized group
+  3. mixed inputs → alphabetical specifics then Uncategorized last
+  4. omits empty area groups (no `<area> (0)` headers)
+  5. preserves input order within a group (no internal re-sort)
+  6. multiple items per area grouped correctly
+- `packages/vscode/src/test/backlog.test.ts` — `suite('spawnableBacklog')` retained; `suite('groupBacklogByArea')` removed (covered above). Backlog provider regression risk caught by the core tests + manual review of the mechanical migration.
+- `packages/vscode/src/test/builders.test.ts` — `suite('orderForDisplay')` and `suite('isIdleWaiting')` retained, untouched. No new grouping-specific tests at vscode level (the generic helper carries the behavioural coverage).
 
 ### Manual (`dev-approval` gate)
 
 Reviewer runs `afx dev pir-818` and exercises in the running VSCode instance:
 
-- **Side-by-side with backlog**: open the Codev sidebar; verify Builders renders with the same group-header style as Backlog (`<area> (count)`, alphabetical, `Uncategorized` last).
+- **Backlog regression check** (refactor surface): open the Backlog view; verify groups render exactly as they did on main (alphabetical, Uncategorized last, count suffix, expand state persists across reloads). The refactor must be invisible from the user's seat.
+- **Builders grouping** (new): open the Builders view; verify the same group-header style applied. Cross-check with the Backlog view — same alphabetical order, same Uncategorized-last placement, same per-group collapse persistence.
 - **Within-group ordering**: ensure a blocked builder still sorts above active builders within its area group (preserves `orderForDisplay()`).
 - **Accordion in grouping mode**: with `codev.buildersAutoCollapse` on (default), expand a builder's changed-files diff. Verify other builders auto-collapse — across groups too, not just within the same group.
-- **Per-group expand/collapse persistence**: collapse one group. Reload the window. Verify the group is still collapsed. Expand it; reload; verify expanded.
-- **Single-Uncategorized flatten**: hard to reproduce naturally on this repo (every issue is labelled), but verifiable by temporarily removing all `area/*` labels from open builders' issues (or, for the reviewer, by reading the test case and accepting the unit coverage).
+- **Per-group expand/collapse persistence**: collapse one group. Reload the window. Verify the group is still collapsed. Expand it; reload; verify expanded. Verify backlog and builders independently — collapsing `vscode` in Backlog must not affect `vscode` in Builders (separate `workspaceState` keys).
+- **Single-Uncategorized flatten**: covered by unit tests. Hard to reproduce on this repo (every issue is labelled); reviewer can verify by reading the test case.
 - **Reactivity**: add or remove an `area/*` label on a builder's underlying issue via `gh issue edit`. Wait for the next `OverviewCache` SSE tick (≤60s) and confirm the builder migrates between groups.
-- **Comparison with Backlog**: switch between the two views and confirm the rule "feels identical" — same alphabetical order, same Uncategorized-last placement, same per-area collapse persistence behaviour.
 
 ### Cross-platform
 

--- a/codev/plans/818-vscode-group-builders-in-the-t.md
+++ b/codev/plans/818-vscode-group-builders-in-the-t.md
@@ -1,0 +1,191 @@
+# PIR Plan: Group Builders Tree by Area
+
+## Understanding
+
+The VSCode `Codev: Builders` tree (`packages/vscode/src/views/builders.ts:89`) is a flat list today. With multiple builders running across product surfaces (vscode, tower, porch, terminal, etc.), engineers can't see "what's running on `vscode` right now" without scanning every row's title. The `area/*` GitHub label namespace — already plumbed onto `OverviewBuilder.area` by the merged #819 — is the right axis: it mirrors how work is coordinated and matches the upcoming backlog grouping (#811) so engineers learn one mental model.
+
+The wire field already exists. `OverviewBuilder.area: string` is **required-with-default** (`'Uncategorized'` when the builder has no issue or the issue has no `area/*` labels). The literal `'Uncategorized'` is exported as `UNCATEGORIZED_AREA` from `@cluesmith/codev-core/constants`. This change is therefore confined to the VSCode package: rendering, toggling, ordering, tests.
+
+### Inheritance from #819 — what this plan does NOT re-litigate
+
+Issue #818's original description was written before #819's design converged. Two reconciliations matter:
+
+1. **`area` is a single string (`builder.area`), not an array.** The original spec proposed `BuilderOverview.areas: string[]` consumed via `parseAreaLabels`. The shipped contract is the single-string projection from `parseArea` (first-alphabetical wins). Each builder lives in exactly one area; the grouping layer doesn't see raw labels.
+
+2. **`area/cross-cutting` has no parser-level privilege.** #819's final design dropped the "cross-cutting takes precedence" rule from the parser — it's now policy-free about label names. A builder tagged `[area/cross-cutting, area/vscode]` is projected to `'cross-cutting'` only because `'c'` < `'v'` alphabetically; tagged `[area/auth, area/cross-cutting]` it's projected to `'auth'`.
+
+   #818's original "If `area/cross-cutting` is present → place under cross-cutting exclusively" rule cannot be honoured at the *resolution* layer without re-extending the wire to carry raw labels (and re-introducing the policy the #819 review deliberately removed). This plan honours the rule's *intent* at the **group-ordering** layer instead: when a `cross-cutting` group exists (because at least one builder has `area === 'cross-cutting'`), its header sorts first. The "exclusivity" property is enforced by the parser — each builder belongs to exactly one group regardless. Teams that want every multi-area builder to land in `cross-cutting` should tag them with `area/cross-cutting` *only* (the #819 convention).
+
+   If we want stronger cross-cutting privilege later, that's a separate change to `parseArea` (not to this view). Flagged in **Risks** below.
+
+The "byte-identical to #811" acceptance criterion translates to: both views use the same `area` projection + the same group-ordering rule (extracted as a shared helper so the code itself is shared, not just the spec).
+
+## Proposed Change
+
+### 1. Shared helper in core: `sortAreaGroups`
+
+Extract one small pure function to `@cluesmith/codev-core` so #811's backlog grouping (and any dashboard equivalent) can reuse the same code, not just the same prose.
+
+```ts
+// packages/core/src/area-grouping.ts (new)
+import { UNCATEGORIZED_AREA } from './constants.js';
+
+/**
+ * Sort area group names per the canonical Codev convention:
+ *  1. `cross-cutting` first (when present) — coordination-risk surface
+ *  2. alphabetical middle
+ *  3. `UNCATEGORIZED_AREA` (`'Uncategorized'`) last
+ *
+ * Pure — operates on a list of distinct area names (typically the keys
+ * of a Map<area, items[]>). Used by both the Builders view (#818) and
+ * the Backlog view (#811) so engineers learn one mental model.
+ */
+export function sortAreaGroups(areas: string[]): string[] { ... }
+```
+
+Re-exported from the package barrel alongside `isIdleWaiting`.
+
+### 2. Grouping mode in `BuildersProvider`
+
+`BuildersProvider.getChildren()` gains a top-level branch on `codev.buildersGroupByArea`:
+
+- **Off** (today's behaviour): root returns ordered builder rows directly. Zero diff to existing UX.
+- **On**: root returns `BuilderAreaGroupTreeItem[]` (the group headers); each group's `getChildren` returns the builders mapped into that group (already in `orderForDisplay` order).
+
+Mapping algorithm:
+
+```ts
+const ordered = orderForDisplay(data.builders, now);  // unchanged
+const byArea = new Map<string, OverviewBuilder[]>();
+for (const b of ordered) {
+  const list = byArea.get(b.area) ?? [];
+  list.push(b);
+  byArea.set(b.area, list);
+}
+const areaOrder = sortAreaGroups([...byArea.keys()]);
+return areaOrder.map(area => new BuilderAreaGroupTreeItem(area, byArea.get(area)!));
+```
+
+Map iteration preserves insertion order → within-group order preserves `orderForDisplay()`'s blocked → idle-waiting → active sequence (acceptance criterion).
+
+**Empty groups are not rendered** — only areas with ≥1 builder appear. The issue's mock shows `Uncategorized (0)` as a teaching device; rendering empty groups is noise in practice. Easy to flip if the reviewer prefers always-show-Uncategorized.
+
+### 3. New tree item: `BuilderAreaGroupTreeItem`
+
+`packages/vscode/src/views/builder-area-group-tree-item.ts` (new file, follows the existing one-file-per-TreeItem-subclass convention used by `BuilderTreeItem`, `BuilderFileTreeItem`, `BuilderFolderTreeItem`):
+
+- Label: `<area> (<count>)` — e.g. `vscode (4)`
+- Stable `id`: `area-group:<area>` — so VSCode persists expand/collapse state per-group across reloads (acceptance criterion)
+- `collapsibleState`: `Expanded` by default (first-time render); VSCode replaces this with the persisted state on subsequent renders via the stable `id`
+- `contextValue`: `builder-area-group` (lets us hang future per-group context-menu actions off it without touching the row-level menus)
+- Carries the resolved `OverviewBuilder[]` for its area so `getChildren(group)` doesn't recompute the bucket
+
+### 4. `getParent` for `reveal()`
+
+The auto-collapse accordion (`extension.ts:312`) calls `buildersView.reveal(builderItem, { expand: 3 })`. `reveal()` requires `getParent` to return the parent chain. Today `getParent()` returns `undefined` for everything — fine because builder rows are roots.
+
+With grouping on, builder rows are no longer roots. `getParent` must return the appropriate `BuilderAreaGroupTreeItem` for any `BuilderTreeItem`. Implementation: keep a `Map<builderId, BuilderAreaGroupTreeItem>` on the provider, populated each time `getChildren(root)` runs in grouping mode. (Group items, file items, folder items continue to return `undefined` — they're either roots themselves or never reveal targets.)
+
+Without this, the accordion's `reveal()` in grouping mode would silently fail to expand the builder after the `collapseAll` half of the swap. With it, accordion behavior is identical in both modes.
+
+### 5. Config flag + toggle commands
+
+Mirror the existing `buildersFileViewAsTree` pattern exactly:
+
+**`packages/vscode/package.json`** — declare:
+
+```jsonc
+// contributes.commands
+{ "command": "codev.enableBuildersGroupByArea",  "title": "Codev: Group Builders by Area",       "icon": "$(group-by-ref-type)" },
+{ "command": "codev.disableBuildersGroupByArea", "title": "Codev: Show Builders as Flat List",   "icon": "$(list-flat)" },
+
+// contributes.menus.view/title
+{ "command": "codev.disableBuildersGroupByArea", "when": "view == codev.builders && codev.buildersGroupByArea",  "group": "navigation" },
+{ "command": "codev.enableBuildersGroupByArea",  "when": "view == codev.builders && !codev.buildersGroupByArea", "group": "navigation" },
+
+// contributes.configuration.properties
+"codev.buildersGroupByArea": {
+  "type": "boolean",
+  "default": true,
+  "description": "Group the Builders tree by area/* label (cross-cutting first, alphabetical middle, Uncategorized last). When off, renders as a flat list."
+}
+```
+
+**`packages/vscode/src/extension.ts`** — register the two commands (paired with the existing `enableBuildersFileTreeMode` / `disableBuildersFileTreeMode` pair around line 609) and a `setContext` mirror + `onDidChangeConfiguration` listener that calls `buildersProvider.refresh()` on flip (paired with the existing `buildersFileViewAsTree` block around lines 330-339).
+
+Default `true` is safe even for repos without `area/*` labels: every builder projects to `'Uncategorized'`, so the tree renders as a single `Uncategorized (N)` group containing the same builders in the same order — functionally identical to flat. Engineers who actively prefer flat can flip the toggle.
+
+### 6. Tests
+
+Extend `packages/vscode/src/test/builders.test.ts` with a `groupBuildersByArea` suite (testing the pure mapping function extracted alongside the rendering) and a `sortAreaGroups` suite (covering the cross-cutting/alphabetical/Uncategorized ordering — owned by core but exercised here too since the integration matters).
+
+Core unit tests for `sortAreaGroups` go in `packages/core/src/__tests__/area-grouping.test.ts` alongside the existing core tests.
+
+### 7. Out of scope (preserve issue's contract)
+
+- Grouping by `type:*` / `priority:*` / any non-area axis (the issue is explicit).
+- Duplicating a builder across multiple area groups (the parser projects to one — `cross-cutting` tag is the explicit answer).
+- Per-builder user-pickable primary area override (deferred).
+- Backlog grouping (#811's job, but the shared `sortAreaGroups` helper unblocks it).
+- Dashboard equivalent of grouping (no existing dashboard consumer of `builder.area` — separate change).
+
+## Files to Change
+
+- `packages/core/src/area-grouping.ts` — **new**, exports `sortAreaGroups(areas: string[]): string[]` and (optionally) `groupBuildersByArea` if we keep the mapping logic shared between dashboard and vscode; otherwise keep mapping in vscode only.
+- `packages/core/src/index.ts` (or barrel) — re-export `sortAreaGroups`.
+- `packages/core/src/__tests__/area-grouping.test.ts` — **new**, unit tests for `sortAreaGroups` (empty input, cross-cutting present/absent, Uncategorized handling, alphabetical sort, deduplication).
+- `packages/vscode/src/views/builder-area-group-tree-item.ts` — **new** TreeItem subclass; carries `area`, `builders: OverviewBuilder[]`, stable id, label `<area> (<count>)`.
+- `packages/vscode/src/views/builders.ts` — extend `BuildersProvider`:
+  - `getChildren(root)`: branch on `codev.buildersGroupByArea` config; when on, build the `Map<area, OverviewBuilder[]>`, sort keys via `sortAreaGroups`, return group items.
+  - `getChildren(BuilderAreaGroupTreeItem)`: return the group's builders, rendered with the existing per-builder logic refactored into a `renderBuilderRow(b, isBlocked, isIdle, ...)` helper to avoid duplication.
+  - `getParent`: return the cached group for any `BuilderTreeItem` when in grouping mode; `undefined` otherwise.
+  - Private `groupCache: Map<builderId, BuilderAreaGroupTreeItem>` populated on each root render.
+- `packages/vscode/src/extension.ts:600` area — register `codev.enableBuildersGroupByArea` / `codev.disableBuildersGroupByArea`; add a `readGroupByArea()` + `setContext('codev.buildersGroupByArea', ...)` mirror + an `onDidChangeConfiguration('codev.buildersGroupByArea')` handler that calls `buildersProvider.refresh()`.
+- `packages/vscode/package.json` — add the two commands, the two `view/title` menu entries, and the `codev.buildersGroupByArea` config property.
+- `packages/vscode/src/test/builders.test.ts` — add `suite('groupBuildersByArea')` (within-group preserves `orderForDisplay`, mapping accuracy, count fields) and `suite('sortAreaGroups')` (cross-cutting first, alphabetical, Uncategorized last).
+
+## Risks & Alternatives Considered
+
+### Risks
+
+- **`reveal()` regression in grouping mode**: If `getParent` doesn't return the right group, the accordion's `collapseAll + reveal` will fail to re-expand the builder after a click. Mitigation: cache the `builderId → group` map at root-render time; assert via an integration smoke test (manual at the `dev-approval` gate).
+- **Expand state divergence between modes**: The stable id `area-group:<area>` persists per group; builder ids persist per builder. When the user toggles off and back on, VSCode restores whichever state it remembers per id. Acceptable — same model as the existing file-view-as-tree toggle.
+- **Empty `Uncategorized` group**: When grouping is on and no builder lacks an area, no `Uncategorized` row renders. The issue's mock shows `Uncategorized (0)` as a teaching aid; I've chosen "render only non-empty groups" as the cleaner default. Reviewer can flip this preference at the `plan-approval` gate.
+- **Default `true` is a UX change**: Existing users will see grouping appear on next launch. Mitigation: in single-area repos (Codev's own) everything lands under one group (e.g. `vscode (4)`) — visually similar to flat. Engineers who want true flat can flip the toggle.
+
+### Alternatives Considered
+
+- **Re-extend the wire to carry raw labels and re-implement cross-cutting privilege at the view layer.** Rejected: #819 deliberately removed the privilege from the parser; re-adding it at one consumer (vscode) without the parser (and without the backlog/dashboard consumers) creates inconsistency. If the privilege is wanted, the right move is reopening the policy discussion against `parseArea`.
+- **Don't extract `sortAreaGroups` — duplicate the sort in vscode and in #811 later.** Rejected: the acceptance criterion explicitly calls out "byte-identical resolution rule" — the cheapest enforcement is one shared function. The extraction is ~10 LOC.
+- **Default the toggle to `false` for a quieter rollout.** Rejected: the issue explicitly specifies `true` ("since the area-label set is established"). Reviewer can override at the `plan-approval` gate.
+- **Always render every area group, including empties.** Rejected as default for the noise reason above; flip if review prefers.
+
+## Test Plan
+
+### Unit (CI + local `pnpm test`)
+
+- `packages/core/src/__tests__/area-grouping.test.ts`:
+  - empty input → empty output
+  - `['vscode', 'tower', 'porch']` → alphabetical
+  - `['vscode', 'cross-cutting', 'tower']` → cross-cutting first, then alphabetical
+  - `['vscode', 'Uncategorized', 'tower']` → alphabetical then Uncategorized last
+  - `['vscode', 'cross-cutting', 'Uncategorized', 'tower']` → all three rules at once
+  - deduplication (defensive — caller may pass a non-unique list)
+- `packages/vscode/src/test/builders.test.ts`:
+  - `groupBuildersByArea`: each builder lands in exactly one group; within-group order preserves `orderForDisplay()` semantics (mix blocked + idle + active in two areas; verify per-area sequence)
+  - count per group reflects the number of builders
+
+### Manual (`dev-approval` gate)
+
+The reviewer runs the worktree via `afx dev pir-818` and exercises:
+
+- **Grouping on (default)**: open the Codev sidebar → Builders. Verify group headers render as `<area> (<count>)`. Verify cross-cutting (if any) sorts first, alphabetical middle, Uncategorized last.
+- **Toggle off**: click the title-bar `Codev: Show Builders as Flat List` button. Verify the tree flattens to the existing-today layout. Verify the title-bar icon swaps to the "group" affordance.
+- **Toggle on**: click the swapped button. Verify groups reappear; verify each group's expand/collapse state survives a sidebar hide/show.
+- **Accordion in grouping mode**: with `buildersAutoCollapse` on, expand one builder's changed-files diff. Verify other builders (in same and other groups) auto-collapse. Verify the expanded builder remains expanded.
+- **Reload**: close and reopen the VSCode window. Verify per-group expand/collapse state persists.
+- **Zero `area/*` labels case**: there's no easy way to fake this without editing issue labels, but it's covered by unit tests. If reviewer wants to exercise manually, change all open issues' `area/*` labels temporarily.
+
+### Cross-cutting
+
+N/A — VSCode-only change, no cross-platform surface.

--- a/codev/plans/818-vscode-group-builders-in-the-t.md
+++ b/codev/plans/818-vscode-group-builders-in-the-t.md
@@ -1,191 +1,196 @@
-# PIR Plan: Group Builders Tree by Area
+# PIR Plan: Group Builders Tree by Area (mirror #811)
 
 ## Understanding
 
-The VSCode `Codev: Builders` tree (`packages/vscode/src/views/builders.ts:89`) is a flat list today. With multiple builders running across product surfaces (vscode, tower, porch, terminal, etc.), engineers can't see "what's running on `vscode` right now" without scanning every row's title. The `area/*` GitHub label namespace — already plumbed onto `OverviewBuilder.area` by the merged #819 — is the right axis: it mirrors how work is coordinated and matches the upcoming backlog grouping (#811) so engineers learn one mental model.
+The VSCode `Codev: Builders` tree (`packages/vscode/src/views/builders.ts:89`) is flat today. The `area/*` label namespace — already projected onto `OverviewBuilder.area` (single string, `'Uncategorized'` default) by #819 — is the right grouping axis. **The exact pattern was shipped in PR #886 (sibling #811) on 2026-05-27** for the Backlog view; this issue applies the same pattern to Builders.
 
-The wire field already exists. `OverviewBuilder.area: string` is **required-with-default** (`'Uncategorized'` when the builder has no issue or the issue has no `area/*` labels). The literal `'Uncategorized'` is exported as `UNCATEGORIZED_AREA` from `@cluesmith/codev-core/constants`. This change is therefore confined to the VSCode package: rendering, toggling, ordering, tests.
+The design has converged to a deliberately simpler shape than #818's original framing:
 
-### Inheritance from #819 — what this plan does NOT re-litigate
+- **Pure alphabetical group ordering, `Uncategorized` last** — no `cross-cutting` privilege, no priority-areas knob, no configurable preference. Framework-neutrality discipline from #819 (the parser is policy-free; UI ordering matches).
+- **No toggle** — grouping is the only mode. Single-`Uncategorized` flatten optimization (below) makes "off" unnecessary for repos that don't use `area/*` labels.
+- **Single-`Uncategorized` flatten** — when the only group is `Uncategorized` (no `area/*` labels in the repo at all), render builder rows directly at root with no group header. Zero visual regression for unlabeled repos.
+- **Per-area expand/collapse state persists via `workspaceState`** — same key shape as backlog's `codev.backlogGroupExpansion`, here `codev.buildersGroupExpansion`. Default for an untouched area: expanded.
 
-Issue #818's original description was written before #819's design converged. Two reconciliations matter:
+### Wire-field note
 
-1. **`area` is a single string (`builder.area`), not an array.** The original spec proposed `BuilderOverview.areas: string[]` consumed via `parseAreaLabels`. The shipped contract is the single-string projection from `parseArea` (first-alphabetical wins). Each builder lives in exactly one area; the grouping layer doesn't see raw labels.
-
-2. **`area/cross-cutting` has no parser-level privilege.** #819's final design dropped the "cross-cutting takes precedence" rule from the parser — it's now policy-free about label names. A builder tagged `[area/cross-cutting, area/vscode]` is projected to `'cross-cutting'` only because `'c'` < `'v'` alphabetically; tagged `[area/auth, area/cross-cutting]` it's projected to `'auth'`.
-
-   #818's original "If `area/cross-cutting` is present → place under cross-cutting exclusively" rule cannot be honoured at the *resolution* layer without re-extending the wire to carry raw labels (and re-introducing the policy the #819 review deliberately removed). This plan honours the rule's *intent* at the **group-ordering** layer instead: when a `cross-cutting` group exists (because at least one builder has `area === 'cross-cutting'`), its header sorts first. The "exclusivity" property is enforced by the parser — each builder belongs to exactly one group regardless. Teams that want every multi-area builder to land in `cross-cutting` should tag them with `area/cross-cutting` *only* (the #819 convention).
-
-   If we want stronger cross-cutting privilege later, that's a separate change to `parseArea` (not to this view). Flagged in **Risks** below.
-
-The "byte-identical to #811" acceptance criterion translates to: both views use the same `area` projection + the same group-ordering rule (extracted as a shared helper so the code itself is shared, not just the spec).
+Revised #818 still references `OverviewBuilder.areas[]` (plural) in prose, but #886 actually ships against `OverviewBuilder.area: string` (single, projected via `parseArea` — first-alphabetical wins). `views/backlog.ts:37` reads `item.area`. I'll mirror that — `b.area` — so both views consume the same field. If the architect prefers re-introducing the plural shape, that's a wire change against #819, not this view.
 
 ## Proposed Change
 
-### 1. Shared helper in core: `sortAreaGroups`
+Mirror PR #886's three pieces in `views/backlog.ts` + `views/backlog-tree-item.ts` + `test/backlog.test.ts` onto the Builders side.
 
-Extract one small pure function to `@cluesmith/codev-core` so #811's backlog grouping (and any dashboard equivalent) can reuse the same code, not just the same prose.
+### 1. `groupBuildersByArea` pure helper
 
-```ts
-// packages/core/src/area-grouping.ts (new)
-import { UNCATEGORIZED_AREA } from './constants.js';
-
-/**
- * Sort area group names per the canonical Codev convention:
- *  1. `cross-cutting` first (when present) — coordination-risk surface
- *  2. alphabetical middle
- *  3. `UNCATEGORIZED_AREA` (`'Uncategorized'`) last
- *
- * Pure — operates on a list of distinct area names (typically the keys
- * of a Map<area, items[]>). Used by both the Builders view (#818) and
- * the Backlog view (#811) so engineers learn one mental model.
- */
-export function sortAreaGroups(areas: string[]): string[] { ... }
-```
-
-Re-exported from the package barrel alongside `isIdleWaiting`.
-
-### 2. Grouping mode in `BuildersProvider`
-
-`BuildersProvider.getChildren()` gains a top-level branch on `codev.buildersGroupByArea`:
-
-- **Off** (today's behaviour): root returns ordered builder rows directly. Zero diff to existing UX.
-- **On**: root returns `BuilderAreaGroupTreeItem[]` (the group headers); each group's `getChildren` returns the builders mapped into that group (already in `orderForDisplay` order).
-
-Mapping algorithm:
+In `packages/vscode/src/views/builders.ts`, structurally identical to `groupBacklogByArea` (`views/backlog.ts:32-60`):
 
 ```ts
-const ordered = orderForDisplay(data.builders, now);  // unchanged
-const byArea = new Map<string, OverviewBuilder[]>();
-for (const b of ordered) {
-  const list = byArea.get(b.area) ?? [];
-  list.push(b);
-  byArea.set(b.area, list);
-}
-const areaOrder = sortAreaGroups([...byArea.keys()]);
-return areaOrder.map(area => new BuilderAreaGroupTreeItem(area, byArea.get(area)!));
-```
+export function groupBuildersByArea(
+  builders: OverviewBuilder[],
+): Array<{ area: string; builders: OverviewBuilder[] }> {
+  const buckets = new Map<string, OverviewBuilder[]>();
+  for (const b of builders) {
+    const bucket = buckets.get(b.area);
+    if (bucket) bucket.push(b);
+    else buckets.set(b.area, [b]);
+  }
 
-Map iteration preserves insertion order → within-group order preserves `orderForDisplay()`'s blocked → idle-waiting → active sequence (acceptance criterion).
-
-**Empty groups are not rendered** — only areas with ≥1 builder appear. The issue's mock shows `Uncategorized (0)` as a teaching device; rendering empty groups is noise in practice. Easy to flip if the reviewer prefers always-show-Uncategorized.
-
-### 3. New tree item: `BuilderAreaGroupTreeItem`
-
-`packages/vscode/src/views/builder-area-group-tree-item.ts` (new file, follows the existing one-file-per-TreeItem-subclass convention used by `BuilderTreeItem`, `BuilderFileTreeItem`, `BuilderFolderTreeItem`):
-
-- Label: `<area> (<count>)` — e.g. `vscode (4)`
-- Stable `id`: `area-group:<area>` — so VSCode persists expand/collapse state per-group across reloads (acceptance criterion)
-- `collapsibleState`: `Expanded` by default (first-time render); VSCode replaces this with the persisted state on subsequent renders via the stable `id`
-- `contextValue`: `builder-area-group` (lets us hang future per-group context-menu actions off it without touching the row-level menus)
-- Carries the resolved `OverviewBuilder[]` for its area so `getChildren(group)` doesn't recompute the bucket
-
-### 4. `getParent` for `reveal()`
-
-The auto-collapse accordion (`extension.ts:312`) calls `buildersView.reveal(builderItem, { expand: 3 })`. `reveal()` requires `getParent` to return the parent chain. Today `getParent()` returns `undefined` for everything — fine because builder rows are roots.
-
-With grouping on, builder rows are no longer roots. `getParent` must return the appropriate `BuilderAreaGroupTreeItem` for any `BuilderTreeItem`. Implementation: keep a `Map<builderId, BuilderAreaGroupTreeItem>` on the provider, populated each time `getChildren(root)` runs in grouping mode. (Group items, file items, folder items continue to return `undefined` — they're either roots themselves or never reveal targets.)
-
-Without this, the accordion's `reveal()` in grouping mode would silently fail to expand the builder after the `collapseAll` half of the swap. With it, accordion behavior is identical in both modes.
-
-### 5. Config flag + toggle commands
-
-Mirror the existing `buildersFileViewAsTree` pattern exactly:
-
-**`packages/vscode/package.json`** — declare:
-
-```jsonc
-// contributes.commands
-{ "command": "codev.enableBuildersGroupByArea",  "title": "Codev: Group Builders by Area",       "icon": "$(group-by-ref-type)" },
-{ "command": "codev.disableBuildersGroupByArea", "title": "Codev: Show Builders as Flat List",   "icon": "$(list-flat)" },
-
-// contributes.menus.view/title
-{ "command": "codev.disableBuildersGroupByArea", "when": "view == codev.builders && codev.buildersGroupByArea",  "group": "navigation" },
-{ "command": "codev.enableBuildersGroupByArea",  "when": "view == codev.builders && !codev.buildersGroupByArea", "group": "navigation" },
-
-// contributes.configuration.properties
-"codev.buildersGroupByArea": {
-  "type": "boolean",
-  "default": true,
-  "description": "Group the Builders tree by area/* label (cross-cutting first, alphabetical middle, Uncategorized last). When off, renders as a flat list."
+  const result: Array<{ area: string; builders: OverviewBuilder[] }> = [];
+  const uncategorized = buckets.get(UNCATEGORIZED_AREA);
+  const specifics = [...buckets.keys()].filter(a => a !== UNCATEGORIZED_AREA).sort();
+  for (const area of specifics) result.push({ area, builders: buckets.get(area)! });
+  if (uncategorized) result.push({ area: UNCATEGORIZED_AREA, builders: uncategorized });
+  return result;
 }
 ```
 
-**`packages/vscode/src/extension.ts`** — register the two commands (paired with the existing `enableBuildersFileTreeMode` / `disableBuildersFileTreeMode` pair around line 609) and a `setContext` mirror + `onDidChangeConfiguration` listener that calls `buildersProvider.refresh()` on flip (paired with the existing `buildersFileViewAsTree` block around lines 330-339).
+Pure, VSCode-free, unit-testable. Caller passes builders in display order (i.e. `orderForDisplay()` output) so within-group order is preserved by Map insertion.
 
-Default `true` is safe even for repos without `area/*` labels: every builder projects to `'Uncategorized'`, so the tree renders as a single `Uncategorized (N)` group containing the same builders in the same order — functionally identical to flat. Engineers who actively prefer flat can flip the toggle.
+### 2. `BuilderGroupTreeItem` class
+
+In `packages/vscode/src/views/builder-tree-item.ts` (alongside `BuilderTreeItem`), structurally identical to `BacklogGroupTreeItem` (`views/backlog-tree-item.ts:36-46`):
+
+```ts
+export class BuilderGroupTreeItem extends vscode.TreeItem {
+  constructor(
+    public readonly areaName: string,
+    count: number,
+    collapsibleState: vscode.TreeItemCollapsibleState,
+  ) {
+    super(`${areaName} (${count})`, collapsibleState);
+    this.id = `builder-group:${areaName}`;
+    this.contextValue = 'builder-group';
+  }
+}
+```
+
+Stable `id` keyed off area name → VSCode reuses TreeItem identity across `OverviewCache` ticks → the user's collapse choice survives every refresh. `contextValue = 'builder-group'` lets us hang future per-group context menus off it without retrofitting selectors.
+
+### 3. Two-level `BuildersProvider`
+
+Restructure `BuildersProvider` in `views/builders.ts` to mirror `BacklogProvider`'s shape (`views/backlog.ts:78-188`):
+
+- **Constructor gains a `workspaceState: vscode.Memento` parameter** for persistence. Existing call site (`extension.ts:255`) becomes `new BuildersProvider(overviewCache, builderDiffCache, context.workspaceState)`.
+- **`getChildren(element?)`**: branch on element type.
+  - `BuilderTreeItem` → file children (unchanged: `fileChildren(builderId)`)
+  - `BuilderFolderTreeItem` → folder children (unchanged)
+  - `BuilderFileTreeItem` → `[]` (unchanged)
+  - `BuilderGroupTreeItem` → builder rows for that area (new — `rowsForGroup(areaName)`)
+  - `undefined` (root) → group rows OR flattened builder rows (new — `rootChildren()`)
+- **`rootChildren()`**: compute ordered builders once, group via `groupBuildersByArea`, apply single-`Uncategorized` flatten:
+
+  ```ts
+  const ordered = orderForDisplay(data.builders, now);
+  const groups = groupBuildersByArea(ordered);
+  if (groups.length === 1 && groups[0].area === UNCATEGORIZED_AREA) {
+    return groups[0].builders.map(b => this.makeBuilderRow(b, now));
+  }
+  const expansion = this.readExpansionState();
+  return groups.map(g => new BuilderGroupTreeItem(g.area, g.builders.length,
+    (expansion[g.area] ?? true) ? vscode.TreeItemCollapsibleState.Expanded
+                                 : vscode.TreeItemCollapsibleState.Collapsed));
+  ```
+
+- **`rowsForGroup(areaName)`**: recompute the same ordered+grouped result and return the matching group's builder rows, each built via the same `makeBuilderRow` helper used by the flatten branch.
+- **`makeBuilderRow(b, now)`**: extract today's per-builder rendering (`builders.ts:89-136`) into a single helper so flatten + grouped paths share it byte-for-byte. No behavior change.
+- **`setGroupExpanded(areaName, expanded)`**: persistence method, identical to `BacklogProvider.setGroupExpanded` (`views/backlog.ts:107-111`).
+- **`readExpansionState()`**: read the `EXPANSION_STATE_KEY = 'codev.buildersGroupExpansion'` map from `workspaceState`, defaulting to `{}`.
+
+### 4. `getParent` for accordion `reveal()`
+
+This is the **one** divergence from backlog: the Builders accordion (`extension.ts:310`) calls `buildersView.reveal(builderItem, { expand: 3 })`. With groups inserted, `reveal` needs a real parent chain — today's `getParent(): undefined` will break the accordion in grouping mode.
+
+Solution: maintain a `Map<builderId, BuilderGroupTreeItem>` populated by `rootChildren()` whenever it returns groups (i.e. multi-group case). `getParent(BuilderTreeItem)` returns the cached group; `getParent` for everything else (and in the single-`Uncategorized` flatten case, where builders are root) returns `undefined`. Clean and minimal.
+
+### 5. Wire `onDidExpand/CollapseElement` in `extension.ts`
+
+Mirror the backlog wiring (`extension.ts:261-271`) immediately after creating `buildersView`:
+
+```ts
+context.subscriptions.push(
+  buildersView.onDidExpandElement((e) => {
+    if (e.element instanceof BuilderGroupTreeItem) {
+      buildersProvider.setGroupExpanded(e.element.areaName, true);
+    }
+  }),
+  buildersView.onDidCollapseElement((e) => {
+    if (e.element instanceof BuilderGroupTreeItem) {
+      buildersProvider.setGroupExpanded(e.element.areaName, false);
+    }
+  }),
+);
+```
+
+Existing `buildersView.onDidExpandElement` accordion handler (line 297) is untouched — its `instanceof BuilderTreeItem` guard already ignores group rows.
 
 ### 6. Tests
 
-Extend `packages/vscode/src/test/builders.test.ts` with a `groupBuildersByArea` suite (testing the pure mapping function extracted alongside the rendering) and a `sortAreaGroups` suite (covering the cross-cutting/alphabetical/Uncategorized ordering — owned by core but exercised here too since the integration matters).
+`packages/vscode/src/test/builders.test.ts` gains a `suite('groupBuildersByArea')` mirroring `suite('groupBacklogByArea')` from `test/backlog.test.ts:43-100`. Same test cases adapted to the builders shape:
 
-Core unit tests for `sortAreaGroups` go in `packages/core/src/__tests__/area-grouping.test.ts` alongside the existing core tests.
+- empty in → empty out
+- single Uncategorized builder → one Uncategorized group
+- alphabetical specifics then Uncategorized last
+- omits empty area groups (no `<area> (0)` headers)
+- preserves input order within a group (no internal re-sort) — this is the within-group `orderForDisplay()` preservation
+- groups multiple builders per area correctly
 
 ### 7. Out of scope (preserve issue's contract)
 
-- Grouping by `type:*` / `priority:*` / any non-area axis (the issue is explicit).
-- Duplicating a builder across multiple area groups (the parser projects to one — `cross-cutting` tag is the explicit answer).
-- Per-builder user-pickable primary area override (deferred).
-- Backlog grouping (#811's job, but the shared `sortAreaGroups` helper unblocks it).
-- Dashboard equivalent of grouping (no existing dashboard consumer of `builder.area` — separate change).
+- Configurable priority-areas mechanism
+- Hardcoded `area/cross-cutting` or any area-name privilege
+- Toggle to disable grouping
+- Grouping by `type:*` / `priority:*` / any non-area axis
+- Duplicating a builder under multiple area groups (single primary area derived from `parseArea`)
+- Per-builder user-pickable primary area override
+- Dashboard equivalent (no existing dashboard consumer of `builder.area` — separate change)
 
 ## Files to Change
 
-- `packages/core/src/area-grouping.ts` — **new**, exports `sortAreaGroups(areas: string[]): string[]` and (optionally) `groupBuildersByArea` if we keep the mapping logic shared between dashboard and vscode; otherwise keep mapping in vscode only.
-- `packages/core/src/index.ts` (or barrel) — re-export `sortAreaGroups`.
-- `packages/core/src/__tests__/area-grouping.test.ts` — **new**, unit tests for `sortAreaGroups` (empty input, cross-cutting present/absent, Uncategorized handling, alphabetical sort, deduplication).
-- `packages/vscode/src/views/builder-area-group-tree-item.ts` — **new** TreeItem subclass; carries `area`, `builders: OverviewBuilder[]`, stable id, label `<area> (<count>)`.
-- `packages/vscode/src/views/builders.ts` — extend `BuildersProvider`:
-  - `getChildren(root)`: branch on `codev.buildersGroupByArea` config; when on, build the `Map<area, OverviewBuilder[]>`, sort keys via `sortAreaGroups`, return group items.
-  - `getChildren(BuilderAreaGroupTreeItem)`: return the group's builders, rendered with the existing per-builder logic refactored into a `renderBuilderRow(b, isBlocked, isIdle, ...)` helper to avoid duplication.
-  - `getParent`: return the cached group for any `BuilderTreeItem` when in grouping mode; `undefined` otherwise.
-  - Private `groupCache: Map<builderId, BuilderAreaGroupTreeItem>` populated on each root render.
-- `packages/vscode/src/extension.ts:600` area — register `codev.enableBuildersGroupByArea` / `codev.disableBuildersGroupByArea`; add a `readGroupByArea()` + `setContext('codev.buildersGroupByArea', ...)` mirror + an `onDidChangeConfiguration('codev.buildersGroupByArea')` handler that calls `buildersProvider.refresh()`.
-- `packages/vscode/package.json` — add the two commands, the two `view/title` menu entries, and the `codev.buildersGroupByArea` config property.
-- `packages/vscode/src/test/builders.test.ts` — add `suite('groupBuildersByArea')` (within-group preserves `orderForDisplay`, mapping accuracy, count fields) and `suite('sortAreaGroups')` (cross-cutting first, alphabetical, Uncategorized last).
+- `packages/vscode/src/views/builders.ts` — add `groupBuildersByArea` pure helper; restructure `BuildersProvider` into two-level form with `rootChildren` / `rowsForGroup` / `makeBuilderRow` / `setGroupExpanded` / `readExpansionState` (mirror `BacklogProvider`); add `getParent` with group-cache map; widen constructor to accept `workspaceState: vscode.Memento`; import `UNCATEGORIZED_AREA` from `@cluesmith/codev-core/constants`.
+- `packages/vscode/src/views/builder-tree-item.ts` — add `BuilderGroupTreeItem` class (mirror `BacklogGroupTreeItem` in `backlog-tree-item.ts:36-46`).
+- `packages/vscode/src/extension.ts:255` — update `new BuildersProvider(...)` call to pass `context.workspaceState`; add `buildersView.onDidExpand/CollapseElement` subscriptions that call `buildersProvider.setGroupExpanded` for `BuilderGroupTreeItem` (mirror lines 261-271); import `BuilderGroupTreeItem`.
+- `packages/vscode/src/test/builders.test.ts` — add `suite('groupBuildersByArea')` with the six test cases mirrored from `backlog.test.ts`.
+- **No changes** to `packages/core/`, `packages/types/`, `packages/codev/`, `packages/vscode/package.json`. No new settings, no new commands, no new menu entries.
 
 ## Risks & Alternatives Considered
 
 ### Risks
 
-- **`reveal()` regression in grouping mode**: If `getParent` doesn't return the right group, the accordion's `collapseAll + reveal` will fail to re-expand the builder after a click. Mitigation: cache the `builderId → group` map at root-render time; assert via an integration smoke test (manual at the `dev-approval` gate).
-- **Expand state divergence between modes**: The stable id `area-group:<area>` persists per group; builder ids persist per builder. When the user toggles off and back on, VSCode restores whichever state it remembers per id. Acceptable — same model as the existing file-view-as-tree toggle.
-- **Empty `Uncategorized` group**: When grouping is on and no builder lacks an area, no `Uncategorized` row renders. The issue's mock shows `Uncategorized (0)` as a teaching aid; I've chosen "render only non-empty groups" as the cleaner default. Reviewer can flip this preference at the `plan-approval` gate.
-- **Default `true` is a UX change**: Existing users will see grouping appear on next launch. Mitigation: in single-area repos (Codev's own) everything lands under one group (e.g. `vscode (4)`) — visually similar to flat. Engineers who want true flat can flip the toggle.
+- **Accordion `reveal()` regression in grouping mode** — addressed by the `getParent` + `Map<builderId, BuilderGroupTreeItem>` mechanism. Validated manually at the `dev-approval` gate (expand a builder; verify others auto-collapse across groups).
+- **`workspaceState` key collision** — `codev.buildersGroupExpansion` is namespaced under `codev.` and is distinct from `codev.backlogGroupExpansion`. No collision.
+- **Single-`Uncategorized` flatten makes `getParent` semantics differ between modes** — handled: the group cache is empty in flatten mode, so `getParent(builderItem)` returns `undefined` (today's behavior); accordion works unchanged.
+- **`orderForDisplay()` only runs once** — root render computes `ordered` then groups it; `rowsForGroup` recomputes the same pipeline so within-group order matches. Slightly wasteful (two `orderForDisplay` calls per refresh) but matches the backlog's `orderedSpawnable` pattern (`backlog.ts:113-147`) — caching across calls would diverge from the reference.
 
 ### Alternatives Considered
 
-- **Re-extend the wire to carry raw labels and re-implement cross-cutting privilege at the view layer.** Rejected: #819 deliberately removed the privilege from the parser; re-adding it at one consumer (vscode) without the parser (and without the backlog/dashboard consumers) creates inconsistency. If the privilege is wanted, the right move is reopening the policy discussion against `parseArea`.
-- **Don't extract `sortAreaGroups` — duplicate the sort in vscode and in #811 later.** Rejected: the acceptance criterion explicitly calls out "byte-identical resolution rule" — the cheapest enforcement is one shared function. The extraction is ~10 LOC.
-- **Default the toggle to `false` for a quieter rollout.** Rejected: the issue explicitly specifies `true` ("since the area-label set is established"). Reviewer can override at the `plan-approval` gate.
-- **Always render every area group, including empties.** Rejected as default for the noise reason above; flip if review prefers.
+- **Keep the toggle from v1 of this plan.** Rejected per architect's revised directive: #886 didn't ship one and the design discipline is "no configurable knob unless there's a real demand".
+- **Extract `groupByArea` to `@cluesmith/codev-core` as a shared helper.** Rejected to match #886's actually-shipped shape exactly — backlog inlined its helper in `views/backlog.ts`, so builders does the same. If/when a third consumer needs it (dashboard), extraction is a one-line refactor.
+- **Use `OverviewBuilder.areas[]` (plural) as the issue body still suggests.** Rejected — `#886` ships against the single `.area` projection from `parseArea`. Wire alignment matters more than copying the issue's prose verbatim.
 
 ## Test Plan
 
-### Unit (CI + local `pnpm test`)
+### Unit (CI + local `pnpm test --filter @cluesmith/codev-vscode`)
 
-- `packages/core/src/__tests__/area-grouping.test.ts`:
-  - empty input → empty output
-  - `['vscode', 'tower', 'porch']` → alphabetical
-  - `['vscode', 'cross-cutting', 'tower']` → cross-cutting first, then alphabetical
-  - `['vscode', 'Uncategorized', 'tower']` → alphabetical then Uncategorized last
-  - `['vscode', 'cross-cutting', 'Uncategorized', 'tower']` → all three rules at once
-  - deduplication (defensive — caller may pass a non-unique list)
-- `packages/vscode/src/test/builders.test.ts`:
-  - `groupBuildersByArea`: each builder lands in exactly one group; within-group order preserves `orderForDisplay()` semantics (mix blocked + idle + active in two areas; verify per-area sequence)
-  - count per group reflects the number of builders
+Six tests in `suite('groupBuildersByArea')`:
+
+1. empty in → empty out
+2. single Uncategorized builder → one `Uncategorized` group
+3. mixed inputs → alphabetical specifics then `Uncategorized` last
+4. omits empty area groups (no `<area> (0)` headers)
+5. preserves input order within a group (no internal re-sort) — confirms within-group ordering relies on caller-supplied order (i.e. `orderForDisplay()` semantics flow through unchanged)
+6. groups multiple builders per area correctly
 
 ### Manual (`dev-approval` gate)
 
-The reviewer runs the worktree via `afx dev pir-818` and exercises:
+Reviewer runs `afx dev pir-818` and exercises in the running VSCode instance:
 
-- **Grouping on (default)**: open the Codev sidebar → Builders. Verify group headers render as `<area> (<count>)`. Verify cross-cutting (if any) sorts first, alphabetical middle, Uncategorized last.
-- **Toggle off**: click the title-bar `Codev: Show Builders as Flat List` button. Verify the tree flattens to the existing-today layout. Verify the title-bar icon swaps to the "group" affordance.
-- **Toggle on**: click the swapped button. Verify groups reappear; verify each group's expand/collapse state survives a sidebar hide/show.
-- **Accordion in grouping mode**: with `buildersAutoCollapse` on, expand one builder's changed-files diff. Verify other builders (in same and other groups) auto-collapse. Verify the expanded builder remains expanded.
-- **Reload**: close and reopen the VSCode window. Verify per-group expand/collapse state persists.
-- **Zero `area/*` labels case**: there's no easy way to fake this without editing issue labels, but it's covered by unit tests. If reviewer wants to exercise manually, change all open issues' `area/*` labels temporarily.
+- **Side-by-side with backlog**: open the Codev sidebar; verify Builders renders with the same group-header style as Backlog (`<area> (count)`, alphabetical, `Uncategorized` last).
+- **Within-group ordering**: ensure a blocked builder still sorts above active builders within its area group (preserves `orderForDisplay()`).
+- **Accordion in grouping mode**: with `codev.buildersAutoCollapse` on (default), expand a builder's changed-files diff. Verify other builders auto-collapse — across groups too, not just within the same group.
+- **Per-group expand/collapse persistence**: collapse one group. Reload the window. Verify the group is still collapsed. Expand it; reload; verify expanded.
+- **Single-Uncategorized flatten**: hard to reproduce naturally on this repo (every issue is labelled), but verifiable by temporarily removing all `area/*` labels from open builders' issues (or, for the reviewer, by reading the test case and accepting the unit coverage).
+- **Reactivity**: add or remove an `area/*` label on a builder's underlying issue via `gh issue edit`. Wait for the next `OverviewCache` SSE tick (≤60s) and confirm the builder migrates between groups.
+- **Comparison with Backlog**: switch between the two views and confirm the rule "feels identical" — same alphabetical order, same Uncategorized-last placement, same per-area collapse persistence behaviour.
 
-### Cross-cutting
+### Cross-platform
 
-N/A — VSCode-only change, no cross-platform surface.
+N/A — VSCode-only change, runs identically across OSes.

--- a/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
+++ b/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
@@ -1,7 +1,7 @@
 id: '818'
 title: vscode-group-builders-in-the-t
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T10:37:01.231Z'
-updated_at: '2026-05-27T22:24:00.297Z'
+updated_at: '2026-05-27T22:24:07.424Z'

--- a/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
+++ b/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T10:37:01.231Z'
-updated_at: '2026-05-27T22:24:07.424Z'
+updated_at: '2026-05-27T22:26:19.682Z'
+pr_history:
+  - phase: review
+    pr_number: 890
+    branch: builder/pir-818
+    created_at: '2026-05-27T22:26:19.682Z'

--- a/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
+++ b/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-05-27T21:49:35.967Z'
   dev-approval:
     status: pending
+    requested_at: '2026-05-27T21:59:16.703Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T10:37:01.231Z'
-updated_at: '2026-05-27T21:49:58.606Z'
+updated_at: '2026-05-27T21:59:16.704Z'

--- a/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
+++ b/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-05-27T10:43:21.931Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T10:37:01.231Z'
-updated_at: '2026-05-27T10:37:01.231Z'
+updated_at: '2026-05-27T10:43:21.931Z'

--- a/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
+++ b/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-05-27T10:43:21.931Z'
+    approved_at: '2026-05-27T21:49:35.967Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T10:37:01.231Z'
-updated_at: '2026-05-27T10:43:21.931Z'
+updated_at: '2026-05-27T21:49:35.967Z'

--- a/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
+++ b/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
@@ -1,7 +1,7 @@
 id: '818'
 title: vscode-group-builders-in-the-t
 protocol: pir
-phase: review
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -21,7 +21,7 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-27T10:37:01.231Z'
-updated_at: '2026-05-27T22:46:56.316Z'
+updated_at: '2026-05-27T22:47:05.719Z'
 pr_history:
   - phase: review
     pr_number: 890

--- a/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
+++ b/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-05-27T22:24:00.296Z'
   pr:
     status: pending
+    requested_at: '2026-05-27T22:40:05.894Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-27T10:37:01.231Z'
-updated_at: '2026-05-27T22:26:26.776Z'
+updated_at: '2026-05-27T22:40:05.895Z'
 pr_history:
   - phase: review
     pr_number: 890
     branch: builder/pir-818
     created_at: '2026-05-27T22:26:19.682Z'
+pr_ready_for_human: true

--- a/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
+++ b/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-05-27T10:43:21.931Z'
     approved_at: '2026-05-27T21:49:35.967Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-05-27T21:59:16.703Z'
+    approved_at: '2026-05-27T22:24:00.296Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T10:37:01.231Z'
-updated_at: '2026-05-27T21:59:16.704Z'
+updated_at: '2026-05-27T22:24:00.297Z'

--- a/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
+++ b/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
@@ -1,0 +1,18 @@
+id: '818'
+title: vscode-group-builders-in-the-t
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-27T10:37:01.231Z'
+updated_at: '2026-05-27T10:37:01.231Z'

--- a/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
+++ b/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-05-27T21:59:16.703Z'
     approved_at: '2026-05-27T22:24:00.296Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-05-27T22:40:05.894Z'
+    approved_at: '2026-05-27T22:46:56.315Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-27T10:37:01.231Z'
-updated_at: '2026-05-27T22:40:05.895Z'
+updated_at: '2026-05-27T22:46:56.316Z'
 pr_history:
   - phase: review
     pr_number: 890
     branch: builder/pir-818
     created_at: '2026-05-27T22:26:19.682Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
+++ b/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-05-27T10:37:01.231Z'
-updated_at: '2026-05-27T22:26:19.682Z'
+updated_at: '2026-05-27T22:26:26.776Z'
 pr_history:
   - phase: review
     pr_number: 890

--- a/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
+++ b/codev/projects/818-vscode-group-builders-in-the-t/status.yaml
@@ -1,7 +1,7 @@
 id: '818'
 title: vscode-group-builders-in-the-t
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-27T10:37:01.231Z'
-updated_at: '2026-05-27T21:49:35.967Z'
+updated_at: '2026-05-27T21:49:58.606Z'

--- a/codev/resources/lessons-learned.md
+++ b/codev/resources/lessons-learned.md
@@ -145,6 +145,7 @@ Generalizable wisdom extracted from review documents, ordered by impact. Updated
 - [From 0376] Archive `status.yaml` files before `afx cleanup` -- most projects' porch state files are deleted after PR merge, losing valuable timing data for future development analyses.
 - [From 0589] Concept command abstraction (shell command per operation, env vars for params, JSON on stdout) is an effective pattern for decoupling from a specific CLI tool. Default commands wrap the existing tool, overrides in config enable alternatives. Key: provide both sync and async variants, support `raw` mode for non-JSON output, and always thread the config through all call sites.
 - [From 0589] When migrating multiple call sites to a new abstraction, configuration threading (passing `forgeConfig`/`workspaceRoot` to every call) is easy to miss at non-obvious sites like porch checks and merge instructions. Phase-scoped consultation reviews are effective at catching these gaps.
+- [From 818] An acceptance criterion of "rule structurally identical to X" is a written-rule trap when the rule lives as duplicated prose in two views. Two copies drift even with diligence; the only durable enforcement is one shared function both views import. Extract when the second consumer lands — not before (no abstraction without users) and not later (drift starts on day one).
 
 ## Process
 

--- a/codev/reviews/818-vscode-group-builders-in-the-t.md
+++ b/codev/reviews/818-vscode-group-builders-in-the-t.md
@@ -1,0 +1,79 @@
+# PIR Review: Group Builders Tree by Area (mirror #811, dedup primitives)
+
+Fixes #818
+
+## Summary
+
+Builders tree in the VSCode sidebar now groups by `area/*` label (alphabetical specific areas, `Uncategorized` last), mirroring the backlog grouping that #886 shipped. To avoid duplicating ~67 LOC of structural code across the two views, the PR also extracts three shared primitives (`groupByArea<T>`, `AreaGroupTreeItem` base class, `AreaGroupExpansionStore` + `persistAreaGroupExpansion` helper) and migrates the already-shipped backlog view onto them in the same PR. Net effect: builders gains the new feature, backlog loses 50 LOC, and the "rule structurally identical to backlog's" acceptance criterion is enforced by `import`, not by reviewer attention.
+
+## Files Changed
+
+- `packages/core/package.json` (+4 / -0) — new `./area-grouping` export
+- `packages/core/src/area-grouping.ts` (+44 / -0) — NEW: generic `groupByArea<T>`
+- `packages/vscode/src/views/area-group-tree-item.ts` (+27 / -0) — NEW: shared `AreaGroupTreeItem` base
+- `packages/vscode/src/views/area-group-expansion.ts` (+59 / -0) — NEW: `AreaGroupExpansionStore` + `persistAreaGroupExpansion`
+- `packages/vscode/src/test/area-grouping.test.ts` (+82 / -0) — NEW: 7 tests for `groupByArea<T>`
+- `packages/vscode/src/views/builders.ts` (+143 / -50) — two-level provider, `getParent`, single-Uncategorized flatten
+- `packages/vscode/src/views/builder-tree-item.ts` (+13 / -0) — `BuilderGroupTreeItem` thin subclass
+- `packages/vscode/src/views/backlog.ts` (+10 / -61) — migrated onto shared primitives
+- `packages/vscode/src/views/backlog-tree-item.ts` (+10 / -0) — `BacklogGroupTreeItem` thin subclass
+- `packages/vscode/src/test/backlog.test.ts` (+1 / -57) — dropped `groupBacklogByArea` suite (covered by generic)
+- `packages/vscode/src/extension.ts` (+5 / -14) — `persistAreaGroupExpansion` ×2
+- `codev/plans/818-vscode-group-builders-in-the-t.md` (+334 / -0) — plan artifact
+
+## Commits
+
+- `9e838a6c` [PIR #818] Rename wireAreaGroupExpansion → persistAreaGroupExpansion
+- `a6561d29` [PIR #818] Thread: log implement phase completion
+- `4419a7d7` [PIR #818] Apply area grouping to Builders tree
+- `8bd1537c` [PIR #818] Migrate backlog view onto shared area-grouping primitives
+- `d5186d46` [PIR #818] Extract shared area-grouping primitives (groupByArea, AreaGroupTreeItem, AreaGroupExpansionStore)
+- `227ea3f3` [PIR #818] Plan revised — extract groupByArea + AreaGroupTreeItem + AreaGroupExpansionStore, migrate backlog onto them
+- `6519ea35` [PIR #818] Plan revised — mirror #886's shipped shape (no toggle, alphabetical-only, single-Uncategorized flatten)
+- `b6021767` [PIR #818] Plan draft
+
+## Test Results
+
+- `pnpm --filter codev-vscode check-types`: ✓ pass
+- `pnpm --filter codev-vscode lint`: ✓ pass
+- `pnpm --filter codev-vscode compile` (esbuild bundle): ✓ pass
+- `pnpm --filter codev-vscode test`: ✓ pass (90 tests, 7 new `suite('groupByArea')`, 4 dropped `suite('groupBacklogByArea')` — coverage shifted to the generic)
+- Manual verification at the dev-approval gate: human approved after side-by-side comparison with the backlog grouping; rename `wireAreaGroupExpansion → persistAreaGroupExpansion` applied as part of the same review pass
+
+## Architecture Updates
+
+No changes to `codev/resources/arch.md`. The change is confined to the VSCode extension's view layer — no impact on Tower internals, builder lifecycle, worktree management, shellper protocol, or any other surface arch.md documents.
+
+## Lessons Learned Updates
+
+Added one entry to `codev/resources/lessons-learned.md` under **Architecture**:
+
+> [From 818] An acceptance criterion of "rule structurally identical to X" is a written-rule trap when the rule lives as duplicated prose in two views. Two copies drift even with diligence; the only durable enforcement is one shared function both views import. Extract when the second consumer lands — not before (no abstraction without users) and not later (drift starts on day one).
+
+The original plan (v2) committed knowingly-duplicated code with the "byte-identical to #886" criterion enforced only by prose. The human caught it before approval; v3 added the extraction. The extraction itself was cheap (~3 small files, mechanical backlog migration); the lesson is recognizing the trap at plan time so the extraction lands together with the second consumer, not as a follow-up that competes with other priorities.
+
+## Things to Look At During PR Review
+
+- **Mechanical backlog migration**: `packages/vscode/src/views/backlog.ts` loses ~50 LOC. The diff is intentionally a no-op — `groupBacklogByArea` is replaced with `groupByArea(items, i => i.area)`; `setGroupExpanded` / `readExpansionState` / `EXPANSION_STATE_KEY` are replaced with an `AreaGroupExpansionStore` field. Walk the backlog view in VSCode first and confirm zero visible change — that's the highest-blast-radius part of the diff.
+- **Accordion `reveal()` in grouping mode**: `views/builders.ts` overrides `getParent` to return the cached group for `BuilderTreeItem` children. The cache (`groupParentByBuilderId`) is repopulated every time `rootChildren()` runs in multi-group mode; cleared in the single-`Uncategorized` flatten case (builders are root again). Watch for the accordion behaviour with two builders in different areas — expanding one should auto-collapse the other.
+- **`AreaGroupTreeItem` sub-classing pattern**: `BacklogGroupTreeItem` and `BuilderGroupTreeItem` are 3-line subclasses that exist solely so `extension.ts`'s per-view expand/collapse handlers can scope via `instanceof`. Without them, both handlers would fire on every group expand/collapse. Mentioned for clarity; the design isn't novel but the subclasses look almost empty so worth a sentence.
+- **Wire-field reconciliation**: the revised #818 issue body still says `OverviewBuilder.areas[]` (plural) in places. The implementation consumes the single-string `OverviewBuilder.area` projection that #886 / #819 actually shipped. If you'd prefer rolling the wire shape forward to plural, that's a separate change against #819 — out of scope here.
+
+## How to Test Locally
+
+For reviewers pulling the branch:
+
+- **View diff**: VSCode sidebar → right-click builder pir-818 → **Codev: View Diff** (auto-detects the repo's default branch)
+- **Run dev server**: VSCode sidebar → right-click builder pir-818 → **Run Dev Server**, or `afx dev pir-818`
+- **What to verify**:
+  - Open the Backlog view → confirm grouping renders exactly as it did on `main` (no visible regression from the migration)
+  - Open the Builders view → groups render with `<area> (<count>)` headers, alphabetical specifics, `Uncategorized` last
+  - Within-group order preserves `orderForDisplay()` (blocked → idle-waiting → active)
+  - Collapse a group, reload the window → still collapsed
+  - Collapse `vscode` in Backlog → Builders' `vscode` group stays expanded (separate `workspaceState` keys)
+  - With `codev.buildersAutoCollapse` on, expand one builder → others auto-collapse across groups
+  - Add/remove an `area/*` label on an open issue via `gh issue edit` → next overview tick (~60s) re-groups the affected builder
+
+## Flaky Tests
+
+None.

--- a/codev/state/pir-818_thread.md
+++ b/codev/state/pir-818_thread.md
@@ -65,3 +65,17 @@ Check results:
 - `pnpm --filter codev-vscode test` ✓ — 90 tests passing, 7 new (`suite('groupByArea')`), 4 removed (`suite('groupBacklogByArea')`)
 
 Awaiting dev-approval gate review.
+
+## 2026-05-27 — dev-approval gate approved + review phase complete
+
+User asked the right hard questions before approving:
+- "what is the purpose of `area-group-expansion.ts` and tree item? is that a shared component?" → confirmed both are deliberately shared between backlog and builders; explained the `kind` discriminator + thin-subclass pattern for `instanceof` discrimination
+- "`wireAreaGroupExpansion` looks like an odd name" → agreed, renamed to `persistAreaGroupExpansion` (commit `9e838a6c`)
+- "why are we persisting area group expansions? is that an existing concept? what else is state persisted in the extension?" → enumerated all `workspaceState` usage (gate-toast seen set, backlog group expansion from #886, now builders); explained that persistence is required because VSCode's collapsibleState from the provider wins on each refresh
+
+After gate approval, advanced to review phase. PR #890 opened with the review file as body. 3-way consultation ran cleanly:
+- Gemini: APPROVE, HIGH confidence, no key issues
+- Codex: APPROVE, HIGH confidence, no key issues
+- Claude: APPROVE — detailed plan-adherence review confirming the extraction is byte-shared (~50 LOC reduction in backlog.ts on the merge-base, mechanical migration); flagged the minor plan deviations (test location, 7 tests vs 6, package.json exports vs barrel) as reasonable
+
+Architect notified; `pr` gate pending. Waiting for human merge approval.

--- a/codev/state/pir-818_thread.md
+++ b/codev/state/pir-818_thread.md
@@ -47,3 +47,21 @@ User chose option 1 (fold the refactor into #818). Revised plan now:
 Single-Uncategorized flatten (6 LOC per provider) is kept inline — extracting it cleanly would require an abstract provider with generics, disproportionate complexity for the residual duplication.
 
 Risk: this expands #818's scope to touch the shipped backlog code in the same PR. Mitigated by the mechanical nature of the migration and by the test suite (which moves but tests the same invariants).
+
+## 2026-05-27 — implement phase complete
+
+Plan-approval gate approved; advanced to implement. Three commits on builder/pir-818:
+
+1. `d5186d46` — extracted primitives (`groupByArea`, `AreaGroupTreeItem`, `AreaGroupExpansionStore`, `wireAreaGroupExpansion`, area-grouping tests; new core export)
+2. `8bd1537c` — mechanical backlog migration onto the shared primitives; `groupBacklogByArea` and its tests dropped (behaviour covered by the generic)
+3. `4419a7d7` — builders applied: `BuilderGroupTreeItem`, two-level `BuildersProvider`, `getParent` + per-render group-cache map for accordion `reveal()`, single-Uncategorized flatten; extension.ts widens `BuildersProvider` constructor with `workspaceState` and wires `wireAreaGroupExpansion`
+
+Plan deviation: tests for the generic `groupByArea<T>` landed in `packages/vscode/src/test/area-grouping.test.ts` (mocha-style, reusing the vscode-test runner) rather than `packages/core/src/__tests__/`. Core has no test infrastructure today; bootstrapping vitest just for seven tests would be disproportionate. Covered by all the same behavioural invariants from the plan, plus one extra demonstrating the generic via an arbitrary item shape.
+
+Check results:
+- `pnpm --filter codev-vscode check-types` ✓
+- `pnpm --filter codev-vscode lint` ✓
+- `pnpm --filter codev-vscode compile` ✓ (esbuild bundle)
+- `pnpm --filter codev-vscode test` ✓ — 90 tests passing, 7 new (`suite('groupByArea')`), 4 removed (`suite('groupBacklogByArea')`)
+
+Awaiting dev-approval gate review.

--- a/codev/state/pir-818_thread.md
+++ b/codev/state/pir-818_thread.md
@@ -30,3 +30,20 @@ Rewrote the plan to mirror #886's actually-shipped shape exactly:
 Only structural divergence from backlog: the accordion's `reveal()` requires a real `getParent` chain in grouping mode. Solved with a `Map<builderId, BuilderGroupTreeItem>` populated by `rootChildren()` (empty in single-Uncategorized flatten mode, so accordion semantics are unchanged on that branch).
 
 Wire-field note: revised issue body says `OverviewBuilder.areas[]` (plural) but #886 reads `item.area` (single). Plan mirrors the shipped reality, with a sentence flagging the discrepancy in case the architect wants to roll the wire shape forward to plural — that'd be a separate change against #819 anyway.
+
+## 2026-05-27 — plan revised (v3) to dedup primitives across backlog + builders
+
+User pointed out the v2 plan would commit ~67 LOC of structural duplication across 5 surfaces (grouping helper, TreeItem class, flatten predicate, expansion-state plumbing, wiring) between `views/backlog.ts` (shipped via #886) and the new `views/builders.ts` work. Verified against #885 — that issue is about display capitalization (`vscode` → `Vscode`), not deduplication; the refactor concern is unaddressed elsewhere.
+
+User chose option 1 (fold the refactor into #818). Revised plan now:
+
+1. Extracts three primitives:
+   - `groupByArea<T>(items, getArea)` to `@cluesmith/codev-core/area-grouping.ts` (generic, with a sibling test file in core's `__tests__/`)
+   - `AreaGroupTreeItem` base class in `views/area-group-tree-item.ts` with a `kind: 'backlog' | 'builder'` discriminator driving stable id prefix and contextValue; thin subclasses (`BacklogGroupTreeItem`, `BuilderGroupTreeItem`) preserve `instanceof` discrimination
+   - `AreaGroupExpansionStore` class + `wireAreaGroupExpansion` helper in `views/area-group-expansion.ts`
+2. Mechanically migrates `views/backlog.ts` / `backlog-tree-item.ts` / `extension.ts:261-271` / `test/backlog.test.ts` onto the shared primitives — behaviour byte-identical, ~50 LOC dropped from backlog code, `groupBacklogByArea` tests move to core.
+3. Wires Builders onto the same primitives.
+
+Single-Uncategorized flatten (6 LOC per provider) is kept inline — extracting it cleanly would require an abstract provider with generics, disproportionate complexity for the residual duplication.
+
+Risk: this expands #818's scope to touch the shipped backlog code in the same PR. Mitigated by the mechanical nature of the migration and by the test suite (which moves but tests the same invariants).

--- a/codev/state/pir-818_thread.md
+++ b/codev/state/pir-818_thread.md
@@ -1,0 +1,15 @@
+# PIR-818: Group Builders Tree by Area
+
+## 2026-05-27 — plan phase
+
+Drafted `codev/plans/818-vscode-group-builders-in-the-t.md`.
+
+Key reconciliation point with the merged #819: the wire is `OverviewBuilder.area: string` (single, projected via `parseArea` — first-alphabetical-area wins), **not** the `areas: string[]` shape the original #818 description assumed. Consequences captured in the plan:
+
+- Each builder lives in exactly one area at the parser level → grouping is a simple `groupBy(b.area)`.
+- The original `cross-cutting` *resolution-time privilege* is gone (per #819's final design — parser is policy-free). Honoured the *intent* at the **group-ordering** layer instead: when a `cross-cutting` group exists because at least one builder projects to it, its header sorts first. Documented as a deliberate inheritance from #819, flagged in Risks for review.
+- "Render only non-empty groups" chosen as default (issue mock shows `Uncategorized (0)` as a teaching aid; treating that literally would be UI noise). Flagged for review override.
+
+Sharing extracted to `@cluesmith/codev-core`: a `sortAreaGroups(areas: string[])` helper so the same ordering rule is byte-shared with #811 (backlog) when it lands — not just byte-described.
+
+Awaiting plan-approval gate review.

--- a/codev/state/pir-818_thread.md
+++ b/codev/state/pir-818_thread.md
@@ -13,3 +13,20 @@ Key reconciliation point with the merged #819: the wire is `OverviewBuilder.area
 Sharing extracted to `@cluesmith/codev-core`: a `sortAreaGroups(areas: string[])` helper so the same ordering rule is byte-shared with #811 (backlog) when it lands — not just byte-described.
 
 Awaiting plan-approval gate review.
+
+## 2026-05-27 — plan revised after architect directive
+
+Architect updated the issue body and directed a rebase on main to pick up #886 (#811's merged backlog grouping). Rebased cleanly. Read the revised body + the merged `views/backlog.ts` / `views/backlog-tree-item.ts` / `test/backlog.test.ts`.
+
+Rewrote the plan to mirror #886's actually-shipped shape exactly:
+
+- Dropped the `codev.buildersGroupByArea` config flag and the paired enable/disable toggle commands entirely (backlog has no toggle either).
+- Dropped the `sortAreaGroups` core extraction (#886 inlined the sort in `groupBacklogByArea`; matching that).
+- Dropped any privilege for `cross-cutting` (framework-neutrality discipline; pure alphabetical with `Uncategorized` last).
+- Added the single-`Uncategorized` flatten optimization (`backlog.ts:124-126`) so unlabeled repos see zero visual regression.
+- Added per-group expand/collapse persistence via `workspaceState` under `codev.buildersGroupExpansion` (paired with backlog's `codev.backlogGroupExpansion`).
+- Constructor widened to accept `workspaceState: vscode.Memento`; `onDidExpand/CollapseElement` wired in `extension.ts` immediately after `buildersView` creation, mirroring lines 261-271.
+
+Only structural divergence from backlog: the accordion's `reveal()` requires a real `getParent` chain in grouping mode. Solved with a `Map<builderId, BuilderGroupTreeItem>` populated by `rootChildren()` (empty in single-Uncategorized flatten mode, so accordion semantics are unchanged on that branch).
+
+Wire-field note: revised issue body says `OverviewBuilder.areas[]` (plural) but #886 reads `item.area` (single). Plan mirrors the shipped reality, with a sentence flagging the discrepancy in case the architect wants to roll the wire shape forward to plural — that'd be a separate change against #819 anyway.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,10 @@
     "./builder-helpers": {
       "types": "./dist/builder-helpers.d.ts",
       "default": "./dist/builder-helpers.js"
+    },
+    "./area-grouping": {
+      "types": "./dist/area-grouping.d.ts",
+      "default": "./dist/area-grouping.js"
     }
   },
   "files": [

--- a/packages/core/src/area-grouping.ts
+++ b/packages/core/src/area-grouping.ts
@@ -1,0 +1,44 @@
+import { UNCATEGORIZED_AREA } from './constants.js';
+
+/**
+ * Bucket items by their resolved area, returning groups in canonical
+ * Codev order: alphabetical specific areas first, then `Uncategorized`
+ * last. Within each group, the input order is preserved (the caller
+ * has already applied any sort policy — display-order for builders,
+ * mine-first for backlog).
+ *
+ * Pure, generic over the item type. Both `views/backlog.ts` and
+ * `views/builders.ts` in the VSCode extension consume this directly,
+ * keying off each item's resolved `area` (already projected on the
+ * server via `parseArea`; see #819). Future consumers (dashboard
+ * equivalents, etc.) reuse the same function so the grouping rule
+ * stays byte-shared, not merely prose-described.
+ */
+export function groupByArea<T>(
+  items: T[],
+  getArea: (item: T) => string,
+): Array<{ area: string; items: T[] }> {
+  const buckets = new Map<string, T[]>();
+  for (const item of items) {
+    const area = getArea(item);
+    const bucket = buckets.get(area);
+    if (bucket) {
+      bucket.push(item);
+    } else {
+      buckets.set(area, [item]);
+    }
+  }
+
+  const result: Array<{ area: string; items: T[] }> = [];
+  const uncategorized = buckets.get(UNCATEGORIZED_AREA);
+  const specifics = [...buckets.keys()]
+    .filter(a => a !== UNCATEGORIZED_AREA)
+    .sort();
+  for (const area of specifics) {
+    result.push({ area, items: buckets.get(area)! });
+  }
+  if (uncategorized) {
+    result.push({ area: UNCATEGORIZED_AREA, items: uncategorized });
+  }
+  return result;
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -39,7 +39,7 @@ import { BuilderFileTreeItem } from './views/builder-file-tree-item.js';
 import { BuilderDiffCache } from './views/builder-diff-cache.js';
 import { BuilderFileDecorationProvider } from './views/builder-file-decoration.js';
 import { BacklogGroupTreeItem, BacklogTreeItem } from './views/backlog-tree-item.js';
-import { wireAreaGroupExpansion } from './views/area-group-expansion.js';
+import { persistAreaGroupExpansion } from './views/area-group-expansion.js';
 
 let connectionManager: ConnectionManager | null = null;
 let terminalManager: TerminalManager | null = null;
@@ -256,13 +256,13 @@ export async function activate(context: vscode.ExtensionContext) {
 	// count; the rest stay on registerTreeDataProvider.
 	const buildersProvider = new BuildersProvider(overviewCache, builderDiffCache, context.workspaceState);
 	buildersView = vscode.window.createTreeView('codev.builders', { treeDataProvider: buildersProvider });
-	context.subscriptions.push(...wireAreaGroupExpansion(
+	context.subscriptions.push(...persistAreaGroupExpansion(
 		buildersView, BuilderGroupTreeItem, buildersProvider.expansion,
 	));
 	pullRequestsView = vscode.window.createTreeView('codev.pullRequests', { treeDataProvider: new PullRequestsProvider(overviewCache) });
 	const backlogProvider = new BacklogProvider(overviewCache, context.workspaceState);
 	backlogView = vscode.window.createTreeView('codev.backlog', { treeDataProvider: backlogProvider });
-	context.subscriptions.push(...wireAreaGroupExpansion(
+	context.subscriptions.push(...persistAreaGroupExpansion(
 		backlogView, BacklogGroupTreeItem, backlogProvider.expansion,
 	));
 	recentlyClosedView = vscode.window.createTreeView('codev.recentlyClosed', { treeDataProvider: new RecentlyClosedProvider(overviewCache) });

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -27,6 +27,7 @@ import { BuilderSpawnHandler } from './builder-spawn-handler.js';
 import { BuilderTerminalLinkProvider } from './terminal-link-provider.js';
 import { isIdleWaiting } from '@cluesmith/codev-core/builder-helpers';
 import { BuildersProvider } from './views/builders.js';
+import { BuilderGroupTreeItem } from './views/builder-tree-item.js';
 import { PullRequestsProvider } from './views/pull-requests.js';
 import { BacklogProvider, spawnableBacklog } from './views/backlog.js';
 import { RecentlyClosedProvider } from './views/recently-closed.js';
@@ -38,6 +39,7 @@ import { BuilderFileTreeItem } from './views/builder-file-tree-item.js';
 import { BuilderDiffCache } from './views/builder-diff-cache.js';
 import { BuilderFileDecorationProvider } from './views/builder-file-decoration.js';
 import { BacklogGroupTreeItem, BacklogTreeItem } from './views/backlog-tree-item.js';
+import { wireAreaGroupExpansion } from './views/area-group-expansion.js';
 
 let connectionManager: ConnectionManager | null = null;
 let terminalManager: TerminalManager | null = null;
@@ -252,23 +254,17 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// List views use createTreeView so their title can carry a live item
 	// count; the rest stay on registerTreeDataProvider.
-	const buildersProvider = new BuildersProvider(overviewCache, builderDiffCache);
+	const buildersProvider = new BuildersProvider(overviewCache, builderDiffCache, context.workspaceState);
 	buildersView = vscode.window.createTreeView('codev.builders', { treeDataProvider: buildersProvider });
+	context.subscriptions.push(...wireAreaGroupExpansion(
+		buildersView, BuilderGroupTreeItem, buildersProvider.expansion,
+	));
 	pullRequestsView = vscode.window.createTreeView('codev.pullRequests', { treeDataProvider: new PullRequestsProvider(overviewCache) });
 	const backlogProvider = new BacklogProvider(overviewCache, context.workspaceState);
 	backlogView = vscode.window.createTreeView('codev.backlog', { treeDataProvider: backlogProvider });
-	context.subscriptions.push(
-		backlogView.onDidExpandElement((e) => {
-			if (e.element instanceof BacklogGroupTreeItem) {
-				backlogProvider.setGroupExpanded(e.element.areaName, true);
-			}
-		}),
-		backlogView.onDidCollapseElement((e) => {
-			if (e.element instanceof BacklogGroupTreeItem) {
-				backlogProvider.setGroupExpanded(e.element.areaName, false);
-			}
-		}),
-	);
+	context.subscriptions.push(...wireAreaGroupExpansion(
+		backlogView, BacklogGroupTreeItem, backlogProvider.expansion,
+	));
 	recentlyClosedView = vscode.window.createTreeView('codev.recentlyClosed', { treeDataProvider: new RecentlyClosedProvider(overviewCache) });
 	// Seed the badge so it's correct immediately if overview data is already
 	// cached, instead of waiting for the next onDidChange tick.

--- a/packages/vscode/src/test/area-grouping.test.ts
+++ b/packages/vscode/src/test/area-grouping.test.ts
@@ -1,0 +1,82 @@
+import * as assert from 'assert';
+import { groupByArea } from '@cluesmith/codev-core/area-grouping';
+
+interface AreaItem {
+	id: string;
+	area: string;
+}
+
+const item = (id: string, area: string): AreaItem => ({ id, area });
+const getArea = (i: AreaItem) => i.area;
+
+suite('groupByArea', () => {
+	test('empty in -> empty out', () => {
+		assert.deepStrictEqual(groupByArea<AreaItem>([], getArea), []);
+	});
+
+	test('single Uncategorized item -> one Uncategorized group', () => {
+		const out = groupByArea([item('1', 'Uncategorized')], getArea);
+		assert.deepStrictEqual(out.map(g => g.area), ['Uncategorized']);
+		assert.deepStrictEqual(out[0].items.map(i => i.id), ['1']);
+	});
+
+	test('alphabetical specifics then Uncategorized last', () => {
+		const out = groupByArea([
+			item('1', 'tower'),
+			item('2', 'Uncategorized'),
+			item('3', 'auth'),
+			item('4', 'porch'),
+		], getArea);
+		assert.deepStrictEqual(
+			out.map(g => g.area),
+			['auth', 'porch', 'tower', 'Uncategorized'],
+		);
+	});
+
+	test('omits empty area groups (no "<area> (0)" headers)', () => {
+		// No items with area "vscode" -> no vscode header even though it's a
+		// real area in the repo's label set.
+		const out = groupByArea([
+			item('1', 'auth'),
+			item('2', 'tower'),
+		], getArea);
+		assert.deepStrictEqual(out.map(g => g.area), ['auth', 'tower']);
+	});
+
+	test('preserves input order within a group (no internal re-sort)', () => {
+		const out = groupByArea([
+			item('5', 'vscode'),
+			item('2', 'vscode'),
+			item('9', 'vscode'),
+			item('1', 'vscode'),
+		], getArea);
+		assert.deepStrictEqual(out.map(g => g.area), ['vscode']);
+		assert.deepStrictEqual(out[0].items.map(i => i.id), ['5', '2', '9', '1']);
+	});
+
+	test('groups multiple items per area correctly', () => {
+		const out = groupByArea([
+			item('1', 'vscode'),
+			item('2', 'tower'),
+			item('3', 'vscode'),
+			item('4', 'tower'),
+			item('5', 'vscode'),
+		], getArea);
+		assert.deepStrictEqual(out.map(g => g.area), ['tower', 'vscode']);
+		assert.deepStrictEqual(out[0].items.map(i => i.id), ['2', '4']);
+		assert.deepStrictEqual(out[1].items.map(i => i.id), ['1', '3', '5']);
+	});
+
+	test('works with arbitrary item shapes via getArea selector', () => {
+		// Demonstrates the generic — items don't have to expose `.area`.
+		const builders = [
+			{ id: 'a', meta: { resolved: 'tower' } },
+			{ id: 'b', meta: { resolved: 'vscode' } },
+			{ id: 'c', meta: { resolved: 'tower' } },
+		];
+		const out = groupByArea(builders, b => b.meta.resolved);
+		assert.deepStrictEqual(out.map(g => g.area), ['tower', 'vscode']);
+		assert.deepStrictEqual(out[0].items.map(b => b.id), ['a', 'c']);
+		assert.deepStrictEqual(out[1].items.map(b => b.id), ['b']);
+	});
+});

--- a/packages/vscode/src/test/backlog.test.ts
+++ b/packages/vscode/src/test/backlog.test.ts
@@ -1,14 +1,10 @@
 import * as assert from 'assert';
 import type { OverviewBacklogItem } from '@cluesmith/codev-types';
-import { groupBacklogByArea, spawnableBacklog } from '../views/backlog.js';
+import { spawnableBacklog } from '../views/backlog.js';
 
 function item(id: string, hasBuilder: boolean): OverviewBacklogItem {
 	// Only the fields spawnableBacklog reads matter; cast the rest.
 	return { id, title: `t${id}`, hasBuilder } as unknown as OverviewBacklogItem;
-}
-
-function backlogItem(id: string, area: string): OverviewBacklogItem {
-	return { id, title: `t${id}`, area } as unknown as OverviewBacklogItem;
 }
 
 suite('spawnableBacklog', () => {
@@ -37,64 +33,5 @@ suite('spawnableBacklog', () => {
 			item('d', false),
 		]);
 		assert.deepStrictEqual(out.map(i => i.id), ['a', 'c', 'd']);
-	});
-});
-
-suite('groupBacklogByArea', () => {
-	test('empty in -> empty out', () => {
-		assert.deepStrictEqual(groupBacklogByArea([]), []);
-	});
-
-	test('single Uncategorized item -> one Uncategorized group', () => {
-		const out = groupBacklogByArea([backlogItem('1', 'Uncategorized')]);
-		assert.deepStrictEqual(out.map(g => g.area), ['Uncategorized']);
-		assert.deepStrictEqual(out[0].items.map(i => i.id), ['1']);
-	});
-
-	test('alphabetical specifics then Uncategorized last', () => {
-		const out = groupBacklogByArea([
-			backlogItem('1', 'tower'),
-			backlogItem('2', 'Uncategorized'),
-			backlogItem('3', 'auth'),
-			backlogItem('4', 'porch'),
-		]);
-		assert.deepStrictEqual(
-			out.map(g => g.area),
-			['auth', 'porch', 'tower', 'Uncategorized'],
-		);
-	});
-
-	test('omits empty area groups (no "<area> (0)" headers)', () => {
-		// No items with area "vscode" -> no vscode header even though it's a
-		// real area in the repo's label set.
-		const out = groupBacklogByArea([
-			backlogItem('1', 'auth'),
-			backlogItem('2', 'tower'),
-		]);
-		assert.deepStrictEqual(out.map(g => g.area), ['auth', 'tower']);
-	});
-
-	test('preserves input order within a group (no internal re-sort)', () => {
-		const out = groupBacklogByArea([
-			backlogItem('5', 'vscode'),
-			backlogItem('2', 'vscode'),
-			backlogItem('9', 'vscode'),
-			backlogItem('1', 'vscode'),
-		]);
-		assert.deepStrictEqual(out.map(g => g.area), ['vscode']);
-		assert.deepStrictEqual(out[0].items.map(i => i.id), ['5', '2', '9', '1']);
-	});
-
-	test('groups multiple items per area correctly', () => {
-		const out = groupBacklogByArea([
-			backlogItem('1', 'vscode'),
-			backlogItem('2', 'tower'),
-			backlogItem('3', 'vscode'),
-			backlogItem('4', 'tower'),
-			backlogItem('5', 'vscode'),
-		]);
-		assert.deepStrictEqual(out.map(g => g.area), ['tower', 'vscode']);
-		assert.deepStrictEqual(out[0].items.map(i => i.id), ['2', '4']);
-		assert.deepStrictEqual(out[1].items.map(i => i.id), ['1', '3', '5']);
 	});
 });

--- a/packages/vscode/src/views/area-group-expansion.ts
+++ b/packages/vscode/src/views/area-group-expansion.ts
@@ -39,7 +39,7 @@ export class AreaGroupExpansionStore {
  * Returns the two `Disposable` subscriptions so the caller can push
  * them into the extension `context.subscriptions` array.
  */
-export function wireAreaGroupExpansion(
+export function persistAreaGroupExpansion(
   view: vscode.TreeView<vscode.TreeItem>,
   GroupClass: new (...args: never[]) => AreaGroupTreeItem,
   store: AreaGroupExpansionStore,

--- a/packages/vscode/src/views/area-group-expansion.ts
+++ b/packages/vscode/src/views/area-group-expansion.ts
@@ -1,0 +1,59 @@
+import * as vscode from 'vscode';
+import { AreaGroupTreeItem } from './area-group-tree-item.js';
+
+/**
+ * Per-area expand/collapse state, persisted in `workspaceState`. One
+ * instance per view (each view scopes its own key, e.g.
+ * `codev.backlogGroupExpansion` / `codev.buildersGroupExpansion`),
+ * so users can collapse a `vscode` group in Builders without affecting
+ * the same group in Backlog.
+ *
+ * Default state for an untouched area is "expanded" — callers read
+ * the map and apply `?? true` at render time.
+ */
+export class AreaGroupExpansionStore {
+  constructor(
+    private readonly workspaceState: vscode.Memento,
+    private readonly storageKey: string,
+  ) {}
+
+  read(): Record<string, boolean> {
+    return this.workspaceState.get<Record<string, boolean>>(this.storageKey, {});
+  }
+
+  set(areaName: string, expanded: boolean): void {
+    const map = this.read();
+    map[areaName] = expanded;
+    this.workspaceState.update(this.storageKey, map);
+  }
+}
+
+/**
+ * Wire a TreeView's expand/collapse events into an
+ * AreaGroupExpansionStore. The `GroupClass` parameter is the
+ * view-specific subclass (`BacklogGroupTreeItem` or
+ * `BuilderGroupTreeItem`); the `instanceof` check ensures each store
+ * only records events from its own view's groups, even though both
+ * views ultimately produce `AreaGroupTreeItem`-derived rows.
+ *
+ * Returns the two `Disposable` subscriptions so the caller can push
+ * them into the extension `context.subscriptions` array.
+ */
+export function wireAreaGroupExpansion(
+  view: vscode.TreeView<vscode.TreeItem>,
+  GroupClass: new (...args: never[]) => AreaGroupTreeItem,
+  store: AreaGroupExpansionStore,
+): vscode.Disposable[] {
+  return [
+    view.onDidExpandElement((e) => {
+      if (e.element instanceof GroupClass) {
+        store.set(e.element.areaName, true);
+      }
+    }),
+    view.onDidCollapseElement((e) => {
+      if (e.element instanceof GroupClass) {
+        store.set(e.element.areaName, false);
+      }
+    }),
+  ];
+}

--- a/packages/vscode/src/views/area-group-tree-item.ts
+++ b/packages/vscode/src/views/area-group-tree-item.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+
+export type AreaGroupKind = 'backlog' | 'builder';
+
+/**
+ * Shared base for area-group header rows in the Backlog and Builders
+ * trees. The `kind` discriminator drives both the stable `id` prefix
+ * (so VSCode persists per-group expansion across cache ticks) and the
+ * `contextValue` (so per-view context menus can scope cleanly).
+ *
+ * Concrete subclasses (`BacklogGroupTreeItem`, `BuilderGroupTreeItem`)
+ * are thin tags around this base — they exist so each view's
+ * onDidExpand/Collapse handler can scope to its own groups via
+ * `instanceof` rather than discriminating on a string field.
+ */
+export class AreaGroupTreeItem extends vscode.TreeItem {
+  constructor(
+    public readonly areaName: string,
+    public readonly kind: AreaGroupKind,
+    count: number,
+    collapsibleState: vscode.TreeItemCollapsibleState,
+  ) {
+    super(`${areaName} (${count})`, collapsibleState);
+    this.id = `${kind}-group:${areaName}`;
+    this.contextValue = `${kind}-group`;
+  }
+}

--- a/packages/vscode/src/views/backlog-tree-item.ts
+++ b/packages/vscode/src/views/backlog-tree-item.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { AreaGroupTreeItem } from './area-group-tree-item.js';
 
 /**
  * TreeItem subclass that carries a backlog issue's id and URL as typed fields.
@@ -24,23 +25,13 @@ export class BacklogTreeItem extends vscode.TreeItem {
 }
 
 /**
- * TreeItem subclass for an area group header in the backlog tree.
- *
- * Carries the canonical area name (e.g. `'vscode'`, `'cross-cutting'`,
- * `'Uncategorized'`) so the expand/collapse persistence handler can key
- * the workspaceState map by area name regardless of the rendered label
- * (which includes the count suffix). `id` is set from the area name so
- * VSCode reuses the same TreeItem identity across refreshes — letting
- * the user's collapse choice survive `OverviewCache` ticks.
+ * Area group header in the Backlog tree. Thin subclass of
+ * `AreaGroupTreeItem` so the per-view expand/collapse handler in
+ * `extension.ts` can scope to backlog groups via `instanceof`
+ * (distinct from `BuilderGroupTreeItem`, which uses the same base).
  */
-export class BacklogGroupTreeItem extends vscode.TreeItem {
-  constructor(
-    public readonly areaName: string,
-    count: number,
-    collapsibleState: vscode.TreeItemCollapsibleState,
-  ) {
-    super(`${areaName} (${count})`, collapsibleState);
-    this.id = `backlog-group:${areaName}`;
-    this.contextValue = 'backlog-group';
+export class BacklogGroupTreeItem extends AreaGroupTreeItem {
+  constructor(areaName: string, count: number, collapsibleState: vscode.TreeItemCollapsibleState) {
+    super(areaName, 'backlog', count, collapsibleState);
   }
 }

--- a/packages/vscode/src/views/backlog.ts
+++ b/packages/vscode/src/views/backlog.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode';
 import type { OverviewBacklogItem } from '@cluesmith/codev-types';
 import { UNCATEGORIZED_AREA } from '@cluesmith/codev-core/constants';
+import { groupByArea } from '@cluesmith/codev-core/area-grouping';
 import type { OverviewCache } from './overview-data.js';
 import { BacklogGroupTreeItem, BacklogTreeItem } from './backlog-tree-item.js';
-
-const EXPANSION_STATE_KEY = 'codev.backlogGroupExpansion';
+import { AreaGroupExpansionStore } from './area-group-expansion.js';
 
 /**
  * Backlog rows the user can act on — exclude issues that already have an
@@ -14,49 +14,6 @@ const EXPANSION_STATE_KEY = 'codev.backlogGroupExpansion';
  */
 export function spawnableBacklog(items: OverviewBacklogItem[]): OverviewBacklogItem[] {
   return items.filter(i => !i.hasBuilder);
-}
-
-/**
- * Group backlog items by their resolved `area` (already projected on the
- * server via `parseArea`; see #819). Returned groups are ordered:
- *
- *   1. Alphabetical specific areas
- *   2. `Uncategorized` (last)
- *
- * Within-group order preserves the input order — the caller has already
- * applied any "mine-first" or sort policy. Empty groups are omitted
- * (no `<area> (0)` headers).
- *
- * Pure function — no VSCode dependency, unit-testable.
- */
-export function groupBacklogByArea(
-  items: OverviewBacklogItem[],
-): Array<{ area: string; items: OverviewBacklogItem[] }> {
-  const buckets = new Map<string, OverviewBacklogItem[]>();
-  for (const item of items) {
-    const bucket = buckets.get(item.area);
-    if (bucket) {
-      bucket.push(item);
-    } else {
-      buckets.set(item.area, [item]);
-    }
-  }
-
-  const result: Array<{ area: string; items: OverviewBacklogItem[] }> = [];
-  const uncategorized = buckets.get(UNCATEGORIZED_AREA);
-
-  const specifics = [...buckets.keys()]
-    .filter(a => a !== UNCATEGORIZED_AREA)
-    .sort();
-  for (const area of specifics) {
-    result.push({ area, items: buckets.get(area)! });
-  }
-
-  if (uncategorized) {
-    result.push({ area: UNCATEGORIZED_AREA, items: uncategorized });
-  }
-
-  return result;
 }
 
 /**
@@ -78,11 +35,13 @@ export function groupBacklogByArea(
 export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
   private readonly changeEmitter = new vscode.EventEmitter<void>();
   readonly onDidChangeTreeData = this.changeEmitter.event;
+  readonly expansion: AreaGroupExpansionStore;
 
   constructor(
     private readonly cache: OverviewCache,
-    private readonly workspaceState: vscode.Memento,
+    workspaceState: vscode.Memento,
   ) {
+    this.expansion = new AreaGroupExpansionStore(workspaceState, 'codev.backlogGroupExpansion');
     cache.onDidChange(() => this.changeEmitter.fire());
   }
 
@@ -100,22 +59,12 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
     return this.rootChildren();
   }
 
-  /**
-   * Persist a user's expand/collapse choice for an area group. Called
-   * from `extension.ts` via `backlogView.onDidExpand/CollapseElement`.
-   */
-  setGroupExpanded(areaName: string, expanded: boolean): void {
-    const map = this.readExpansionState();
-    map[areaName] = expanded;
-    this.workspaceState.update(EXPANSION_STATE_KEY, map);
-  }
-
   private rootChildren(): vscode.TreeItem[] {
     const data = this.cache.getData();
     if (!data) { return []; }
 
     const items = this.orderedSpawnable(data);
-    const groups = groupBacklogByArea(items);
+    const groups = groupByArea(items, i => i.area);
 
     // Degenerate case: a repo that doesn't use `area/*` labels yields a
     // single `Uncategorized` group containing every issue. Rendering its
@@ -125,7 +74,7 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
       return groups[0].items.map(item => this.makeRow(item, data));
     }
 
-    const expansion = this.readExpansionState();
+    const expansion = this.expansion.read();
     return groups.map(g => {
       const expanded = expansion[g.area] ?? true;
       const state = expanded
@@ -140,7 +89,7 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
     if (!data) { return []; }
 
     const items = this.orderedSpawnable(data);
-    const group = groupBacklogByArea(items).find(g => g.area === areaName);
+    const group = groupByArea(items, i => i.area).find(g => g.area === areaName);
     if (!group) { return []; }
 
     return group.items.map(item => this.makeRow(item, data));
@@ -180,9 +129,5 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
     const mine = items.filter(isMine);
     const rest = items.filter(item => !isMine(item));
     return [...mine, ...rest];
-  }
-
-  private readExpansionState(): Record<string, boolean> {
-    return this.workspaceState.get<Record<string, boolean>>(EXPANSION_STATE_KEY, {});
   }
 }

--- a/packages/vscode/src/views/builder-tree-item.ts
+++ b/packages/vscode/src/views/builder-tree-item.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { AreaGroupTreeItem } from './area-group-tree-item.js';
 
 /**
  * TreeItem subclass that carries a builder id as a typed field.
@@ -19,5 +20,17 @@ export class BuilderTreeItem extends vscode.TreeItem {
     label: string,
   ) {
     super(label);
+  }
+}
+
+/**
+ * Area group header in the Builders tree. Thin subclass of
+ * `AreaGroupTreeItem` so the per-view expand/collapse handler in
+ * `extension.ts` can scope to builder groups via `instanceof`
+ * (distinct from `BacklogGroupTreeItem`, which uses the same base).
+ */
+export class BuilderGroupTreeItem extends AreaGroupTreeItem {
+  constructor(areaName: string, count: number, collapsibleState: vscode.TreeItemCollapsibleState) {
+    super(areaName, 'builder', count, collapsibleState);
   }
 }

--- a/packages/vscode/src/views/builders.ts
+++ b/packages/vscode/src/views/builders.ts
@@ -1,12 +1,15 @@
 import * as vscode from 'vscode';
 import type { OverviewBuilder } from '@cluesmith/codev-types';
 import { isIdleWaiting } from '@cluesmith/codev-core/builder-helpers';
+import { UNCATEGORIZED_AREA } from '@cluesmith/codev-core/constants';
+import { groupByArea } from '@cluesmith/codev-core/area-grouping';
 import type { OverviewCache } from './overview-data.js';
-import { BuilderTreeItem } from './builder-tree-item.js';
+import { BuilderGroupTreeItem, BuilderTreeItem } from './builder-tree-item.js';
 import { BuilderFileTreeItem } from './builder-file-tree-item.js';
 import { BuilderFolderTreeItem } from './builder-folder-tree-item.js';
 import { buildFilePathTree, type FilePathNode } from './file-path-tree.js';
 import type { BuilderDiffCache } from './builder-diff-cache.js';
+import { AreaGroupExpansionStore } from './area-group-expansion.js';
 
 /**
  * Order builders for the Builders tree: three buckets, top-down.
@@ -29,20 +32,37 @@ export function orderForDisplay(builders: OverviewBuilder[], now: number = Date.
 }
 
 /**
- * Unified Builders view. Blocked builders sort to the top with a bell icon
+ * Unified Builders view. Builders are grouped by their resolved `area`
+ * (alphabetical specific areas first, then `Uncategorized` last), and
+ * within each group blocked builders sort to the top with a bell icon
  * and a wait-time suffix; active builders sit below with a play icon.
- * Replaces the previous split between a Needs Attention tree (blocked only)
- * and a Builders tree (everything) — the duplication caused more noise than
- * the at-a-glance triage was worth.
+ * Replaces the previous split between a Needs Attention tree (blocked
+ * only) and a Builders tree (everything) — the duplication caused more
+ * noise than the at-a-glance triage was worth.
+ *
+ * Group expand/collapse state persists per area name via `workspaceState`
+ * under `codev.buildersGroupExpansion`. Default for an untouched group:
+ * expanded. When the only group present is `Uncategorized` (repo
+ * hasn't adopted `area/*` labels), the header is suppressed and builder
+ * rows render at root — zero visual regression for unlabeled repos.
  */
 export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
   private readonly changeEmitter = new vscode.EventEmitter<void>();
   readonly onDidChangeTreeData = this.changeEmitter.event;
+  readonly expansion: AreaGroupExpansionStore;
+  // Populated each time `rootChildren()` returns groups; consulted by
+  // `getParent` so the accordion's `reveal(builderItem)` can walk the
+  // parent chain in grouping mode. Empty in the single-`Uncategorized`
+  // flatten case (builders are root again), so `getParent` returns
+  // `undefined` and the accordion works unchanged on that branch.
+  private groupParentByBuilderId = new Map<string, BuilderGroupTreeItem>();
 
   constructor(
     private cache: OverviewCache,
     private readonly diffCache: BuilderDiffCache,
+    workspaceState: vscode.Memento,
   ) {
+    this.expansion = new AreaGroupExpansionStore(workspaceState, 'codev.buildersGroupExpansion');
     cache.onDidChange(() => this.changeEmitter.fire());
   }
 
@@ -59,9 +79,14 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
     return element;
   }
 
-  // Required for `TreeView.reveal` (used by the accordion). Builder rows are
-  // roots → undefined; file rows are never revealed.
-  getParent(): vscode.TreeItem | undefined {
+  // The accordion's `reveal(builderItem)` needs the parent chain.
+  // Builders nested under a group return their cached group; everything
+  // else (group rows themselves, file/folder rows, builders in the
+  // single-Uncategorized flatten case) is treated as a root by VSCode.
+  getParent(element: vscode.TreeItem): vscode.TreeItem | undefined {
+    if (element instanceof BuilderTreeItem) {
+      return this.groupParentByBuilderId.get(element.builderId);
+    }
     return undefined;
   }
 
@@ -81,59 +106,108 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
     if (element instanceof BuilderFileTreeItem) {
       return [];
     }
-    // Root: the builder list.
+    // Group rows expand to their builders.
+    if (element instanceof BuilderGroupTreeItem) {
+      return this.rowsForGroup(element.areaName);
+    }
+    // Root: group headers, or the single-Uncategorized flatten case.
+    return this.rootChildren();
+  }
+
+  private rootChildren(): vscode.TreeItem[] {
+    const data = this.cache.getData();
+    if (!data) {
+      this.groupParentByBuilderId.clear();
+      return [];
+    }
+
+    const now = Date.now();
+    const ordered = orderForDisplay(data.builders, now);
+    const groups = groupByArea(ordered, b => b.area);
+
+    // Degenerate case: a repo that doesn't use `area/*` labels yields a
+    // single `Uncategorized` group containing every builder. Rendering
+    // its header would add no information — collapse to flat rows so
+    // the tree looks the same as it did before grouping shipped.
+    if (groups.length === 1 && groups[0].area === UNCATEGORIZED_AREA) {
+      this.groupParentByBuilderId.clear();
+      return groups[0].items.map(b => this.makeBuilderRow(b, now));
+    }
+
+    const expansion = this.expansion.read();
+    this.groupParentByBuilderId.clear();
+    return groups.map(g => {
+      const expanded = expansion[g.area] ?? true;
+      const state = expanded
+        ? vscode.TreeItemCollapsibleState.Expanded
+        : vscode.TreeItemCollapsibleState.Collapsed;
+      const groupItem = new BuilderGroupTreeItem(g.area, g.items.length, state);
+      for (const b of g.items) {
+        this.groupParentByBuilderId.set(b.id, groupItem);
+      }
+      return groupItem;
+    });
+  }
+
+  private rowsForGroup(areaName: string): vscode.TreeItem[] {
     const data = this.cache.getData();
     if (!data) { return []; }
 
     const now = Date.now();
-    return orderForDisplay(data.builders, now).map(b => {
-      const isBlocked = !!b.blocked;
-      const isIdle = !isBlocked && isIdleWaiting(b, now);
-      const waitTime = isBlocked && b.blockedSince ? ` [${timeSince(b.blockedSince)}]` : '';
-      const idleTime = isIdle && b.lastDataAt ? ` [${timeSince(b.lastDataAt)} silent]` : '';
-      const phaseLabel = isBlocked
-        ? `blocked on ${b.blocked}${waitTime}`
-        : isIdle
-        ? `waiting on input${idleTime}`
-        : `[${b.phase}]`;
-      const item = new BuilderTreeItem(b.id, `#${b.issueId ?? b.id} ${b.issueTitle ?? ''} ${phaseLabel}`);
-      // Stable id (not the churning label) so VSCode persists expansion across
-      // the frequent overview-poll refreshes, and so the accordion's
-      // collapseAll+reveal can target this row reliably.
-      item.id = b.id;
-      // Expandable so the second-level changed-files list can hang off it.
-      // The row keeps its open-terminal command (single click); the chevron
-      // toggles the file list.
-      item.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
-      item.tooltip = `Protocol: ${b.protocol} | Mode: ${b.mode} | Progress: ${b.progress}%`;
-      // contextValue encodes the row's state-family + protocol so menus can
-      // scope by either (Approve Gate inline only on blocked-builder-*;
-      // everything else applies to all three families).
-      item.contextValue = isBlocked
-        ? `blocked-builder-${b.protocol || 'unknown'}`
-        : isIdle
-        ? `awaiting-builder-${b.protocol || 'unknown'}`
-        : `builder-${b.protocol || 'unknown'}`;
-      // Three icons for three states: bell (gate), comment-discussion
-      // (silent, likely waiting on a question), circle-filled (live/active).
-      item.iconPath = isBlocked
-        ? new vscode.ThemeIcon('bell', new vscode.ThemeColor('notificationsWarningIcon.foreground'))
-        : isIdle
-        ? new vscode.ThemeIcon('comment-discussion', new vscode.ThemeColor('notificationsInfoIcon.foreground'))
-        : new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('testing.iconPassed'));
-      // The row click runs `codev.openBuilderRow` — a wrapper that opens the
-      // builder terminal AND expands the row (so single-click matches what
-      // most users expect). Pass the item itself so the handler can call
-      // `buildersView.reveal(...)` against this row. Other callers
-      // (terminal-link clicks, etc.) still use `codev.openBuilderById`
-      // directly with just the id and don't trigger expansion.
-      item.command = {
-        command: 'codev.openBuilderRow',
-        title: 'Open Builder Terminal',
-        arguments: [item],
-      };
-      return item;
-    });
+    const ordered = orderForDisplay(data.builders, now);
+    const group = groupByArea(ordered, b => b.area).find(g => g.area === areaName);
+    if (!group) { return []; }
+
+    return group.items.map(b => this.makeBuilderRow(b, now));
+  }
+
+  private makeBuilderRow(b: OverviewBuilder, now: number): BuilderTreeItem {
+    const isBlocked = !!b.blocked;
+    const isIdle = !isBlocked && isIdleWaiting(b, now);
+    const waitTime = isBlocked && b.blockedSince ? ` [${timeSince(b.blockedSince)}]` : '';
+    const idleTime = isIdle && b.lastDataAt ? ` [${timeSince(b.lastDataAt)} silent]` : '';
+    const phaseLabel = isBlocked
+      ? `blocked on ${b.blocked}${waitTime}`
+      : isIdle
+      ? `waiting on input${idleTime}`
+      : `[${b.phase}]`;
+    const item = new BuilderTreeItem(b.id, `#${b.issueId ?? b.id} ${b.issueTitle ?? ''} ${phaseLabel}`);
+    // Stable id (not the churning label) so VSCode persists expansion across
+    // the frequent overview-poll refreshes, and so the accordion's
+    // collapseAll+reveal can target this row reliably.
+    item.id = b.id;
+    // Expandable so the second-level changed-files list can hang off it.
+    // The row keeps its open-terminal command (single click); the chevron
+    // toggles the file list.
+    item.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+    item.tooltip = `Protocol: ${b.protocol} | Mode: ${b.mode} | Progress: ${b.progress}%`;
+    // contextValue encodes the row's state-family + protocol so menus can
+    // scope by either (Approve Gate inline only on blocked-builder-*;
+    // everything else applies to all three families).
+    item.contextValue = isBlocked
+      ? `blocked-builder-${b.protocol || 'unknown'}`
+      : isIdle
+      ? `awaiting-builder-${b.protocol || 'unknown'}`
+      : `builder-${b.protocol || 'unknown'}`;
+    // Three icons for three states: bell (gate), comment-discussion
+    // (silent, likely waiting on a question), circle-filled (live/active).
+    item.iconPath = isBlocked
+      ? new vscode.ThemeIcon('bell', new vscode.ThemeColor('notificationsWarningIcon.foreground'))
+      : isIdle
+      ? new vscode.ThemeIcon('comment-discussion', new vscode.ThemeColor('notificationsInfoIcon.foreground'))
+      : new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('testing.iconPassed'));
+    // The row click runs `codev.openBuilderRow` — a wrapper that opens the
+    // builder terminal AND expands the row (so single-click matches what
+    // most users expect). Pass the item itself so the handler can call
+    // `buildersView.reveal(...)` against this row. Other callers
+    // (terminal-link clicks, etc.) still use `codev.openBuilderById`
+    // directly with just the id and don't trigger expansion.
+    item.command = {
+      command: 'codev.openBuilderRow',
+      title: 'Open Builder Terminal',
+      arguments: [item],
+    };
+    return item;
   }
 
   /**


### PR DESCRIPTION
# PIR Review: Group Builders Tree by Area (mirror #811, dedup primitives)

Fixes #818

## Summary

Builders tree in the VSCode sidebar now groups by `area/*` label (alphabetical specific areas, `Uncategorized` last), mirroring the backlog grouping that #886 shipped. To avoid duplicating ~67 LOC of structural code across the two views, the PR also extracts three shared primitives (`groupByArea<T>`, `AreaGroupTreeItem` base class, `AreaGroupExpansionStore` + `persistAreaGroupExpansion` helper) and migrates the already-shipped backlog view onto them in the same PR. Net effect: builders gains the new feature, backlog loses 50 LOC, and the "rule structurally identical to backlog's" acceptance criterion is enforced by `import`, not by reviewer attention.

## Files Changed

- `packages/core/package.json` (+4 / -0) — new `./area-grouping` export
- `packages/core/src/area-grouping.ts` (+44 / -0) — NEW: generic `groupByArea<T>`
- `packages/vscode/src/views/area-group-tree-item.ts` (+27 / -0) — NEW: shared `AreaGroupTreeItem` base
- `packages/vscode/src/views/area-group-expansion.ts` (+59 / -0) — NEW: `AreaGroupExpansionStore` + `persistAreaGroupExpansion`
- `packages/vscode/src/test/area-grouping.test.ts` (+82 / -0) — NEW: 7 tests for `groupByArea<T>`
- `packages/vscode/src/views/builders.ts` (+143 / -50) — two-level provider, `getParent`, single-Uncategorized flatten
- `packages/vscode/src/views/builder-tree-item.ts` (+13 / -0) — `BuilderGroupTreeItem` thin subclass
- `packages/vscode/src/views/backlog.ts` (+10 / -61) — migrated onto shared primitives
- `packages/vscode/src/views/backlog-tree-item.ts` (+10 / -0) — `BacklogGroupTreeItem` thin subclass
- `packages/vscode/src/test/backlog.test.ts` (+1 / -57) — dropped `groupBacklogByArea` suite (covered by generic)
- `packages/vscode/src/extension.ts` (+5 / -14) — `persistAreaGroupExpansion` ×2
- `codev/plans/818-vscode-group-builders-in-the-t.md` (+334 / -0) — plan artifact

## Commits

- `9e838a6c` [PIR #818] Rename wireAreaGroupExpansion → persistAreaGroupExpansion
- `a6561d29` [PIR #818] Thread: log implement phase completion
- `4419a7d7` [PIR #818] Apply area grouping to Builders tree
- `8bd1537c` [PIR #818] Migrate backlog view onto shared area-grouping primitives
- `d5186d46` [PIR #818] Extract shared area-grouping primitives (groupByArea, AreaGroupTreeItem, AreaGroupExpansionStore)
- `227ea3f3` [PIR #818] Plan revised — extract groupByArea + AreaGroupTreeItem + AreaGroupExpansionStore, migrate backlog onto them
- `6519ea35` [PIR #818] Plan revised — mirror #886's shipped shape (no toggle, alphabetical-only, single-Uncategorized flatten)
- `b6021767` [PIR #818] Plan draft

## Test Results

- `pnpm --filter codev-vscode check-types`: ✓ pass
- `pnpm --filter codev-vscode lint`: ✓ pass
- `pnpm --filter codev-vscode compile` (esbuild bundle): ✓ pass
- `pnpm --filter codev-vscode test`: ✓ pass (90 tests, 7 new `suite('groupByArea')`, 4 dropped `suite('groupBacklogByArea')` — coverage shifted to the generic)
- Manual verification at the dev-approval gate: human approved after side-by-side comparison with the backlog grouping; rename `wireAreaGroupExpansion → persistAreaGroupExpansion` applied as part of the same review pass

## Architecture Updates

No changes to `codev/resources/arch.md`. The change is confined to the VSCode extension's view layer — no impact on Tower internals, builder lifecycle, worktree management, shellper protocol, or any other surface arch.md documents.

## Lessons Learned Updates

Added one entry to `codev/resources/lessons-learned.md` under **Architecture**:

> [From 818] An acceptance criterion of "rule structurally identical to X" is a written-rule trap when the rule lives as duplicated prose in two views. Two copies drift even with diligence; the only durable enforcement is one shared function both views import. Extract when the second consumer lands — not before (no abstraction without users) and not later (drift starts on day one).

The original plan (v2) committed knowingly-duplicated code with the "byte-identical to #886" criterion enforced only by prose. The human caught it before approval; v3 added the extraction. The extraction itself was cheap (~3 small files, mechanical backlog migration); the lesson is recognizing the trap at plan time so the extraction lands together with the second consumer, not as a follow-up that competes with other priorities.

## Things to Look At During PR Review

- **Mechanical backlog migration**: `packages/vscode/src/views/backlog.ts` loses ~50 LOC. The diff is intentionally a no-op — `groupBacklogByArea` is replaced with `groupByArea(items, i => i.area)`; `setGroupExpanded` / `readExpansionState` / `EXPANSION_STATE_KEY` are replaced with an `AreaGroupExpansionStore` field. Walk the backlog view in VSCode first and confirm zero visible change — that's the highest-blast-radius part of the diff.
- **Accordion `reveal()` in grouping mode**: `views/builders.ts` overrides `getParent` to return the cached group for `BuilderTreeItem` children. The cache (`groupParentByBuilderId`) is repopulated every time `rootChildren()` runs in multi-group mode; cleared in the single-`Uncategorized` flatten case (builders are root again). Watch for the accordion behaviour with two builders in different areas — expanding one should auto-collapse the other.
- **`AreaGroupTreeItem` sub-classing pattern**: `BacklogGroupTreeItem` and `BuilderGroupTreeItem` are 3-line subclasses that exist solely so `extension.ts`'s per-view expand/collapse handlers can scope via `instanceof`. Without them, both handlers would fire on every group expand/collapse. Mentioned for clarity; the design isn't novel but the subclasses look almost empty so worth a sentence.
- **Wire-field reconciliation**: the revised #818 issue body still says `OverviewBuilder.areas[]` (plural) in places. The implementation consumes the single-string `OverviewBuilder.area` projection that #886 / #819 actually shipped. If you'd prefer rolling the wire shape forward to plural, that's a separate change against #819 — out of scope here.

## How to Test Locally

For reviewers pulling the branch:

- **View diff**: VSCode sidebar → right-click builder pir-818 → **Codev: View Diff** (auto-detects the repo's default branch)
- **Run dev server**: VSCode sidebar → right-click builder pir-818 → **Run Dev Server**, or `afx dev pir-818`
- **What to verify**:
  - Open the Backlog view → confirm grouping renders exactly as it did on `main` (no visible regression from the migration)
  - Open the Builders view → groups render with `<area> (<count>)` headers, alphabetical specifics, `Uncategorized` last
  - Within-group order preserves `orderForDisplay()` (blocked → idle-waiting → active)
  - Collapse a group, reload the window → still collapsed
  - Collapse `vscode` in Backlog → Builders' `vscode` group stays expanded (separate `workspaceState` keys)
  - With `codev.buildersAutoCollapse` on, expand one builder → others auto-collapse across groups
  - Add/remove an `area/*` label on an open issue via `gh issue edit` → next overview tick (~60s) re-groups the affected builder

## Flaky Tests

None.
