### PR TITLE
vscode: Backlog title-count reflects the active view mode

### DIFF
--- a/codev/plans/911-vscode-backlog-tree-title-coun.md
+++ b/codev/plans/911-vscode-backlog-tree-title-coun.md
@@ -1,0 +1,94 @@
+# PIR Plan: Backlog tree title-count reflects active view mode
+
+## Understanding
+
+The Backlog view's title is rendered as `Backlog (<count>)` at `packages/vscode/src/extension.ts:184`, where `<count>` is the total spawnable issue count (`spawnableBacklog(data.backlog).length`). Since #809 added a mine-only / show-all toggle, the tree below the title only renders the **current view mode's** rows — but the title-count still shows the unfiltered total in **both** modes.
+
+Result: a fresh install opens to mine-only mode and shows a title like `Backlog (47)` while only 3 rows are visible — disorienting. The eye icon hints at the mode, but the title-count is the most prominent integer on the view, and right now it disagrees with what's visible.
+
+Two coupled gaps to close:
+1. **The count itself** — it always reads the unfiltered total, ignoring the filter mode.
+2. **The refresh trigger** — `updateListViewTitles()` is wired into the overview-data listener at `extension.ts:243-248`, but flipping `codev.backlogShowAll` doesn't go through that listener. So even if (1) is fixed, the title would still stay stale until the next overview refresh fired.
+
+## Proposed Change
+
+Implement **option 2** from the issue's proposed-fix list (the architect's mild preference): `Backlog (3 of 47)` when mine-only, `Backlog (47)` when show-all. Surfaces both numbers; the "of 47" signals "there are more, click the eye to see them" without needing the user to click the toggle to confirm. Doesn't add a redundant mode label (the eye icon already labels the mode).
+
+Edge case: when mine-only is active but `currentUser` is null (gh unavailable), `filterMine` is a no-op (per #809's safety branch), so visible count == total. In that case, fall back to plain `Backlog (47)` — no point rendering `Backlog (47 of 47)`.
+
+Concretely:
+
+1. **New pure helper** `visibleBacklogCount(data, showAll)` in `packages/vscode/src/views/backlog-filter.ts`. Takes overview data and the show-all flag; returns `{ visible, total }`. Mirrors `orderedSpawnable`'s filter chain (`spawnableBacklog` → conditionally `filterMine`) but only counts. Lives next to `filterMine` (same file, same vscode-free constraints) so it's unit-testable in the vitest harness.
+
+2. **Title formatter** `formatBacklogTitle(visible, total)` — also in `backlog-filter.ts`, also vscode-free. Returns `Backlog` (no data), `Backlog (N)` (visible == total), or `Backlog (V of T)` (visible < total). Pure string function — cheap to test exhaustively.
+
+3. **Wire the helper into `updateListViewTitles()`** at `extension.ts:178-186`. Replace the inline `spawnableBacklog(data.backlog).length` with a call to `visibleBacklogCount` + `formatBacklogTitle`. Read `codev.backlogShowAll` via the existing `readBacklogShowAll` reader (lifted from its current inner-scope position at line 358-359 to module scope or hoisted earlier in `activate`, so `updateListViewTitles` can see it — see Files to Change).
+
+4. **Add `updateListViewTitles()` to the showAll-config-change listener** at `extension.ts:361-367`. Right now that listener calls `backlogProvider.refresh()` to redraw the tree rows; it also needs to call `updateListViewTitles()` so the title-count updates in lockstep.
+
+Why not put the helper in `backlog.ts`? Because `backlog.ts` imports `vscode` (it defines `BacklogProvider` which extends a vscode interface). The whole point of `backlog-filter.ts` is to keep pure helpers vitest-testable without the vscode mock dance. Same precedent as `filterMine`.
+
+## Files to Change
+
+- `packages/vscode/src/views/backlog-filter.ts` — add `visibleBacklogCount(data, showAll)` and `formatBacklogTitle(visible, total)` helpers next to `filterMine`. The `data` parameter is typed as `Pick<OverviewData, 'backlog' | 'currentUser'>` so the helper has the minimum surface area it needs and is easy to test with bare objects.
+- `packages/vscode/src/extension.ts:178-186` — `updateListViewTitles()` reads showAll and calls the new helpers for the backlog row.
+- `packages/vscode/src/extension.ts:353-367` — re-order so `readBacklogShowAll` is declared *before* `updateListViewTitles` is wired (or hoist `readBacklogShowAll` to a top-of-`activate` const, matching how `readFileViewAsTree` is already structured). Add `updateListViewTitles()` to the showAll-config-change listener body.
+- `packages/vscode/src/__tests__/backlog-filter.test.ts` — extend the existing test file with cases for `visibleBacklogCount` and `formatBacklogTitle`:
+  - mine-only + currentUser known: visible reflects filterMine
+  - mine-only + currentUser null: visible == total (the safety fallthrough)
+  - show-all: visible == total
+  - title format: no data → `Backlog`; equal counts → `Backlog (N)`; unequal counts → `Backlog (V of T)`
+  - spawnable-vs-raw: items with `hasBuilder: true` excluded from both `visible` and `total` (mirrors `spawnableBacklog`'s contract)
+  - empty backlog: returns `{ visible: 0, total: 0 }`, title is `Backlog (0)`
+
+No changes to:
+- `backlog.ts` itself — `orderedSpawnable` already computes the visible rows; we just need a parallel pure-count path that doesn't go through the provider class.
+- `BacklogProvider.refresh()` — already fires on showAll-change (#809); the tree redraws in lockstep with the title once `updateListViewTitles()` is also called.
+
+## Risks & Alternatives Considered
+
+- **Risk: drift between the title count and the actual rendered rows.** The title helper and `BacklogProvider.orderedSpawnable` could diverge over time. Mitigation: both call `spawnableBacklog` and `filterMine` (the existing pure helpers) — the shared primitives are the source of truth. Mild duplication of the filter-chain shape (two callers), but no duplicated *logic*. Worth it to keep the title computation independent of instantiating the provider.
+- **Risk: `currentUser` semantics.** `filterMine` is a no-op when `currentUser` is null. The acceptance criterion says "title shows the full count, matching the visible rows" in that case. The proposed `formatBacklogTitle(visible, total)` handles this naturally — when `visible == total`, the format is `Backlog (N)`, no "of" suffix. Verified in the test plan.
+- **Risk: showAll-change listener fires before the views are constructed.** `updateListViewTitles` already guards with `if (backlogView)` so a too-early call is a no-op. Safe.
+- **Alternative: emit a `visibleCount` via `BacklogProvider`'s `onDidChangeTreeData`.** Rejected — would couple the title-update to the provider's internal change emitter and require either a custom event or recomputing the visible count in the provider. The pure-helper approach keeps the title formatter independent of provider lifecycle.
+- **Alternative: title format option 3 (`Backlog · Mine (3)`).** Rejected per the issue's stated mild preference for option 2. Option 3 duplicates info that the eye icon already conveys.
+- **Alternative: title format option 1 (`Backlog (3)` flat).** Rejected because it loses the "you have a filter on, the full set is bigger" affordance that option 2 surfaces. Acceptable but less informative.
+
+## Test Plan
+
+### Unit tests (vitest, `packages/vscode/src/__tests__/backlog-filter.test.ts`)
+
+- `visibleBacklogCount`:
+  - showAll=true → visible == total == spawnable count
+  - showAll=false, currentUser known → visible == filterMine'd spawnable count, total == spawnable count
+  - showAll=false, currentUser null → visible == total (safety fallthrough)
+  - items with `hasBuilder: true` excluded from both counts
+  - empty `data.backlog` → `{ visible: 0, total: 0 }`
+- `formatBacklogTitle`:
+  - `(undefined, undefined)` → `Backlog` (no-data fallback)
+  - `(5, 5)` → `Backlog (5)`
+  - `(3, 47)` → `Backlog (3 of 47)`
+  - `(0, 0)` → `Backlog (0)` (empty is still a known state, not the no-data case)
+  - `(0, 5)` → `Backlog (0 of 5)` (mine-only with nothing assigned to you — title still shows you what's available)
+
+Run: `pnpm --filter @cluesmith/codev test` (vitest unit suite).
+
+### Manual verification at the dev-approval gate
+
+1. Reviewer runs `afx dev pir-911` from the main checkout.
+2. Open Codev sidebar → Backlog view.
+3. **Default mode (mine-only):** verify title reads `Backlog (V of T)` where V matches the row count and T matches the total spawnable backlog. If you have nothing assigned, expect `Backlog (0 of T)` — and the empty-state placeholder row.
+4. **Toggle the eye icon to show-all:** title immediately updates to `Backlog (T)`, row count matches.
+5. **Toggle back to mine-only:** title immediately reverts to `Backlog (V of T)`.
+6. **`currentUser` unavailable case (harder to reproduce):** when no GitHub auth, mine-only falls through to show-all per #809's branch. Title should read `Backlog (T)`, not `Backlog (T of T)`.
+
+### Cross-platform
+
+VSCode extension code — same behavior on macOS / Linux / Windows VSCode hosts. No platform-specific paths.
+
+### No regression
+
+- Builders view title still reads `Builders (N)`.
+- Pull Requests view title still reads `Pull Requests (N)`.
+- Recently Closed view title still reads `Recently Closed (N)`.
+- Empty-state placeholder for mine-only still renders when mine-only + currentUser known + no matches (unchanged from #809).

--- a/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
+++ b/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-05-28T09:10:15.134Z'
   pr:
     status: pending
+    requested_at: '2026-05-28T09:14:32.452Z'
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-05-28T08:16:25.739Z'
-updated_at: '2026-05-28T09:11:44.130Z'
+updated_at: '2026-05-28T09:14:32.453Z'
 pr_history:
   - phase: review
     pr_number: 914
     branch: builder/pir-911
     created_at: '2026-05-28T09:11:36.159Z'
+pr_ready_for_human: true

--- a/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
+++ b/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
@@ -1,0 +1,18 @@
+id: '911'
+title: vscode-backlog-tree-title-coun
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-28T08:16:25.739Z'
+updated_at: '2026-05-28T08:16:25.740Z'

--- a/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
+++ b/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-05-28T08:16:25.739Z'
-updated_at: '2026-05-28T09:11:36.159Z'
+updated_at: '2026-05-28T09:11:44.130Z'
 pr_history:
   - phase: review
     pr_number: 914

--- a/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
+++ b/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-05-28T08:18:39.996Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T08:16:25.739Z'
-updated_at: '2026-05-28T08:16:25.740Z'
+updated_at: '2026-05-28T08:18:39.996Z'

--- a/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
+++ b/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
@@ -1,7 +1,7 @@
 id: '911'
 title: vscode-backlog-tree-title-coun
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T08:16:25.739Z'
-updated_at: '2026-05-28T08:21:30.632Z'
+updated_at: '2026-05-28T08:21:37.545Z'

--- a/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
+++ b/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-05-28T08:27:03.161Z'
     approved_at: '2026-05-28T09:10:15.134Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-05-28T09:14:32.452Z'
+    approved_at: '2026-05-28T09:15:21.222Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T08:16:25.739Z'
-updated_at: '2026-05-28T09:14:32.453Z'
+updated_at: '2026-05-28T09:15:21.224Z'
 pr_history:
   - phase: review
     pr_number: 914
     branch: builder/pir-911
     created_at: '2026-05-28T09:11:36.159Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
+++ b/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-05-28T08:21:30.631Z'
   dev-approval:
     status: pending
+    requested_at: '2026-05-28T08:27:03.161Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T08:16:25.739Z'
-updated_at: '2026-05-28T08:21:37.545Z'
+updated_at: '2026-05-28T08:27:03.162Z'

--- a/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
+++ b/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
@@ -1,7 +1,7 @@
 id: '911'
 title: vscode-backlog-tree-title-coun
 protocol: pir
-phase: review
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -21,7 +21,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T08:16:25.739Z'
-updated_at: '2026-05-28T09:15:21.224Z'
+updated_at: '2026-05-28T09:15:32.050Z'
 pr_history:
   - phase: review
     pr_number: 914

--- a/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
+++ b/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T08:16:25.739Z'
-updated_at: '2026-05-28T09:10:26.532Z'
+updated_at: '2026-05-28T09:11:36.159Z'
+pr_history:
+  - phase: review
+    pr_number: 914
+    branch: builder/pir-911
+    created_at: '2026-05-28T09:11:36.159Z'

--- a/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
+++ b/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-05-28T08:18:39.996Z'
+    approved_at: '2026-05-28T08:21:30.631Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T08:16:25.739Z'
-updated_at: '2026-05-28T08:18:39.996Z'
+updated_at: '2026-05-28T08:21:30.632Z'

--- a/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
+++ b/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-05-28T08:18:39.996Z'
     approved_at: '2026-05-28T08:21:30.631Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-05-28T08:27:03.161Z'
+    approved_at: '2026-05-28T09:10:15.134Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T08:16:25.739Z'
-updated_at: '2026-05-28T08:27:03.162Z'
+updated_at: '2026-05-28T09:10:15.135Z'

--- a/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
+++ b/codev/projects/911-vscode-backlog-tree-title-coun/status.yaml
@@ -1,7 +1,7 @@
 id: '911'
 title: vscode-backlog-tree-title-coun
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T08:16:25.739Z'
-updated_at: '2026-05-28T09:10:15.135Z'
+updated_at: '2026-05-28T09:10:26.532Z'

--- a/codev/reviews/911-vscode-backlog-tree-title-coun.md
+++ b/codev/reviews/911-vscode-backlog-tree-title-coun.md
@@ -1,0 +1,62 @@
+# PIR Review: vscode Backlog title-count reflects the active view mode
+
+Fixes #911
+
+## Summary
+
+The Backlog tree title used to read `Backlog (47)` (the unfiltered spawnable total) even when the view was in mine-only mode showing just 3 rows — the most prominent integer on the view disagreed with what was rendered below. This PR rewrites the title to `Backlog (3 of 47)` in mine-only mode and `Backlog (47)` in show-all mode (option 2 from the issue), and wires the title-update into the `codev.backlogShowAll` config-change listener so it refreshes in lockstep with the tree rather than waiting for the next overview tick.
+
+## Files Changed
+
+- `packages/vscode/src/views/backlog-filter.ts` (+54 / -3) — new `visibleBacklogCount` and `formatBacklogTitle` helpers; `spawnableBacklog` moved in from `backlog.ts` so the vscode-free module owns all three primitives the title and the provider share.
+- `packages/vscode/src/views/backlog.ts` (+5 / -10) — drops the local `spawnableBacklog`; imports + re-exports it from `backlog-filter.ts` so existing call sites keep working.
+- `packages/vscode/src/extension.ts` (+22 / -4) — `updateListViewTitles` now calls `visibleBacklogCount` + `formatBacklogTitle` for the backlog row; `readBacklogShowAll` hoisted above the title helper; showAll-config-change listener also calls `updateListViewTitles()`.
+- `packages/vscode/src/__tests__/backlog-filter.test.ts` (+131 / -1) — coverage for `spawnableBacklog`, `visibleBacklogCount`, `formatBacklogTitle`. Existing `filterMine` coverage preserved.
+- `codev/plans/911-vscode-backlog-tree-title-coun.md` (new, +94) — approved plan.
+- `codev/state/pir-911_thread.md` (new, +25) — builder thread.
+
+## Commits
+
+- `b6e98cf4` [PIR #911] Plan draft
+- `8ee5e308` [PIR #911] Thread: plan phase complete
+- `c614bf76` [PIR #911] Backlog title-count reflects active view mode
+- `9512bbd8` [PIR #911] Thread: implement phase complete
+
+(porch-managed phase-transition / gate commits omitted.)
+
+## Test Results
+
+- `pnpm check-types`: ✓ pass
+- `pnpm lint`: ✓ pass (eslint, zero warnings)
+- `pnpm test:unit`: ✓ pass — 113 tests across 10 files, ~20 new for the title-count path
+- `pnpm package` (esbuild bundle, production): ✓ pass
+- Manual verification at the `dev-approval` gate: ✓ approved by the human
+
+## Architecture Updates
+
+No arch changes needed. This PR works inside the existing Backlog-view module boundary (`backlog.ts` provider + `backlog-filter.ts` pure helpers) — the only structural shift is moving `spawnableBacklog` from `backlog.ts` (vscode-dependent) into `backlog-filter.ts` (vscode-free) so the title helper can reuse it from the vitest harness. That mirrors the precedent `filterMine` established in #809; not a new pattern.
+
+## Lessons Learned Updates
+
+No new durable lessons. The "keep vscode-free helpers in `backlog-filter.ts` so vitest can test them without vscode mocks" pattern is already documented implicitly by `filterMine`'s existence — this PR just continues that pattern. A re-statement in `lessons-learned.md` would be churn, not signal.
+
+One contextual observation worth recording in the PR body (not the lessons file): two coupled bugs were closed at once — the count itself, and the refresh trigger. The count being wrong would have been obvious; the refresh trigger being wrong would have been masked by the periodic overview poll (the title would have updated within 60s of any showAll toggle, so it looked "almost right" most of the time). Worth knowing for future title/badge-counter work: any view title that depends on user-toggleable state needs to be refreshed on the toggle's listener, not just on the data-change listener.
+
+## Things to Look At During PR Review
+
+- **`visibleBacklogCount`'s `currentUser` fallthrough** (`backlog-filter.ts`). When mine-only is active but `currentUser` is null (gh unavailable), `filterMine` is a no-op, so `visible == total`. The title helper short-circuits this to plain `Backlog (T)` rather than `Backlog (T of T)` — matches the safety branch in `BacklogProvider.orderedSpawnable` and the third acceptance criterion in the issue.
+- **Hoisting `readBacklogShowAll`** in `extension.ts`. The reader was previously declared inside the backlog-toggle listener block (around line 358 pre-change). The hoist moves it above `updateListViewTitles` so the title helper can call it on every refresh. The original site (now the listener) uses the hoisted reader.
+- **Title format choice**. Option 2 (`Backlog (V of T)`) was the issue's mild preference. Options 1 and 3 are also acceptable and the helper could be swapped to either with a one-line change in `formatBacklogTitle`. Worth one re-read by the architect at PR review to confirm.
+- **`src/test/backlog.test.ts` left in place**. The vscode-test (Electron) harness still has the old `spawnableBacklog` test file; it imports from `backlog.ts` which re-exports the moved helper, so it still passes. Deleting it would be cleanup but goes beyond the issue's "purely a count/title-string fix" scope.
+
+## How to Test Locally
+
+For reviewers pulling the branch:
+
+- **View diff**: VSCode sidebar → right-click builder pir-911 → **Review Diff** (auto-detects the default branch)
+- **Run dev server**: VSCode sidebar → **Run Dev Server**, or `afx dev pir-911`
+- **What to verify** (mapped from the plan's Test Plan):
+  - Open the Backlog view in mine-only mode (default): title reads `Backlog (V of T)` where V matches the row count and T matches the unfiltered spawnable total. With nothing assigned to you, expect `Backlog (0 of T)` plus the empty-state placeholder from #809.
+  - Toggle the eye icon to show-all: title immediately becomes `Backlog (T)`, row count matches.
+  - Toggle back to mine-only: title immediately reverts to `Backlog (V of T)`. No stale count waiting for the next overview tick.
+  - Other tree titles (`Builders`, `Pull Requests`, `Recently Closed`) still render with their existing `(N)` format — no regression.

--- a/codev/state/pir-911_thread.md
+++ b/codev/state/pir-911_thread.md
@@ -22,4 +22,13 @@ Plan-approval gate granted.
   - Wired `updateListViewTitles()` into the `codev.backlogShowAll` config-change listener so the title updates in lockstep with the tree (closes bug 2 from the plan).
 - Tests: extended `__tests__/backlog-filter.test.ts` with new coverage for `spawnableBacklog`, `visibleBacklogCount`, and `formatBacklogTitle`. Vitest reports 113 passed (10 files), check-types and lint clean, esbuild bundle clean.
 
-Awaiting dev-approval gate.
+Dev-approval gate granted.
+
+## Review phase
+
+PR #914 opened with `codev/reviews/911-vscode-backlog-tree-title-coun.md` as the body. 3-way consultation single pass:
+- Gemini: APPROVE (HIGH)
+- Codex: APPROVE (HIGH)
+- Claude: APPROVE (HIGH)
+
+All three flagged zero issues. The `spawnableBacklog` move from `backlog.ts` into `backlog-filter.ts` was noted by Claude as a necessary deviation from the plan's "no changes to backlog.ts" line — the helper had to migrate to keep the vscode-free guarantee of `backlog-filter.ts`, and `backlog.ts`'s re-export preserves the existing import paths. Awaiting human pr-gate approval.

--- a/codev/state/pir-911_thread.md
+++ b/codev/state/pir-911_thread.md
@@ -10,4 +10,16 @@ Wrote `codev/plans/911-vscode-backlog-tree-title-coun.md`. Picked option 2 (`Bac
 
 Two coupled bugs being closed at once: (1) the count itself was unfiltered; (2) `updateListViewTitles` is wired only to the overview-data listener, so even a correct count would stay stale until the next overview tick when the user flipped showAll. Plan addresses both — the showAll-config-change listener at `extension.ts:361-367` will also call `updateListViewTitles()`.
 
-Awaiting plan-approval gate.
+Plan-approval gate granted.
+
+## Implement phase
+
+- Moved `spawnableBacklog` into `backlog-filter.ts` so the count helper and `BacklogProvider` share the same primitive without dragging `vscode` into the vitest harness. `backlog.ts` re-exports it (and uses it internally) so existing import paths in `extension.ts` and `src/test/backlog.test.ts` keep working.
+- Added `visibleBacklogCount(data, showAll)` and `formatBacklogTitle(visible, total)` to `backlog-filter.ts`.
+- `extension.ts`:
+  - Replaced the inline `spawnableBacklog(data.backlog).length` title computation with `visibleBacklogCount` + `formatBacklogTitle`.
+  - Hoisted `readBacklogShowAll` above `updateListViewTitles` so it can be read on every refresh.
+  - Wired `updateListViewTitles()` into the `codev.backlogShowAll` config-change listener so the title updates in lockstep with the tree (closes bug 2 from the plan).
+- Tests: extended `__tests__/backlog-filter.test.ts` with new coverage for `spawnableBacklog`, `visibleBacklogCount`, and `formatBacklogTitle`. Vitest reports 113 passed (10 files), check-types and lint clean, esbuild bundle clean.
+
+Awaiting dev-approval gate.

--- a/codev/state/pir-911_thread.md
+++ b/codev/state/pir-911_thread.md
@@ -1,0 +1,13 @@
+# PIR #911 — vscode backlog title-count
+
+Issue: vscode Backlog tree title-count should reflect the active view mode, not the total spawnable set. Surfaced as a CMAP-2 nit on #910 / PIR #809.
+
+## Plan phase
+
+Wrote `codev/plans/911-vscode-backlog-tree-title-coun.md`. Picked option 2 (`Backlog (3 of 47)` mine-only / `Backlog (47)` show-all) per the architect's mild preference. Two pure helpers go into `backlog-filter.ts`:
+- `visibleBacklogCount(data, showAll)` — mirrors `BacklogProvider.orderedSpawnable`'s filter chain (`spawnableBacklog` → conditionally `filterMine`) but only counts.
+- `formatBacklogTitle(visible, total)` — returns `Backlog` / `Backlog (N)` / `Backlog (V of T)`.
+
+Two coupled bugs being closed at once: (1) the count itself was unfiltered; (2) `updateListViewTitles` is wired only to the overview-data listener, so even a correct count would stay stale until the next overview tick when the user flipped showAll. Plan addresses both — the showAll-config-change listener at `extension.ts:361-367` will also call `updateListViewTitles()`.
+
+Awaiting plan-approval gate.

--- a/packages/vscode/src/__tests__/backlog-filter.test.ts
+++ b/packages/vscode/src/__tests__/backlog-filter.test.ts
@@ -1,16 +1,35 @@
 /**
- * Unit tests for `filterMine`, the pure helper that powers the
- * Backlog view's mine-only / show-all toggle. Lives in `__tests__/`
- * (vitest harness) rather than `src/test/` (vscode-test Electron
- * harness) because it touches no `vscode` APIs.
+ * Unit tests for the pure helpers that back the Backlog view:
+ * - `filterMine` (mine-only / show-all toggle, from #809)
+ * - `spawnableBacklog` (excludes issues with active builders)
+ * - `visibleBacklogCount` and `formatBacklogTitle` (title-count, from #911)
+ *
+ * Lives in `__tests__/` (vitest harness) rather than `src/test/` (vscode-test
+ * Electron harness) because the helpers touch no `vscode` APIs.
  */
 
 import { describe, it, expect } from 'vitest';
-import type { OverviewBacklogItem } from '@cluesmith/codev-types';
-import { filterMine } from '../views/backlog-filter.js';
+import type { OverviewBacklogItem, OverviewData } from '@cluesmith/codev-types';
+import {
+  filterMine,
+  spawnableBacklog,
+  visibleBacklogCount,
+  formatBacklogTitle,
+} from '../views/backlog-filter.js';
 
 function assignedItem(id: string, assignees: string[]): OverviewBacklogItem {
   return { id, title: `t${id}`, hasBuilder: false, assignees } as unknown as OverviewBacklogItem;
+}
+
+function spawnableItem(id: string, hasBuilder: boolean, assignees: string[] = []): OverviewBacklogItem {
+  return { id, title: `t${id}`, hasBuilder, assignees } as unknown as OverviewBacklogItem;
+}
+
+function dataFrom(
+  backlog: OverviewBacklogItem[],
+  currentUser?: string | null,
+): Pick<OverviewData, 'backlog' | 'currentUser'> {
+  return { backlog, currentUser: currentUser ?? undefined };
 }
 
 describe('filterMine', () => {
@@ -49,5 +68,106 @@ describe('filterMine', () => {
     const noAssignees = { id: 'x', title: 'tx', hasBuilder: false } as unknown as OverviewBacklogItem;
     const out = filterMine([noAssignees, assignedItem('y', ['alice'])], 'alice');
     expect(out.map(i => i.id)).toEqual(['y']);
+  });
+});
+
+describe('spawnableBacklog', () => {
+  it('drops items that already have an active builder', () => {
+    const out = spawnableBacklog([
+      spawnableItem('1', false),
+      spawnableItem('2', true),
+      spawnableItem('3', false),
+    ]);
+    expect(out.map(i => i.id)).toEqual(['1', '3']);
+  });
+
+  it('returns empty for empty input', () => {
+    expect(spawnableBacklog([])).toEqual([]);
+  });
+
+  it('preserves order of the kept items', () => {
+    const out = spawnableBacklog([
+      spawnableItem('a', false),
+      spawnableItem('b', true),
+      spawnableItem('c', false),
+      spawnableItem('d', false),
+    ]);
+    expect(out.map(i => i.id)).toEqual(['a', 'c', 'd']);
+  });
+});
+
+describe('visibleBacklogCount', () => {
+  it('returns full spawnable count for both visible and total when showAll is true', () => {
+    const data = dataFrom([
+      spawnableItem('1', false, ['alice']),
+      spawnableItem('2', false, ['bob']),
+      spawnableItem('3', false, []),
+    ], 'alice');
+    expect(visibleBacklogCount(data, true)).toEqual({ visible: 3, total: 3 });
+  });
+
+  it('filters visible to currentUser-assigned when showAll is false', () => {
+    const data = dataFrom([
+      spawnableItem('1', false, ['alice']),
+      spawnableItem('2', false, ['bob']),
+      spawnableItem('3', false, ['alice', 'carol']),
+    ], 'alice');
+    expect(visibleBacklogCount(data, false)).toEqual({ visible: 2, total: 3 });
+  });
+
+  it('falls through to total when mine-only is on but currentUser is null', () => {
+    const data = dataFrom([
+      spawnableItem('1', false, ['alice']),
+      spawnableItem('2', false, ['bob']),
+    ], null);
+    // filterMine is a no-op here, so visible == total — matches BacklogProvider's safety branch.
+    expect(visibleBacklogCount(data, false)).toEqual({ visible: 2, total: 2 });
+  });
+
+  it('excludes items with active builders from both visible and total', () => {
+    const data = dataFrom([
+      spawnableItem('1', false, ['alice']),
+      spawnableItem('2', true,  ['alice']),  // has a builder — out
+      spawnableItem('3', false, ['bob']),
+      spawnableItem('4', true,  ['bob']),    // has a builder — out
+    ], 'alice');
+    // total = spawnable count (2); visible = spawnable + filterMine = 1.
+    expect(visibleBacklogCount(data, false)).toEqual({ visible: 1, total: 2 });
+    expect(visibleBacklogCount(data, true)).toEqual({ visible: 2, total: 2 });
+  });
+
+  it('returns zeros for empty backlog', () => {
+    const data = dataFrom([], 'alice');
+    expect(visibleBacklogCount(data, false)).toEqual({ visible: 0, total: 0 });
+    expect(visibleBacklogCount(data, true)).toEqual({ visible: 0, total: 0 });
+  });
+
+  it('returns visible: 0, total > 0 when nothing is assigned to the current user', () => {
+    const data = dataFrom([
+      spawnableItem('1', false, ['bob']),
+      spawnableItem('2', false, ['carol']),
+    ], 'alice');
+    expect(visibleBacklogCount(data, false)).toEqual({ visible: 0, total: 2 });
+  });
+});
+
+describe('formatBacklogTitle', () => {
+  it('returns plain "Backlog" when counts are unknown (no data)', () => {
+    expect(formatBacklogTitle(undefined, undefined)).toBe('Backlog');
+  });
+
+  it('returns "Backlog (N)" when visible == total', () => {
+    expect(formatBacklogTitle(5, 5)).toBe('Backlog (5)');
+    expect(formatBacklogTitle(0, 0)).toBe('Backlog (0)');
+  });
+
+  it('returns "Backlog (V of T)" when mine-only is hiding rows', () => {
+    expect(formatBacklogTitle(3, 47)).toBe('Backlog (3 of 47)');
+    expect(formatBacklogTitle(0, 5)).toBe('Backlog (0 of 5)');
+  });
+
+  it('treats partial undefined counts as the no-data case', () => {
+    expect(formatBacklogTitle(undefined, 5)).toBe('Backlog');
+    expect(formatBacklogTitle(5, undefined)).toBe('Backlog');
   });
 });

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -30,7 +30,8 @@ import { isIdleWaiting } from '@cluesmith/codev-core/builder-helpers';
 import { BuildersProvider } from './views/builders.js';
 import { BuilderGroupTreeItem } from './views/builder-tree-item.js';
 import { PullRequestsProvider } from './views/pull-requests.js';
-import { BacklogProvider, spawnableBacklog } from './views/backlog.js';
+import { BacklogProvider } from './views/backlog.js';
+import { visibleBacklogCount, formatBacklogTitle } from './views/backlog-filter.js';
 import { RecentlyClosedProvider } from './views/recently-closed.js';
 import { TeamProvider } from './views/team.js';
 import { StatusProvider } from './views/status.js';
@@ -175,13 +176,24 @@ export async function activate(context: vscode.ExtensionContext) {
 	let pullRequestsView: vscode.TreeView<vscode.TreeItem> | undefined;
 	let backlogView: vscode.TreeView<vscode.TreeItem> | undefined;
 	let recentlyClosedView: vscode.TreeView<vscode.TreeItem> | undefined;
+	const readBacklogShowAll = () =>
+		vscode.workspace.getConfiguration('codev').get<boolean>('backlogShowAll', false);
 	const updateListViewTitles = () => {
 		const data = overviewCache.getData();
 		const withCount = (base: string, n: number | undefined) =>
 			typeof n === 'number' ? `${base} (${n})` : base;
 		if (buildersView) { buildersView.title = withCount('Builders', data?.builders.length); }
 		if (pullRequestsView) { pullRequestsView.title = withCount('Pull Requests', data?.pendingPRs.length); }
-		if (backlogView) { backlogView.title = withCount('Backlog', data ? spawnableBacklog(data.backlog).length : undefined); }
+		if (backlogView) {
+			// Backlog title reflects the *visible* row count (mine-only vs show-all),
+			// not the unfiltered spawnable total. `formatBacklogTitle` renders
+			// `Backlog (V of T)` when the mine-only filter is hiding rows, so the
+			// "of T" affordance signals "click the eye icon to see all".
+			const { visible, total } = data
+				? visibleBacklogCount(data, readBacklogShowAll())
+				: { visible: undefined, total: undefined };
+			backlogView.title = formatBacklogTitle(visible, total);
+		}
 		if (recentlyClosedView) { recentlyClosedView.title = withCount('Recently Closed', data?.recentlyClosed.length); }
 	};
 
@@ -354,15 +366,19 @@ export async function activate(context: vscode.ExtensionContext) {
 	// so a fresh install opens to "what's on my plate". Same mechanics as
 	// the two toggles above: read setting, mirror to context key so the
 	// paired view-title commands swap correctly, refresh the provider on
-	// change so the filter takes effect immediately.
-	const readBacklogShowAll = () =>
-		vscode.workspace.getConfiguration('codev').get<boolean>('backlogShowAll', false);
+	// change so the filter takes effect immediately. `readBacklogShowAll`
+	// is hoisted above `updateListViewTitles` so the title-count helper
+	// can read it on every refresh.
 	vscode.commands.executeCommand('setContext', 'codev.backlogShowAll', readBacklogShowAll());
 	context.subscriptions.push(
 		vscode.workspace.onDidChangeConfiguration((e) => {
 			if (!e.affectsConfiguration('codev.backlogShowAll')) { return; }
 			vscode.commands.executeCommand('setContext', 'codev.backlogShowAll', readBacklogShowAll());
 			backlogProvider.refresh();
+			// Title-count depends on the showAll flag too — refresh it in lockstep
+			// with the tree, otherwise the title stays stale until the next overview
+			// tick rebroadcasts.
+			updateListViewTitles();
 		}),
 	);
 

--- a/packages/vscode/src/views/backlog-filter.ts
+++ b/packages/vscode/src/views/backlog-filter.ts
@@ -1,4 +1,18 @@
-import type { OverviewBacklogItem } from '@cluesmith/codev-types';
+import type { OverviewBacklogItem, OverviewData } from '@cluesmith/codev-types';
+
+/**
+ * Backlog rows the user can act on — exclude issues that already have an
+ * active builder. Mirrors the dashboard's BacklogList
+ * (`items.filter(i => !i.hasBuilder)`) so the extension and web show the
+ * same "available work" set and you can't double-spawn from the Backlog.
+ *
+ * Lives in this file (vscode-free) so both `BacklogProvider` and the
+ * title-count helper can share the same primitive without dragging the
+ * vscode module into the vitest harness.
+ */
+export function spawnableBacklog(items: OverviewBacklogItem[]): OverviewBacklogItem[] {
+  return items.filter(i => !i.hasBuilder);
+}
 
 /**
  * Filter a backlog list to items assigned to `currentUser`. If
@@ -18,4 +32,42 @@ export function filterMine(
   const me = currentUser?.toLowerCase();
   if (!me) { return items; }
   return items.filter(item => !!item.assignees?.some(a => a.toLowerCase() === me));
+}
+
+/**
+ * Compute the visible-vs-total counts the Backlog view's title should
+ * display. Mirrors `BacklogProvider.orderedSpawnable`'s filter chain
+ * (`spawnableBacklog` → conditionally `filterMine`) but only counts —
+ * cheap to recompute on every title refresh and independent of the
+ * provider's lifecycle.
+ *
+ * `total` is the full spawnable count (mode-independent). `visible` is
+ * what the tree actually renders given `showAll` and `data.currentUser`.
+ * When mine-only is active but `currentUser` is unavailable, `filterMine`
+ * is a no-op so `visible == total` — matching the safety branch in
+ * `orderedSpawnable`.
+ */
+export function visibleBacklogCount(
+  data: Pick<OverviewData, 'backlog' | 'currentUser'>,
+  showAll: boolean,
+): { visible: number; total: number } {
+  const spawnable = spawnableBacklog(data.backlog);
+  const visible = showAll ? spawnable : filterMine(spawnable, data.currentUser);
+  return { visible: visible.length, total: spawnable.length };
+}
+
+/**
+ * Format the Backlog view's title. Renders `Backlog` when counts are
+ * unknown (disconnected / loading — falls back to the plain base name,
+ * no misleading "(0)"), `Backlog (N)` when the visible set is the full
+ * set, and `Backlog (V of T)` when the user has the mine-only filter on
+ * and there's more available behind the toggle.
+ */
+export function formatBacklogTitle(
+  visible: number | undefined,
+  total: number | undefined,
+): string {
+  if (typeof visible !== 'number' || typeof total !== 'number') { return 'Backlog'; }
+  if (visible === total) { return `Backlog (${total})`; }
+  return `Backlog (${visible} of ${total})`;
 }

--- a/packages/vscode/src/views/backlog.ts
+++ b/packages/vscode/src/views/backlog.ts
@@ -5,17 +5,12 @@ import { groupByArea } from '@cluesmith/codev-core/area-grouping';
 import type { OverviewCache } from './overview-data.js';
 import { BacklogGroupTreeItem, BacklogTreeItem } from './backlog-tree-item.js';
 import { AreaGroupExpansionStore } from './area-group-expansion.js';
-import { filterMine } from './backlog-filter.js';
+import { filterMine, spawnableBacklog } from './backlog-filter.js';
 
-/**
- * Backlog rows the user can act on — exclude issues that already have an
- * active builder. Mirrors the dashboard's BacklogList
- * (`items.filter(i => !i.hasBuilder)`) so the extension and web show the
- * same "available work" set and you can't double-spawn from the Backlog.
- */
-export function spawnableBacklog(items: OverviewBacklogItem[]): OverviewBacklogItem[] {
-  return items.filter(i => !i.hasBuilder);
-}
+// Re-export so existing call sites (extension.ts, src/test/backlog.test.ts)
+// keep their import path. The definition lives in `backlog-filter.ts` so
+// vitest helpers can share the primitive without pulling in `vscode`.
+export { spawnableBacklog };
 
 /**
  * Backlog view: open GitHub issues with no PR yet, grouped by `area/*`


### PR DESCRIPTION
# PIR Review: vscode Backlog title-count reflects the active view mode

Fixes #911

## Summary

The Backlog tree title used to read `Backlog (47)` (the unfiltered spawnable total) even when the view was in mine-only mode showing just 3 rows — the most prominent integer on the view disagreed with what was rendered below. This PR rewrites the title to `Backlog (3 of 47)` in mine-only mode and `Backlog (47)` in show-all mode (option 2 from the issue), and wires the title-update into the `codev.backlogShowAll` config-change listener so it refreshes in lockstep with the tree rather than waiting for the next overview tick.

## Files Changed

- `packages/vscode/src/views/backlog-filter.ts` (+54 / -3) — new `visibleBacklogCount` and `formatBacklogTitle` helpers; `spawnableBacklog` moved in from `backlog.ts` so the vscode-free module owns all three primitives the title and the provider share.
- `packages/vscode/src/views/backlog.ts` (+5 / -10) — drops the local `spawnableBacklog`; imports + re-exports it from `backlog-filter.ts` so existing call sites keep working.
- `packages/vscode/src/extension.ts` (+22 / -4) — `updateListViewTitles` now calls `visibleBacklogCount` + `formatBacklogTitle` for the backlog row; `readBacklogShowAll` hoisted above the title helper; showAll-config-change listener also calls `updateListViewTitles()`.
- `packages/vscode/src/__tests__/backlog-filter.test.ts` (+131 / -1) — coverage for `spawnableBacklog`, `visibleBacklogCount`, `formatBacklogTitle`. Existing `filterMine` coverage preserved.
- `codev/plans/911-vscode-backlog-tree-title-coun.md` (new, +94) — approved plan.
- `codev/state/pir-911_thread.md` (new, +25) — builder thread.

## Commits

- `b6e98cf4` [PIR #911] Plan draft
- `8ee5e308` [PIR #911] Thread: plan phase complete
- `c614bf76` [PIR #911] Backlog title-count reflects active view mode
- `9512bbd8` [PIR #911] Thread: implement phase complete

(porch-managed phase-transition / gate commits omitted.)

## Test Results

- `pnpm check-types`: ✓ pass
- `pnpm lint`: ✓ pass (eslint, zero warnings)
- `pnpm test:unit`: ✓ pass — 113 tests across 10 files, ~20 new for the title-count path
- `pnpm package` (esbuild bundle, production): ✓ pass
- Manual verification at the `dev-approval` gate: ✓ approved by the human

## Architecture Updates

No arch changes needed. This PR works inside the existing Backlog-view module boundary (`backlog.ts` provider + `backlog-filter.ts` pure helpers) — the only structural shift is moving `spawnableBacklog` from `backlog.ts` (vscode-dependent) into `backlog-filter.ts` (vscode-free) so the title helper can reuse it from the vitest harness. That mirrors the precedent `filterMine` established in #809; not a new pattern.

## Lessons Learned Updates

No new durable lessons. The "keep vscode-free helpers in `backlog-filter.ts` so vitest can test them without vscode mocks" pattern is already documented implicitly by `filterMine`'s existence — this PR just continues that pattern. A re-statement in `lessons-learned.md` would be churn, not signal.

One contextual observation worth recording in the PR body (not the lessons file): two coupled bugs were closed at once — the count itself, and the refresh trigger. The count being wrong would have been obvious; the refresh trigger being wrong would have been masked by the periodic overview poll (the title would have updated within 60s of any showAll toggle, so it looked "almost right" most of the time). Worth knowing for future title/badge-counter work: any view title that depends on user-toggleable state needs to be refreshed on the toggle's listener, not just on the data-change listener.

## Things to Look At During PR Review

- **`visibleBacklogCount`'s `currentUser` fallthrough** (`backlog-filter.ts`). When mine-only is active but `currentUser` is null (gh unavailable), `filterMine` is a no-op, so `visible == total`. The title helper short-circuits this to plain `Backlog (T)` rather than `Backlog (T of T)` — matches the safety branch in `BacklogProvider.orderedSpawnable` and the third acceptance criterion in the issue.
- **Hoisting `readBacklogShowAll`** in `extension.ts`. The reader was previously declared inside the backlog-toggle listener block (around line 358 pre-change). The hoist moves it above `updateListViewTitles` so the title helper can call it on every refresh. The original site (now the listener) uses the hoisted reader.
- **Title format choice**. Option 2 (`Backlog (V of T)`) was the issue's mild preference. Options 1 and 3 are also acceptable and the helper could be swapped to either with a one-line change in `formatBacklogTitle`. Worth one re-read by the architect at PR review to confirm.
- **`src/test/backlog.test.ts` left in place**. The vscode-test (Electron) harness still has the old `spawnableBacklog` test file; it imports from `backlog.ts` which re-exports the moved helper, so it still passes. Deleting it would be cleanup but goes beyond the issue's "purely a count/title-string fix" scope.

## How to Test Locally

For reviewers pulling the branch:

- **View diff**: VSCode sidebar → right-click builder pir-911 → **Review Diff** (auto-detects the default branch)
- **Run dev server**: VSCode sidebar → **Run Dev Server**, or `afx dev pir-911`
- **What to verify** (mapped from the plan's Test Plan):
  - Open the Backlog view in mine-only mode (default): title reads `Backlog (V of T)` where V matches the row count and T matches the unfiltered spawnable total. With nothing assigned to you, expect `Backlog (0 of T)` plus the empty-state placeholder from #809.
  - Toggle the eye icon to show-all: title immediately becomes `Backlog (T)`, row count matches.
  - Toggle back to mine-only: title immediately reverts to `Backlog (V of T)`. No stale count waiting for the next overview tick.
  - Other tree titles (`Builders`, `Pull Requests`, `Recently Closed`) still render with their existing `(N)` format — no regression.
