### PR TITLE
Add team bio for Mohid Makhdoomi

### DIFF
--- a/codev/team/people/mohidmakhdoomi.md
+++ b/codev/team/people/mohidmakhdoomi.md
@@ -1,0 +1,19 @@
+---
+name: Mohid Makhdoomi
+github: mohidmakhdoomi
+role: Developer — Porch & Skeleton
+---
+
+Mohid contributes to Codev's correctness and hygiene, with a focus on the **porch** protocol orchestrator and the project **skeleton**. His work tends toward small, well-scoped, high-leverage fixes that harden the framework's reliability rather than expand its surface area — including catching and reverting an out-of-scope change mid-review when it strayed past the issue.
+
+## Contributions
+
+- **[#904](https://github.com/cluesmith/codev/pull/904) — `porch done` idempotency** (porch state machine): made `porch done` a no-op when a project is already in its terminal state, eliminating redundant `status.yaml` writes and spurious "protocol complete" commits. Closed an edge in the phase-advance path that fell through to re-stamping the terminal phase.
+- **[#923](https://github.com/cluesmith/codev/pull/923) — Skeleton YAML hygiene** (`codev-skeleton`): fixed an unquoted YAML `description:` scalar in the `update-arch-docs` skill whose bare `: ` broke strict YAML loaders; quoted it so it parses cleanly and stays robust against future edits. Scoped deliberately to the skeleton copy.
+- **[#741](https://github.com/cluesmith/codev/pull/741) — Docs fix** (`tips.md`): corrected the guidance for restarting Tower.
+
+## Focus areas
+
+- Porch correctness — state-machine edge cases, idempotency
+- Skeleton & skill-definition hygiene — YAML / frontmatter robustness
+- Documentation accuracy

--- a/codev/team/people/mohidmakhdoomi.md
+++ b/codev/team/people/mohidmakhdoomi.md
@@ -4,16 +4,4 @@ github: mohidmakhdoomi
 role: Developer — Porch & Skeleton
 ---
 
-Mohid contributes to Codev's correctness and hygiene, with a focus on the **porch** protocol orchestrator and the project **skeleton**. His work tends toward small, well-scoped, high-leverage fixes that harden the framework's reliability rather than expand its surface area — including catching and reverting an out-of-scope change mid-review when it strayed past the issue.
-
-## Contributions
-
-- **[#904](https://github.com/cluesmith/codev/pull/904) — `porch done` idempotency** (porch state machine): made `porch done` a no-op when a project is already in its terminal state, eliminating redundant `status.yaml` writes and spurious "protocol complete" commits. Closed an edge in the phase-advance path that fell through to re-stamping the terminal phase.
-- **[#923](https://github.com/cluesmith/codev/pull/923) — Skeleton YAML hygiene** (`codev-skeleton`): fixed an unquoted YAML `description:` scalar in the `update-arch-docs` skill whose bare `: ` broke strict YAML loaders; quoted it so it parses cleanly and stays robust against future edits. Scoped deliberately to the skeleton copy.
-- **[#741](https://github.com/cluesmith/codev/pull/741) — Docs fix** (`tips.md`): corrected the guidance for restarting Tower.
-
-## Focus areas
-
-- Porch correctness — state-machine edge cases, idempotency
-- Skeleton & skill-definition hygiene — YAML / frontmatter robustness
-- Documentation accuracy
+Mohid contributes to Codev's correctness and hygiene, with a focus on the porch protocol orchestrator and the project skeleton. His work tends toward small, well-scoped, high-leverage fixes that harden the framework's reliability.


### PR DESCRIPTION
Drafts a team bio for @mohidmakhdoomi in `codev/team/people/`, based on contributions to date.

**@mohidmakhdoomi — please review and edit freely.** This is a draft written on your behalf; correct anything that misrepresents you (role label, focus areas, tone, or how the work is described). It's your bio — final wording is yours.

Covers:
- #904 — `porch done` idempotency (porch state machine)
- #923 — skeleton YAML hygiene (`update-arch-docs` SKILL.md)
- #741 — docs fix (Tower restart tip)

Role set to "Developer — Porch & Skeleton" — adjust if you'd prefer something else.
