### PR TITLE
[Bugfix #828] Scope work-view test locators to section headings

### DIFF
--- a/codev/projects/bugfix-828-test-dashboard-e2e-strict-mode/status.yaml
+++ b/codev/projects/bugfix-828-test-dashboard-e2e-strict-mode/status.yaml
@@ -7,13 +7,15 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-05-28T10:40:10.269Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T10:30:53.869Z'
-updated_at: '2026-05-28T10:39:55.081Z'
+updated_at: '2026-05-28T10:40:10.270Z'
 pr_history:
   - phase: pr
     pr_number: 917
     branch: builder/bugfix-828
     created_at: '2026-05-28T10:39:55.080Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-828-test-dashboard-e2e-strict-mode/status.yaml
+++ b/codev/projects/bugfix-828-test-dashboard-e2e-strict-mode/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-828
 title: test-dashboard-e2e-strict-mode
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T10:30:53.869Z'
-updated_at: '2026-05-28T10:37:30.379Z'
+updated_at: '2026-05-28T10:39:40.865Z'

--- a/codev/projects/bugfix-828-test-dashboard-e2e-strict-mode/status.yaml
+++ b/codev/projects/bugfix-828-test-dashboard-e2e-strict-mode/status.yaml
@@ -6,16 +6,17 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-05-28T10:40:10.269Z'
+    approved_at: '2026-05-28T10:40:57.591Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T10:30:53.869Z'
-updated_at: '2026-05-28T10:40:10.270Z'
+updated_at: '2026-05-28T10:40:57.592Z'
 pr_history:
   - phase: pr
     pr_number: 917
     branch: builder/bugfix-828
     created_at: '2026-05-28T10:39:55.080Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/bugfix-828-test-dashboard-e2e-strict-mode/status.yaml
+++ b/codev/projects/bugfix-828-test-dashboard-e2e-strict-mode/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-828
+title: test-dashboard-e2e-strict-mode
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-28T10:30:53.869Z'
+updated_at: '2026-05-28T10:30:53.870Z'

--- a/codev/projects/bugfix-828-test-dashboard-e2e-strict-mode/status.yaml
+++ b/codev/projects/bugfix-828-test-dashboard-e2e-strict-mode/status.yaml
@@ -11,4 +11,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T10:30:53.869Z'
-updated_at: '2026-05-28T10:39:40.865Z'
+updated_at: '2026-05-28T10:39:55.081Z'
+pr_history:
+  - phase: pr
+    pr_number: 917
+    branch: builder/bugfix-828
+    created_at: '2026-05-28T10:39:55.080Z'

--- a/codev/projects/bugfix-828-test-dashboard-e2e-strict-mode/status.yaml
+++ b/codev/projects/bugfix-828-test-dashboard-e2e-strict-mode/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-828
 title: test-dashboard-e2e-strict-mode
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-28T10:30:53.869Z'
-updated_at: '2026-05-28T10:30:53.870Z'
+updated_at: '2026-05-28T10:37:30.379Z'

--- a/codev/state/bugfix-828_thread.md
+++ b/codev/state/bugfix-828_thread.md
@@ -1,0 +1,32 @@
+# bugfix-828 — strict-mode locator collision
+
+## Investigate
+
+Issue #828: scheduled Dashboard E2E failed because `.work-section:has-text("Recently Closed")` matched **two** sections — the actual Recently Closed section *and* the Backlog section, which renders issue #813 ("vscode: migrate Recently Closed view from sidebar to Codev panel tab") as a row whose title contains the substring "Recently Closed".
+
+`:has-text()` does substring-match across the whole subtree, so any backlog item whose title contains a section heading literal poisons the selector.
+
+Four occurrences of the loose pattern, all in `packages/codev/src/agent-farm/__tests__/e2e/work-view-backlog.test.ts`:
+
+- L77 `Backlog`
+- L116 `Backlog`
+- L152 `Recently Closed`
+- L173 `Recently Closed`
+
+`Backlog` is also vulnerable — any future issue whose title contains "Backlog" would break L77/L116 the same way.
+
+`grep -rn ':has-text' packages/codev/src/agent-farm/__tests__/e2e/` shows no other `.work-section:has-text` matches — the rest of the `:has-text` usage is on tab buttons and `.instance a`, which aren't vulnerable to the same collision.
+
+## Plan
+
+Replace all four with the heading-scoped form:
+
+```ts
+page.locator('.work-section:has(h3.work-section-title:text-is("Backlog"))')
+```
+
+`:text-is()` matches the exact text content of the heading, not a substring of the section subtree.
+
+## Implement
+
+(in progress)

--- a/codev/state/bugfix-828_thread.md
+++ b/codev/state/bugfix-828_thread.md
@@ -29,4 +29,21 @@ page.locator('.work-section:has(h3.work-section-title:text-is("Backlog"))')
 
 ## Implement
 
-(in progress)
+All four `.work-section:has-text(...)` occurrences in `work-view-backlog.test.ts` replaced with `.work-section:has(h3.work-section-title:text-is("..."))`. Single short comment on the first occurrence explains the workaround (referencing #828). Diff: +60 / -5, test-only.
+
+`porch check` build/tests both pass (after one-time core build to materialize `@cluesmith/codev-core` declaration files in the worktree).
+
+## Review
+
+CMAP-3 all APPROVE:
+- Gemini — APPROVE / HIGH
+- Codex — APPROVE / MEDIUM
+- Claude — APPROVE / HIGH
+
+No KEY_ISSUES from any reviewer. Claude noted `.tab-bar-item:has-text("Work")` uses the same `:has-text` pattern but is safe (button with fixed link text, no dynamic descendants) — verified during sweep.
+
+PR #917 created with CMAP table in body. Architect notified.
+
+## Awaiting
+
+`pr` gate approval from human.

--- a/packages/codev/src/agent-farm/__tests__/e2e/work-view-backlog.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/work-view-backlog.test.ts
@@ -73,8 +73,11 @@ test.describe('Work view: backlog clickability and artifacts', () => {
       await workTab.click();
     }
 
-    // Wait for backlog section to appear
-    const backlogSection = page.locator('.work-section:has-text("Backlog")');
+    // Scope to the heading element — `:has-text` would collide with any backlog
+    // item whose title contains the section name (see #828).
+    const backlogSection = page.locator(
+      '.work-section:has(h3.work-section-title:text-is("Backlog"))',
+    );
     await expect(backlogSection).toBeVisible({ timeout: 15_000 });
 
     // Check if there are backlog rows
@@ -113,7 +116,9 @@ test.describe('Work view: backlog clickability and artifacts', () => {
       await workTab.click();
     }
 
-    const backlogSection = page.locator('.work-section:has-text("Backlog")');
+    const backlogSection = page.locator(
+      '.work-section:has(h3.work-section-title:text-is("Backlog"))',
+    );
     await expect(backlogSection).toBeVisible({ timeout: 15_000 });
 
     // Check for artifact link buttons (they appear when items have specs/plans/reviews)
@@ -149,7 +154,9 @@ test.describe('Work view: backlog clickability and artifacts', () => {
 
     if (data.recentlyClosed && data.recentlyClosed.length > 0) {
       // Recently Closed section should be visible
-      const closedSection = page.locator('.work-section:has-text("Recently Closed")');
+      const closedSection = page.locator(
+        '.work-section:has(h3.work-section-title:text-is("Recently Closed"))',
+      );
       await expect(closedSection).toBeVisible({ timeout: 5_000 });
 
       // Items should be clickable links
@@ -170,7 +177,9 @@ test.describe('Work view: backlog clickability and artifacts', () => {
     }
     // If no recently closed items, the section should not be visible
     else {
-      const closedSection = page.locator('.work-section:has-text("Recently Closed")');
+      const closedSection = page.locator(
+        '.work-section:has(h3.work-section-title:text-is("Recently Closed"))',
+      );
       await expect(closedSection).not.toBeVisible();
     }
   });


### PR DESCRIPTION
## Summary
Fixes #828

The scheduled Dashboard E2E workflow on `main` was failing with a Playwright strict-mode violation: `locator('.work-section:has-text("Recently Closed")')` resolved to two elements — the actual *Recently Closed* section and the *Backlog* section, because issue #813's title contains the literal substring "Recently Closed" and `:has-text(...)` matches anywhere in the subtree.

## Root cause
`:has-text("Foo")` on `.work-section` matches the section heading **and** any backlog row whose issue title contains "Foo". The test was implicitly coupled to GitHub issue-title content — it passed only while no open backlog issue contained the section-name substring.

## Fix
Scope the locator to the section's heading element via `:has(h3.work-section-title:text-is("..."))`. `:text-is()` matches the heading's *exact* text, so the match is anchored to the heading and immune to issue-title content.

Hardened all four occurrences in `packages/codev/src/agent-farm/__tests__/e2e/work-view-backlog.test.ts`:
- L77, L116 — `"Backlog"` (also vulnerable: any issue titled with "Backlog" would have broken these)
- L152, L173 — `"Recently Closed"` (the symptom from #828)

Swept the rest of the e2e suite for `.work-section:has-text(...)` — no other occurrences. Other `:has-text` uses (tab buttons, `.instance a:has-text("Open")`) target elements whose content is fixed link text, not nested issue rows, so they are not vulnerable to the same collision.

## Test plan
- [ ] Scheduled Dashboard E2E workflow on `main` is green for two consecutive runs (per acceptance criteria — to be observed post-merge)
- [x] Diff is test-only; no product code changes
- [x] No other dashboard e2e tests use the loose `.work-section:has-text(...)` pattern

## CMAP Review

| Model  | Verdict   | Confidence | Notes |
|--------|-----------|------------|-------|
| Gemini | APPROVE   | HIGH       | Clean and highly focused test fix replacing fragile subtree text-matching with exact heading locators. |
| Codex  | APPROVE   | MEDIUM     | Narrowly scoped; targets the actual strict-mode collision; updated locators match the real dashboard structure. |
| Claude | APPROVE   | HIGH       | Clean, focused test-only fix that correctly scopes Playwright locators to heading elements. |

No KEY_ISSUES from any reviewer. Claude noted `.tab-bar-item:has-text("Work")` uses the same pattern but is safe (targets a button with fixed link text, not a container with dynamic descendants) — confirmed during the sweep.