### PR TITLE
[PIR #808] vscode: inject issue title into architect reference

### DIFF
--- a/codev/plans/808-vscode-backlog-architect-refer.md
+++ b/codev/plans/808-vscode-backlog-architect-refer.md
@@ -1,0 +1,105 @@
+# PIR Plan: Backlog → Architect reference includes issue title
+
+## Understanding
+
+The "Reference Issue in Architect" inline action on a backlog row injects only `#<id> ` into the architect's prompt buffer. The architect AI (and the user) then lack the working context until they fetch the issue. The issue (#808) asks us to include the title in the injection, formatted as `#<id> "<title>" ` so the user can keep typing and downstream parsing isn't confused by punctuation in the title.
+
+Confirmed locations on this branch:
+
+- `packages/vscode/src/extension.ts:555-566` — `codev.referenceIssueInArchitect` handler. Currently:
+  ```ts
+  const issueId = extractIssueId(arg);
+  if (!issueId) { return; }
+  await vscode.commands.executeCommand('codev.openArchitectTerminal');
+  const ok = terminalManager?.injectArchitectText(`#${issueId} `);
+  ```
+- `packages/vscode/src/extension.ts:63-75` — `extractIssueId(arg)` helper reads from `BacklogTreeItem`.
+- `packages/vscode/src/views/backlog-tree-item.ts:17-25` — `BacklogTreeItem` constructor currently takes `(issueId, issueUrl, label)`. The title is **not** a separate field today — it's baked into the composite `label` (`#${item.id} ${item.title}${author}`) constructed in `backlog.ts:105`.
+- `packages/vscode/src/views/backlog.ts:98-116` — `makeRow` builds the `BacklogTreeItem`. `item.title` (from `OverviewBacklogItem`) is the source of truth.
+- `packages/vscode/src/__tests__/extension-architect-commands.test.ts:77-85` — source-sentinel test that pattern-matches `injectArchitectText(\`#\${issueId} \`)`. This **will need updating** to match the new injection shape, otherwise the unit suite fails.
+
+The issue body proposed adding `extractIssueTitle(arg)` "alongside the existing `extractIssueId(arg)`," noting both should "read from `BacklogTreeItem`'s known fields." The title isn't currently a known field on `BacklogTreeItem` — it's only present in the composite label. So either we (a) parse the title out of the label (brittle — author suffix and `#id` prefix would have to be stripped) or (b) add `issueTitle` as a proper typed field on `BacklogTreeItem` alongside `issueId`/`issueUrl`. Option (b) is the right call: it matches the precedent the class set for `issueId` and `issueUrl`, costs one constructor parameter and one field, and avoids string surgery on a display label that already varies (with/without `@author` suffix).
+
+## Proposed Change
+
+1. **Thread the title as a typed field on `BacklogTreeItem`.**
+   Add `issueTitle: string` to the constructor and store it readonly, alongside `issueId` and `issueUrl`. `makeRow` in `backlog.ts` passes `item.title` (the un-decorated title from `OverviewBacklogItem`, without `#id` prefix or `@author` suffix).
+
+2. **Add `extractIssueTitle(arg)` next to `extractIssueId(arg)` in `extension.ts`.**
+   Same shape as `extractIssueId`: narrow via `instanceof BacklogTreeItem` and return `.issueTitle`. Returns `undefined` if the arg isn't a `BacklogTreeItem` or if the title is empty.
+
+3. **Update the `codev.referenceIssueInArchitect` handler.**
+   Build the injection string conditionally:
+   ```ts
+   const issueId = extractIssueId(arg);
+   if (!issueId) { return; }
+   const title = extractIssueTitle(arg);
+   const escaped = title?.replace(/"/g, '\\"');
+   const injection = escaped ? `#${issueId} "${escaped}" ` : `#${issueId} `;
+   await vscode.commands.executeCommand('codev.openArchitectTerminal');
+   const ok = terminalManager?.injectArchitectText(injection);
+   ```
+   - Empty / missing title → fall back to the current `#<id> ` form (preserves the acceptance criterion "If the title is unexpectedly missing/empty, the fallback `#<id> ` injection is used").
+   - Escape only the double-quote character (`"` → `\"`). Backslashes in titles are left untouched: GitHub issue titles rendering literal `\` are vanishingly rare, and double-escaping `\` would change what the user sees on screen vs what they typed, which is more surprising than leaving a bare `\` in the buffer.
+
+4. **Update the existing source-sentinel test.**
+   `extension-architect-commands.test.ts:84` currently asserts the exact old injection literal. Update it to match the new shape (regex that accepts either the title-present injection or the fallback). Keep the spirit of the assertion — that the call still happens, still no architect-name arg, defaulting to 'main'.
+
+5. **Add new unit tests for the escape + fallback logic.**
+   Pull the injection-building logic into a small pure helper (e.g. `buildArchitectReferenceInjection(issueId: string, title: string | undefined): string`) co-located in `extension.ts` (or extracted to a sibling utility file if `extension.ts` doesn't currently export anything testable). Cover:
+   - Title present → `#<id> "<title>" `
+   - Title contains `"` → escaped to `\"`
+   - Title undefined → `#<id> ` fallback
+   - Title empty string → `#<id> ` fallback (treat empty as missing)
+
+   Decision point captured here: I'd prefer to **extract a small pure helper** so the escape + fallback logic has direct unit coverage instead of relying on regex pattern-matching against `extension.ts` source. The current architect-commands test file is a "source-sentinel" style (pattern-matches the source string) because activating the full extension requires mocking `vscode` — but a pure string helper has no `vscode` dependency and can be unit-tested directly. This adds a small, exported helper but cleanly separates the testable logic from the command registration boilerplate.
+
+## Files to Change
+
+- `packages/vscode/src/views/backlog-tree-item.ts` — add `issueTitle: string` to `BacklogTreeItem` constructor / readonly field.
+- `packages/vscode/src/views/backlog.ts:105` — pass `item.title` as the new constructor arg.
+- `packages/vscode/src/extension.ts` — add `extractIssueTitle` near `extractIssueId` (line ~75); add `buildArchitectReferenceInjection` pure helper (exported for testing); update `codev.referenceIssueInArchitect` handler (lines 555-566) to use the helper.
+- `packages/vscode/src/__tests__/extension-architect-commands.test.ts:77-85` — update the existing sentinel test to match the new injection shape.
+- `packages/vscode/src/__tests__/extension-architect-commands.test.ts` (or a new sibling file) — add direct unit tests for `buildArchitectReferenceInjection`.
+
+No changes outside `packages/vscode/`. No new dependencies. No package.json / contribution-point changes — the command is already registered.
+
+## Risks & Alternatives Considered
+
+- **Risk: titles with shell-special characters or VSCode-terminal escape sequences breaking the buffer.** Mitigation: `injectArchitectText` writes the literal string to the terminal input buffer (not through a shell). The terminal renders the characters; the model only sees them when the user hits Enter. Quoted titles are exactly the same characters the user could type by hand, so this widens nothing. The only escaping we owe is `"` so the quoted form parses as a single quoted span downstream.
+- **Risk: titles containing backslashes.** Decision: don't escape backslashes. Rationale in §3 above. Acceptance criteria specify `"` escaping only.
+- **Risk: regressing the source-sentinel test.** Mitigation: explicit step 4 updates the assertion. Worth flagging because the existing test pattern (regex against source) will silently still pass against the wrong shape if the regex is too loose — keep it tight on the helper-call shape.
+- **Alternative: parse title out of the composite label string** rather than threading a new field. Rejected — brittle and tightly couples `extractIssueTitle` to the exact label format (`#id title @author`), which has varied historically. A typed field is the clearer contract.
+- **Alternative: extend `extractIssueId` to return `{ id, title }` instead of adding a separate function.** Rejected — the issue explicitly asks for `extractIssueTitle` as a sibling, and a `{id, title}` return would force all existing callers (`codev.spawnBuilder`, `codev.viewBacklogIssue`) to destructure even though they don't need the title.
+- **Alternative: inline the build logic, no helper.** Rejected — the escape + fallback is the only part of this change with branching logic worth covering directly. Inlining keeps the source-sentinel test as the only safety net, which is weaker than a direct unit test.
+
+## Test Plan
+
+### Unit
+
+- `buildArchitectReferenceInjection('1234', 'Build feature X')` → `#1234 "Build feature X" ` (trailing space preserved).
+- `buildArchitectReferenceInjection('1234', 'Has "quoted" word')` → `#1234 "Has \"quoted\" word" `.
+- `buildArchitectReferenceInjection('1234', undefined)` → `#1234 ` (fallback).
+- `buildArchitectReferenceInjection('1234', '')` → `#1234 ` (empty treated as missing).
+- Existing source-sentinel test in `extension-architect-commands.test.ts` updated to match the new injection-call shape.
+
+### Manual (at the `dev-approval` gate)
+
+The reviewer will spin up the worktree with `afx dev pir-808` (VSCode dev server) and:
+
+1. Open the Codev sidebar → Backlog view.
+2. Click the "Reference Issue in Architect" inline button on any backlog row.
+3. The architect terminal opens and focuses; the prompt contains `#<id> "<title>" ` with the cursor positioned after the trailing space.
+4. No Enter is sent (matches existing behavior — the change is to the injected text only).
+5. Try a backlog item whose title contains a literal `"` — confirm the buffer shows `\"` for each occurrence.
+6. (Optional, harder to reproduce) If a backlog item with an empty title is available, confirm the fallback `#<id> ` is injected. If not reproducible, the unit test covers this.
+
+### Cross-platform
+
+VSCode extension only — no native code paths. macOS / Windows / Linux behave identically here.
+
+## Out of scope
+
+- Other inject sites (per the issue body — `codev.referenceIssueInArchitect` is the only one with an id+title shape today).
+- A user-facing toggle for the injection format.
+- Changes to `OverviewBacklogItem` or `BacklogProvider.makeRow`'s label rendering (the visible row label stays `#id title @author`; only the injection text changes).

--- a/codev/projects/808-vscode-backlog-architect-refer/status.yaml
+++ b/codev/projects/808-vscode-backlog-architect-refer/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-05-28T01:32:02.420Z'
+    approved_at: '2026-05-28T01:35:42.384Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T01:29:30.057Z'
-updated_at: '2026-05-28T01:32:02.420Z'
+updated_at: '2026-05-28T01:35:42.385Z'

--- a/codev/projects/808-vscode-backlog-architect-refer/status.yaml
+++ b/codev/projects/808-vscode-backlog-architect-refer/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-05-28T01:29:30.057Z'
-updated_at: '2026-05-28T01:44:16.193Z'
+updated_at: '2026-05-28T01:44:23.208Z'
 pr_history:
   - phase: review
     pr_number: 899

--- a/codev/projects/808-vscode-backlog-architect-refer/status.yaml
+++ b/codev/projects/808-vscode-backlog-architect-refer/status.yaml
@@ -1,7 +1,7 @@
 id: '808'
 title: vscode-backlog-architect-refer
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T01:29:30.057Z'
-updated_at: '2026-05-28T01:42:57.951Z'
+updated_at: '2026-05-28T01:43:06.765Z'

--- a/codev/projects/808-vscode-backlog-architect-refer/status.yaml
+++ b/codev/projects/808-vscode-backlog-architect-refer/status.yaml
@@ -1,7 +1,7 @@
 id: '808'
 title: vscode-backlog-architect-refer
 protocol: pir
-phase: review
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -21,7 +21,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T01:29:30.057Z'
-updated_at: '2026-05-28T01:47:44.585Z'
+updated_at: '2026-05-28T01:47:52.249Z'
 pr_history:
   - phase: review
     pr_number: 899

--- a/codev/projects/808-vscode-backlog-architect-refer/status.yaml
+++ b/codev/projects/808-vscode-backlog-architect-refer/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-05-28T01:32:02.420Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T01:29:30.057Z'
-updated_at: '2026-05-28T01:29:30.058Z'
+updated_at: '2026-05-28T01:32:02.420Z'

--- a/codev/projects/808-vscode-backlog-architect-refer/status.yaml
+++ b/codev/projects/808-vscode-backlog-architect-refer/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-05-28T01:41:31.761Z'
     approved_at: '2026-05-28T01:42:57.951Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-05-28T01:46:07.631Z'
+    approved_at: '2026-05-28T01:47:44.584Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T01:29:30.057Z'
-updated_at: '2026-05-28T01:46:07.632Z'
+updated_at: '2026-05-28T01:47:44.585Z'
 pr_history:
   - phase: review
     pr_number: 899
     branch: builder/pir-808
     created_at: '2026-05-28T01:44:16.193Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/808-vscode-backlog-architect-refer/status.yaml
+++ b/codev/projects/808-vscode-backlog-architect-refer/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-05-28T01:42:57.951Z'
   pr:
     status: pending
+    requested_at: '2026-05-28T01:46:07.631Z'
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-05-28T01:29:30.057Z'
-updated_at: '2026-05-28T01:44:23.208Z'
+updated_at: '2026-05-28T01:46:07.632Z'
 pr_history:
   - phase: review
     pr_number: 899
     branch: builder/pir-808
     created_at: '2026-05-28T01:44:16.193Z'
+pr_ready_for_human: true

--- a/codev/projects/808-vscode-backlog-architect-refer/status.yaml
+++ b/codev/projects/808-vscode-backlog-architect-refer/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-05-28T01:35:42.384Z'
   dev-approval:
     status: pending
+    requested_at: '2026-05-28T01:41:31.761Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T01:29:30.057Z'
-updated_at: '2026-05-28T01:35:49.656Z'
+updated_at: '2026-05-28T01:41:31.761Z'

--- a/codev/projects/808-vscode-backlog-architect-refer/status.yaml
+++ b/codev/projects/808-vscode-backlog-architect-refer/status.yaml
@@ -1,0 +1,18 @@
+id: '808'
+title: vscode-backlog-architect-refer
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-28T01:29:30.057Z'
+updated_at: '2026-05-28T01:29:30.058Z'

--- a/codev/projects/808-vscode-backlog-architect-refer/status.yaml
+++ b/codev/projects/808-vscode-backlog-architect-refer/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T01:29:30.057Z'
-updated_at: '2026-05-28T01:43:06.765Z'
+updated_at: '2026-05-28T01:44:16.193Z'
+pr_history:
+  - phase: review
+    pr_number: 899
+    branch: builder/pir-808
+    created_at: '2026-05-28T01:44:16.193Z'

--- a/codev/projects/808-vscode-backlog-architect-refer/status.yaml
+++ b/codev/projects/808-vscode-backlog-architect-refer/status.yaml
@@ -1,7 +1,7 @@
 id: '808'
 title: vscode-backlog-architect-refer
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T01:29:30.057Z'
-updated_at: '2026-05-28T01:35:42.385Z'
+updated_at: '2026-05-28T01:35:49.656Z'

--- a/codev/projects/808-vscode-backlog-architect-refer/status.yaml
+++ b/codev/projects/808-vscode-backlog-architect-refer/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-05-28T01:32:02.420Z'
     approved_at: '2026-05-28T01:35:42.384Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-05-28T01:41:31.761Z'
+    approved_at: '2026-05-28T01:42:57.951Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T01:29:30.057Z'
-updated_at: '2026-05-28T01:41:31.761Z'
+updated_at: '2026-05-28T01:42:57.951Z'

--- a/codev/reviews/808-vscode-backlog-architect-refer.md
+++ b/codev/reviews/808-vscode-backlog-architect-refer.md
@@ -1,0 +1,62 @@
+# PIR Review: Inject issue title into backlog → architect reference
+
+Fixes #808
+
+## Summary
+
+The Backlog inline action **Reference Issue in Architect** previously injected only `#<id> ` into the architect terminal's prompt buffer, forcing the user (and the architect AI) to look up the title before the prompt carried any working context. This PR threads the title through as a typed field on `BacklogTreeItem`, formats the injection as `#<id> "<title>" ` (with `"` → `\"` escaping and a fallback to the old `#<id> ` form for empty/missing titles), and adds direct unit coverage for the formatting helper.
+
+## Files Changed
+
+- `packages/vscode/src/architect-reference-injection.ts` (+21 / -0, new) — pure helper that builds the injection string; no `vscode` deps so it can be unit-tested directly.
+- `packages/vscode/src/__tests__/architect-reference-injection.test.ts` (+47 / -0, new) — 6 tests covering title-present formatting, multi-quote escape, undefined/empty fallback, and backslash passthrough.
+- `packages/vscode/src/extension.ts` (+25 / -1) — `extractIssueTitle(arg)` alongside `extractIssueId(arg)`; `codev.referenceIssueInArchitect` resolves both and passes them to the new helper.
+- `packages/vscode/src/views/backlog-tree-item.ts` (+1 / -0) — `issueTitle: string` added as a readonly typed field on `BacklogTreeItem` next to `issueId` / `issueUrl`.
+- `packages/vscode/src/views/backlog.ts` (+1 / -1) — `makeRow` passes `item.title` (the undecorated title from `OverviewBacklogItem`) into the new `BacklogTreeItem` constructor slot.
+- `packages/vscode/src/__tests__/extension-architect-commands.test.ts` (+5 / -3) — source-sentinel regex updated to assert on the helper call rather than the old inline template literal; the spirit of the assertion (still no architect-name arg → defaults to `'main'`) is preserved.
+- `codev/plans/808-vscode-backlog-architect-refer.md`, `codev/state/pir-808_thread.md` — protocol artifacts.
+
+## Commits
+
+- `5160a438` [PIR #808] Inject issue title into architect reference
+- `f55896c8` [PIR #808] Update thread for implement phase
+- `792b56bb` [PIR #808] Plan draft
+
+(Porch state-transition commits omitted from the human-relevant list — they're visible in `git log` for audit.)
+
+## Test Results
+
+- `pnpm check-types` (vscode): ✓ pass (clean, no errors)
+- `pnpm lint` (vscode): ✓ pass
+- `node esbuild.js` (vscode): ✓ pass
+- `pnpm test:unit` (vscode): ✓ 55 tests pass (49 baseline + 6 new in `architect-reference-injection.test.ts`)
+- Porch gate checks at `implement → dev-approval`: `build` ✓ (5.4s), `tests` ✓ (20.5s)
+- Manual verification: human reviewed the running worktree at the `dev-approval` gate and approved.
+
+## Architecture Updates
+
+No arch changes — the change is local to the VSCode extension's backlog command handler and one tree-item class. No new module boundaries, no new patterns. The "pure helper in its own file so it can be unit-tested without mocking `vscode`" approach (`architect-reference-injection.ts`) is a continuation of the existing precedent set by `prune-builder-terminals.ts`, not a new architectural rule.
+
+## Lessons Learned Updates
+
+No lessons captured — the change was mechanical (thread a field, escape one character, branch on a fallback). The one decision worth noting in the per-PR review (and already in the plan) was extracting the helper into its own file rather than exporting from `extension.ts`, but that's a re-use of an existing pattern, not new wisdom.
+
+## Things to Look At During PR Review
+
+- **Helper-file extraction vs plan.** The plan said `buildArchitectReferenceInjection` would be exported from `extension.ts`. I moved it into `packages/vscode/src/architect-reference-injection.ts` so the unit test can import the live function — `extension.ts` imports `vscode` at top level and won't load under vitest's node env without mocking the whole module. Same precedent as `prune-builder-terminals.ts`. The plan's intent (direct unit coverage of escape + fallback) is preserved.
+- **Backslash policy.** Acceptance criteria specify `"` escaping only; titles with literal `\` pass through unmodified. The rationale is in `architect-reference-injection.ts`'s docstring: double-escaping would diverge from the visible row label (`#id title @author`), surprising the user.
+- **Empty-title normalisation.** `extractIssueTitle` returns `undefined` for an empty string so the fallback branch in the helper is identical to the missing-title path. The helper *also* guards against `''` independently — defense in depth in case a future caller skips the wrapper.
+- **Source-sentinel test loosening.** The pre-existing assertion at `extension-architect-commands.test.ts:84` regex-matched the literal `injectArchitectText(\`#\${issueId} \`)`. The new assertion matches `injectArchitectText(buildArchitectReferenceInjection(...)` — tight enough to catch a regression to the old inline shape, broad enough to not break if the helper's argument order or layout changes. Worth eyeballing.
+
+## How to Test Locally
+
+For reviewers pulling the branch:
+
+- **View diff**: VSCode sidebar → right-click builder `pir-808` → **View Diff**
+- **Run dev server**: VSCode sidebar → right-click → **Run Dev Server**, or CLI `afx dev pir-808`
+- **What to verify**:
+  - Open the Codev sidebar → Backlog view. Click the "Reference Issue in Architect" inline button on any backlog row. The architect terminal opens and focuses; the prompt buffer contains `#<id> "<title>" ` with the cursor after the trailing space, no Enter sent.
+  - Try a backlog item whose title contains a literal `"` (the unit test `'Has "quoted" word'` covers this in code — for a live test, any GitHub issue with quotes in its title works). The buffer should show `\"` for each occurrence.
+  - Confirm the fallback case via the unit tests (an empty-title backlog item is hard to reproduce in the wild).
+
+No new dependencies, no contribution-point changes, no settings.

--- a/codev/state/pir-808_thread.md
+++ b/codev/state/pir-808_thread.md
@@ -11,3 +11,16 @@ Wrote `codev/plans/808-vscode-backlog-architect-refer.md`. Key decisions capture
 Existing sentinel test at `extension-architect-commands.test.ts:77-85` needs updating; current literal regex `injectArchitectText(\`#\${issueId} \`)` will fail against the new injection shape.
 
 Sitting at `plan-approval` gate after commit + push.
+
+## Plan approved → implement (2026-05-28)
+
+Implemented as planned. One mechanical change vs the plan: extracted `buildArchitectReferenceInjection` into its own file `packages/vscode/src/architect-reference-injection.ts` (rather than exporting it from `extension.ts`) so the unit test can import the live function — `extension.ts` imports `vscode` at top level which can't load under vitest's node env without mocking. Same precedent as `prune-builder-terminals.ts`.
+
+Local checks:
+- `pnpm check-types` ✓ (clean — note: needed `pnpm -w build` first to populate workspace package types, then `packages/types pnpm build` for esbuild to resolve `@cluesmith/codev-types`)
+- `pnpm lint` ✓
+- `node esbuild.js` ✓
+- `pnpm test:unit` ✓ 55 tests (was 49, +6 from `architect-reference-injection.test.ts`)
+- `porch done` checks: build ✓ (5.4s), tests ✓ (20.5s)
+
+Sitting at `dev-approval` gate.

--- a/codev/state/pir-808_thread.md
+++ b/codev/state/pir-808_thread.md
@@ -1,0 +1,13 @@
+# pir-808 thread
+
+## Plan phase — initial draft (2026-05-28)
+
+Wrote `codev/plans/808-vscode-backlog-architect-refer.md`. Key decisions captured there:
+
+- Thread `issueTitle` as a typed field on `BacklogTreeItem` (option B). Rejected parsing it out of the composite display label (option A) — too brittle, label format has varied historically.
+- Extract a small pure `buildArchitectReferenceInjection(issueId, title)` helper so the escape + fallback logic gets direct unit coverage instead of relying on the source-sentinel regex pattern in `extension-architect-commands.test.ts`.
+- Escape `"` → `\"` only; leave backslashes untouched (acceptance criteria say `"` escaping only, and double-escaping `\` would change rendered vs typed semantics).
+
+Existing sentinel test at `extension-architect-commands.test.ts:77-85` needs updating; current literal regex `injectArchitectText(\`#\${issueId} \`)` will fail against the new injection shape.
+
+Sitting at `plan-approval` gate after commit + push.

--- a/codev/state/pir-808_thread.md
+++ b/codev/state/pir-808_thread.md
@@ -24,3 +24,14 @@ Local checks:
 - `porch done` checks: build ✓ (5.4s), tests ✓ (20.5s)
 
 Sitting at `dev-approval` gate.
+
+## dev-approval approved → review (2026-05-28)
+
+Wrote `codev/reviews/808-vscode-backlog-architect-refer.md`, opened PR #899, recorded with `porch done --pr 899 --branch builder/pir-808`. Structural checks (`pr_exists`, `review_has_arch_updates`, `review_has_lessons_updates`) all passed.
+
+3-way consultation (single advisory pass, `max_iterations: 1`):
+- gemini: APPROVE / HIGH
+- codex: APPROVE / MEDIUM
+- claude: APPROVE / HIGH (with detailed line-by-line review confirming plan adherence, code quality, and test coverage; no key issues)
+
+No REQUEST_CHANGES to address or rebut. Notified architect via afx send. Sitting at `pr` gate awaiting human merge approval.

--- a/packages/vscode/src/__tests__/architect-reference-injection.test.ts
+++ b/packages/vscode/src/__tests__/architect-reference-injection.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Unit tests for the pure helper that builds the text injected into the
+ * architect terminal by `codev.referenceIssueInArchitect` (issue #808).
+ *
+ * The helper has no `vscode` dependency, so we can import the live
+ * implementation directly (same pattern as `prune-builder-terminals.test.ts`).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildArchitectReferenceInjection } from '../architect-reference-injection.js';
+
+describe('buildArchitectReferenceInjection', () => {
+  it('includes the title in quotes with a trailing space when present', () => {
+    expect(buildArchitectReferenceInjection('1234', 'Build feature X'))
+      .toBe('#1234 "Build feature X" ');
+  });
+
+  it('escapes embedded double-quotes in the title', () => {
+    expect(buildArchitectReferenceInjection('1234', 'Has "quoted" word'))
+      .toBe('#1234 "Has \\"quoted\\" word" ');
+  });
+
+  it('escapes every double-quote, not just the first', () => {
+    expect(buildArchitectReferenceInjection('1234', '"a" "b" "c"'))
+      .toBe('#1234 "\\"a\\" \\"b\\" \\"c\\"" ');
+  });
+
+  it('falls back to `#<id> ` when the title is undefined', () => {
+    expect(buildArchitectReferenceInjection('1234', undefined))
+      .toBe('#1234 ');
+  });
+
+  it('falls back to `#<id> ` when the title is an empty string', () => {
+    // The extractIssueTitle wrapper normalises '' to undefined, but the
+    // helper guards against '' independently so the fallback is correct
+    // even if a future caller skips that normalisation.
+    expect(buildArchitectReferenceInjection('1234', ''))
+      .toBe('#1234 ');
+  });
+
+  it('leaves backslashes in the title untouched', () => {
+    // Acceptance criteria specify `"` escaping only; double-escaping `\`
+    // would diverge from the visible row label.
+    expect(buildArchitectReferenceInjection('1234', 'path\\to\\thing'))
+      .toBe('#1234 "path\\to\\thing" ');
+  });
+});

--- a/packages/vscode/src/__tests__/extension-architect-commands.test.ts
+++ b/packages/vscode/src/__tests__/extension-architect-commands.test.ts
@@ -79,9 +79,15 @@ describe('Spec 786 Phase 6 — extension.ts architect commands', () => {
     // targets main, regardless of how many sibling architects exist. The
     // signature default (`architectName: string = 'main'`) makes the no-arg
     // call route to main.
+    //
+    // Post-#808 the injection text comes from buildArchitectReferenceInjection
+    // (so the call is `injectArchitectText(buildArchitectReferenceInjection(...))`
+    // instead of an inline template literal). The assertion now anchors on the
+    // helper call rather than the literal `#${issueId} ` template — the
+    // architect-name default behaviour is still the point of this test.
     const refBlock = EXT_SRC.split("registerCommand('codev.referenceIssueInArchitect'")[1] ?? '';
     // The injection call passes only the text — no architect name.
-    expect(refBlock).toMatch(/injectArchitectText\(`#\$\{issueId\} `\)/);
+    expect(refBlock).toMatch(/injectArchitectText\(buildArchitectReferenceInjection\(/);
   });
 
   it('workspaceProvider is held in a const so commands can call .refresh()', () => {

--- a/packages/vscode/src/architect-reference-injection.ts
+++ b/packages/vscode/src/architect-reference-injection.ts
@@ -1,0 +1,21 @@
+/**
+ * Pure helper that builds the text injected into the architect terminal
+ * by the `codev.referenceIssueInArchitect` command (issue #808).
+ *
+ * Lives outside `extension.ts` so it can be unit-tested directly without
+ * mocking the `vscode` module — same precedent as `prune-builder-terminals.ts`.
+ *
+ * - Title present → `#<id> "<title>" ` (quoted; trailing space).
+ * - Title missing/empty → `#<id> ` (preserves pre-#808 behaviour as the
+ *   fallback when the source arg isn't a BacklogTreeItem, e.g. the
+ *   row-click path that passes only the id string).
+ * - Embedded `"` in the title is escaped to `\"` so the quoted span stays
+ *   well-formed for any downstream parser. Backslashes are left as-is —
+ *   issue titles with literal `\` are vanishingly rare and double-escaping
+ *   would diverge from the visible row label.
+ */
+export function buildArchitectReferenceInjection(issueId: string, title: string | undefined): string {
+  if (!title) { return `#${issueId} `; }
+  const escaped = title.replace(/"/g, '\\"');
+  return `#${issueId} "${escaped}" `;
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -41,6 +41,7 @@ import { BuilderDiffCache } from './views/builder-diff-cache.js';
 import { BuilderFileDecorationProvider } from './views/builder-file-decoration.js';
 import { BacklogGroupTreeItem, BacklogTreeItem } from './views/backlog-tree-item.js';
 import { persistAreaGroupExpansion } from './views/area-group-expansion.js';
+import { buildArchitectReferenceInjection } from './architect-reference-injection.js';
 
 let connectionManager: ConnectionManager | null = null;
 let terminalManager: TerminalManager | null = null;
@@ -71,6 +72,21 @@ function extractBuilderId(arg: vscode.TreeItem | string | undefined): string | u
 function extractIssueId(arg: vscode.TreeItem | string | undefined): string | undefined {
 	if (typeof arg === 'string') { return arg; }
 	if (arg instanceof BacklogTreeItem) { return arg.issueId; }
+	return undefined;
+}
+
+/**
+ * Resolve an issue title from a command argument.
+ *
+ * Only `BacklogTreeItem` carries the title; string args (used by row-click
+ * which only passes the id) and undefined return undefined so callers can
+ * fall back. An empty title is normalised to undefined so the fallback
+ * branch handles it identically to a missing title.
+ */
+function extractIssueTitle(arg: vscode.TreeItem | string | undefined): string | undefined {
+	if (arg instanceof BacklogTreeItem) {
+		return arg.issueTitle || undefined;
+	}
 	return undefined;
 }
 
@@ -554,12 +570,15 @@ export async function activate(context: vscode.ExtensionContext) {
 			viewBacklogIssue(connectionManager!, extractIssueId(arg))),
 		vscode.commands.registerCommand('codev.referenceIssueInArchitect', async (arg: vscode.TreeItem | string | undefined) => {
 			// Inline-button action on a backlog row: open + focus the architect
-			// terminal, then type `#<id> ` into its prompt without submitting,
-			// so the user can keep typing their context before hitting Enter.
+			// terminal, then type `#<id> "<title>" ` into its prompt without
+			// submitting, so the user can keep typing their context before
+			// hitting Enter. Falls back to `#<id> ` when the title isn't
+			// available (e.g. row-click path that passes only the id string).
 			const issueId = extractIssueId(arg);
 			if (!issueId) { return; }
+			const title = extractIssueTitle(arg);
 			await vscode.commands.executeCommand('codev.openArchitectTerminal');
-			const ok = terminalManager?.injectArchitectText(`#${issueId} `);
+			const ok = terminalManager?.injectArchitectText(buildArchitectReferenceInjection(issueId, title));
 			if (!ok) {
 				vscode.window.showWarningMessage('Codev: Architect terminal not available');
 			}

--- a/packages/vscode/src/views/backlog-tree-item.ts
+++ b/packages/vscode/src/views/backlog-tree-item.ts
@@ -18,6 +18,7 @@ export class BacklogTreeItem extends vscode.TreeItem {
   constructor(
     public readonly issueId: string,
     public readonly issueUrl: string,
+    public readonly issueTitle: string,
     label: string,
   ) {
     super(label);

--- a/packages/vscode/src/views/backlog.ts
+++ b/packages/vscode/src/views/backlog.ts
@@ -102,7 +102,7 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
     const me = data.currentUser?.toLowerCase();
     const assigned = !!me && !!item.assignees?.some(a => a.toLowerCase() === me);
     const author = item.author ? ` @${item.author}` : '';
-    const ti = new BacklogTreeItem(item.id, item.url, `#${item.id} ${item.title}${author}`);
+    const ti = new BacklogTreeItem(item.id, item.url, item.title, `#${item.id} ${item.title}${author}`);
     ti.tooltip = item.url;
     ti.contextValue = 'backlog-item';
     ti.iconPath = new vscode.ThemeIcon(assigned ? 'account' : 'issues');


### PR DESCRIPTION
# PIR Review: Inject issue title into backlog → architect reference

Fixes #808

## Summary

The Backlog inline action **Reference Issue in Architect** previously injected only `#<id> ` into the architect terminal's prompt buffer, forcing the user (and the architect AI) to look up the title before the prompt carried any working context. This PR threads the title through as a typed field on `BacklogTreeItem`, formats the injection as `#<id> "<title>" ` (with `"` → `\"` escaping and a fallback to the old `#<id> ` form for empty/missing titles), and adds direct unit coverage for the formatting helper.

## Files Changed

- `packages/vscode/src/architect-reference-injection.ts` (+21 / -0, new) — pure helper that builds the injection string; no `vscode` deps so it can be unit-tested directly.
- `packages/vscode/src/__tests__/architect-reference-injection.test.ts` (+47 / -0, new) — 6 tests covering title-present formatting, multi-quote escape, undefined/empty fallback, and backslash passthrough.
- `packages/vscode/src/extension.ts` (+25 / -1) — `extractIssueTitle(arg)` alongside `extractIssueId(arg)`; `codev.referenceIssueInArchitect` resolves both and passes them to the new helper.
- `packages/vscode/src/views/backlog-tree-item.ts` (+1 / -0) — `issueTitle: string` added as a readonly typed field on `BacklogTreeItem` next to `issueId` / `issueUrl`.
- `packages/vscode/src/views/backlog.ts` (+1 / -1) — `makeRow` passes `item.title` (the undecorated title from `OverviewBacklogItem`) into the new `BacklogTreeItem` constructor slot.
- `packages/vscode/src/__tests__/extension-architect-commands.test.ts` (+5 / -3) — source-sentinel regex updated to assert on the helper call rather than the old inline template literal; the spirit of the assertion (still no architect-name arg → defaults to `'main'`) is preserved.
- `codev/plans/808-vscode-backlog-architect-refer.md`, `codev/state/pir-808_thread.md` — protocol artifacts.

## Commits

- `5160a438` [PIR #808] Inject issue title into architect reference
- `f55896c8` [PIR #808] Update thread for implement phase
- `792b56bb` [PIR #808] Plan draft

(Porch state-transition commits omitted from the human-relevant list — they're visible in `git log` for audit.)

## Test Results

- `pnpm check-types` (vscode): ✓ pass (clean, no errors)
- `pnpm lint` (vscode): ✓ pass
- `node esbuild.js` (vscode): ✓ pass
- `pnpm test:unit` (vscode): ✓ 55 tests pass (49 baseline + 6 new in `architect-reference-injection.test.ts`)
- Porch gate checks at `implement → dev-approval`: `build` ✓ (5.4s), `tests` ✓ (20.5s)
- Manual verification: human reviewed the running worktree at the `dev-approval` gate and approved.

## Architecture Updates

No arch changes — the change is local to the VSCode extension's backlog command handler and one tree-item class. No new module boundaries, no new patterns. The "pure helper in its own file so it can be unit-tested without mocking `vscode`" approach (`architect-reference-injection.ts`) is a continuation of the existing precedent set by `prune-builder-terminals.ts`, not a new architectural rule.

## Lessons Learned Updates

No lessons captured — the change was mechanical (thread a field, escape one character, branch on a fallback). The one decision worth noting in the per-PR review (and already in the plan) was extracting the helper into its own file rather than exporting from `extension.ts`, but that's a re-use of an existing pattern, not new wisdom.

## Things to Look At During PR Review

- **Helper-file extraction vs plan.** The plan said `buildArchitectReferenceInjection` would be exported from `extension.ts`. I moved it into `packages/vscode/src/architect-reference-injection.ts` so the unit test can import the live function — `extension.ts` imports `vscode` at top level and won't load under vitest's node env without mocking the whole module. Same precedent as `prune-builder-terminals.ts`. The plan's intent (direct unit coverage of escape + fallback) is preserved.
- **Backslash policy.** Acceptance criteria specify `"` escaping only; titles with literal `\` pass through unmodified. The rationale is in `architect-reference-injection.ts`'s docstring: double-escaping would diverge from the visible row label (`#id title @author`), surprising the user.
- **Empty-title normalisation.** `extractIssueTitle` returns `undefined` for an empty string so the fallback branch in the helper is identical to the missing-title path. The helper *also* guards against `''` independently — defense in depth in case a future caller skips the wrapper.
- **Source-sentinel test loosening.** The pre-existing assertion at `extension-architect-commands.test.ts:84` regex-matched the literal `injectArchitectText(\`#\${issueId} \`)`. The new assertion matches `injectArchitectText(buildArchitectReferenceInjection(...)` — tight enough to catch a regression to the old inline shape, broad enough to not break if the helper's argument order or layout changes. Worth eyeballing.

## How to Test Locally

For reviewers pulling the branch:

- **View diff**: VSCode sidebar → right-click builder `pir-808` → **View Diff**
- **Run dev server**: VSCode sidebar → right-click → **Run Dev Server**, or CLI `afx dev pir-808`
- **What to verify**:
  - Open the Codev sidebar → Backlog view. Click the "Reference Issue in Architect" inline button on any backlog row. The architect terminal opens and focuses; the prompt buffer contains `#<id> "<title>" ` with the cursor after the trailing space, no Enter sent.
  - Try a backlog item whose title contains a literal `"` (the unit test `'Has "quoted" word'` covers this in code — for a live test, any GitHub issue with quotes in its title works). The buffer should show `\"` for each occurrence.
  - Confirm the fallback case via the unit tests (an empty-title backlog item is hard to reproduce in the wild).

No new dependencies, no contribution-point changes, no settings.
