### PR TITLE
Fix #894: mock fetchIssue in next.test.ts to eliminate gh-CLI flake

### DIFF
--- a/codev/projects/bugfix-894-porch-flaky-5s-timeout-in-next/status.yaml
+++ b/codev/projects/bugfix-894-porch-flaky-5s-timeout-in-next/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-894
 title: porch-flaky-5s-timeout-in-next
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T00:50:34.526Z'
-updated_at: '2026-05-28T00:55:59.958Z'
+updated_at: '2026-05-28T00:58:26.606Z'

--- a/codev/projects/bugfix-894-porch-flaky-5s-timeout-in-next/status.yaml
+++ b/codev/projects/bugfix-894-porch-flaky-5s-timeout-in-next/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-894
+title: porch-flaky-5s-timeout-in-next
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-28T00:50:34.526Z'
+updated_at: '2026-05-28T00:50:34.527Z'

--- a/codev/projects/bugfix-894-porch-flaky-5s-timeout-in-next/status.yaml
+++ b/codev/projects/bugfix-894-porch-flaky-5s-timeout-in-next/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-05-28T01:01:35.340Z'
+    approved_at: '2026-05-28T01:03:06.484Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T00:50:34.526Z'
-updated_at: '2026-05-28T01:01:35.341Z'
-pr_ready_for_human: true
+updated_at: '2026-05-28T01:03:06.485Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-894-porch-flaky-5s-timeout-in-next/status.yaml
+++ b/codev/projects/bugfix-894-porch-flaky-5s-timeout-in-next/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-05-28T01:01:35.340Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T00:50:34.526Z'
-updated_at: '2026-05-28T00:58:26.606Z'
+updated_at: '2026-05-28T01:01:35.341Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-894-porch-flaky-5s-timeout-in-next/status.yaml
+++ b/codev/projects/bugfix-894-porch-flaky-5s-timeout-in-next/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-894
 title: porch-flaky-5s-timeout-in-next
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T00:50:34.526Z'
-updated_at: '2026-05-28T00:50:34.527Z'
+updated_at: '2026-05-28T00:55:59.958Z'

--- a/codev/state/bugfix-894_thread.md
+++ b/codev/state/bugfix-894_thread.md
@@ -1,0 +1,32 @@
+# bugfix-894 — Thread
+
+## 2026-05-28 — INVESTIGATE phase started
+
+Issue #894: flaky 5s timeout in `next.test.ts` "emits BUILD tasks for fresh specify phase"
+
+Failure observed on CI for PR #893 (pir-885), passed on `main` post-merge ~30s later with identical code → timing-dependent flake at 5s boundary.
+
+Failing test location: `packages/codev/src/commands/porch/__tests__/next.test.ts:174`
+
+Hypotheses from the issue:
+1. Real subprocess spawn (git/afx/node) — startup variability on CI
+2. File-system I/O slow on CI runner
+3. Racy timer / event-await pattern
+
+Investigating now: read `next.ts` to understand what the test actually exercises, then run locally to measure timing.
+
+## Root cause
+
+`next()` calls `buildPhasePrompt()` → `getProjectSummary()` → `fetchIssue()` → `executeForgeCommand('issue-view', …)` → real `gh` subprocess hitting GitHub API.
+
+The `next.test.ts` mocks `loadConfig` but does **not** mock `../../../lib/github.js`. So every test exercising the "need build" path (~10 of 30 tests) spawns `gh issue view 0001`. Per-test timings from verbose run:
+
+- Tests that hit the build path: 836-2000ms each (one gh call each, "is idempotent…" runs `next()` twice → ~1960ms)
+- Tests that skip the build path: 2-7ms each
+
+Locally each `gh` call is ~900ms (network round-trip). On CI under variable load that can spike past 5s → vitest's default per-test timeout fires.
+
+Hypothesis #2 from the issue ("subprocess that should be mocked") is the correct one. Fixing by adding `vi.mock('../../../lib/github.js', …)` to `next.test.ts` — mirrors the established pattern in `src/__tests__/project-summary.test.ts:14`.
+
+Side benefit: total file time drops from ~11s to ~1s; eliminates this whole class of flake (the failing test happened to be the first one to cross 5s; any of the 10 build-path tests was equally at risk).
+

--- a/packages/codev/src/commands/porch/__tests__/next.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/next.test.ts
@@ -28,6 +28,14 @@ vi.mock('../../../lib/config.js', async (importOriginal) => {
   };
 });
 
+// Mock fetchIssue so buildPhasePrompt → getProjectSummary doesn't shell out to
+// `gh issue view` for every test that hits the build path. Without this, each
+// such test pays a ~900ms gh+network round-trip locally and can spike past
+// vitest's 5s per-test default on CI — the flake fixed in #894.
+vi.mock('../../../lib/github.js', () => ({
+  fetchIssue: vi.fn().mockResolvedValue(null),
+}));
+
 // ============================================================================
 // Test Fixtures
 // ============================================================================


### PR DESCRIPTION
## Summary

The `emits BUILD tasks for fresh specify phase` test (and ~9 other tests in `next.test.ts` that hit the build path) intermittently timed out at vitest's default 5s on CI. Root cause was a real `gh issue view` subprocess on every `next()` call. This PR mocks `fetchIssue` to make the suite deterministic and ~40x faster.

Fixes #894

## Root Cause

`next()` → `buildPhasePrompt()` → `getProjectSummary()` → `fetchIssue()` shells out to `gh issue view <id>` via `executeForgeCommand`. Every test exercising the build path therefore pays one gh+network round-trip. Locally each call is ~900ms; on CI under variable load it can spike past 5s — vitest's default per-test timeout — and any of the 10 affected tests is equally at risk on a slow run. The failing test in PR #893's CI happened to be the first to cross the line.

This matches hypothesis #2 from the issue's fix-options table ("subprocess that should be mocked").

## Fix

Added a single `vi.mock('../../../lib/github.js', …)` block (8 lines including comment) to `next.test.ts`, returning `null` from `fetchIssue`. This is the same pattern already used in `src/__tests__/project-summary.test.ts`. Tests fall through to the existing spec-file / status-title fallbacks — the same path they implicitly took before, since fixtures don't create real GitHub issues.

## Test Plan

- [x] Build passes (`pnpm build`)
- [x] All 30 tests in `next.test.ts` still pass
- [x] All 334 tests across `src/commands/porch/__tests__/` still pass
- [x] File duration drops from ~11s → ~258ms; per-test build-path times drop from 836-2000ms → 2-8ms (even a 100x CI slowdown stays well under 5s)
- [ ] No follow-up "test genuinely slow" issue needed — the fix is a proper mock, not a timeout bump, so there's no real performance bloat being papered over

## Verification across CI runs

After this lands, the test should pass consistently. If the flake recurs, the cause is something other than `fetchIssue` and would need fresh investigation.