### PR TITLE
[Spec 927] Needs Attention: surface PRs via the universal pr gate; delete gateless builder-derived fallbacks

### DIFF
--- a/codev/plans/927-needs-attention-surface-prs-vi.md
+++ b/codev/plans/927-needs-attention-surface-prs-vi.md
@@ -43,14 +43,18 @@ Sequenced into **three phases** so every commit type-checks and tests green in b
 
 #### Objectives
 - Make the overview server emit a **gate-authoritative**, `requested_at`-aware `prReady` signal and surface `verify-approval` as a blocked gate — the shared-infrastructure change that all consumers (dashboard **and** VSCode) read.
+- **Own the VSCode blast-radius validation here** (not as a downstream note): this phase concretely covers the VSCode consumers of the changed shared infra, with their own acceptance criteria and tests. See *Cross-Cutting: VSCode blast radius* for the consumer map and the Amr coordination flag.
 
 #### Files to modify
 - `packages/codev/src/agent-farm/servers/overview.ts`
   - **`derivePrReady`**: reduce to gate-authoritative — return `parsed.gates['pr'] === 'pending' && !!parsed.gateRequestedAt['pr']`. Delete the `bugfix && phase === 'verified'` branch **and** the `pr_ready_for_human` field dependency (`if (parsed.prReadyForHuman !== null) return …`). Update the doc comment to state the universal-`pr`-gate contract and the `requested_at` invariant.
+  - **`OverviewBuilder.prReady` doc comment** (the server-side interface, ~L106 region): update the mirrored comment that currently describes the `pr_ready_for_human` + v3.1.3 derivation.
   - **`GATE_LABELS`**: add `'verify-approval': 'verify review'`. Keep `'pr': 'PR review'` (VSCode depends on it; the dashboard excludes it locally in Phase 2).
   - **`detectBlockedSince`**: replace the hardcoded `['spec-approval','plan-approval','dev-approval','pr']` array with iteration over `Object.keys(GATE_LABELS)` so the gate set lives in one place and `verify-approval` automatically gets a `blockedSince`. (`detectBlocked` / `detectBlockedGate` already iterate `GATE_LABELS`.)
-  - Leave `parseStatusYaml`'s `prReadyForHuman` parse in place (harmless; field still written by porch). Do **not** touch `recentlyMergedIssueIds` here.
+  - Leave `parseStatusYaml`'s `prReadyForHuman` parse in place (harmless; field still written by porch). Do **not** touch `recentlyMergedIssueIds` here (Phase 3).
+- `packages/types/src/api.ts` — update the `OverviewBuilder.prReady` doc comment (L183–194) which still describes the old `pr_ready_for_human` + v3.1.3 fallback derivation; rewrite it to the gate-authoritative contract. (This is the "+ types" work the title promises. The `recentlyMergedIssueIds` field at L250–259 is **not** touched here — it is removed in Phase 3.)
 - `packages/codev/src/agent-farm/__tests__/overview.test.ts` — update/extend (see Test Plan).
+- `packages/vscode/src/test/builders.test.ts` — extend with VSCode-side coverage of the shared-infra change (see Test Plan / Acceptance Criteria). Touch other VSCode consumers only if a regression surfaces (none expected — `pr` unchanged; verify-approval flows the gate-toast generic fallback).
 
 #### Implementation Details
 - The `requested_at` guard is the correctness crux: porch initializes **every** gate to `status: pending` with no `requested_at`; a bare `=== 'pending'` check would mark freshly-initialized projects PR-ready. Keep the `&& !!parsed.gateRequestedAt['pr']` conjunct.
@@ -60,10 +64,13 @@ Sequenced into **three phases** so every commit type-checks and tests green in b
 - [ ] `derivePrReady` true ⇔ `pr` gate `pending` **and** `requested_at` present; false for bugfix-verified-without-pr-gate and for freshly-initialized projects.
 - [ ] `detectBlocked`/`detectBlockedSince` return `'verify review'` + timestamp for a verify-approval-pending builder; unchanged for spec/plan/dev/pr.
 - [ ] `packages/codev` builds; all overview tests pass.
+- [ ] **VSCode (blast-radius ownership):** `packages/vscode` builds and its tests pass; a `verify-approval`-pending builder surfaces in the Builders tree as blocked with `blockedSince` (bell/sort), the gate-toast generic fallback (`{ label: 'Review', command: 'codev.openBuilderById' }`) handles `verify-approval` without error, and **`pr`-gate VSCode behavior is unchanged** (regression-guarded by a test).
 
 #### Test Plan
 - **Unit (`overview.test.ts`)**: gate-authoritative `derivePrReady` (pr pending+requested ⇒ true; pr pending no-requested ⇒ false; bugfix `verified` no pr gate ⇒ false; field present but pr gate not pending ⇒ false — proves field no longer load-bearing); `detectBlockedSince` returns verify-approval timestamp; `GATE_LABELS` maps verify-approval.
-- **Manual**: n/a (pure derivation).
+- **Unit (`packages/vscode/src/test/builders.test.ts`)**: a `verify-approval`-pending builder is treated as blocked (appears in the attention/blocked grouping with `blockedSince`); a `pr`-gate-pending builder's tree treatment is unchanged from today (regression guard).
+- **Build**: `pnpm --filter @cluesmith/codev build` and the VSCode package build both green.
+- **Manual**: n/a (pure derivation; VSCode UI render-verify deferred to Amr's area review at plan-approval).
 
 #### Rollback Strategy
 Revert the phase commit; `derivePrReady`/`GATE_LABELS`/`detectBlockedSince` return to prior behavior. No data migration involved.
@@ -85,6 +92,7 @@ Revert the phase commit; `derivePrReady`/`GATE_LABELS`/`detectBlockedSince` retu
   - **`buildItems`**: delete the builder-emit branch (the `if (b.prReady) { … emit gate-${b.id} … }` block and its `emittedPrReadyIssueIds`/`mergedIssueIdSet` bookkeeping). Replace the builder loop's PR-handling with a single early **`if (b.prReady) continue;`** so PR-ready builders surface *only* via the PR loop (and never fall through to the gate-row catch-all). Keep the PR loop (PR rows for `prReady` linked builders + unaffiliated `REVIEW_REQUIRED`) and the gate-row emission for `b.blocked && b.blockedSince` (now naturally covers verify).
   - Remove the `recentlyMergedIssueIds` parameter/prop usage from `buildItems` and `NeedsAttentionList` (stop consuming it; prop becomes unused → drop from the interface).
   - **`gateKindClass`**: add `case 'verify review': return 'attention-kind--verify';`.
+  - **Optional drive-by (flagged — pre-existing, not in spec scope)**: `GATE_LABELS['dev-approval'] = 'dev review'` but `gateKindClass` has a `'code review'` case (matching no current label) and no `'dev review'` case, so dev-approval gate rows already fall back to `--plan` styling. Since this is the exact function being edited, a one-line `case 'dev review': return 'attention-kind--dev';` (+ CSS) would fix it. **Default: do NOT include** (out of #927 scope) unless the architect okays it at plan-approval — see Approval / open question.
 - `packages/dashboard/src/index.css` — add a `.attention-kind--verify { … }` rule (mirror `.attention-kind--spec/--plan`; pick a distinct accent).
 - `packages/dashboard/src/components/WorkView.tsx` — stop passing `recentlyMergedIssueIds={…}` to `NeedsAttentionList`.
 - `packages/dashboard/__tests__/NeedsAttentionList.test.tsx` — invert/remove + add (see Test Plan).
@@ -163,9 +171,10 @@ The Phase 1 change to **shared** `overview.ts` infra (`derivePrReady`, `GATE_LAB
 1. `pr` **stays** in `GATE_LABELS` → VSCode pr-gate behavior is **unchanged** (no regression by construction).
 2. `verify-approval` is **newly** present → a pending verify-approval gate now surfaces as a blocked builder (tree bell + toast + status count). This is arguably a *fix* (a pending human gate genuinely needs attention) but is a behavior change. `GATE_ACTIONS`/`approve.ts` have no `verify-approval` entry → generic fallback ("Review" → open builder terminal), which is acceptable.
 
-**Test coverage to add/verify (in Phase 1, or a VSCode-scoped addition):**
-- [ ] A VSCode-side test (or extend `builders.test.ts`) asserting a `verify-approval`-pending builder appears in the Builders tree as blocked with `blockedSince`, and that `pr`-gate behavior is unchanged.
-- [ ] Confirm `gate-toast.ts` generic-fallback path handles `verify-approval` without error (no `GATE_ACTIONS` entry required).
+**Test coverage — OWNED BY PHASE 1** (these are Phase 1 acceptance criteria + test-plan items, not loose coordination notes):
+- [ ] VSCode-side test in `packages/vscode/src/test/builders.test.ts`: a `verify-approval`-pending builder appears in the Builders tree as blocked with `blockedSince`; a `pr`-gate-pending builder's treatment is **unchanged** (regression guard).
+- [ ] `gate-toast.ts` generic-fallback path handles `verify-approval` without error (no `GATE_ACTIONS` entry required — verified at `gate-toast.ts:123`).
+- [ ] `packages/vscode` builds.
 
 **🚩 Flag for Amr (needs area/vscode eyes at plan-approval):**
 - Is surfacing **verify-approval** as a blocked builder in the VSCode tree/toast/status-bar the desired UX, or should VSCode (like the dashboard for `pr`) treat verify-approval specially? Default in this plan: surface it (consistent with "every genuine human gate needs attention"). If Amr wants a `GATE_ACTIONS` entry for verify-approval (e.g. a "Verify" action), that is an additive follow-up, not a blocker for #927.
@@ -198,14 +207,23 @@ Phase 1 (server-derivation) ──→ Phase 2 (dashboard-surfacing) ──→ Ph
 - [ ] Reconcile #919 (descope its Needs-Attention / `derivePrReady` parts) and #902 (recentlyMergedIssueIds removed) — note in the PR/review.
 
 ## Expert Review
-**Date**: (pending — porch runs 3-way after this draft)
-**Models**: Gemini, Codex, Claude
-**Key Feedback**: (to be filled)
-**Plan Adjustments**: (to be filled)
+**Date**: 2026-05-29
+**Models**: Gemini (APPROVE), Codex (REQUEST_CHANGES), Claude (APPROVE) — 3-way, HIGH confidence.
+
+**Key Feedback**:
+- **Codex (REQUEST_CHANGES)**: (1) the VSCode blast radius was *discussed* but not *concretely owned* in a phase — Phase 1 should own the VSCode test/build work via explicit file edits + acceptance criteria + tests; (2) Phase 1's title says "+ types" but its file list omitted the shared type contract/docs (`packages/types/src/api.ts`) that still describe the old `prReady` derivation.
+- **Claude (APPROVE)**: verified every file/line claim against disk (all accurate). Non-blocking: (a) VSCode test-scope was ambiguous between "Phase 1 acceptance criteria" and "coordination note"; (b) pre-existing `'dev review'` → `gateKindClass` styling gap (drive-by opportunity in the function being edited).
+- **Gemini (APPROVE)**: no issues.
+
+**Plan Adjustments**:
+- Phase 1 now **owns** the VSCode blast-radius validation: added `packages/types/src/api.ts` (the `prReady` doc-comment rewrite) and `packages/vscode/src/test/builders.test.ts` to its file list; added concrete VSCode acceptance criteria (build green; verify-approval surfaces as blocked in the Builders tree; gate-toast generic fallback handles verify-approval; `pr` behavior regression-guarded) and matching test-plan items. (Resolves Codex #1+#2 and Claude obs-a.)
+- The cross-cutting section's VSCode test checkboxes are now explicitly labeled "OWNED BY PHASE 1," removing the ambiguity.
+- Added the pre-existing `'dev review'` styling gap to Phase 2 as a **flagged optional drive-by**, defaulting to *not* included (out of #927 scope) pending architect okay. (Claude obs-b.)
 
 ## Approval
 - [ ] Technical Lead Review (architect — `plan-approval` gate)
-- [ ] area/vscode review (Amr) — VSCode blast radius
+- [ ] area/vscode review (Amr) — VSCode blast radius. **Open question for Amr**: is surfacing `verify-approval` as a blocked builder in the VSCode tree/toast/status-bar the desired UX, and does VSCode want a dedicated `GATE_ACTIONS`/approve "Verify" action (additive follow-up, not a #927 blocker)?
+- [ ] **Architect decision (plan-approval)**: include the optional `'dev review'` `gateKindClass` drive-by fix, or leave out of scope? (Default: out of scope.)
 - [ ] Expert AI Consultation Complete (3-way)
 
 ## Change Log

--- a/codev/plans/927-needs-attention-surface-prs-vi.md
+++ b/codev/plans/927-needs-attention-surface-prs-vi.md
@@ -1,9 +1,14 @@
+---
+approved: 2026-05-29
+validated: [gemini, codex, claude]
+---
+
 # Plan: Needs Attention — surface PRs via the universal `pr` gate; delete gateless builder-derived fallbacks
 
 ## Metadata
 - **ID**: plan-2026-05-29-needs-attention-surface-prs-vi
 - **Issue**: #927
-- **Status**: draft
+- **Status**: approved
 - **Specification**: `codev/specs/927-needs-attention-surface-prs-vi.md`
 - **Created**: 2026-05-29
 

--- a/codev/plans/927-needs-attention-surface-prs-vi.md
+++ b/codev/plans/927-needs-attention-surface-prs-vi.md
@@ -1,0 +1,224 @@
+# Plan: Needs Attention — surface PRs via the universal `pr` gate; delete gateless builder-derived fallbacks
+
+## Metadata
+- **ID**: plan-2026-05-29-needs-attention-surface-prs-vi
+- **Issue**: #927
+- **Status**: draft
+- **Specification**: `codev/specs/927-needs-attention-surface-prs-vi.md`
+- **Created**: 2026-05-29
+
+## Executive Summary
+
+Implements the spec's **selected Approach 1 (gate-authoritative surfacing)**. The work is largely *deletion*: the `derivePrReady` `bugfix && verified` fallback, the `NeedsAttentionList.buildItems` builder-emit branch, the `pr_ready_for_human` field *dependency*, and the `recentlyMergedIssueIds` projection all go away. One small addition: `verify-approval` joins the human-gate allowlist with label `"verify review"`. The signal everything keys on already exists — the **`pr` gate going `pending`** (with `requested_at`).
+
+Sequenced into **three phases** so every commit type-checks and tests green in both `packages/codev` and `packages/dashboard`, and so the **shared-infrastructure / VSCode blast radius is concentrated in Phase 1** (the crisp target for area/vscode review — see *Cross-Cutting: VSCode blast radius*).
+
+**Decisions locked by the spec + consultation** (do not relitigate): gate-authoritative `derivePrReady` with a `requested_at`-aware predicate; keep `pr` in shared `GATE_LABELS`/`detectBlocked*` (the "no builder stand-in" rule is dashboard-local); `verify-approval → "verify review"`; remove `recentlyMergedIssueIds` end-to-end but **retain** `fetchRecentMergedPRs` (second consumer: recentlyClosed `issueToPrUrl`).
+
+## Success Metrics
+- [ ] All spec success criteria met (PR rows keyed on `pr` gate pending; no builder stand-in; merged PRs drop; gate rows for spec/plan/dev/verify; `requested_at`-aware predicate; unaffiliated REVIEW_REQUIRED preserved).
+- [ ] Both `packages/codev` and `packages/dashboard` type-check and all unit tests pass after **each** phase commit.
+- [ ] No reduction in coverage; new tests cover the contract + the `requested_at` guard.
+- [ ] No VSCode regression (Builders tree, gate toast, status-bar counter); verify-approval surfacing in VSCode confirmed acceptable (flagged for Amr).
+- [ ] Documentation/arch notes updated in Review phase.
+
+## Phases (Machine Readable)
+
+<!-- REQUIRED: porch uses this JSON to track phase progress. Update this when adding/removing phases. -->
+
+```json
+{
+  "phases": [
+    {"id": "server-derivation", "title": "Gate-authoritative pr signal + verify-approval label (overview server + types)"},
+    {"id": "dashboard-surfacing", "title": "PR-rows-only Needs Attention + verify styling (dashboard)"},
+    {"id": "remove-dead-projection", "title": "Delete recentlyMergedIssueIds end-to-end (retain fetchRecentMergedPRs)"}
+  ]
+}
+```
+
+## Phase Breakdown
+
+### Phase 1: server-derivation — Gate-authoritative `pr` signal + `verify-approval` label
+**Dependencies**: None
+
+#### Objectives
+- Make the overview server emit a **gate-authoritative**, `requested_at`-aware `prReady` signal and surface `verify-approval` as a blocked gate — the shared-infrastructure change that all consumers (dashboard **and** VSCode) read.
+
+#### Files to modify
+- `packages/codev/src/agent-farm/servers/overview.ts`
+  - **`derivePrReady`**: reduce to gate-authoritative — return `parsed.gates['pr'] === 'pending' && !!parsed.gateRequestedAt['pr']`. Delete the `bugfix && phase === 'verified'` branch **and** the `pr_ready_for_human` field dependency (`if (parsed.prReadyForHuman !== null) return …`). Update the doc comment to state the universal-`pr`-gate contract and the `requested_at` invariant.
+  - **`GATE_LABELS`**: add `'verify-approval': 'verify review'`. Keep `'pr': 'PR review'` (VSCode depends on it; the dashboard excludes it locally in Phase 2).
+  - **`detectBlockedSince`**: replace the hardcoded `['spec-approval','plan-approval','dev-approval','pr']` array with iteration over `Object.keys(GATE_LABELS)` so the gate set lives in one place and `verify-approval` automatically gets a `blockedSince`. (`detectBlocked` / `detectBlockedGate` already iterate `GATE_LABELS`.)
+  - Leave `parseStatusYaml`'s `prReadyForHuman` parse in place (harmless; field still written by porch). Do **not** touch `recentlyMergedIssueIds` here.
+- `packages/codev/src/agent-farm/__tests__/overview.test.ts` — update/extend (see Test Plan).
+
+#### Implementation Details
+- The `requested_at` guard is the correctness crux: porch initializes **every** gate to `status: pending` with no `requested_at`; a bare `=== 'pending'` check would mark freshly-initialized projects PR-ready. Keep the `&& !!parsed.gateRequestedAt['pr']` conjunct.
+- After this phase, `OverviewBuilder.prReady` is true iff the `pr` gate is genuinely pending, and a `verify-approval`-pending builder carries `blocked='verify review'` + `blockedSince`.
+
+#### Acceptance Criteria
+- [ ] `derivePrReady` true ⇔ `pr` gate `pending` **and** `requested_at` present; false for bugfix-verified-without-pr-gate and for freshly-initialized projects.
+- [ ] `detectBlocked`/`detectBlockedSince` return `'verify review'` + timestamp for a verify-approval-pending builder; unchanged for spec/plan/dev/pr.
+- [ ] `packages/codev` builds; all overview tests pass.
+
+#### Test Plan
+- **Unit (`overview.test.ts`)**: gate-authoritative `derivePrReady` (pr pending+requested ⇒ true; pr pending no-requested ⇒ false; bugfix `verified` no pr gate ⇒ false; field present but pr gate not pending ⇒ false — proves field no longer load-bearing); `detectBlockedSince` returns verify-approval timestamp; `GATE_LABELS` maps verify-approval.
+- **Manual**: n/a (pure derivation).
+
+#### Rollback Strategy
+Revert the phase commit; `derivePrReady`/`GATE_LABELS`/`detectBlockedSince` return to prior behavior. No data migration involved.
+
+#### Risks
+- **Risk**: Adding `verify-approval` to `GATE_LABELS` changes VSCode behavior (verify-approval gates now surface as blocked builders / toast / status count). **Mitigation**: this is the intended, arguably-correct blast radius — covered explicitly under *Cross-Cutting: VSCode blast radius* with test coverage; flagged for Amr at plan-approval.
+- **Risk**: Dropping the `pr_ready_for_human` field dependency could change behavior if any state has `pr` gate pending but field false (or vice-versa). **Mitigation**: they are coincident by construction (porch writes both together); gate-authoritative is strictly more correct (kills the #919 sticky-field hazard). Add a test for the divergent case.
+
+---
+
+### Phase 2: dashboard-surfacing — PR-rows-only Needs Attention + verify styling
+**Dependencies**: Phase 1 (consumes gate-authoritative `prReady` and `verify review` blocked label — though dashboard unit tests inject these directly, so this phase is independently testable)
+
+#### Objectives
+- Make the dashboard surface PRs **only** as PR rows (never a builder stand-in), preserve gate rows for spec/plan/dev/**verify**, and style the verify gate.
+
+#### Files to modify
+- `packages/dashboard/src/components/NeedsAttentionList.tsx`
+  - **`buildItems`**: delete the builder-emit branch (the `if (b.prReady) { … emit gate-${b.id} … }` block and its `emittedPrReadyIssueIds`/`mergedIssueIdSet` bookkeeping). Replace the builder loop's PR-handling with a single early **`if (b.prReady) continue;`** so PR-ready builders surface *only* via the PR loop (and never fall through to the gate-row catch-all). Keep the PR loop (PR rows for `prReady` linked builders + unaffiliated `REVIEW_REQUIRED`) and the gate-row emission for `b.blocked && b.blockedSince` (now naturally covers verify).
+  - Remove the `recentlyMergedIssueIds` parameter/prop usage from `buildItems` and `NeedsAttentionList` (stop consuming it; prop becomes unused → drop from the interface).
+  - **`gateKindClass`**: add `case 'verify review': return 'attention-kind--verify';`.
+- `packages/dashboard/src/index.css` — add a `.attention-kind--verify { … }` rule (mirror `.attention-kind--spec/--plan`; pick a distinct accent).
+- `packages/dashboard/src/components/WorkView.tsx` — stop passing `recentlyMergedIssueIds={…}` to `NeedsAttentionList`.
+- `packages/dashboard/__tests__/NeedsAttentionList.test.tsx` — invert/remove + add (see Test Plan).
+
+#### Implementation Details
+- `OverviewData.recentlyMergedIssueIds` (the type field) and the server computation are **not** removed in this phase — only the dashboard's *consumption* stops. This keeps the dashboard green now and isolates the type/computation removal to Phase 3. (The field remains emitted-but-ignored between Phase 2 and Phase 3 — dead but harmless.)
+- PR-row `waitingSince` continues to come from `b.blockedSince` (= `pr` gate `requested_at`, since `pr` stays in `detectBlockedSince`), with `pr.createdAt` fallback for unaffiliated PRs.
+
+#### Acceptance Criteria
+- [ ] Open PR + pr-gate-pending builder ⇒ exactly one PR row; cache-miss (PR absent) ⇒ **no row**; merged PR (absent) ⇒ **no row**.
+- [ ] spec/plan/dev/**verify**-approval pending builders ⇒ gate rows with correct label/kind/age; verify row styled via `--verify`.
+- [ ] pr-gate-pending builder never emits a builder/gate row.
+- [ ] Unaffiliated `REVIEW_REQUIRED` PR still surfaces; no double-emit.
+- [ ] `packages/dashboard` builds; all NeedsAttentionList tests pass.
+
+#### Test Plan
+- **Unit (`NeedsAttentionList.test.tsx`)**:
+  - **Invert** "still surfaces a prReady BUGFIX builder when its PR is missing" (~L183) and "still surfaces a prReady gated builder … when its PR is missing" (~L253) → assert **no row**.
+  - **Remove** "does NOT surface a prReady builder whose PR has been merged (Issue #901)" (~L222) → mechanism deleted; replaced by the generic "missing PR ⇒ no row" case.
+  - **Add**: verify-approval ⇒ gate row labeled "verify review"; pr-gate builder with missing PR ⇒ no row; no double-emit when PR+builder present (retain existing).
+  - Keep the existing PR-gating, unaffiliated, and waitingSince tests (still valid).
+- **Manual (render verification — per architect/UI policy)**: render Needs Attention in a browser/Playwright for (a) a PR row, (b) a verify-approval gate row (confirm `--verify` styling renders), (c) empty state. Capture before/after for the verify row since it's a new `className`.
+
+#### Rollback Strategy
+Revert the phase commit; `buildItems` returns to the builder-emit model and re-accepts the prop (still present on the type).
+
+#### Risks
+- **Risk**: A real cache-miss now shows nothing instead of a defensive row. **Mitigation**: intended by spec (req 1); the next refresh surfaces the PR once `pendingPRs` includes it. Documented tradeoff.
+- **Risk**: New `--verify` className without matching CSS renders unstyled. **Mitigation**: add the CSS rule in the same commit; render-verify before marking done (memory: UI visual verification).
+
+---
+
+### Phase 3: remove-dead-projection — Delete `recentlyMergedIssueIds` end-to-end
+**Dependencies**: Phase 2 (dashboard no longer consumes the field)
+
+#### Objectives
+- Remove the now-dead `recentlyMergedIssueIds` projection while **retaining** `fetchRecentMergedPRs` and the `mergedPRs` fetch (still needed for the recentlyClosed `issueToPrUrl` map).
+
+#### Files to modify
+- `packages/types/src/api.ts` — remove `recentlyMergedIssueIds` from `OverviewData` (and the related doc comment).
+- `packages/codev/src/agent-farm/servers/overview.ts` — remove the `recentlyMergedIssueIds` field from the local `OverviewData` mirror/interface, delete its computation block (~L1006–1021) and its inclusion in the returned `result`. **Keep** the `fetchRecentMergedPRs` import, the `mergedPRs` Promise.all fetch (~L914), and the `issueToPrUrl` build (~L971).
+- `packages/codev/src/agent-farm/__tests__/overview.test.ts` — remove assertions on `recentlyMergedIssueIds`; confirm the recentlyClosed PR-link enrichment test (uses `mergedPRs`) still passes (proves the fetch is retained).
+
+#### Implementation Details
+- This is pure dead-code removal. The mock `fetchRecentMergedPRs` in `overview.test.ts` stays (recentlyClosed uses it).
+
+#### Acceptance Criteria
+- [ ] `recentlyMergedIssueIds` absent from `OverviewData` and `overview.ts`; both packages type-check.
+- [ ] `fetchRecentMergedPRs` retained; recentlyClosed items still carry `prUrl`.
+- [ ] All tests pass; no consumer references the removed field (grep clean).
+
+#### Test Plan
+- **Unit**: existing recentlyClosed test still green (PR-link enrichment intact); grep confirms no remaining `recentlyMergedIssueIds` references.
+- **Build**: `pnpm --filter @cluesmith/codev build` + dashboard build green.
+
+#### Rollback Strategy
+Revert the phase commit; the field and computation return. (Low risk — additive-to-revert.)
+
+#### Risks
+- **Risk**: A non-obvious consumer of the field exists. **Mitigation**: grep across `packages/` before removal (current grep shows only the now-removed dashboard consumer + type + computation); TS build catches stragglers.
+
+---
+
+## Cross-Cutting: VSCode blast radius (architect coordination — area/vscode / Amr)
+
+The Phase 1 change to **shared** `overview.ts` infra (`derivePrReady`, `GATE_LABELS`, `detectBlocked*`) is read by VSCode as well as the dashboard. Per the architect's note, this is an **explicit blast-radius item with its own test coverage**, and Amr (owns `area/vscode`) is looped in on #927.
+
+**VSCode consumers (verified on disk):**
+- `packages/vscode/src/views/builders.ts` — Builders tree: blocked builders sort to top with a bell, using `b.blocked`/`b.blockedSince`.
+- `packages/vscode/src/notifications/gate-toast.ts` — gate toast: fires when a builder enters the blocked set; `GATE_ACTIONS` has `pr`/`dev-approval`/etc. with a **generic fallback** for unmapped gates.
+- `packages/vscode/src/commands/approve.ts` — mirrors `GATE_ACTIONS` one-for-one (per its own comment).
+- `packages/vscode/src/extension.ts` — status-bar counter of attention items.
+- Existing tests: `packages/vscode/src/test/builders.test.ts`, `packages/vscode/src/__tests__/menu-when-clauses.test.ts`.
+
+**What changes for VSCode (intended):**
+1. `pr` **stays** in `GATE_LABELS` → VSCode pr-gate behavior is **unchanged** (no regression by construction).
+2. `verify-approval` is **newly** present → a pending verify-approval gate now surfaces as a blocked builder (tree bell + toast + status count). This is arguably a *fix* (a pending human gate genuinely needs attention) but is a behavior change. `GATE_ACTIONS`/`approve.ts` have no `verify-approval` entry → generic fallback ("Review" → open builder terminal), which is acceptable.
+
+**Test coverage to add/verify (in Phase 1, or a VSCode-scoped addition):**
+- [ ] A VSCode-side test (or extend `builders.test.ts`) asserting a `verify-approval`-pending builder appears in the Builders tree as blocked with `blockedSince`, and that `pr`-gate behavior is unchanged.
+- [ ] Confirm `gate-toast.ts` generic-fallback path handles `verify-approval` without error (no `GATE_ACTIONS` entry required).
+
+**🚩 Flag for Amr (needs area/vscode eyes at plan-approval):**
+- Is surfacing **verify-approval** as a blocked builder in the VSCode tree/toast/status-bar the desired UX, or should VSCode (like the dashboard for `pr`) treat verify-approval specially? Default in this plan: surface it (consistent with "every genuine human gate needs attention"). If Amr wants a `GATE_ACTIONS` entry for verify-approval (e.g. a "Verify" action), that is an additive follow-up, not a blocker for #927.
+
+## Dependency Map
+```
+Phase 1 (server-derivation) ──→ Phase 2 (dashboard-surfacing) ──→ Phase 3 (remove-dead-projection)
+        │
+        └── VSCode blast radius (verified + tested in Phase 1; Amr review at plan-approval)
+```
+
+## Risk Analysis
+### Technical Risks
+| Risk | Probability | Impact | Mitigation | Owner |
+|------|------------|--------|------------|-------|
+| VSCode regression from shared GATE_LABELS/detectBlocked change | L | M | `pr` kept in map (no change); verify-approval covered by added tests + Amr review | builder / Amr |
+| Bare gate-pending predicate mis-flags fresh projects | L | M | `requested_at`-aware predicate + dedicated test | builder |
+| `recentlyMergedIssueIds` has a hidden consumer | L | L | grep before removal; TS build | builder |
+| New `--verify` className unstyled | L | L | CSS in same commit; render-verify | builder |
+| Cross-package build breakage between phases | L | M | phase ordering keeps each commit green (consume-then-remove) | builder |
+
+## Validation Checkpoints
+1. **After Phase 1**: overview tests green; manually confirm `derivePrReady`/`detectBlockedSince` via the test cases; VSCode build green.
+2. **After Phase 2**: dashboard tests green; render-verify Needs Attention (PR row, verify gate row, empty).
+3. **After Phase 3**: grep clean for `recentlyMergedIssueIds`; full `packages/codev` + `packages/dashboard` build + test green.
+4. **Before PR**: run the full test suites for both packages; CMAP at PR (`pr` gate).
+
+## Documentation Updates Required
+- [ ] Review phase: note the universal-`pr`-gate contract and the dashboard-local "no builder stand-in" rule in `codev/resources/arch.md` (via update-arch-docs skill) if it adds durable architectural shape.
+- [ ] Reconcile #919 (descope its Needs-Attention / `derivePrReady` parts) and #902 (recentlyMergedIssueIds removed) — note in the PR/review.
+
+## Expert Review
+**Date**: (pending — porch runs 3-way after this draft)
+**Models**: Gemini, Codex, Claude
+**Key Feedback**: (to be filled)
+**Plan Adjustments**: (to be filled)
+
+## Approval
+- [ ] Technical Lead Review (architect — `plan-approval` gate)
+- [ ] area/vscode review (Amr) — VSCode blast radius
+- [ ] Expert AI Consultation Complete (3-way)
+
+## Change Log
+| Date | Change | Reason | Author |
+|------|--------|--------|--------|
+| 2026-05-29 | Initial plan draft | Spec #927 approved | builder spir-927 |
+
+## Notes
+- No time estimates (per SPIR). Phases are ordered by dependency and build-greenness, not effort.
+- The whole change nets to deletion + one small gate addition; complexity is Low–Medium and concentrated in Phase 1's shared infra.
+
+---
+
+## Amendment History
+
+<!-- When adding a TICK amendment, add a new entry below this line in chronological order -->

--- a/codev/projects/927-needs-attention-surface-prs-vi/927-dashboard-surfacing-iter1-rebuttals.md
+++ b/codev/projects/927-needs-attention-surface-prs-vi/927-dashboard-surfacing-iter1-rebuttals.md
@@ -1,0 +1,39 @@
+# Phase 2 (dashboard-surfacing) — Rebuttal to iteration-1 consultation
+
+**Verdicts**: Gemini APPROVE · Claude APPROVE · Codex REQUEST_CHANGES (HIGH).
+
+Codex's REQUEST_CHANGES is **correct and accepted** — I made the changes. It caught that Phase 2 carried over a fallback path and two tests that encode the **old gateless-BUGFIX shape** (`prReady: true` with no gate / no `blockedSince`), which is *impossible* under the gate-authoritative model delivered in Phase 1 (where `prReady === true` ⟺ `pr` gate `pending` ⟹ `blockedSince` present). They contradicted the spec's waiting-time contract.
+
+---
+
+## Codex KEY_ISSUES
+
+### C1 — `waitingSince: readySince || pr.createdAt` for affiliated PRs (NeedsAttentionList.tsx)
+**Accepted; fixed.** The spec says the `pr.createdAt` fallback remains **only** for unaffiliated/human PRs; affiliated (linked) PRs use the builder's gate-requested time (`blockedSince`). I restructured the PR-loop to make this explicit:
+
+```ts
+const waitingSince = prReady ? (readySince ?? pr.createdAt) : pr.createdAt;
+```
+
+- **Affiliated** (`prReady`): uses `readySince` (= the builder's `blockedSince` = `pr` gate `requested_at`). Under the gate-authoritative model a `prReady` builder always carries `blockedSince`, so `readySince` is always present; the `?? pr.createdAt` is now an **unreachable type guard** (documented as such in a comment), *not* the old gateless-BUGFIX createdAt fallback.
+- **Unaffiliated / human** PR: uses `pr.createdAt` (no gate signal) — the only place that fallback legitimately lives.
+
+I kept the `?? pr.createdAt` type guard rather than a non-null assertion / omission because (a) `readySince` is typed `string | undefined` and (b) silently dropping or crashing the whole Needs Attention list on a transiently-malformed builder record is worse than a fail-soft presentational default. With the obsolete tests removed (C2), nothing claims that guard is load-bearing for affiliated PRs.
+
+### C2 — Tests at :86–105 and :160–180 codify the removed gateless-BUGFIX shape
+**Accepted; fixed.**
+- **`:86–105`** ("surfaces a BUGFIX PR whose builder has no gate (Issue #872)") → **reframed** to the post-#887 gate-authoritative shape: the BUGFIX builder now carries `blocked: 'PR review'`, `blockedGate: 'pr'`, `blockedSince` set, `prReady: true`. The test now also asserts `waitingSince === blockedSince` (gate-requested time, not `createdAt`), locking the new invariant.
+- **`:160–180`** ("falls back to pr.createdAt for a prReady builder without blockedSince (BUGFIX shape)") → **removed**. It tested a state that can no longer occur under gate-authoritative `derivePrReady`. The affiliated-uses-`blockedSince` invariant is covered by the existing ":145–158" test and the reframed ":86–105".
+- **Bonus**: strengthened the unaffiliated/human-PR test to assert `waitingSince === pr.createdAt`, explicitly locking the *only* legitimate `createdAt` path.
+
+Dashboard tests: **13 passed** (was 14; −1 obsolete test removed).
+
+---
+
+## Gemini APPROVE / Claude APPROVE
+No issues. Both confirmed the builder-emit deletion, the `if (b.prReady) continue;` exclusion, the verify styling, and the `recentlyMergedIssueIds` prop removal match the plan.
+
+---
+
+## Net
+Codex's catch tightened the gate-authoritative contract: affiliated PR wait time now flows exclusively from the `pr` gate timestamp (createdAt reserved for unaffiliated PRs), and the test suite no longer encodes the impossible gateless-BUGFIX shape. Build + dashboard tests green.

--- a/codev/projects/927-needs-attention-surface-prs-vi/927-dashboard-surfacing-iter2-context.md
+++ b/codev/projects/927-needs-attention-surface-prs-vi/927-dashboard-surfacing-iter2-context.md
@@ -1,0 +1,54 @@
+### Iteration 1 Reviews
+- gemini: APPROVE — Successfully implemented Phase 2: dashboard-surfacing with correct logic for PR rows, 'verify review' styling, and removal of dead props.
+- codex: REQUEST_CHANGES — Dashboard mostly matches the phase plan, but it still preserves the deleted BUGFIX-era affiliated-PR fallback, so PR wait time can still fall back to `pr.createdAt` for linked builders and the tests lock that obsolete behavior in.
+- claude: APPROVE — Phase 2 is a clean, well-tested implementation that exactly matches the spec and plan — net deletion of fragile code, verify-approval styling added, all acceptance criteria met.
+
+### Builder Response to Iteration 1
+# Phase 2 (dashboard-surfacing) — Rebuttal to iteration-1 consultation
+
+**Verdicts**: Gemini APPROVE · Claude APPROVE · Codex REQUEST_CHANGES (HIGH).
+
+Codex's REQUEST_CHANGES is **correct and accepted** — I made the changes. It caught that Phase 2 carried over a fallback path and two tests that encode the **old gateless-BUGFIX shape** (`prReady: true` with no gate / no `blockedSince`), which is *impossible* under the gate-authoritative model delivered in Phase 1 (where `prReady === true` ⟺ `pr` gate `pending` ⟹ `blockedSince` present). They contradicted the spec's waiting-time contract.
+
+---
+
+## Codex KEY_ISSUES
+
+### C1 — `waitingSince: readySince || pr.createdAt` for affiliated PRs (NeedsAttentionList.tsx)
+**Accepted; fixed.** The spec says the `pr.createdAt` fallback remains **only** for unaffiliated/human PRs; affiliated (linked) PRs use the builder's gate-requested time (`blockedSince`). I restructured the PR-loop to make this explicit:
+
+```ts
+const waitingSince = prReady ? (readySince ?? pr.createdAt) : pr.createdAt;
+```
+
+- **Affiliated** (`prReady`): uses `readySince` (= the builder's `blockedSince` = `pr` gate `requested_at`). Under the gate-authoritative model a `prReady` builder always carries `blockedSince`, so `readySince` is always present; the `?? pr.createdAt` is now an **unreachable type guard** (documented as such in a comment), *not* the old gateless-BUGFIX createdAt fallback.
+- **Unaffiliated / human** PR: uses `pr.createdAt` (no gate signal) — the only place that fallback legitimately lives.
+
+I kept the `?? pr.createdAt` type guard rather than a non-null assertion / omission because (a) `readySince` is typed `string | undefined` and (b) silently dropping or crashing the whole Needs Attention list on a transiently-malformed builder record is worse than a fail-soft presentational default. With the obsolete tests removed (C2), nothing claims that guard is load-bearing for affiliated PRs.
+
+### C2 — Tests at :86–105 and :160–180 codify the removed gateless-BUGFIX shape
+**Accepted; fixed.**
+- **`:86–105`** ("surfaces a BUGFIX PR whose builder has no gate (Issue #872)") → **reframed** to the post-#887 gate-authoritative shape: the BUGFIX builder now carries `blocked: 'PR review'`, `blockedGate: 'pr'`, `blockedSince` set, `prReady: true`. The test now also asserts `waitingSince === blockedSince` (gate-requested time, not `createdAt`), locking the new invariant.
+- **`:160–180`** ("falls back to pr.createdAt for a prReady builder without blockedSince (BUGFIX shape)") → **removed**. It tested a state that can no longer occur under gate-authoritative `derivePrReady`. The affiliated-uses-`blockedSince` invariant is covered by the existing ":145–158" test and the reframed ":86–105".
+- **Bonus**: strengthened the unaffiliated/human-PR test to assert `waitingSince === pr.createdAt`, explicitly locking the *only* legitimate `createdAt` path.
+
+Dashboard tests: **13 passed** (was 14; −1 obsolete test removed).
+
+---
+
+## Gemini APPROVE / Claude APPROVE
+No issues. Both confirmed the builder-emit deletion, the `if (b.prReady) continue;` exclusion, the verify styling, and the `recentlyMergedIssueIds` prop removal match the plan.
+
+---
+
+## Net
+Codex's catch tightened the gate-authoritative contract: affiliated PR wait time now flows exclusively from the `pr` gate timestamp (createdAt reserved for unaffiliated PRs), and the test suite no longer encodes the impossible gateless-BUGFIX shape. Build + dashboard tests green.
+
+
+### IMPORTANT: Stateful Review Context
+This is NOT the first review iteration. Previous reviewers raised concerns and the builder has responded.
+Before re-raising a previous concern:
+1. Check if the builder has already addressed it in code
+2. If the builder disputes a concern with evidence, verify the claim against actual project files before insisting
+3. Do not re-raise concerns that have been explained as false positives with valid justification
+4. Check package.json and config files for version numbers before flagging missing configuration

--- a/codev/projects/927-needs-attention-surface-prs-vi/927-plan-iter1-rebuttals.md
+++ b/codev/projects/927-needs-attention-surface-prs-vi/927-plan-iter1-rebuttals.md
@@ -1,0 +1,35 @@
+# Plan #927 — Rebuttal to iteration-1 consultation
+
+**Verdicts**: Gemini APPROVE · Claude APPROVE · Codex REQUEST_CHANGES (all HIGH confidence).
+
+Codex's REQUEST_CHANGES were about making the plan a stronger *execution guide* (own the VSCode work concretely; align the "+ types" title with the file list) — not design disagreements. I **accept both** and updated the plan. Claude's two non-blocking observations are also addressed.
+
+---
+
+## Codex REQUEST_CHANGES
+
+### C1 — VSCode blast radius is discussed, not concretely owned in a phase
+**Accepted.** The cross-cutting section described the VSCode impact but left the work as a loose note rather than phase-owned. **Phase 1 now owns it:**
+- **Files added to Phase 1**: `packages/vscode/src/test/builders.test.ts` (VSCode-side coverage).
+- **Acceptance criteria added to Phase 1**: `packages/vscode` builds; a `verify-approval`-pending builder surfaces in the Builders tree as blocked with `blockedSince`; the gate-toast generic fallback (`{ label: 'Review', command: 'codev.openBuilderById' }`, verified at `gate-toast.ts:123`) handles `verify-approval` without error; **`pr`-gate VSCode behavior is unchanged** (regression-guarded by a test).
+- **Test-plan items added to Phase 1**: the two VSCode-side tests above + VSCode build.
+- The cross-cutting section's checkboxes are now explicitly labeled **"OWNED BY PHASE 1"** to remove the ambiguity Claude also flagged (obs-a).
+
+### C2 — Phase 1 titled "+ types" but file list omits the type contract/docs
+**Accepted.** Added `packages/types/src/api.ts` to Phase 1's file list: the `OverviewBuilder.prReady` doc comment (L183–194) still describes the old `pr_ready_for_human` + v3.1.3 fallback derivation; Phase 1 rewrites it to the gate-authoritative contract. Also added the mirrored `OverviewBuilder.prReady` comment in `overview.ts` to Phase 1's edit list. (The `recentlyMergedIssueIds` field at api.ts:250–259 remains a **Phase 3** removal — deliberately split so each commit stays green.)
+
+---
+
+## Claude APPROVE — observations
+- **obs-a (VSCode test-scope ambiguity)**: resolved together with C1 — the VSCode test/build items are now Phase 1 acceptance criteria + test-plan items, labeled "OWNED BY PHASE 1."
+- **obs-b (pre-existing `'dev review'` → `gateKindClass` styling gap)**: `GATE_LABELS['dev-approval'] = 'dev review'` but `gateKindClass` has a `'code review'` case (matching no live label) and no `'dev review'` case, so dev-approval rows already fall back to `--plan` styling. Since Phase 2 edits exactly this function, I added it as a **flagged optional drive-by**, **defaulting to NOT included** (it is pre-existing and out of #927's spec scope). Teed up as an explicit architect decision at plan-approval.
+
+---
+
+## Gemini APPROVE
+No issues raised. Endorsed the shared-code update, the dashboard-local enforcement, the dependency ordering, and the graceful removal of the dead projection.
+
+---
+
+## Net
+Both REQUEST_CHANGES items resolved by concretely assigning the VSCode validation and the type/doc edits to **Phase 1** (with acceptance criteria + tests), and by aligning the file list with the title. No phase or design changed in substance — the plan is now a tighter execution guide. Two coordination decisions are teed up for the human/Amr at plan-approval (VSCode verify-approval UX; optional dev-review styling drive-by), neither of which blocks the #927 contract.

--- a/codev/projects/927-needs-attention-surface-prs-vi/927-review-iter1-rebuttals.md
+++ b/codev/projects/927-needs-attention-surface-prs-vi/927-review-iter1-rebuttals.md
@@ -1,0 +1,28 @@
+# PR-level CMAP (review phase) — Rebuttal to iteration-1
+
+**Verdicts**: Gemini APPROVE · Claude APPROVE · Codex REQUEST_CHANGES (HIGH).
+
+## Codex KEY_ISSUES
+
+### C1 — spec/plan missing `approved`/`validated` frontmatter (Status: draft)
+**Accepted; fixed.** Per the SPIR protocol's final-approval steps (Specify §12 / Plan §11) and the repo's CLAUDE.md policy, an approved spec/plan must carry YAML frontmatter. Both gates were human-approved (spec-approval 2026-05-29, plan-approval 2026-05-29), but I left the artifacts as `Status: draft` with no frontmatter — a genuine miss. Fixed:
+
+- `codev/specs/927-…md` and `codev/plans/927-…md` now start with:
+  ```yaml
+  ---
+  approved: 2026-05-29
+  validated: [gemini, codex, claude]
+  ---
+  ```
+  and `## Metadata → Status` flipped `draft → approved`.
+
+### C2 — `gateKindClass` has `code review` instead of `dev review` (dev-approval rows fall back to `--plan` styling)
+**Rebutted — explicitly out of scope by architect decision.** This pre-existing styling gap was raised in the plan as a *flagged optional drive-by*, and the **architect ruled it OUT of scope at the plan-approval gate** (verbatim: "leave the optional 'dev review' gateKindClass styling drive-by OUT of scope (confirmed) — not part of #927; can be filed separately"). Codex correctly notes it is "not a correctness bug for #927." It is unrelated to the `pr`-gate surfacing work, predates this PR, and touching it would be scope creep against an explicit human decision.
+
+**Tracked as a follow-up** (Review doc → Follow-up Items): file a separate issue to add `case 'dev review': return 'attention-kind--dev'` + CSS. Not addressed here by design.
+
+## Gemini / Claude
+APPROVE, no issues.
+
+## Net
+C1 fixed (approval frontmatter added to spec + plan). C2 rebutted on the basis of the architect's explicit plan-approval decision; tracked as a separate follow-up. No code changes to the #927 surfacing logic.

--- a/codev/projects/927-needs-attention-surface-prs-vi/927-specify-iter1-rebuttals.md
+++ b/codev/projects/927-needs-attention-surface-prs-vi/927-specify-iter1-rebuttals.md
@@ -1,0 +1,50 @@
+# Spec #927 — Rebuttal to iteration-1 consultation
+
+**Verdicts**: Gemini APPROVE · Claude APPROVE · Codex REQUEST_CHANGES.
+
+Codex's REQUEST_CHANGES raised two *clarity* gaps (not design disagreements). I **accept both** and have updated the spec. Gemini and Claude were APPROVE with COMMENT-level items, which I also incorporated. Below I address each, note the change, and flag two reviewer suggestions I deliberately did **not** apply verbatim because they were incorrect.
+
+---
+
+## Codex REQUEST_CHANGES
+
+### C1 — Pin down shared `blocked`/`blockedGate`/`blockedSince` semantics for the `pr` gate
+**Accepted.** The spec was ambiguous about whether removing the builder stand-in is global or dashboard-local. **Resolution: dashboard-local.** New subsection *"Scope of the no-builder-stand-in rule"* in Desired State:
+- `pr` **stays** in shared `GATE_LABELS` / `detectBlocked` / `detectBlockedGate` / `detectBlockedSince`. VSCode (tree/toast/status bar) is builder-centric and *should* keep surfacing a pr-gate-pending builder as a blocked builder — existing, correct behavior preserved.
+- The "PR-as-PR-row, never builder-row" rule is enforced **only** in the dashboard `buildItems` via an early `if (b.prReady) continue;` (which also subsumes the deleted builder-emit branch).
+- **Timestamp consequence made explicit**: because `pr` stays in `detectBlockedSince`, a pr-gate builder still carries `blockedSince = gateRequestedAt['pr']`, so the PR row's waiting-since chip keeps measuring *gate-requested time* (satisfying success criterion 1). This also closes Claude's COMMENT #2 (waitingSince source).
+
+### C2 — `verify-approval` has no defined human-facing label/string contract
+**Accepted.** New subsection *"Human-facing label contract for `verify-approval`"*:
+- `GATE_LABELS['verify-approval'] = 'verify review'` (mirrors `spec review`/`plan review`).
+- Add `gateKindClass('verify review') → 'attention-kind--verify'` and a new `.attention-kind--verify` CSS rule (today only `--pr/--spec/--plan/--code-review` exist; unmapped labels fall back to `--plan`).
+- VSCode gate-toast `GATE_ACTIONS` uses its generic fallback for `verify-approval` — acceptable, no change needed.
+
+---
+
+## Gemini APPROVE — COMMENT items
+- **`detectBlockedSince` "implementation trap"** (hardcoded gate array distinct from `GATE_LABELS`): **accepted** — documented as a separate sync point in Current State; recommend unifying all three `detectBlocked*` functions on `Object.keys(GATE_LABELS)` so the gate set lives in one place.
+- **`if (b.prReady) continue;`** as the clean replacement for the builder-emit block: **adopted** in the dashboard-local subsection.
+- **Remove `recentlyMergedIssueIds` end-to-end**: **accepted** (success criteria + non-functional test).
+- **Gate-authoritative `derivePrReady`**: **accepted** as the selected approach.
+
+## Claude APPROVE — COMMENT items
+- **#1 `detectBlockedSince` sync point**: covered (see above).
+- **#2 `waitingSince` source after `pr` handling**: resolved by keeping `pr` in `detectBlockedSince` (see C1).
+- **#3 `gateKindClass` needs a `verify-approval` case**: covered (see C2).
+- **#5 three existing tests need inverting, not one**: **accepted** — enumerated the three `NeedsAttentionList.test.tsx` tests (invert ~183 and ~253; remove ~222 merged-suppression) and dropped the conditional on the verify-approval test scenario.
+
+---
+
+## Two reviewer suggestions I did NOT apply verbatim (verified incorrect)
+
+1. **Gemini: "redefine `derivePrReady` to simply check `parsed.gates['pr'] === 'pending'`."**
+   **Rejected as written.** Porch initializes *every* gate to `status: pending` with **no `requested_at`** at project creation (verified in this project's own `status.yaml` — `pr`, `spec-approval`, `plan-approval`, `verify-approval` all start `pending`). A bare `=== 'pending'` check would mark *every freshly-initialized project* as PR-ready. The predicate must be **`status: pending` AND `requested_at` present**. Captured as a correctness invariant + a dedicated test scenario. (Gemini's *intent* — gate-authoritative — is adopted; only the exact predicate is corrected.)
+
+2. **Gemini: "delete the `fetchRecentMergedPRs` helper in github.ts."**
+   **Rejected.** Verified against `overview.ts`: `fetchRecentMergedPRs`'s result (`mergedPRs`) is consumed **twice** — once for `recentlyMergedIssueIds` (being removed) and once at ~line 971 to build the `issueToPrUrl` map enriching the **recentlyClosed** section with PR links. The helper and its fetch are **retained**; only the `recentlyMergedIssueIds` projection and its consumers are removed. Documented in Current State + success criteria.
+
+---
+
+## Net
+Both REQUEST_CHANGES items are resolved by explicit spec additions; all APPROVE COMMENTs incorporated; two over-broad suggestions corrected with code-grounded reasoning. Design is unchanged from the unanimous Approach 1; the spec is now unambiguous enough to plan/implement from directly.

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -24,6 +24,7 @@ gates:
     approved_at: '2026-05-29T17:27:03.979Z'
   pr:
     status: pending
+    requested_at: '2026-05-29T18:13:40.170Z'
   verify-approval:
     status: pending
 iteration: 1
@@ -46,4 +47,5 @@ history:
         file: >-
           /Users/mwk/Development/cluesmith/codev/.builders/spir-927/codev/projects/927-needs-attention-surface-prs-vi/927-dashboard-surfacing-iter1-claude.txt
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T18:09:21.115Z'
+updated_at: '2026-05-29T18:13:40.170Z'
+pr_ready_for_human: true

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   spec-approval:
-    status: pending
+    status: approved
     requested_at: '2026-05-29T17:03:20.375Z'
+    approved_at: '2026-05-29T17:07:20.553Z'
   plan-approval:
     status: pending
   pr:
@@ -18,4 +19,4 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T17:03:20.375Z'
+updated_at: '2026-05-29T17:07:20.554Z'

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -1,7 +1,7 @@
 id: '927'
 title: needs-attention-surface-prs-vi
 protocol: spir
-phase: implement
+phase: review
 plan_phases:
   - id: server-derivation
     title: Gate-authoritative pr signal + verify-approval label (overview server + types)
@@ -11,8 +11,8 @@ plan_phases:
     status: complete
   - id: remove-dead-projection
     title: Delete recentlyMergedIssueIds end-to-end (retain fetchRecentMergedPRs)
-    status: in_progress
-current_plan_phase: remove-dead-projection
+    status: complete
+current_plan_phase: null
 gates:
   spec-approval:
     status: approved
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history:
   - iteration: 1
     plan_phase: dashboard-surfacing
@@ -46,4 +46,4 @@ history:
         file: >-
           /Users/mwk/Development/cluesmith/codev/.builders/spir-927/codev/projects/927-needs-attention-surface-prs-vi/927-dashboard-surfacing-iter1-claude.txt
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T18:00:39.775Z'
+updated_at: '2026-05-29T18:02:21.605Z'

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 2
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: dashboard-surfacing
@@ -46,4 +46,4 @@ history:
         file: >-
           /Users/mwk/Development/cluesmith/codev/.builders/spir-927/codev/projects/927-needs-attention-surface-prs-vi/927-dashboard-surfacing-iter1-claude.txt
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T17:53:26.743Z'
+updated_at: '2026-05-29T17:55:26.236Z'

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -10,8 +10,9 @@ gates:
     requested_at: '2026-05-29T17:03:20.375Z'
     approved_at: '2026-05-29T17:07:20.553Z'
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-05-29T17:17:05.611Z'
+    approved_at: '2026-05-29T17:27:03.979Z'
   pr:
     status: pending
   verify-approval:
@@ -20,4 +21,4 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T17:17:05.611Z'
+updated_at: '2026-05-29T17:27:03.980Z'

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -1,7 +1,7 @@
 id: '927'
 title: needs-attention-surface-prs-vi
 protocol: spir
-phase: specify
+phase: plan
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -16,7 +16,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T17:07:20.554Z'
+updated_at: '2026-05-29T17:08:04.289Z'

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -1,9 +1,18 @@
 id: '927'
 title: needs-attention-surface-prs-vi
 protocol: spir
-phase: plan
-plan_phases: []
-current_plan_phase: null
+phase: implement
+plan_phases:
+  - id: server-derivation
+    title: Gate-authoritative pr signal + verify-approval label (overview server + types)
+    status: in_progress
+  - id: dashboard-surfacing
+    title: PR-rows-only Needs Attention + verify styling (dashboard)
+    status: pending
+  - id: remove-dead-projection
+    title: Delete recentlyMergedIssueIds end-to-end (retain fetchRecentMergedPRs)
+    status: pending
+current_plan_phase: server-derivation
 gates:
   spec-approval:
     status: approved
@@ -18,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T17:27:03.980Z'
+updated_at: '2026-05-29T17:28:18.116Z'

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -1,0 +1,20 @@
+id: '927'
+title: needs-attention-surface-prs-vi
+protocol: spir
+phase: specify
+plan_phases: []
+current_plan_phase: null
+gates:
+  spec-approval:
+    status: pending
+  plan-approval:
+    status: pending
+  pr:
+    status: pending
+  verify-approval:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-29T16:47:35.190Z'
+updated_at: '2026-05-29T16:47:35.191Z'

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -16,7 +16,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T17:08:04.289Z'
+updated_at: '2026-05-29T17:11:41.034Z'

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: dashboard-surfacing
@@ -46,4 +46,4 @@ history:
         file: >-
           /Users/mwk/Development/cluesmith/codev/.builders/spir-927/codev/projects/927-needs-attention-surface-prs-vi/927-dashboard-surfacing-iter1-claude.txt
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T17:57:50.206Z'
+updated_at: '2026-05-29T18:00:39.775Z'

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T17:28:18.116Z'
+updated_at: '2026-05-29T17:37:51.426Z'

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   spec-approval:
     status: pending
+    requested_at: '2026-05-29T17:03:20.375Z'
   plan-approval:
     status: pending
   pr:
@@ -17,4 +18,4 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T16:54:46.812Z'
+updated_at: '2026-05-29T17:03:20.375Z'

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -23,8 +23,9 @@ gates:
     requested_at: '2026-05-29T17:17:05.611Z'
     approved_at: '2026-05-29T17:27:03.979Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-05-29T18:13:40.170Z'
+    approved_at: '2026-05-29T22:22:11.644Z'
   verify-approval:
     status: pending
 iteration: 1
@@ -47,5 +48,5 @@ history:
         file: >-
           /Users/mwk/Development/cluesmith/codev/.builders/spir-927/codev/projects/927-needs-attention-surface-prs-vi/927-dashboard-surfacing-iter1-claude.txt
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T18:13:40.170Z'
-pr_ready_for_human: true
+updated_at: '2026-05-29T22:22:11.645Z'
+pr_ready_for_human: false

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -11,6 +11,7 @@ gates:
     approved_at: '2026-05-29T17:07:20.553Z'
   plan-approval:
     status: pending
+    requested_at: '2026-05-29T17:17:05.611Z'
   pr:
     status: pending
   verify-approval:
@@ -19,4 +20,4 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T17:11:41.034Z'
+updated_at: '2026-05-29T17:17:05.611Z'

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -8,11 +8,11 @@ plan_phases:
     status: complete
   - id: dashboard-surfacing
     title: PR-rows-only Needs Attention + verify styling (dashboard)
-    status: in_progress
+    status: complete
   - id: remove-dead-projection
     title: Delete recentlyMergedIssueIds end-to-end (retain fetchRecentMergedPRs)
-    status: pending
-current_plan_phase: dashboard-surfacing
+    status: in_progress
+current_plan_phase: remove-dead-projection
 gates:
   spec-approval:
     status: approved
@@ -26,8 +26,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 2
-build_complete: true
+iteration: 1
+build_complete: false
 history:
   - iteration: 1
     plan_phase: dashboard-surfacing
@@ -46,4 +46,4 @@ history:
         file: >-
           /Users/mwk/Development/cluesmith/codev/.builders/spir-927/codev/projects/927-needs-attention-surface-prs-vi/927-dashboard-surfacing-iter1-claude.txt
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T17:55:26.236Z'
+updated_at: '2026-05-29T17:57:50.206Z'

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -14,7 +14,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T16:47:35.191Z'
+updated_at: '2026-05-29T16:54:46.812Z'

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: dashboard-surfacing
@@ -46,4 +46,4 @@ history:
         file: >-
           /Users/mwk/Development/cluesmith/codev/.builders/spir-927/codev/projects/927-needs-attention-surface-prs-vi/927-dashboard-surfacing-iter1-claude.txt
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T18:02:21.605Z'
+updated_at: '2026-05-29T18:09:21.115Z'

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T17:41:14.314Z'
+updated_at: '2026-05-29T17:46:05.090Z'

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -26,8 +26,24 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 1
-build_complete: true
-history: []
+iteration: 2
+build_complete: false
+history:
+  - iteration: 1
+    plan_phase: dashboard-surfacing
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /Users/mwk/Development/cluesmith/codev/.builders/spir-927/codev/projects/927-needs-attention-surface-prs-vi/927-dashboard-surfacing-iter1-gemini.txt
+      - model: codex
+        verdict: REQUEST_CHANGES
+        file: >-
+          /Users/mwk/Development/cluesmith/codev/.builders/spir-927/codev/projects/927-needs-attention-surface-prs-vi/927-dashboard-surfacing-iter1-codex.txt
+      - model: claude
+        verdict: APPROVE
+        file: >-
+          /Users/mwk/Development/cluesmith/codev/.builders/spir-927/codev/projects/927-needs-attention-surface-prs-vi/927-dashboard-surfacing-iter1-claude.txt
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T17:46:05.090Z'
+updated_at: '2026-05-29T17:53:26.743Z'

--- a/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
+++ b/codev/projects/927-needs-attention-surface-prs-vi/status.yaml
@@ -5,14 +5,14 @@ phase: implement
 plan_phases:
   - id: server-derivation
     title: Gate-authoritative pr signal + verify-approval label (overview server + types)
-    status: in_progress
+    status: complete
   - id: dashboard-surfacing
     title: PR-rows-only Needs Attention + verify styling (dashboard)
-    status: pending
+    status: in_progress
   - id: remove-dead-projection
     title: Delete recentlyMergedIssueIds end-to-end (retain fetchRecentMergedPRs)
     status: pending
-current_plan_phase: server-derivation
+current_plan_phase: dashboard-surfacing
 gates:
   spec-approval:
     status: approved
@@ -27,7 +27,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-05-29T16:47:35.190Z'
-updated_at: '2026-05-29T17:37:51.426Z'
+updated_at: '2026-05-29T17:41:14.314Z'

--- a/codev/reviews/927-needs-attention-surface-prs-vi.md
+++ b/codev/reviews/927-needs-attention-surface-prs-vi.md
@@ -1,0 +1,109 @@
+# Review: Needs Attention — surface PRs via the universal `pr` gate; delete gateless builder-derived fallbacks
+
+## Summary
+
+Reworked the dashboard's **Needs Attention** surface so PR-readiness is keyed on the **universal `pr` gate** instead of fragile builder-state derivations. Three SPIR phases, net **deletion** (+227 / −272 = **−45 LOC** across `packages/`): removed the `derivePrReady` `bugfix && verified` fallback, the `NeedsAttentionList` builder-emit branch, the `pr_ready_for_human` field *dependency*, and the `recentlyMergedIssueIds` projection; added one gate (`verify-approval → "verify review"`) to the shared human-gate allowlist. Behavior is now: **(A)** open PRs whose linked builder has a pending `pr` gate → PR rows only; **(B)** gate rows for spec/plan/dev/verify-approval; never a builder standing in for a PR.
+
+## Spec Compliance
+
+- [x] **PR-surfacing keys on the `pr` gate** — `derivePrReady` reduced to the `requested_at`-aware `pr`-gate-pending check (Phase 1).
+- [x] **No builder-stand-in** — builder-emit branch deleted; `if (b.prReady) continue;` excludes PR-ready builders from the gate-row loop (Phase 2).
+- [x] **Merged PRs drop automatically** — open-only `pendingPRs` + no builder-emit ⇒ a missing PR yields no row, no suppression list (Phase 2/3).
+- [x] **Gate rows for spec/plan/dev/verify-approval** — `verify-approval` added to `GATE_LABELS` as `"verify review"` + `gateKindClass` + `.attention-kind--verify` CSS (Phase 1/2).
+- [x] **`pr` gate excluded from the dashboard gate-row path** (dashboard-local), while **kept** in shared `GATE_LABELS`/`detectBlocked*` so VSCode is unaffected (Phase 1/2).
+- [x] **Gate-pending predicate is `requested_at`-aware** — guards freshly-initialized projects (Phase 1, dedicated test).
+- [x] **Unaffiliated/human-PR fallback preserved** (`REVIEW_REQUIRED`, no builder) — and is now the *only* place `pr.createdAt` is used for waiting-time (Phase 2, post-Codex fix).
+- [x] **`recentlyMergedIssueIds` removed end-to-end**; **`fetchRecentMergedPRs` retained** (recentlyClosed PR-link enrichment) (Phase 3).
+- [x] **#919 reconciled** — see Follow-up Items; the `verified → complete` rename is *not* done here.
+
+## Deviations from Plan
+
+- **Phase 2 (iter-2, Codex CMAP)**: the initial Phase 2 carried over a `waitingSince: readySince || pr.createdAt` fallback and two tests encoding the now-impossible gateless-BUGFIX shape (`prReady` with no gate/no `blockedSince`). Fixed: affiliated PRs use the gate timestamp exclusively (`createdAt` reserved for unaffiliated PRs); the two obsolete-shape tests were reframed/removed. No plan-phase boundaries changed.
+- **Worktree setup**: this repo has no `worktree.postSpawn`, so the worktree spawned without `node_modules`; ran `pnpm install --frozen-lockfile` before builds/tests. (See Follow-up Items.)
+
+## Key Metrics
+
+- **Commits**: 26 on the branch (11 substantive `[Spec 927]`/phase commits + porch bookkeeping).
+- **Tests**: codev overview suite + dashboard `NeedsAttentionList` (13 passing) + VSCode `builders.test.ts` blast-radius suite. New: gate-authoritative `derivePrReady` cases incl. `requested_at` guard; verify-approval in `detectBlocked`/`detectBlockedSince`; verify gate-row + "missing PR ⇒ no row" + unaffiliated-uses-createdAt; VSCode verify-blocked ordering. Removed: 2 inverted + 1 merged-suppression + 1 impossible-shape + 2 `recentlyMergedIssueIds` server tests.
+- **Files changed**: 8 (`packages/`): `overview.ts`, `overview.test.ts`, `types/api.ts`, `vscode/test/builders.test.ts`, `dashboard/NeedsAttentionList.tsx`, `dashboard/NeedsAttentionList.test.tsx`, `dashboard/WorkView.tsx`, `dashboard/index.css`.
+- **Net LOC impact**: **−45** (+227 / −272) — a net simplification.
+
+## Consultation Iteration Summary
+
+18 consultation files (spec + plan + 3 impl phases, several with 3 models/round). Verdict pattern: Gemini and Claude APPROVE throughout; Codex was the consistent, valuable skeptic.
+
+| Phase | Iters | Who Blocked | What They Caught |
+|-------|-------|-------------|------------------|
+| Specify | 1 | Codex (RC) | Pin shared `blocked` semantics for `pr`; define the `verify-approval` label string |
+| Plan | 1 | Codex (RC) | VSCode blast radius must be *owned* in a phase (files+tests), not just discussed; align Phase-1 "+types" file list |
+| server-derivation | 1 | — (Gemini infra-flaked once, retried clean) | Unanimous APPROVE |
+| dashboard-surfacing | 2 | Codex (RC iter-1) | Affiliated PR `waitingSince` still fell back to `createdAt`; tests locked the impossible gateless-BUGFIX shape |
+| remove-dead-projection | 1 | — | Unanimous APPROVE |
+
+**Most frequent blocker**: Codex — focused on contract precision and removing vestigial behavior. All blocks were legitimate and accepted.
+
+### Avoidable Iterations
+
+1. **Carried-over tests/fallback (Phase 2)**: when a downstream phase changes an invariant (gate-authoritative `prReady` ⇒ `blockedSince` always present), the builder should proactively audit *existing* tests/fallbacks that encode the old invariant rather than leaving them for a reviewer to catch. Codex's Phase-2 RC was avoidable with a self-audit of the `pr.createdAt` fallback against the new contract.
+
+## Consultation Feedback
+
+### Specify (Round 1) — Codex RC, Gemini/Claude APPROVE
+- **Codex**: shared `pr` semantics + `verify-approval` label undefined. **Addressed**: added the dashboard-local scope rule, the `requested_at` invariant, and the `"verify review"` label contract.
+- **Builder-initiated corrections**: caught two over-broad Gemini suggestions — a bare `gates['pr']==='pending'` check (would mis-flag fresh projects) and "delete `fetchRecentMergedPRs`" (it has a second consumer). Both **rebutted with evidence** and the spec/plan reflect the correct form.
+
+### Plan (Round 1) — Codex RC, Gemini/Claude APPROVE
+- **Codex**: own the VSCode blast radius in Phase 1; align the "+types" file list. **Addressed**: Phase 1 took explicit ownership (files + acceptance criteria + tests).
+
+### dashboard-surfacing (Round 1) — Codex RC, Gemini/Claude APPROVE
+- **Codex**: affiliated PR `waitingSince` could still use `pr.createdAt`; obsolete gateless-BUGFIX tests. **Addressed**: explicit affiliated→gate-timestamp / unaffiliated→createdAt split; tests reframed/removed. **Round 2: unanimous APPROVE.**
+
+### server-derivation / remove-dead-projection
+- No substantive concerns — unanimous APPROVE (one Gemini consult infra-flaked with a tool error and was re-run).
+
+## Lessons Learned
+
+### What Went Well
+- **The signal already existed.** Reframing the whole problem around the existing `pr` gate (rather than inventing a marker) made the change a net deletion — the most robust kind of fix.
+- **Scrutinizing reviewer suggestions paid off repeatedly** — two over-confident Gemini suggestions (bad predicate, wrong helper deletion) were caught and corrected with code evidence rather than applied blindly.
+- **Phase ordering kept every commit green** in both packages (consume-then-remove for `recentlyMergedIssueIds`).
+- **Render-verify caught nothing broken — but proved it** (see Architecture Updates): the new `.attention-kind--verify` class renders the intended amber, not unstyled.
+
+### Challenges Encountered
+- **Worktree had no `node_modules`** (no `worktree.postSpawn`): resolved with `pnpm install --frozen-lockfile`; cost a short detour diagnosing a vitest resolution error.
+- **porch check coverage gap**: the `tests` check runs only `@cluesmith/codev` tests — dashboard and VSCode tests are *not* porch-gated. Verified those manually each phase. (1 Codex iteration on Phase 2.)
+
+### What Would Be Done Differently
+- Audit pre-existing tests/fallbacks against a newly-introduced invariant *before* signaling phase-complete (would have pre-empted the Phase-2 Codex RC).
+
+## Architecture Updates
+
+No edits to `codev/resources/arch.md` were needed — it does not document Needs-Attention internals (`derivePrReady` / `recentlyMergedIssueIds` / gate labels) at this level, and the change *clarifies and simplifies* existing behavior rather than introducing new architectural shape. The durable contract is recorded here:
+
+- **Needs Attention surfacing contract**: a PR surfaces iff its linked builder's `pr` gate is genuinely pending (`status: pending` **and** `requested_at`). The `pr` gate going pending is the **uniform post-CMAP "ready for human" signal** across all PR-producing protocols (BUGFIX, AIR, SPIR, ASPIR, PIR — #887 gave BUGFIX a `pr` gate). A protocol must carry a `pr` gate for its PR to surface; gateless variants don't surface PR rows, by design.
+- **Dashboard-local "no builder stand-in" rule**: `pr` stays in the shared `GATE_LABELS`/`detectBlocked*` (VSCode tree/toast/status-bar depend on it and surface a pr-gate builder as a blocked builder); only the dashboard `NeedsAttentionList` enforces "PR-as-PR-row" because only it has the open-PR set.
+- **`verify-approval`** now surfaces as a blocked human gate (`"verify review"`) everywhere `detectBlocked` is consumed (dashboard gate row + VSCode), via the gate-toast generic fallback.
+
+**Render verification (per architect instruction + UI-PR policy)**: headless chromium loaded the **built** dashboard CSS with the exact `NeedsAttentionList` row DOM. The `.attention-kind--verify` span computed to `rgb(234, 179, 8)` (`--status-waiting`, == the PR row), distinct from spec (`rgb(239,68,68)`) and from an unstyled control — proving the new className actually receives styling (no "className without matching CSS" gap). Screenshot captured during review.
+
+## Lessons Learned Updates
+
+No edits to `codev/resources/lessons-learned.md` were made in-branch (that file is curated during MAINTAIN from review docs). Candidate lessons for the next MAINTAIN harvest:
+
+- **Reframe to an existing signal before adding one.** The cleanest fix to an over-derived state is often to key on a signal that already exists end-to-end (here, the `pr` gate) — turning a feature into a deletion.
+- **Audit existing tests/fallbacks against new invariants.** When a phase tightens an invariant, pre-existing tests encoding the looser shape become false-confidence; audit and update them proactively.
+- **Scrutinize CMAP suggestions, especially confident deletions.** Verify blast radius (e.g. second consumers) before applying a reviewer's "just delete X."
+- **porch `tests` is single-package.** Dashboard/VSCode tests aren't gated by porch's check; run them manually per phase when touching those packages.
+
+## Technical Debt
+
+- The affiliated-PR `?? pr.createdAt` is an unreachable type guard (documented). It exists because `OverviewBuilder.blockedSince` is typed `string | null` independently of `prReady`; a future type-level coupling could remove it, but it's not worth a type gymnastics now.
+
+## Follow-up Items
+
+- **#919** (`verified → complete` terminal-state rename): its Needs-Attention / `derivePrReady` parts are now **unnecessary** (this work supersedes them). The honesty rename of the terminal state stands on its own — recommend descoping #919 to just the rename.
+- **#902 / #901** (`recentlyMergedIssueIds`): the projection is removed; #902's mechanism is retired. No further action beyond noting it in the PR.
+- **External adopter (shannon)**: align its gateless bugfix variant to the pr-gated upstream so it's covered by the universal mechanism (tracked outside this repo).
+- **VSCode `verify-approval` UX (for Amr / area/vscode)**: verify-approval now surfaces as a blocked builder via the generic gate-toast fallback. A dedicated `GATE_ACTIONS` "Verify" action is an optional additive follow-up — not required by #927.
+- **Worktree DX**: consider adding `worktree.postSpawn: ["pnpm install --frozen-lockfile"]` to `.codev/config.json` so builder worktrees come with deps installed.
+- **EXPERIMENT/MAINTAIN completion gates** (`experiment-complete`/`maintain-complete`) surface nowhere in the dashboard today — out of scope for #927; track separately if surfacing is desired.

--- a/codev/specs/927-needs-attention-surface-prs-vi.md
+++ b/codev/specs/927-needs-attention-surface-prs-vi.md
@@ -1,9 +1,14 @@
+---
+approved: 2026-05-29
+validated: [gemini, codex, claude]
+---
+
 # Specification: Needs Attention — surface PRs via the universal `pr` gate; delete gateless builder-derived fallbacks
 
 ## Metadata
 - **ID**: spec-2026-05-29-needs-attention-surface-prs-vi
 - **Issue**: #927
-- **Status**: draft
+- **Status**: approved
 - **Created**: 2026-05-29
 
 ## Clarifying Questions Asked

--- a/codev/specs/927-needs-attention-surface-prs-vi.md
+++ b/codev/specs/927-needs-attention-surface-prs-vi.md
@@ -35,6 +35,7 @@ These exist solely to cope with **one deviation**: a *gateless* bugfix variant (
 - **Porch** writes `pr_ready_for_human: true` to `status.yaml` exactly when it auto-requests the `pr` gate (sets the gate `pending`), and clears it to `false` on `pr`-gate approval and on rollback past the PR-creating phase. Every upstream PR-producing protocol — BUGFIX, AIR, SPIR, ASPIR, PIR — now carries a `pr` gate on its PR-creating phase (#887 closed the BUGFIX gap). Therefore, **for every upstream protocol, `pr_ready_for_human === true` is coincident with the `pr` gate being `pending`** (written in the same commit).
 - **`derivePrReady(parsed)`** (overview.ts) returns the explicit `pr_ready_for_human` field when present; otherwise it falls back to: `pr` gate pending **OR** `bugfix && phase === 'verified'`. The builder object's `prReady` boolean is set from this.
 - **`detectBlocked` / `GATE_LABELS`** (overview.ts) map pending gates to labels: `spec-approval → "spec review"`, `plan-approval → "plan review"`, `dev-approval → "dev review"`, `pr → "PR review"`. **`verify-approval` is absent from this map**, so a pending `verify-approval` gate produces `blocked = null` and surfaces nowhere.
+- **Three sibling functions hold the gate list redundantly**: `detectBlocked` and `detectBlockedGate` iterate `Object.keys(GATE_LABELS)`, but **`detectBlockedSince` keeps its own hardcoded array** `['spec-approval', 'plan-approval', 'dev-approval', 'pr']` (with a "keep in sync" comment). This is a separate sync point: adding `verify-approval` to `GATE_LABELS` without also adding it to `detectBlockedSince` would yield `blocked = "verify review"` but `blockedSince = null`, and `buildItems`' `if (!b.blocked || !b.blockedSince) continue;` would then silently drop the row. The clean fix is to make `detectBlockedSince` iterate `Object.keys(GATE_LABELS)` too, so the gate set lives in exactly one place.
 
 ### How `NeedsAttentionList.buildItems` assembles rows today
 
@@ -47,6 +48,7 @@ These exist solely to cope with **one deviation**: a *gateless* bugfix variant (
 ### Supporting state
 
 - **`recentlyMergedIssueIds`** (`OverviewData`, #902): computed in `overview.ts` from recently-merged PRs and threaded through `WorkView` into `NeedsAttentionList`. Its **only** consumer is the builder-emit branch's merged-suppression check.
+- **`fetchRecentMergedPRs`** (`packages/codev/src/lib/github.ts`) is the helper that fetches the merged-PR window. **It is NOT exclusive to `recentlyMergedIssueIds`**: its result (`mergedPRs`) is *also* used in `overview.ts` (~line 971) to build the `issueToPrUrl` map that enriches the **recentlyClosed** section with PR links. (Confirmed: `overview.ts` is the helper's only non-test caller, but it uses `mergedPRs` twice.) Therefore removing `recentlyMergedIssueIds` must **keep** `fetchRecentMergedPRs` and the `mergedPRs` fetch intact — only the `recentlyMergedIssueIds` projection (and its consumers) is removed. *(This corrects a consultation suggestion to delete the helper outright.)*
 - **`pendingPRs`** lists **open PRs only** — a merged PR is correctly absent.
 
 ### Why it's wrong
@@ -63,6 +65,35 @@ These exist solely to cope with **one deviation**: a *gateless* bugfix variant (
 - **Plus** the existing fallback for **unaffiliated / human-authored PRs**: surface when `reviewDecision === 'REVIEW_REQUIRED'` and there is no matching builder.
 
 A **builder never stands in for a PR.** The `pr` gate surfaces **only** as a PR row (via the open-PR set), never as a builder/gate row.
+
+### Scope of the "no builder stand-in" rule: dashboard-local (resolves consultation)
+
+The rule **"a builder never stands in for a PR"** is **dashboard-local** to `NeedsAttentionList`. It is *not* a change to the shared blocked-detection infrastructure:
+
+- **Keep `pr` in `GATE_LABELS` / `detectBlocked` / `detectBlockedGate` / `detectBlockedSince`** (the shared `overview.ts` derivation). VSCode's Needs Attention tree, gate toast, and status-bar counter are builder-centric surfaces (they have no PR list to render a proper PR row), so a pr-gate-pending builder *should* keep surfacing there as a blocked builder with the bell icon — that is existing, correct behavior and must not regress.
+- The dashboard alone has the open-PR set (`pendingPRs`) needed to render a real PR row, so the dashboard alone enforces "PR-as-PR-row, never as builder-row." It does this in `buildItems` by **excluding PR-ready builders from the builder/gate-row loop entirely** (an early `if (b.prReady) continue;`), so a pr-gate builder can only ever appear via the PR loop. This single guard replaces the deleted builder-emit branch *and* prevents the gate-row catch-all from emitting a stand-in row.
+
+**Consequence for waiting-time (resolves "gate-requested time" criterion):** because `pr` stays in `detectBlockedSince`, a pr-gate-pending builder still carries `blockedSince = gateRequestedAt['pr']`. The PR row continues to use that value for its waiting-since chip ("how long the human has been the bottleneck"), preserving *gate-requested time* — not PR-creation time. The `pr.createdAt` fallback remains only for the unaffiliated/human-PR case (no builder, no gate timestamp).
+
+### The "pending gate" predicate (correctness invariant)
+
+A gate counts as genuinely pending **only when it has both `status: pending` AND a `requested_at` timestamp**. Porch initializes *every* gate to `status: pending` with no `requested_at` at project creation (verified in this project's own `status.yaml`: `pr`, `spec-approval`, `plan-approval`, `verify-approval` all start `pending` with no `requested_at`). A gate is "really pending" only once porch *requests* it (writes `requested_at`).
+
+Therefore the PR-surfacing predicate is:
+
+```
+gates['pr'] === 'pending'  AND  gateRequestedAt['pr'] is present
+```
+
+and likewise for every gate-row gate. A simplification to `gates['pr'] === 'pending'` alone is **incorrect** — it would mark every freshly-initialized project as PR-ready. (The existing `detectBlocked` / `detectBlockedGate` / `detectBlockedSince` already use the `requested_at`-aware predicate; `derivePrReady` must keep it too.)
+
+### Human-facing label contract for `verify-approval`
+
+`verify-approval` surfaces with the label **`"verify review"`** (mirroring `spec-approval → "spec review"`, `plan-approval → "plan review"`). Consumers render `blocked` directly, so the string is a contract:
+
+- `GATE_LABELS['verify-approval'] = 'verify review'`.
+- Dashboard `gateKindClass` gains a `'verify review' → 'attention-kind--verify'` case, and a new `.attention-kind--verify` CSS rule is added to `packages/dashboard/src/index.css` (today only `--pr`, `--spec`, `--plan`, `--code-review` exist; an unmapped label falls back to `--plan`, which is merely a styling smell, not a functional break).
+- VSCode gate-toast `GATE_ACTIONS` has no `verify-approval` entry; it uses the generic fallback ("Review" → open builder terminal), which is acceptable and need not change.
 
 ### The universal contract
 
@@ -85,10 +116,11 @@ EXPERIMENT and MAINTAIN do **not** follow the CMAP→PR pattern and do **not** p
 - [ ] **PR-surfacing keys on the `pr` gate.** An open PR whose linked builder has a pending `pr` gate surfaces as exactly one **PR row** (linking to the PR URL).
 - [ ] **No builder-stand-in.** When a pr-gated builder's PR is absent from the open-PR set (cache miss), **no row** is emitted for it. The `derivePrReady` `bugfix && phase === 'verified'` fallback and the `NeedsAttentionList.buildItems` builder-emit branch are **deleted**.
 - [ ] **Merged PRs drop automatically.** A merged PR (absent from `pendingPRs`) produces no Needs Attention row, with no reliance on a recently-merged suppression list.
-- [ ] **Gate rows preserved** for `spec-approval`, `plan-approval`, `dev-approval`, and `verify-approval`. (`verify-approval` is **added** to the gate-row path; it is currently missing.)
-- [ ] **`pr` gate excluded from the gate-row path** — it surfaces only as a PR row, so a cache-missed pr-gate builder cannot fall through to a builder/gate row.
+- [ ] **Gate rows preserved** for `spec-approval`, `plan-approval`, `dev-approval`, and `verify-approval`. (`verify-approval` is **added** to `GATE_LABELS` with label `"verify review"`; it is currently missing. Add the matching `gateKindClass` case + `.attention-kind--verify` CSS rule.)
+- [ ] **`pr` gate excluded from the dashboard gate-row path** — it surfaces only as a PR row. The exclusion is dashboard-local (`if (b.prReady) continue;` in `buildItems`); `pr` **remains** in the shared `GATE_LABELS`/`detectBlocked*` so VSCode surfaces are unaffected.
+- [ ] **Gate-pending predicate is `requested_at`-aware** — `derivePrReady` (and any new surfacing check) treats a gate as pending only when `status: pending` **and** `requested_at` is present, so freshly-initialized projects are not mis-flagged.
 - [ ] **Unaffiliated/human-PR fallback preserved** (`reviewDecision === 'REVIEW_REQUIRED'`, no matching builder).
-- [ ] **`recentlyMergedIssueIds` reconciled** — assessed and (recommended) removed end-to-end since its only consumer (the builder-emit branch) is deleted; OR an explicit justification is recorded for keeping it.
+- [ ] **`recentlyMergedIssueIds` removed end-to-end** — the field (`OverviewData`/`api.ts`), its computation block in `overview.ts`, and its prop threading (`WorkView` → `NeedsAttentionList`) are deleted. **`fetchRecentMergedPRs` and the `mergedPRs` fetch are kept** (still needed for the recentlyClosed `issueToPrUrl` map).
 - [ ] **#919 reconciled** — this spec supersedes #919's Needs-Attention / `derivePrReady` parts; the `verified → complete` terminal-state rename is **not** performed here and is documented as independent.
 - [ ] All affected unit tests updated; new tests cover the contract (below). No reduction in coverage.
 - [ ] No regression in the VSCode Needs Attention tree / toast / status-bar counter that share `detectBlocked` (verified, since `GATE_LABELS` is shared infrastructure).
@@ -111,7 +143,7 @@ EXPERIMENT and MAINTAIN do **not** follow the CMAP→PR pattern and do **not** p
 
 ## Solution Approaches
 
-### Approach 1 (recommended): Gate-authoritative surfacing
+### Approach 1 (SELECTED — unanimous consultation): Gate-authoritative surfacing
 
 **Description**: Make the **`pr` gate `pending`** the single source of truth for PR-surfacing.
 
@@ -151,14 +183,15 @@ Explicitly **out of scope** per the issue — the `pr` gate is the universal sig
 ### Critical (Blocks Progress)
 - [ ] **None.** The issue's direction is unambiguous on the core mechanism.
 
-### Important (Affects Design)
-- [ ] **Add `verify-approval` to the gate-row path?** Desired-behavior (B) lists it, but it is currently absent from `GATE_LABELS`/`detectBlocked`, so "keep" cannot be satisfied literally — it must be **added**. Recommendation: **add it** (rounds out "every genuine human gate surfaces; the `pr` gate surfaces as a PR row"). Note the shared-consumer impact (VSCode tree/toast/status bar).
-- [ ] **Remove `recentlyMergedIssueIds` end-to-end, or leave it vestigial?** Recommendation: **remove** (its only consumer is deleted; #902 becomes unnecessary). Confirm no other consumer exists before removal.
-- [ ] **`derivePrReady` form**: gate-authoritative (recommended — kills #919 sticky-field hazard) vs field-first-minus-bugfix-branch (smaller diff). Functionally equivalent for correctly-gated builders.
+### Resolved by consultation (3-way unanimous)
+- [x] **Add `verify-approval`?** **YES.** Add to `GATE_LABELS` as `"verify review"` + `gateKindClass` case + `.attention-kind--verify` CSS. Shared-consumer impact verified manageable (VSCode toast uses a generic fallback for unknown gates; no breakage).
+- [x] **Remove `recentlyMergedIssueIds`?** **YES, end-to-end** — but **keep** `fetchRecentMergedPRs`/`mergedPRs` (still needed for recentlyClosed `issueToPrUrl`). (Builder verified the helper has a second consumer; the consultation suggestion to delete the helper was incorrect.)
+- [x] **`derivePrReady` form?** **Gate-authoritative** — reduce to the `requested_at`-aware `pr`-gate-pending check and drop the `pr_ready_for_human` field dependency, killing the #919 sticky-field hazard. (Keep the `requested_at` guard — see correctness invariant.)
+- [x] **Scope of "no builder stand-in"?** **Dashboard-local.** Keep `pr` in shared blocked-detection (VSCode bell + PR-row waiting-since timestamp depend on it); enforce PR-as-PR-row only in `buildItems`.
 
 ### Nice-to-Know (Optimization)
 - [ ] Should EXPERIMENT/MAINTAIN `experiment-complete` / `maintain-complete` gates surface as gate rows in the dashboard? Currently they surface nowhere. Recommendation: **out of scope** for #927 (not a regression of this work); track separately if desired.
-- [ ] Should porch eventually stop writing `pr_ready_for_human` entirely (becomes vestigial under gate-authoritative surfacing)? Recommendation: **out of scope** (porch-side; the dashboard simply stops depending on it).
+- [ ] Should porch eventually stop writing `pr_ready_for_human` entirely (becomes vestigial under gate-authoritative surfacing)? Recommendation: **out of scope** (porch-side; the dashboard simply stops depending on it). The field stays written; the dashboard simply ignores it.
 
 ## Performance Requirements
 - No new network calls or heavy computation; this is presentational/derivation logic over already-fetched `OverviewData`. No measurable performance impact expected. (Removing `recentlyMergedIssueIds` removes a small amount of per-refresh work.)
@@ -174,15 +207,22 @@ Explicitly **out of scope** per the issue — the `pr` gate is the universal sig
 3. **Merged PR ⇒ nothing** — builder's PR merged (absent from `pendingPRs`) ⇒ **no row**, with no reliance on `recentlyMergedIssueIds`.
 4. **Pre-CMAP PR excluded** — open PR whose builder has NOT yet reached the `pr` gate ⇒ no row.
 5. **Gate rows preserved** — builder pending on `spec-approval` / `plan-approval` / `dev-approval` ⇒ a gate row with the correct kind/label and waiting-since.
-6. **`verify-approval` surfaces** (if Approach 1 adopted) — builder pending on `verify-approval` ⇒ a gate row.
-7. **`pr` gate never a gate row** — builder with `pr` gate `pending` whose PR is missing does NOT produce a "PR review" gate/builder row (intersection of #2 and the exclusion rule).
-8. **Unaffiliated/human PR** — open PR with no matching builder surfaces only when `reviewDecision === 'REVIEW_REQUIRED'`.
-9. **No double-emit** — PR present AND builder present ⇒ exactly one PR row.
-10. **Gateless variant ⇒ nothing** — a builder on a gateless PR-producing protocol does not surface a PR row (documents the universal contract).
+6. **`verify-approval` surfaces** — builder pending on `verify-approval` ⇒ a gate row labeled `"verify review"`.
+7. **`pr` gate never a builder/gate row** — builder with `pr` gate `pending` whose PR is missing from `pendingPRs` produces NO row at all (intersection of #2 and the dashboard-local exclusion).
+8. **Freshly-initialized project ⇒ nothing** — a builder whose `pr` gate is `status: pending` but has **no `requested_at`** is NOT treated as PR-ready (guards the `requested_at` invariant).
+9. **Unaffiliated/human PR** — open PR with no matching builder surfaces only when `reviewDecision === 'REVIEW_REQUIRED'`.
+10. **No double-emit** — PR present AND builder present ⇒ exactly one PR row.
+11. **Gateless variant ⇒ nothing** — a builder on a gateless PR-producing protocol does not surface a PR row (documents the universal contract).
+
+### Existing tests to update (enumerated)
+`packages/dashboard/__tests__/NeedsAttentionList.test.tsx` has three tests that lock in the deleted behavior and must be **inverted or removed**:
+- "still surfaces a prReady BUGFIX builder when its PR is missing from prs" (~lines 183–219) → **invert** (assert no row).
+- "still surfaces a prReady gated builder (AIR/SPIR shape) when its PR is missing" (~lines 253–275) → **invert** (assert no row).
+- "does NOT surface a prReady builder whose PR has been merged (Issue #901)" (~lines 222–251) → **remove** (the `recentlyMergedIssueIds` mechanism it exercises is deleted; covered now by "missing PR ⇒ no row").
 
 ### Non-Functional Tests
 1. **Shared-consumer regression check** — adding `verify-approval` to `GATE_LABELS` does not break the VSCode Needs Attention tree / toast / status-bar counter (build + existing tests pass).
-2. **Dead-code removal** — `recentlyMergedIssueIds` removed cleanly (type, computation, prop threading) with TypeScript build green.
+2. **Dead-code removal** — `recentlyMergedIssueIds` removed cleanly (type, computation, prop threading) with TypeScript build green; `fetchRecentMergedPRs` retained and the recentlyClosed PR-link enrichment still works.
 
 ## Dependencies
 - **External Services**: GitHub/forge PR listing (already used to build `pendingPRs`); no new calls.
@@ -202,11 +242,21 @@ Explicitly **out of scope** per the issue — the `pr` gate is the universal sig
 | Inverting the "cache-miss surfaces a row" tests masks a genuine cache-miss UX gap | Low | Low | Accept by design (issue req 1); the next refresh surfaces the PR once `pendingPRs` includes it. Document the tradeoff. |
 
 ## Expert Consultation
-**Date**: (pending)
-**Models Consulted**: Gemini, Codex, Claude (3-way, run by porch after this draft)
-**Sections Updated**: (to be filled after consultation)
+**Date**: 2026-05-29
+**Models Consulted**: Gemini (APPROVE), Codex (REQUEST_CHANGES), Claude (APPROVE) — 3-way, run by porch.
 
-Note: All consultation feedback will be incorporated directly into the relevant sections above.
+**Verdicts**: 2 APPROVE / 1 REQUEST_CHANGES. Codex's REQUEST_CHANGES asked for two ambiguities to be pinned down explicitly (shared `blocked` semantics for the `pr` gate; the `verify-approval` label string) — both now resolved in the spec. All three converged on the same design (Approach 1).
+
+**Sections Updated from consultation**:
+- **Desired State → "Scope of the no-builder-stand-in rule"** (new): resolves Codex #1 — keep `pr` in shared `GATE_LABELS`/`detectBlocked*` (VSCode bell + PR-row timestamp depend on it); enforce PR-as-PR-row only in the dashboard `buildItems`. Implemented via `if (b.prReady) continue;` (per Gemini).
+- **Desired State → "pending gate predicate" invariant** (new): the builder caught that the gate-pending check must be `requested_at`-aware — a bare `gates['pr'] === 'pending'` (as one consultation suggested) would mis-flag every freshly-initialized project, since porch starts all gates `pending` with no `requested_at`. Verified against this project's own `status.yaml`.
+- **Desired State → `verify-approval` label contract** (new): resolves Codex #2 / Claude #3 — label `"verify review"`, `gateKindClass` case, `.attention-kind--verify` CSS.
+- **Current State**: flagged `detectBlockedSince`'s separate hardcoded gate array as a distinct sync point (Gemini's "implementation trap" / Claude #1); recommend unifying on `Object.keys(GATE_LABELS)`.
+- **Current State**: documented that `fetchRecentMergedPRs`/`mergedPRs` has a *second* consumer (recentlyClosed `issueToPrUrl`), so the helper is **retained** — correcting Gemini's suggestion to delete it (builder verified against `overview.ts:971`).
+- **Test Scenarios**: dropped the conditional on the `verify-approval` test; enumerated the **three** existing `NeedsAttentionList.test.tsx` tests that need inversion/removal (Claude #5); added the freshly-initialized-project guard test.
+- **Open Questions**: the three "Important" design questions are now **resolved** with the consultation's recommendations.
+
+Note: All consultation feedback has been incorporated directly into the relevant sections above.
 
 ## Approval
 - [ ] Technical Lead Review (architect — `spec-approval` gate)
@@ -214,7 +264,7 @@ Note: All consultation feedback will be incorporated directly into the relevant 
 
 ## Notes
 
-- **Net effect is deletion**: two fallbacks (`derivePrReady` bugfix branch, `buildItems` builder-emit branch) and one data field (`recentlyMergedIssueIds`) go away; one gate (`verify-approval`) is added to the human-gate allowlist; the `pr` gate is excluded from the gate-row path. The signal everything keys on already exists — the `pr` gate.
+- **Net effect is deletion**: two fallbacks (`derivePrReady` bugfix branch, `buildItems` builder-emit branch), the `pr_ready_for_human` field *dependency*, and one data projection (`recentlyMergedIssueIds`) go away; one gate (`verify-approval`) is added to the human-gate allowlist; the `pr` gate is excluded from the *dashboard* gate-row path. The signal everything keys on already exists — the `pr` gate. `fetchRecentMergedPRs` is **retained** (second consumer: recentlyClosed PR links).
 - **Scope discipline**: no new markers (req: out of scope), no change to pre-PR gate semantics (req: out of scope), no `verified → complete` rename (belongs to #919).
 
 ---

--- a/codev/specs/927-needs-attention-surface-prs-vi.md
+++ b/codev/specs/927-needs-attention-surface-prs-vi.md
@@ -1,0 +1,226 @@
+# Specification: Needs Attention — surface PRs via the universal `pr` gate; delete gateless builder-derived fallbacks
+
+## Metadata
+- **ID**: spec-2026-05-29-needs-attention-surface-prs-vi
+- **Issue**: #927
+- **Status**: draft
+- **Created**: 2026-05-29
+
+## Clarifying Questions Asked
+
+Issue #927 is highly prescriptive — it names the root cause, the universal signal, the exact code to delete, and the desired behavior. Rather than re-ask answered questions, the design questions that remain are captured under **Open Questions** for the architect/reviewers to settle. The issue's "Direction" section is treated as authoritative intent (effectively baked decisions); this spec fleshes it out and grounds it in the current code.
+
+No `## Baked Decisions` section is present in the issue body, so there is no verbatim-copy block. The five numbered "Direction" items and the "Out of scope" list are honored as fixed intent.
+
+## Problem Statement
+
+The dashboard's **Needs Attention** surface (`WorkView` → `NeedsAttentionList`) has accreted a *builder-state-derived* model for "a PR is ready for a human." That model is fragile and produces three wrong behaviors, all faces of one root cause:
+
+1. It surfaces **builder rows** standing in for PRs (not just PR rows).
+2. It keeps **merged PRs** showing (stale "PR review" rows for already-shipped work).
+3. It can **hide ready PRs**.
+
+The root cause: bugfix-style PR-readiness is derived from porch *terminal/builder* state instead of from the PR. Three artifacts embody this:
+
+- `derivePrReady`'s `bugfix && phase === 'verified'` fallback (`packages/codev/src/agent-farm/servers/overview.ts`),
+- the `pr_ready_for_human` status.yaml field (porch), and
+- the **builder-emit** branch in `NeedsAttentionList.buildItems` (`packages/dashboard/src/components/NeedsAttentionList.tsx`) that emits a *builder* row when a `prReady` builder's PR is absent from the open-PR set.
+
+These exist solely to cope with **one deviation**: a *gateless* bugfix variant (observed on an external adopter, codev 3.1.4 — a 4-phase `investigate/fix/verify/pr` graph with **no `pr` gate**). With no `pr` gate, the dashboard had no uniform "ready for human" signal and fell back to the fragile `bugfix && verified` derivation plus the builder-emit defense. The gated path never broke (it self-heals through rollback by re-requesting the `pr` gate).
+
+## Current State
+
+### How "PR ready for human" is computed today
+
+- **Porch** writes `pr_ready_for_human: true` to `status.yaml` exactly when it auto-requests the `pr` gate (sets the gate `pending`), and clears it to `false` on `pr`-gate approval and on rollback past the PR-creating phase. Every upstream PR-producing protocol — BUGFIX, AIR, SPIR, ASPIR, PIR — now carries a `pr` gate on its PR-creating phase (#887 closed the BUGFIX gap). Therefore, **for every upstream protocol, `pr_ready_for_human === true` is coincident with the `pr` gate being `pending`** (written in the same commit).
+- **`derivePrReady(parsed)`** (overview.ts) returns the explicit `pr_ready_for_human` field when present; otherwise it falls back to: `pr` gate pending **OR** `bugfix && phase === 'verified'`. The builder object's `prReady` boolean is set from this.
+- **`detectBlocked` / `GATE_LABELS`** (overview.ts) map pending gates to labels: `spec-approval → "spec review"`, `plan-approval → "plan review"`, `dev-approval → "dev review"`, `pr → "PR review"`. **`verify-approval` is absent from this map**, so a pending `verify-approval` gate produces `blocked = null` and surfaces nowhere.
+
+### How `NeedsAttentionList.buildItems` assembles rows today
+
+1. **PR loop** over open PRs (`pendingPRs`): emit a **PR row** when the linked builder is `prReady`, or when an unaffiliated/human PR has `reviewStatus === 'REVIEW_REQUIRED'`.
+2. **Builder loop**:
+   - skip builders whose PR was already emitted as a PR row;
+   - **builder-emit branch**: if a `prReady` builder's PR is *missing* from `pendingPRs`, emit a **builder row** as a "PR review" item — unless the builder's issue is in `recentlyMergedIssueIds` (#902), in which case skip (suppress stale post-merge rows);
+   - otherwise, if gate-blocked (`spec/plan/dev` review), emit a **gate row**.
+
+### Supporting state
+
+- **`recentlyMergedIssueIds`** (`OverviewData`, #902): computed in `overview.ts` from recently-merged PRs and threaded through `WorkView` into `NeedsAttentionList`. Its **only** consumer is the builder-emit branch's merged-suppression check.
+- **`pendingPRs`** lists **open PRs only** — a merged PR is correctly absent.
+
+### Why it's wrong
+
+- The builder-emit branch makes a *builder* stand in for a *PR* whenever the open-PR cache misses — and historically when state was stale, surfaced merged work.
+- The `bugfix && verified` fallback fires for the gateless variant and, because `verified` conflates "phases done" with "human-verified" (#919), interacts badly with sticky `pr_ready_for_human` state across version boundaries.
+
+## Desired State
+
+**Needs Attention = (A) ∪ (B):**
+
+- **(A) PR rows** for **open** PRs whose linked builder has a **pending `pr` gate** (the universal, post-CMAP "ready for human" signal). Emit **PR rows only**. If the open PR is not found (cache miss / pagination / transient API failure), **emit nothing** — never a builder row.
+- **(B) Gate rows** for genuine pre-PR / post-merge **human-approval** gates that are **not** the `pr` gate: `spec-approval`, `plan-approval`, `dev-approval`, `verify-approval`.
+- **Plus** the existing fallback for **unaffiliated / human-authored PRs**: surface when `reviewDecision === 'REVIEW_REQUIRED'` and there is no matching builder.
+
+A **builder never stands in for a PR.** The `pr` gate surfaces **only** as a PR row (via the open-PR set), never as a builder/gate row.
+
+### The universal contract
+
+> A protocol must carry a `pr` gate on its PR-creating phase for its PR to surface in Needs Attention.
+
+This is satisfied by all bundled PR-producing protocols (BUGFIX, AIR, SPIR, ASPIR, PIR). A gateless PR-producing variant **will not** surface PR rows — **by design**. Adopters with custom variants align to the pr-gated upstream (the external adopter's bugfix is realigned separately; see Dependencies).
+
+### EXPERIMENT / MAINTAIN
+
+EXPERIMENT and MAINTAIN do **not** follow the CMAP→PR pattern and do **not** produce a `pr` gate; they carry `experiment-complete` / `maintain-complete` completion gates. They therefore **never** surface as PR rows. Their completion gates are the appropriate signal; wiring those completion gates into the dashboard gate-row path is **out of scope** here (they are not regressions of this work) — see Open Questions.
+
+## Stakeholders
+- **Primary Users**: Architects watching the Tower dashboard Work view to know what needs human action (approve a gate, review a PR).
+- **Secondary Users**: External adopters whose custom protocol variants must conform to the pr-gate contract to be surfaced.
+- **Technical Team**: Codev maintainers of `packages/codev` (overview server) and `packages/dashboard` (Work view).
+- **Business Owners**: Codev project (self-hosted).
+
+## Success Criteria
+
+- [ ] **PR-surfacing keys on the `pr` gate.** An open PR whose linked builder has a pending `pr` gate surfaces as exactly one **PR row** (linking to the PR URL).
+- [ ] **No builder-stand-in.** When a pr-gated builder's PR is absent from the open-PR set (cache miss), **no row** is emitted for it. The `derivePrReady` `bugfix && phase === 'verified'` fallback and the `NeedsAttentionList.buildItems` builder-emit branch are **deleted**.
+- [ ] **Merged PRs drop automatically.** A merged PR (absent from `pendingPRs`) produces no Needs Attention row, with no reliance on a recently-merged suppression list.
+- [ ] **Gate rows preserved** for `spec-approval`, `plan-approval`, `dev-approval`, and `verify-approval`. (`verify-approval` is **added** to the gate-row path; it is currently missing.)
+- [ ] **`pr` gate excluded from the gate-row path** — it surfaces only as a PR row, so a cache-missed pr-gate builder cannot fall through to a builder/gate row.
+- [ ] **Unaffiliated/human-PR fallback preserved** (`reviewDecision === 'REVIEW_REQUIRED'`, no matching builder).
+- [ ] **`recentlyMergedIssueIds` reconciled** — assessed and (recommended) removed end-to-end since its only consumer (the builder-emit branch) is deleted; OR an explicit justification is recorded for keeping it.
+- [ ] **#919 reconciled** — this spec supersedes #919's Needs-Attention / `derivePrReady` parts; the `verified → complete` terminal-state rename is **not** performed here and is documented as independent.
+- [ ] All affected unit tests updated; new tests cover the contract (below). No reduction in coverage.
+- [ ] No regression in the VSCode Needs Attention tree / toast / status-bar counter that share `detectBlocked` (verified, since `GATE_LABELS` is shared infrastructure).
+
+## Constraints
+
+### Technical Constraints
+- The surfacing signal is the **`pr` gate `pending`** state in `status.yaml`, read by the afx overview server (`overview.ts`) and exposed via `OverviewData` to the dashboard. No new marker, field, or abstraction is introduced.
+- `GATE_LABELS` / `detectBlocked` / `detectBlockedSince` in `overview.ts` are **shared** by multiple consumers (dashboard `NeedsAttentionList`, VSCode Needs Attention tree, VSCode toast, status-bar counter). Any change to the gate allowlist (e.g. adding `verify-approval`) affects all of them; this is acceptable and arguably correct (a pending human gate genuinely needs attention everywhere), but must be verified, not assumed.
+- `pendingPRs` contains **open PRs only**; this is the mechanism by which merged PRs drop. Do not reintroduce closed/merged PRs into that set.
+- No changes to **pre-PR gate semantics** (porch behavior for spec/plan/dev gates is untouched).
+
+### Business Constraints
+- Self-hosted Codev; ship via the normal SPIR → PR → merge flow. No external deadlines.
+
+## Assumptions
+- For all bundled protocols, `pr_ready_for_human === true` ⟺ `pr` gate `pending` (verified in porch `next.ts` / `index.ts`). The two signals are coincident, so keying on the gate does not change behavior for correctly-gated builders.
+- The external adopter's gateless bugfix variant is realigned to the pr-gated upstream **separately** (out of this repo's scope); this spec does not add compatibility shims for gateless variants — that is the explicit design choice (req 4).
+- `verify-approval` is a real, post-merge, architect-approved gate on SPIR/ASPIR's `verify` phase (confirmed in `spir/protocol.json`).
+
+## Solution Approaches
+
+### Approach 1 (recommended): Gate-authoritative surfacing
+
+**Description**: Make the **`pr` gate `pending`** the single source of truth for PR-surfacing.
+
+- Reduce `derivePrReady` so the PR-ready signal is "the `pr` gate is `pending`" (preferring porch's explicit `pr_ready_for_human` field when present is acceptable since it is coincident, but the `bugfix && phase === 'verified'` branch is **deleted**). Recommendation: treat the **gate** as authoritative to eliminate the sticky-`pr_ready_for_human: false` hazard #919 flagged (a stale field could otherwise suppress a genuinely-pending PR).
+- In `NeedsAttentionList.buildItems`: keep the PR loop (emit PR rows for open PRs whose builder is pr-gate-pending, plus the unaffiliated REVIEW_REQUIRED case); **delete** the builder-emit branch; ensure the gate-row loop **excludes** the `pr` gate and **includes** `verify-approval`.
+- Remove `recentlyMergedIssueIds` end-to-end (dead once the builder-emit branch is gone).
+
+**Pros**:
+- Eliminates all three wrong behaviors at the root; smallest conceptual surface ("the gate is the signal").
+- Kills the sticky-field hazard #919 describes.
+- Net deletion of fragile code (two fallbacks + a now-dead data field).
+
+**Cons**:
+- Touches shared `GATE_LABELS` (to add `verify-approval`) → broader (but correct) blast radius.
+- Gateless variants stop surfacing (intended, but a behavior change for any such adopter).
+
+**Estimated Complexity**: Low–Medium
+**Risk Level**: Low
+
+### Approach 2: Minimal field-first (delete only the bugfix branch)
+
+**Description**: Keep `derivePrReady` field-first; delete only the `bugfix && phase === 'verified'` line and the builder-emit branch; leave `recentlyMergedIssueIds` in place; do not add `verify-approval`.
+
+**Pros**: Smallest diff; lowest chance of unrelated regressions.
+
+**Cons**: Leaves vestigial dead code (`recentlyMergedIssueIds`); leaves the `verify-approval` gap open (contradicts desired-behavior (B)); retains the sticky-field hazard. Does not fully realize the issue's "delete the gateless fallbacks" intent.
+
+**Estimated Complexity**: Low
+**Risk Level**: Low
+
+### Approach 3: Bespoke per-protocol markers (rejected)
+
+Explicitly **out of scope** per the issue — the `pr` gate is the universal signal; no new markers.
+
+## Open Questions
+
+### Critical (Blocks Progress)
+- [ ] **None.** The issue's direction is unambiguous on the core mechanism.
+
+### Important (Affects Design)
+- [ ] **Add `verify-approval` to the gate-row path?** Desired-behavior (B) lists it, but it is currently absent from `GATE_LABELS`/`detectBlocked`, so "keep" cannot be satisfied literally — it must be **added**. Recommendation: **add it** (rounds out "every genuine human gate surfaces; the `pr` gate surfaces as a PR row"). Note the shared-consumer impact (VSCode tree/toast/status bar).
+- [ ] **Remove `recentlyMergedIssueIds` end-to-end, or leave it vestigial?** Recommendation: **remove** (its only consumer is deleted; #902 becomes unnecessary). Confirm no other consumer exists before removal.
+- [ ] **`derivePrReady` form**: gate-authoritative (recommended — kills #919 sticky-field hazard) vs field-first-minus-bugfix-branch (smaller diff). Functionally equivalent for correctly-gated builders.
+
+### Nice-to-Know (Optimization)
+- [ ] Should EXPERIMENT/MAINTAIN `experiment-complete` / `maintain-complete` gates surface as gate rows in the dashboard? Currently they surface nowhere. Recommendation: **out of scope** for #927 (not a regression of this work); track separately if desired.
+- [ ] Should porch eventually stop writing `pr_ready_for_human` entirely (becomes vestigial under gate-authoritative surfacing)? Recommendation: **out of scope** (porch-side; the dashboard simply stops depending on it).
+
+## Performance Requirements
+- No new network calls or heavy computation; this is presentational/derivation logic over already-fetched `OverviewData`. No measurable performance impact expected. (Removing `recentlyMergedIssueIds` removes a small amount of per-refresh work.)
+
+## Security Considerations
+- None. No authn/authz, data-privacy, or audit surface is touched. PR URLs already shown are unchanged.
+
+## Test Scenarios
+
+### Functional Tests (the contract)
+1. **PR row via `pr` gate** — open PR + linked builder with `pr` gate `pending` ⇒ exactly one PR row, linking to the PR URL, waiting-since = gate-requested time. (Covers BUGFIX, AIR, SPIR, ASPIR, PIR shapes uniformly.)
+2. **Cache miss ⇒ nothing** — builder with `pr` gate `pending` but PR absent from `pendingPRs` ⇒ **no row** (no builder stand-in). (Replaces the old "still surfaces a prReady builder when its PR is missing" tests, which must be inverted.)
+3. **Merged PR ⇒ nothing** — builder's PR merged (absent from `pendingPRs`) ⇒ **no row**, with no reliance on `recentlyMergedIssueIds`.
+4. **Pre-CMAP PR excluded** — open PR whose builder has NOT yet reached the `pr` gate ⇒ no row.
+5. **Gate rows preserved** — builder pending on `spec-approval` / `plan-approval` / `dev-approval` ⇒ a gate row with the correct kind/label and waiting-since.
+6. **`verify-approval` surfaces** (if Approach 1 adopted) — builder pending on `verify-approval` ⇒ a gate row.
+7. **`pr` gate never a gate row** — builder with `pr` gate `pending` whose PR is missing does NOT produce a "PR review" gate/builder row (intersection of #2 and the exclusion rule).
+8. **Unaffiliated/human PR** — open PR with no matching builder surfaces only when `reviewDecision === 'REVIEW_REQUIRED'`.
+9. **No double-emit** — PR present AND builder present ⇒ exactly one PR row.
+10. **Gateless variant ⇒ nothing** — a builder on a gateless PR-producing protocol does not surface a PR row (documents the universal contract).
+
+### Non-Functional Tests
+1. **Shared-consumer regression check** — adding `verify-approval` to `GATE_LABELS` does not break the VSCode Needs Attention tree / toast / status-bar counter (build + existing tests pass).
+2. **Dead-code removal** — `recentlyMergedIssueIds` removed cleanly (type, computation, prop threading) with TypeScript build green.
+
+## Dependencies
+- **External Services**: GitHub/forge PR listing (already used to build `pendingPRs`); no new calls.
+- **Internal Systems**: porch `status.yaml` gate state; afx overview server (`overview.ts`); dashboard `WorkView`/`NeedsAttentionList`; shared `OverviewData` types (`packages/types/src/api.ts`).
+- **Related issues**:
+  - **#902** (`recentlyMergedIssueIds` / fixes #901): becomes unnecessary; assess for removal.
+  - **#919** (`verified → complete` rename): its Needs-Attention / `derivePrReady` parts become unnecessary under this model. This spec **supersedes** those parts; the terminal-state rename is independent honesty work and is **not** performed here. Reconcile/descope #919 accordingly.
+  - **#887** (BUGFIX gained a `pr` gate): the precondition that makes the universal contract hold upstream.
+  - **External adopter (shannon)**: realign its bugfix to the pr-gated upstream separately so it is covered by the universal mechanism (tracked outside this repo).
+
+## Risks and Mitigation
+| Risk | Probability | Impact | Mitigation Strategy |
+|------|------------|--------|-------------------|
+| Adding `verify-approval` to shared `GATE_LABELS` regresses another consumer | Low | Medium | Build + run all consumer tests; review VSCode tree/toast/status-bar usages of `detectBlocked`. |
+| Removing `recentlyMergedIssueIds` breaks a non-obvious consumer | Low | Low | Grep all consumers before removal (current grep shows only the builder-emit branch); TS build catches type removals. |
+| A real gateless adopter silently loses PR surfacing | Low | Medium | This is the intended contract; document loudly in review/lessons and in the realignment task for the adopter. |
+| Inverting the "cache-miss surfaces a row" tests masks a genuine cache-miss UX gap | Low | Low | Accept by design (issue req 1); the next refresh surfaces the PR once `pendingPRs` includes it. Document the tradeoff. |
+
+## Expert Consultation
+**Date**: (pending)
+**Models Consulted**: Gemini, Codex, Claude (3-way, run by porch after this draft)
+**Sections Updated**: (to be filled after consultation)
+
+Note: All consultation feedback will be incorporated directly into the relevant sections above.
+
+## Approval
+- [ ] Technical Lead Review (architect — `spec-approval` gate)
+- [ ] Expert AI Consultation Complete (3-way)
+
+## Notes
+
+- **Net effect is deletion**: two fallbacks (`derivePrReady` bugfix branch, `buildItems` builder-emit branch) and one data field (`recentlyMergedIssueIds`) go away; one gate (`verify-approval`) is added to the human-gate allowlist; the `pr` gate is excluded from the gate-row path. The signal everything keys on already exists — the `pr` gate.
+- **Scope discipline**: no new markers (req: out of scope), no change to pre-PR gate semantics (req: out of scope), no `verified → complete` rename (belongs to #919).
+
+---
+
+## Amendments
+
+This section tracks any TICK amendments to this specification.
+
+<!-- When adding a TICK amendment, add a new entry below this line in chronological order -->

--- a/codev/state/spir-927_thread.md
+++ b/codev/state/spir-927_thread.md
@@ -206,3 +206,23 @@ Fixes:
 Good scrutiny outcome: this is the 3rd time scrutinizing reviewer feedback paid off (1st: caught Gemini's bad
 gate-check + helper-delete suggestions on spec; here: Codex's valid catch I accepted in full). Wrote rebuttal,
 re-running porch check → porch done → expect iter-2 consult.
+
+## 2026-05-29 — Phase 2 iter-2 UNANIMOUS APPROVE → Phase 3
+
+Phase 2 iter-2: **Gemini APPROVE, Codex APPROVE (confirms fallback fixed), Claude APPROVE** (all HIGH).
+Phase 2 done. (Porch quirk: after committing the fix + `porch done`, the first `porch next` re-showed the
+iter-2 implement prompt; a second `porch done` → "ready for verification" → `porch next` then yielded the
+iter-2 consult task with `--context …iter2-context.md`. The consults use iterN-context.md to carry the rebuttal.)
+
+## 2026-05-29 — Phase 3 (remove-dead-projection) implemented
+
+Edits:
+- `packages/types/src/api.ts`: removed `recentlyMergedIssueIds` field + doc comment from OverviewData.
+- `overview.ts`: removed the field from the local OverviewData interface, deleted the computation block
+  (#901 merged-issue projection), and dropped it from the returned `result`. **KEPT** `fetchRecentMergedPRs`,
+  the `mergedPRs` Promise.all fetch, and the `issueToPrUrl` build (recentlyClosed PR-link enrichment).
+- `overview.test.ts`: removed the 2 recentlyMergedIssueIds tests + the empty-array assertion in the
+  null-mergedPRs test. The positive prUrl-enrichment test (L1853) stays → proves fetchRecentMergedPRs retained.
+- grep clean: only remaining ref is an explanatory comment in NeedsAttentionList.test.tsx (documents the removal).
+
+Running porch check (build type-checks dashboard+codev w/o the field) + dashboard tests.

--- a/codev/state/spir-927_thread.md
+++ b/codev/state/spir-927_thread.md
@@ -99,3 +99,21 @@ by construction. New: verify-approval surfaces as a blocked builder in VSCode (i
 plan-approval — open Q: does VSCode want a GATE_ACTIONS "Verify" entry? additive follow-up, not a blocker).
 
 Next: commit plan draft → `porch done` → 3-way consult.
+
+## 2026-05-29 — Plan 3-way consult done
+
+**Gemini APPROVE, Claude APPROVE, Codex REQUEST_CHANGES** (all HIGH). Codex's REQUEST_CHANGES was about
+strengthening the plan as an execution guide, not a design problem:
+- (#1) VSCode blast radius was *discussed* not *owned* → moved concrete VSCode work INTO Phase 1
+  (files: `packages/types/src/api.ts` prReady-comment rewrite + `packages/vscode/src/test/builders.test.ts`;
+  added VSCode acceptance criteria + test-plan items; `pr` regression-guarded).
+- (#2) Phase 1 title says "+ types" but omitted api.ts → added api.ts (prReady doc comment, L183-194 describes
+  the old derivation).
+Claude obs-a (VSCode test-scope ambiguity) → resolved by labeling the checkboxes "OWNED BY PHASE 1".
+Claude obs-b (pre-existing `dev review` gateKindClass styling gap) → added as a **flagged optional drive-by** in
+Phase 2, default OUT of scope pending architect okay.
+
+Two architect/Amr decisions teed up at plan-approval: (1) VSCode verify-approval UX (surface as blocked? want a
+GATE_ACTIONS "Verify" action?); (2) include the dev-review styling drive-by or not (default: no).
+
+Next: write plan rebuttal → commit → `porch done` → expect plan-approval gate (STOP, notify architect + note Amr).

--- a/codev/state/spir-927_thread.md
+++ b/codev/state/spir-927_thread.md
@@ -226,3 +226,20 @@ Edits:
 - grep clean: only remaining ref is an explanatory comment in NeedsAttentionList.test.tsx (documents the removal).
 
 Running porch check (build type-checks dashboard+codev w/o the field) + dashboard tests.
+
+## 2026-05-29 — Phase 3 UNANIMOUS APPROVE → Review phase
+
+Phase 3 3-way: **Gemini APPROVE (HIGH), Codex APPROVE (MED), Claude APPROVE (HIGH)** — no issues. All 3
+implement phases done. porch → **review** phase. Checks: pr_exists, review_has_arch_updates,
+review_has_lessons_updates, e2e_tests (e2e soft-skips: no root test:e2e script).
+
+**Render-verify (architect's pre-PR instruction + UI-PR policy):** built the dashboard, loaded the REAL built
+CSS + exact NeedsAttentionList row DOM in headless chromium. `.attention-kind--verify` → `rgb(234,179,8)`
+(=--status-waiting, == PR row), ≠ spec (red), ≠ unstyled control. Proves the new className gets styling (no
+"className w/o CSS" gap). Screenshot tmp/verify-render.png. Harness in tmp/ (NOT committed).
+
+Net change: **−45 LOC** (227+/272−, 8 files) — a deletion, as designed.
+
+Wrote review doc (codev/reviews/927-...md) with Architecture Updates (universal-pr-gate contract +
+dashboard-local rule + render-verify evidence) and Lessons Learned Updates. Next: commit review → push →
+open PR → porch done (review checks) → CMAP-at-PR → pr gate (HUMAN merges).

--- a/codev/state/spir-927_thread.md
+++ b/codev/state/spir-927_thread.md
@@ -243,3 +243,14 @@ Net change: **−45 LOC** (227+/272−, 8 files) — a deletion, as designed.
 Wrote review doc (codev/reviews/927-...md) with Architecture Updates (universal-pr-gate contract +
 dashboard-local rule + render-verify evidence) and Lessons Learned Updates. Next: commit review → push →
 open PR → porch done (review checks) → CMAP-at-PR → pr gate (HUMAN merges).
+
+## 2026-05-29 — PR #928 opened; PR-level CMAP iter-1
+
+PR #928 created. Review checks all ✓ (pr_exists, review_has_arch_updates, review_has_lessons_updates,
+e2e_tests[soft-skip]). PR-level CMAP: **Gemini APPROVE, Claude APPROVE, Codex REQUEST_CHANGES**.
+- C1 (FIXED, legit): spec/plan were still `Status: draft` with no `approved`/`validated` frontmatter — SPIR
+  final-approval steps require it. Added frontmatter (approved: 2026-05-29, validated: [gemini,codex,claude]) +
+  flipped Status→approved on both.
+- C2 (REBUTTED): `dev review` gateKindClass styling gap — architect EXPLICITLY ruled this OUT of scope at
+  plan-approval. Rebutted citing that decision; tracked as a follow-up. Not a #927 correctness issue (Codex agrees).
+Committed + pushed (PR auto-updates). porch done → re-consult iter-2.

--- a/codev/state/spir-927_thread.md
+++ b/codev/state/spir-927_thread.md
@@ -117,3 +117,39 @@ Two architect/Amr decisions teed up at plan-approval: (1) VSCode verify-approval
 GATE_ACTIONS "Verify" action?); (2) include the dev-review styling drive-by or not (default: no).
 
 Next: write plan rebuttal → commit → `porch done` → expect plan-approval gate (STOP, notify architect + note Amr).
+
+## 2026-05-29 — plan-approval APPROVED → Implement
+
+Architect approved plan-approval. Confirmed decisions:
+- (2) dev-review gateKindClass drive-by → **OUT of scope** (file separately if ever).
+- Amr has NOT weighed in on verify-approval VSCode UX → proceed with plan **DEFAULT**: surface verify-approval
+  as a blocked builder in VSCode tree/toast/status-bar via the gate-toast **generic fallback**. A dedicated
+  'Verify' GATE_ACTION is a **non-blocking additive follow-up** — do NOT block implementation on it.
+- Sequence **Phase 1 first** (shared overview infra + the VSCode blast-radius tests it owns), keep EVERY phase
+  commit green in BOTH packages, and **render-verify the dashboard** (esp. new `--verify` styling) before PR.
+- Next gate = **pr gate at the PR** (human's call). No autonomous per-phase PRs.
+
+Starting Phase 1 implementation.
+
+## 2026-05-29 — Phase 1 (server-derivation) implemented
+
+Edits:
+- `overview.ts`: `derivePrReady` → gate-authoritative (`gates['pr']==='pending' && requested_at`), dropped
+  field dependency + bugfix branch; `GATE_LABELS` += `'verify-approval':'verify review'`; `detectBlockedSince`
+  now iterates `Object.keys(GATE_LABELS)` (no more separate hardcoded array); `OverviewBuilder.prReady` comment.
+- `packages/types/src/api.ts`: `prReady` doc comment → gate-authoritative.
+- `overview.test.ts`: rewrote derivePrReady block (universal-gate true; requested_at-guard false;
+  approved false; ignores pr_ready_for_human; no bugfix-verified fallback); added verify-approval cases to
+  detectBlocked + detectBlockedSince.
+- `packages/vscode/src/test/builders.test.ts`: added `orderForDisplay — #927 gate blast radius` suite
+  (verify-review-blocked → blocked bucket; PR-review unchanged; sort together by blockedSince). Extended
+  `builder()` helper with `blockedLabel`.
+
+**Worktree-setup gotcha (cohort note):** this self-hosted codev repo has **no `worktree.postSpawn`** in
+`.codev/config.json`, so the worktree spawned WITHOUT `node_modules` (root missing; vitest unresolvable).
+Builders here must `pnpm install --frozen-lockfile` from the worktree root before any build/test/porch-check.
+Running that now.
+
+porch checks (from protocol.json): `build` = root `npm run build` (core + codev, incl. dashboard; NOT vscode);
+`tests` = `pnpm --filter @cluesmith/codev test` (codev vitest only — NOT vscode, NOT dashboard). So Phase 1's
+overview.test.ts IS gated by porch; the vscode test is verified separately (porch won't run it).

--- a/codev/state/spir-927_thread.md
+++ b/codev/state/spir-927_thread.md
@@ -162,3 +162,47 @@ verdict/file) — retried, clean APPROVE. Phase 1 unanimous, no rebuttal needed.
 
 Next: `porch done`/`next` → advance to Phase 2 (dashboard-surfacing). Per porch's reminder, /compact before
 the new phase if context is heavy.
+
+## 2026-05-29 — Phase 2 (dashboard-surfacing) implemented
+
+Edits (`packages/dashboard`):
+- `NeedsAttentionList.tsx` buildItems: deleted the builder-emit branch + bookkeeping
+  (emittedPrReadyIssueIds, mergedIssueIdSet, recentlyMergedIssueIds param); builder loop now `if (b.prReady)
+  continue;` then gate rows for `b.blocked && b.blockedSince` (covers spec/plan/dev/verify; pr excluded because
+  pr-gate builders are prReady → skipped). gateKindClass += `verify review → attention-kind--verify`.
+- `index.css`: `.attention-kind--verify` (review-style accent, var(--status-waiting)).
+- `WorkView.tsx`: dropped `recentlyMergedIssueIds` prop pass; prop removed from NeedsAttentionListProps.
+- tests: inverted the 2 "missing PR still surfaces builder" → assert no row; replaced merged-suppression test
+  with "missing PR ⇒ no row"; added verify-approval gate-row test. 14/14 pass.
+
+**porch check gating note:** porch `tests` = `pnpm --filter @cluesmith/codev test` runs ONLY codev tests, NOT
+dashboard tests. So Phase 2's NeedsAttentionList.test.tsx is NOT porch-gated — I run it manually
+(`pnpm --filter @cluesmith/codev-dashboard exec vitest run`). porch `build` DOES type-check the dashboard
+(codev build includes dashboard), so the WorkView/buildItems signature changes are gate-covered. porch
+build ✓ + tests ✓; dashboard tests 14/14. Committed 36523a35.
+
+Render-verify of the `--verify` styling: deferred to before-PR (Phase 3 doesn't touch dashboard rendering, so
+the dashboard state is final after Phase 2). Will render Needs Attention (PR row + verify gate row + empty) per
+architect's pre-PR instruction.
+
+Next: Phase 2 3-way impl consult → advance to Phase 3 (remove-dead-projection).
+
+## 2026-05-29 — Phase 2 3-way: Codex REQUEST_CHANGES (valid) → fixed
+
+**Gemini APPROVE, Claude APPROVE, Codex REQUEST_CHANGES** (all HIGH). Codex's catch was correct and I agree:
+Phase 2 carried over the OLD gateless-BUGFIX shape (prReady=true with no gate/no blockedSince) which is
+IMPOSSIBLE under Phase-1 gate-authoritative derivePrReady. Two problems:
+- C1: `waitingSince: readySince || pr.createdAt` let an *affiliated* PR fall back to createdAt — spec says
+  affiliated uses the gate timestamp (blockedSince) exclusively; createdAt is unaffiliated-only.
+- C2: tests at :86 ("BUGFIX has no gate") and :160 ("falls back to createdAt w/o blockedSince") encoded the
+  impossible shape and locked in the stale fallback.
+
+Fixes:
+- Code: `const waitingSince = prReady ? (readySince ?? pr.createdAt) : pr.createdAt;` — affiliated→gate time
+  (the `??` is now an unreachable type guard, documented), unaffiliated→createdAt.
+- Tests: reframed :86 to post-#887 gate shape (asserts waitingSince===blockedSince); removed :160
+  (impossible shape); strengthened the human-PR test to assert waitingSince===createdAt. 13/13 pass.
+
+Good scrutiny outcome: this is the 3rd time scrutinizing reviewer feedback paid off (1st: caught Gemini's bad
+gate-check + helper-delete suggestions on spec; here: Codex's valid catch I accepted in full). Wrote rebuttal,
+re-running porch check → porch done → expect iter-2 consult.

--- a/codev/state/spir-927_thread.md
+++ b/codev/state/spir-927_thread.md
@@ -153,3 +153,12 @@ Running that now.
 porch checks (from protocol.json): `build` = root `npm run build` (core + codev, incl. dashboard; NOT vscode);
 `tests` = `pnpm --filter @cluesmith/codev test` (codev vitest only — NOT vscode, NOT dashboard). So Phase 1's
 overview.test.ts IS gated by porch; the vscode test is verified separately (porch won't run it).
+
+**Phase 1 verification + 3-way:** porch `build` ✓ (5s) + `tests` ✓ (20s). vscode `compile-tests` (tsc) ✓
+(builders.test.ts is a vscode-test/Electron mocha test — vitest doesn't glob `src/test/`; full Electron run
+is area/vscode CI). 3-way impl consult: **Gemini APPROVE, Codex APPROVE, Claude APPROVE** (all HIGH, no
+issues). Note: Gemini's FIRST run errored on a consult infra flake ("Tool run_shell_command not found", no
+verdict/file) — retried, clean APPROVE. Phase 1 unanimous, no rebuttal needed. Committed a4941322.
+
+Next: `porch done`/`next` → advance to Phase 2 (dashboard-surfacing). Per porch's reminder, /compact before
+the new phase if context is heavy.

--- a/codev/state/spir-927_thread.md
+++ b/codev/state/spir-927_thread.md
@@ -39,3 +39,29 @@ builder row we're deleting.
 2. Remove `recentlyMergedIssueIds` end-to-end (recommended) vs leave vestigial.
 3. `derivePrReady` form: gate-authoritative (recommended, kills #919 sticky-field hazard) vs field-first-minus-fallback.
 4. EXPERIMENT/MAINTAIN completion-gate surfacing: documented as out-of-scope (not regressions of this work).
+
+## 2026-05-29 — 3-way consultation done (spec iter-1)
+
+Verdicts: **Gemini APPROVE, Claude APPROVE, Codex REQUEST_CHANGES** (Codex just wanted two things pinned
+down explicitly — now resolved). All three converged on Approach 1. Incorporated:
+
+- **Shared-infra decision (Codex #1)**: keep `pr` in `GATE_LABELS`/`detectBlocked*` (VSCode bell +
+  PR-row waiting-since depend on it). "No builder stand-in" is **dashboard-local** → `if (b.prReady) continue;`
+  in buildItems (Gemini's clean one-liner).
+- **`requested_at` invariant (my catch, NOT a reviewer's)**: a bare `gates['pr']==='pending'` check (Gemini's
+  suggested simplification) is WRONG — porch inits ALL gates to `pending` with no `requested_at` (verified in
+  927's own status.yaml). The predicate MUST be `pending && requested_at present`. Pinned in spec.
+- **`fetchRecentMergedPRs` retention (my catch)**: Gemini said delete the helper. WRONG — `mergedPRs` has a
+  second consumer at overview.ts:971 (issueToPrUrl for recentlyClosed). Helper stays; only the
+  `recentlyMergedIssueIds` projection is removed. Corrected in spec.
+- **verify-approval label (Codex #2 / Claude #3)**: pinned to `"verify review"` + gateKindClass +
+  `.attention-kind--verify` CSS.
+- **detectBlockedSince sync point (Gemini/Claude)**: separate hardcoded array; recommend unifying on
+  `Object.keys(GATE_LABELS)`.
+- **Tests (Claude #5)**: THREE existing NeedsAttentionList tests to invert/remove (lines ~183, ~253 invert;
+  ~222 merged-suppression removed).
+
+Lesson reinforced: scrutinized reviewer suggestions before applying — caught two over-confident Gemini
+recommendations (bare gate check; delete helper) that would have introduced bugs.
+
+Committing reviewed spec, then `porch next` → should hit spec-approval gate (STOP, notify architect).

--- a/codev/state/spir-927_thread.md
+++ b/codev/state/spir-927_thread.md
@@ -65,3 +65,37 @@ Lesson reinforced: scrutinized reviewer suggestions before applying — caught t
 recommendations (bare gate check; delete helper) that would have introduced bugs.
 
 Committing reviewed spec, then `porch next` → should hit spec-approval gate (STOP, notify architect).
+
+## 2026-05-29 — spec-approval APPROVED by architect → Plan phase
+
+Architect approved spec-approval. **Coordination note from architect (load-bearing for the plan):**
+the change touches SHARED infra — keeping `pr` in detectBlocked/GATE_LABELS AND adding `verify-approval`
+to GATE_LABELS affects **VSCode** (Needs Attention tree, gate toast, status-bar counter), not just the
+dashboard. **Amr (owns area/vscode) is looped in on #927.** Plan MUST:
+- treat VSCode consumers of detectBlocked/GATE_LABELS as an explicit **blast-radius item with their own
+  test coverage**;
+- flag anything needing Amr's eyes.
+Do NOT advance past plan-approval without the human.
+
+## 2026-05-29 — Plan drafted (3 phases)
+
+Plan at `codev/plans/927-...md`, checks pass (plan_exists, has_phases_json, 3 phase ids). Phasing chosen so
+every commit type-checks + tests green in BOTH packages, and the VSCode blast radius is concentrated in Phase 1:
+
+1. **server-derivation** (`packages/codev` overview.ts + `packages/types`): gate-authoritative `derivePrReady`
+   (requested_at-aware, drop bugfix branch + field dependency); add `verify-approval`→`"verify review"` to
+   GATE_LABELS; unify `detectBlockedSince` on `Object.keys(GATE_LABELS)`. **Does NOT remove
+   recentlyMergedIssueIds** (keeps dashboard green). ← shared infra / VSCode blast radius lives here.
+2. **dashboard-surfacing** (`packages/dashboard`): delete builder-emit branch; `if (b.prReady) continue;`;
+   add verify gateKindClass + `.attention-kind--verify` CSS; stop consuming recentlyMergedIssueIds (drop prop +
+   WorkView pass); invert 2 tests, remove 1.
+3. **remove-dead-projection** (`packages/codev` + types): delete recentlyMergedIssueIds field+computation;
+   **RETAIN fetchRecentMergedPRs** (issueToPrUrl/recentlyClosed).
+
+VSCode blast radius (architect's coordination note) is an explicit cross-cutting section: consumers verified
+(`views/builders.ts`, `notifications/gate-toast.ts`, `commands/approve.ts`, `extension.ts` status bar; tests
+`test/builders.test.ts`, `__tests__/menu-when-clauses.test.ts`). `pr` stays in GATE_LABELS → no VSCode regression
+by construction. New: verify-approval surfaces as a blocked builder in VSCode (intended; flagged for **Amr** at
+plan-approval — open Q: does VSCode want a GATE_ACTIONS "Verify" entry? additive follow-up, not a blocker).
+
+Next: commit plan draft → `porch done` → 3-way consult.

--- a/codev/state/spir-927_thread.md
+++ b/codev/state/spir-927_thread.md
@@ -1,0 +1,41 @@
+# spir-927 — Needs Attention: surface PRs via the universal pr gate
+
+## 2026-05-29 — Specify phase started
+
+Strict-mode SPIR builder for #927. Porch is at `specify`; no spec existed, so I'm authoring one.
+
+### What I learned from the code (grounding the spec)
+
+- **`derivePrReady`** (`packages/codev/src/agent-farm/servers/overview.ts:493`): prefers porch's
+  `pr_ready_for_human` field, else falls back to `pr` gate pending **OR** `bugfix && phase==='verified'`.
+  The bugfix branch is the gateless-variant crutch the issue wants deleted. Upstream BUGFIX now carries a
+  `pr` gate (#887), so the branch is dead weight upstream.
+- **`pr_ready_for_human`** is written `true` *only* when the `pr` gate is auto-requested (next.ts:756,
+  index.ts:499) and cleared on pr-gate approval (index.ts:753) and on rollback (index.ts:849). So for every
+  upstream protocol `pr_ready_for_human === true` ⟺ `pr` gate `pending`. They are coincident.
+- **`buildItems`** (`packages/dashboard/src/components/NeedsAttentionList.tsx:51`): first loop emits PR rows
+  for open PRs whose builder is `prReady` (or unaffiliated REVIEW_REQUIRED); second loop has the
+  **builder-emit branch** (lines 128-140) that emits a *builder* row when a prReady builder's PR is missing
+  from `prs` — the thing the issue wants deleted. The gate-row path (142-153) handles spec/plan/dev.
+- **`GATE_LABELS`** (overview.ts:430) = {spec-approval, plan-approval, dev-approval, pr}. **`verify-approval`
+  is NOT here** — so a pending verify-approval gate currently does not surface anywhere (dashboard, VSCode tree,
+  toast, status bar all key off `detectBlocked`). Issue req 3 lists verify-approval as something to surface →
+  this is a gap to close.
+- **SPIR protocol.json**: verify phase carries `gate: verify-approval` (real, post-merge, architect-approved).
+- **`recentlyMergedIssueIds`** (#902): consumed ONLY by the builder-emit branch (mergedIssueIdSet, line 129).
+  Delete that branch → the field is dead → removable end-to-end (api.ts type, overview.ts compute 1006-1021,
+  WorkView prop, NeedsAttentionList prop).
+- **#919** (verified→complete rename): its needs-attention/derivePrReady parts become unnecessary under this
+  model. The rename is independent honesty work — NOT done here; reconcile by descoping #919's NA parts.
+
+### Design crux for the spec
+Contract: a PR surfaces iff (linked builder's `pr` gate is `pending`) AND (PR is open / in `pendingPRs`).
+Never a builder standing in for a PR. The `pr` gate must be **excluded** from the gate-row loop (it surfaces
+as a PR row, not a builder row) — otherwise a cache-miss pr-gate builder would fall through and emit the very
+builder row we're deleting.
+
+### Decisions surfaced to architect/reviewers (see spec Open Questions)
+1. Add `verify-approval` to the gate-row allowlist (closes the gap; broadens to shared GATE_LABELS consumers).
+2. Remove `recentlyMergedIssueIds` end-to-end (recommended) vs leave vestigial.
+3. `derivePrReady` form: gate-authoritative (recommended, kills #919 sticky-field hazard) vs field-first-minus-fallback.
+4. EXPERIMENT/MAINTAIN completion-gate surfacing: documented as out-of-scope (not regressions of this work).

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -1900,38 +1900,6 @@ describe('overview', () => {
 
       expect(data.recentlyClosed).toHaveLength(1);
       expect(data.recentlyClosed[0].prUrl).toBeUndefined();
-      // Issue #901: null merged-PR fetch should still yield an empty array,
-      // not undefined, so NeedsAttentionList's `?? []` doesn't have to absorb
-      // an inconsistent shape.
-      expect(data.recentlyMergedIssueIds).toEqual([]);
-    });
-
-    it('exposes recentlyMergedIssueIds for merged-PR consumers (Issue #901)', async () => {
-      mockFetchMergedPRs.mockResolvedValue([
-        { number: 150, title: '[Bugfix #100] Fix the bug', url: 'https://github.com/org/repo/pull/150', body: 'Fixes #100', createdAt: '2026-01-02T00:00:00Z', mergedAt: new Date().toISOString() },
-        { number: 151, title: '[Spec 200] Add feature', url: 'https://github.com/org/repo/pull/151', body: 'Closes #200', createdAt: '2026-01-02T00:00:00Z', mergedAt: new Date().toISOString() },
-        { number: 152, title: 'No linked issue', url: 'https://github.com/org/repo/pull/152', body: 'Cleanup', createdAt: '2026-01-02T00:00:00Z', mergedAt: new Date().toISOString() },
-      ]);
-
-      const cache = new OverviewCache();
-      const data = await cache.getOverview(tmpDir);
-
-      expect(new Set(data.recentlyMergedIssueIds)).toEqual(new Set(['100', '200']));
-    });
-
-    it('deduplicates recentlyMergedIssueIds when the same issue has multiple merged PRs', async () => {
-      // A follow-up PR can land while the original sits in the 24h merged
-      // window — both PRs reference the same `Fixes #N`. The consumer wants
-      // a SET of issue IDs, not a multi-bag, so the dedup is load-bearing.
-      mockFetchMergedPRs.mockResolvedValue([
-        { number: 150, title: '[Bugfix #100] First attempt', url: 'https://github.com/org/repo/pull/150', body: 'Fixes #100', createdAt: '2026-01-02T00:00:00Z', mergedAt: new Date().toISOString() },
-        { number: 151, title: '[Bugfix #100] Follow-up', url: 'https://github.com/org/repo/pull/151', body: 'Fixes #100', createdAt: '2026-01-02T01:00:00Z', mergedAt: new Date().toISOString() },
-      ]);
-
-      const cache = new OverviewCache();
-      const data = await cache.getOverview(tmpDir);
-
-      expect(data.recentlyMergedIssueIds).toEqual(['100']);
     });
 
     it('enriches issueId from DB issue_number for unknown protocols (#664)', async () => {

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -618,6 +618,13 @@ describe('overview', () => {
       }))).toBe('PR review');
     });
 
+    it('returns "verify review" when verify-approval is pending and requested (#927)', () => {
+      expect(detectBlocked(makeParsed({
+        gates: { 'verify-approval': 'pending' },
+        gateRequestedAt: { 'verify-approval': '2026-05-29T12:00:00Z' },
+      }))).toBe('verify review');
+    });
+
     it('returns first blocked gate when multiple are pending', () => {
       expect(detectBlocked(makeParsed({
         gates: { 'spec-approval': 'pending', 'plan-approval': 'pending' },
@@ -683,6 +690,13 @@ describe('overview', () => {
       }))).toBe('2026-02-17T12:00:00Z');
     });
 
+    it('returns requested_at timestamp for pending verify-approval gate (#927)', () => {
+      expect(detectBlockedSince(makeParsed({
+        gates: { 'verify-approval': 'pending' },
+        gateRequestedAt: { 'verify-approval': '2026-05-29T12:00:00Z' },
+      }))).toBe('2026-05-29T12:00:00Z');
+    });
+
     it('returns first blocked gate timestamp when multiple are pending', () => {
       expect(detectBlockedSince(makeParsed({
         gates: { 'spec-approval': 'pending', 'plan-approval': 'pending' },
@@ -699,7 +713,7 @@ describe('overview', () => {
   // ==========================================================================
 
   // ==========================================================================
-  // derivePrReady (Issue #872) — canonical pr_ready_for_human signal
+  // derivePrReady (#927) — gate-authoritative "PR ready for human" signal
   // ==========================================================================
 
   describe('derivePrReady', () => {
@@ -720,53 +734,61 @@ describe('overview', () => {
       };
     }
 
-    it('returns true when status.yaml explicitly says pr_ready_for_human: true', () => {
-      // Explicit field wins, regardless of protocol or gate shape.
-      expect(derivePrReady(makeParsed({ prReadyForHuman: true }))).toBe(true);
+    it('returns true when the pr gate is pending and requested — uniform across protocols', () => {
+      // The signal is the gate shape, not the protocol name. #887 gave BUGFIX a
+      // pr gate, so all five PR-producing protocols use the identical predicate.
+      for (const protocol of ['bugfix', 'air', 'spir', 'aspir', 'pir']) {
+        expect(derivePrReady(makeParsed({
+          protocol,
+          gates: { pr: 'pending' },
+          gateRequestedAt: { pr: '2026-05-26T12:00:00Z' },
+        }))).toBe(true);
+      }
     });
 
-    it('returns false when status.yaml explicitly says pr_ready_for_human: false', () => {
-      // Explicit false (e.g., after pr gate approved) trumps any fallback.
+    it('returns false when the pr gate is pending but has NO requested_at (freshly-initialized project)', () => {
+      // Porch initializes every gate to status: pending with no requested_at;
+      // the requested_at conjunct prevents mis-flagging brand-new projects.
+      expect(derivePrReady(makeParsed({
+        gates: { pr: 'pending', 'spec-approval': 'pending', 'verify-approval': 'pending' },
+        gateRequestedAt: {},
+      }))).toBe(false);
+    });
+
+    it('returns false once the pr gate has been approved', () => {
+      expect(derivePrReady(makeParsed({
+        gates: { pr: 'approved' },
+        gateRequestedAt: { pr: '2026-05-26T12:00:00Z' },
+        gateApprovedAt: { pr: '2026-05-26T13:00:00Z' },
+      }))).toBe(false);
+    });
+
+    it('reads the pr gate directly and ignores pr_ready_for_human (#927)', () => {
+      // Field true but gate not pending → not ready (kills the sticky-field hazard #919).
+      expect(derivePrReady(makeParsed({
+        prReadyForHuman: true,
+        gates: {},
+        gateRequestedAt: {},
+      }))).toBe(false);
+      // Field false but gate genuinely pending → ready (the gate is authoritative).
       expect(derivePrReady(makeParsed({
         prReadyForHuman: false,
         gates: { pr: 'pending' },
         gateRequestedAt: { pr: '2026-05-26T12:00:00Z' },
-      }))).toBe(false);
-    });
-
-    it('falls back to pr gate pending+requested for legacy state files (SPIR/AIR shape)', () => {
-      // Pre-#872 state.yaml has no field — fall back to v3.1.3 derivation.
-      expect(derivePrReady(makeParsed({
-        protocol: 'air',
-        gates: { pr: 'pending' },
-        gateRequestedAt: { pr: '2026-05-26T12:00:00Z' },
       }))).toBe(true);
     });
 
-    it('falls back to BUGFIX phase=verified for legacy state files (the #872 regression case)', () => {
-      // BUGFIX has no pr gate — the v3.1.3 NeedsAttentionList silently dropped
-      // these. The fallback closes that gap until porch writes the explicit
-      // field on the in-flight builder.
+    it('does NOT fall back to bugfix phase=verified (removed gateless crutch)', () => {
+      // A gateless bugfix variant no longer surfaces a PR row — by design (#927).
       expect(derivePrReady(makeParsed({
         protocol: 'bugfix',
         phase: 'verified',
-      }))).toBe(true);
-    });
-
-    it('does NOT fall back to phase=verified for non-BUGFIX protocols', () => {
-      // SPIR/ASPIR `verified` means the verify-approval gate was approved post-merge
-      // — the PR is already merged and reviewed, not waiting.
-      expect(derivePrReady(makeParsed({
-        protocol: 'spir',
-        phase: 'verified',
-      }))).toBe(false);
-      expect(derivePrReady(makeParsed({
-        protocol: 'aspir',
-        phase: 'verified',
+        gates: {},
+        gateRequestedAt: {},
       }))).toBe(false);
     });
 
-    it('returns false when no signal is present', () => {
+    it('returns false when no pr-gate signal is present', () => {
       expect(derivePrReady(makeParsed({ protocol: 'spir', phase: 'implement' }))).toBe(false);
     });
   });

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -93,15 +93,13 @@ export interface BuilderOverview {
    */
   area: string;
   /**
-   * Canonical "PR is waiting on a human reviewer" signal (Issue #872). True the
-   * moment porch transitions out of the CMAP-emitting state for the PR-creating
-   * phase, for ALL bundled protocols. Computed from `pr_ready_for_human` in
-   * status.yaml when present; otherwise falls back to the v3.1.3 derived logic
-   * (`blocked === 'PR review'` || BUGFIX `phase === 'verified'`) so in-flight
-   * projects from before this field shipped continue to surface correctly.
-   *
-   * Consumers (dashboard NeedsAttentionList, VSCode tree) gate on this flag
-   * instead of deriving from the protocol-specific gate shape themselves.
+   * Canonical "PR is waiting on a human reviewer" signal. Gate-authoritative
+   * (#927): true exactly when the builder's `pr` gate is genuinely pending
+   * (`status: pending` + `requested_at`), which porch sets after the PR phase /
+   * CMAP for EVERY bundled PR-producing protocol (BUGFIX, AIR, SPIR, ASPIR,
+   * PIR). See `derivePrReady`. Consumers (dashboard NeedsAttentionList, VSCode
+   * tree) gate on this flag instead of re-deriving from the protocol-specific
+   * gate shape.
    */
   prReady: boolean;
 }
@@ -432,6 +430,12 @@ const GATE_LABELS: Record<string, string> = {
   'plan-approval': 'plan review',
   'dev-approval': 'dev review',
   'pr': 'PR review',
+  // Post-merge human gate on SPIR/ASPIR's `verify` phase (#927). A pending
+  // verify-approval genuinely needs human action, so it surfaces wherever
+  // `detectBlocked` is consumed (dashboard gate rows, VSCode tree/toast/status
+  // bar). The `pr` gate stays mapped here too (VSCode depends on it); the
+  // dashboard alone excludes `pr` from its gate rows since it renders PR rows.
+  'verify-approval': 'verify review',
 };
 
 export function detectBlocked(parsed: ParsedStatus): string | null {
@@ -461,11 +465,12 @@ export function detectBlockedGate(parsed: ParsedStatus): string | null {
  * Detect when the current blocked gate was first requested.
  * Returns the ISO timestamp string or null if not blocked.
  *
- * Keep this list in sync with `detectBlocked`'s `gateLabels` keys.
+ * Iterates `GATE_LABELS` so the gate set lives in exactly one place — sibling
+ * to `detectBlocked` / `detectBlockedGate` (#927 removed this function's
+ * previously-separate hardcoded array, which was a silent drift hazard).
  */
 export function detectBlockedSince(parsed: ParsedStatus): string | null {
-  const gateNames = ['spec-approval', 'plan-approval', 'dev-approval', 'pr'];
-  for (const gate of gateNames) {
+  for (const gate of Object.keys(GATE_LABELS)) {
     if (parsed.gates[gate] === 'pending' && parsed.gateRequestedAt[gate]) {
       return parsed.gateRequestedAt[gate];
     }
@@ -474,30 +479,28 @@ export function detectBlockedSince(parsed: ParsedStatus): string | null {
 }
 
 /**
- * Compute the canonical "PR ready for human review" signal for a builder
- * (Issue #872). Prefers porch's explicit `pr_ready_for_human` field in
- * status.yaml when present; otherwise falls back to the v3.1.3 derivation so
- * builders whose state.yaml pre-dates the field continue to surface.
+ * Compute the canonical "PR ready for human review" signal for a builder.
  *
- * Fallback derivation:
- *   - `blocked === 'PR review'` — protocols with a `pr` gate (AIR/SPIR/ASPIR/PIR)
- *     that reached the human-bottleneck state under v3.1.3 logic.
- *   - BUGFIX `phase === 'verified'` — the v3.1.3 gap this canonical signal
- *     closes. BUGFIX has no `pr` gate, so its post-CMAP state is `verified`
- *     with no gate-pending signal; the fallback adds this case so in-flight
- *     BUGFIX builders aren't dropped from Needs Attention.
+ * Gate-authoritative (#927): a PR is waiting on a human exactly when its
+ * builder's `pr` gate is genuinely pending — `status: pending` AND a
+ * `requested_at` timestamp is present. Porch requests the `pr` gate (writing
+ * `requested_at`) after the PR phase / CMAP completes, for EVERY bundled
+ * PR-producing protocol (BUGFIX, AIR, SPIR, ASPIR, PIR — #887 gave BUGFIX a
+ * `pr` gate). The `pr` gate going pending is therefore the uniform,
+ * post-CMAP "ready for human" signal across all protocols.
  *
- * Once porch has written `pr_ready_for_human` to status.yaml the fallback no
- * longer fires for that project — the explicit field is authoritative.
+ * The `requested_at` conjunct is load-bearing: porch initializes every gate to
+ * `status: pending` with NO `requested_at` at project creation, so a bare
+ * `=== 'pending'` check would mark freshly-initialized projects PR-ready.
+ *
+ * This deliberately no longer consults `pr_ready_for_human` (coincident with
+ * the gate by construction; reading the gate directly removes the sticky-`false`
+ * rollback hazard from #919) nor the old `bugfix && phase === 'verified'`
+ * fallback (a crutch for a gateless BUGFIX variant — gateless PR-producing
+ * protocols do not surface PR rows, by design).
  */
 export function derivePrReady(parsed: ParsedStatus): boolean {
-  if (parsed.prReadyForHuman !== null) return parsed.prReadyForHuman;
-  // Fallback: v3.1.3 logic + BUGFIX case.
-  const prGatePending =
-    parsed.gates['pr'] === 'pending' && !!parsed.gateRequestedAt['pr'];
-  if (prGatePending) return true;
-  if (parsed.protocol === 'bugfix' && parsed.phase === 'verified') return true;
-  return false;
+  return parsed.gates['pr'] === 'pending' && !!parsed.gateRequestedAt['pr'];
 }
 
 /**

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -156,13 +156,6 @@ export interface OverviewData {
   pendingPRs: PROverview[];
   backlog: BacklogItem[];
   recentlyClosed: RecentlyClosedItem[];
-  /**
-   * Issue IDs of PRs merged in the recent window (24h, matching
-   * `fetchRecentMergedPRs`). Consumers cross-reference this against a
-   * builder's `issueId` to skip stale post-merge `prReady` rows (Issue #901).
-   * Empty array when the forge call fails or yields no merge-linked rows.
-   */
-  recentlyMergedIssueIds: string[];
   /** Auto-detected forge login of the current user (via the user-identity concept). */
   currentUser?: string;
   errors?: { prs?: string; issues?: string };
@@ -1006,24 +999,7 @@ export class OverviewCache {
       });
     }
 
-    // 6. Project merged-PR linked-issue IDs for consumers (Issue #901).
-    //    NeedsAttentionList uses this set to skip the cache-miss defensive
-    //    emit for prReady builders whose PR is correctly absent from
-    //    pendingPRs because the PR has been merged. Empty when the forge
-    //    call fails (mergedPRs === null) or returned no merge-linked rows.
-    const recentlyMergedIssueIds: string[] = [];
-    if (mergedPRs) {
-      const seen = new Set<string>();
-      for (const pr of mergedPRs) {
-        const linkedIssue = parseLinkedIssue(pr.body || '', pr.title);
-        if (linkedIssue !== null && !seen.has(linkedIssue)) {
-          seen.add(linkedIssue);
-          recentlyMergedIssueIds.push(linkedIssue);
-        }
-      }
-    }
-
-    const result: OverviewData = { builders, pendingPRs, backlog, recentlyClosed, recentlyMergedIssueIds };
+    const result: OverviewData = { builders, pendingPRs, backlog, recentlyClosed };
     if (currentUser) {
       result.currentUser = currentUser;
     }

--- a/packages/dashboard/__tests__/NeedsAttentionList.test.tsx
+++ b/packages/dashboard/__tests__/NeedsAttentionList.test.tsx
@@ -180,22 +180,12 @@ describe('NeedsAttentionList buildItems — PR gating (issue #844)', () => {
     expect(pr!.waitingSince).toBe(createdAt);
   });
 
-  it('still surfaces a prReady BUGFIX builder when its PR is missing from prs (realistic shape, Issue #872 iter-2)', () => {
-    // Defensive: if a BUGFIX builder signals prReady but its PR didn't appear
-    // in `prs` (cache miss / pagination / API error), do NOT silently drop the
-    // builder. The iter-1 version of this test mocked blocked='PR review' on
-    // a BUGFIX builder, which is unrealistic — real BUGFIX builders have
-    // blocked=null/blockedSince=null because BUGFIX has no `pr` gate. With
-    // the realistic shape, the original gate-loop early-out filtered the
-    // builder before the prReady check could fire. Architect-side CMAP
-    // caught this; the loop now checks prReady BEFORE the !b.blocked skip.
-    //
-    // Issue #901: the defensive emit is only correct when the PR is missing
-    // for a "still open" reason (cache / pagination / transient failure).
-    // recentlyMergedIssueIds is the merged-PR-issue set; this test must NOT
-    // include the builder's issueId there, or the row is correctly skipped.
+  it('does NOT surface a prReady BUGFIX builder when its PR is missing from prs (#927: no builder stand-in)', () => {
+    // #927 inverts the pre-existing defensive builder-emit: a builder NEVER
+    // stands in for a PR. If a prReady builder's PR is absent from `prs` (cache
+    // miss / pagination / merged), emit NOTHING — the next refresh surfaces it
+    // once `pendingPRs` includes the open PR.
     const prs: OverviewPR[] = [];
-    const startedAt = new Date('2026-01-05T12:00:00Z').toISOString();
     const builders = [
       makeBuilder({
         id: 'bugfix-42',
@@ -205,28 +195,43 @@ describe('NeedsAttentionList buildItems — PR gating (issue #844)', () => {
         blocked: null,
         blockedGate: null,
         blockedSince: null,
-        startedAt,
+        startedAt: new Date('2026-01-05T12:00:00Z').toISOString(),
         prReady: true,
       }),
     ];
 
-    const items = buildItems(prs, builders, []);
-    const row = items.find(i => i.key === 'gate-bugfix-42');
+    const items = buildItems(prs, builders);
 
-    expect(row).toBeDefined();
-    expect(row!.kind).toBe('PR review');
-    // Falls back to startedAt when no gate gives us blockedSince.
-    expect(row!.waitingSince).toBe(startedAt);
+    expect(items.find(i => i.key === 'gate-bugfix-42')).toBeUndefined();
+    expect(items).toHaveLength(0);
   });
 
-  it('does NOT surface a prReady builder whose PR has been merged (Issue #901)', () => {
-    // After PR merge, the PR is correctly absent from `prs` (open-only) and
-    // the builder may still carry stale `prReady: true` in status.yaml — the
-    // v3.1.4 line-453 setter wrote it on terminal `pr → verified` advance;
-    // PR #888 fixed that but in-flight builders that crossed the v3.1.4 →
-    // v3.1.5 boundary keep the stale value. Cross-referencing the builder's
-    // issueId against recentlyMergedIssueIds suppresses the stale row
-    // without a one-shot migration.
+  it('does NOT surface a prReady gated builder (AIR/SPIR shape) when its PR is missing from prs (#927)', () => {
+    // Same rule for the gate-bearing shape: prReady + PR absent ⇒ no row.
+    const prs: OverviewPR[] = [];
+    const builders = [
+      makeBuilder({
+        id: 'air-42',
+        issueId: '42',
+        protocol: 'air',
+        blocked: 'PR review',
+        blockedGate: 'pr',
+        blockedSince: new Date('2026-01-05T12:00:00Z').toISOString(),
+        prReady: true,
+      }),
+    ];
+
+    const items = buildItems(prs, builders);
+
+    expect(items.find(i => i.key === 'gate-air-42')).toBeUndefined();
+    expect(items).toHaveLength(0);
+  });
+
+  it('does NOT surface a merged PR (absent from prs) — no recentlyMerged list needed (#927)', () => {
+    // Post-merge the PR is correctly absent from `prs` (open-only) and the
+    // builder may still carry stale prReady. #927 removed the merged-suppression
+    // list (recentlyMergedIssueIds): a missing PR simply yields no row, by the
+    // same "no builder stand-in" rule.
     const prs: OverviewPR[] = [];
     const builders = [
       makeBuilder({
@@ -237,40 +242,40 @@ describe('NeedsAttentionList buildItems — PR gating (issue #844)', () => {
         blocked: null,
         blockedGate: null,
         blockedSince: null,
-        startedAt: new Date('2026-01-05T12:00:00Z').toISOString(),
-        prReady: true,
-      }),
-    ];
-
-    // Merged-PR set includes 1842 — its PR is gone for a reason (merged),
-    // not for a transient failure.
-    const items = buildItems(prs, builders, ['1842']);
-
-    expect(items.find(i => i.key === 'gate-spir-1842')).toBeUndefined();
-    expect(items).toHaveLength(0);
-  });
-
-  it('still surfaces a prReady gated builder (AIR/SPIR shape) when its PR is missing from prs', () => {
-    // Gate-bearing variant — preserves the iter-1 coverage but with the
-    // expectation explicitly tied to the gate-blocked shape.
-    const prs: OverviewPR[] = [];
-    const blockedSince = new Date('2026-01-05T12:00:00Z').toISOString();
-    const builders = [
-      makeBuilder({
-        id: 'air-42',
-        issueId: '42',
-        protocol: 'air',
-        blocked: 'PR review',
-        blockedGate: 'pr',
-        blockedSince,
         prReady: true,
       }),
     ];
 
     const items = buildItems(prs, builders);
-    const row = items.find(i => i.key === 'gate-air-42');
+
+    expect(items).toHaveLength(0);
+  });
+
+  it('surfaces a verify-approval-pending builder as a gate row labeled "verify review" (#927)', () => {
+    // Post-merge human gate. prReady=false (pr gate not pending); `blocked` is
+    // set by the server's GATE_LABELS. Surfaces as a gate row, not a PR row,
+    // with the verify styling class.
+    const prs: OverviewPR[] = [];
+    const blockedSince = new Date('2026-01-06T08:00:00Z').toISOString();
+    const builders = [
+      makeBuilder({
+        id: 'spir-77',
+        issueId: '77',
+        protocol: 'spir',
+        phase: 'verify',
+        blocked: 'verify review',
+        blockedGate: 'verify-approval',
+        blockedSince,
+        prReady: false,
+      }),
+    ];
+
+    const items = buildItems(prs, builders);
+    const row = items.find(i => i.key === 'gate-spir-77');
 
     expect(row).toBeDefined();
+    expect(row!.kind).toBe('verify review');
+    expect(row!.kindClass).toBe('attention-kind--verify');
     expect(row!.waitingSince).toBe(blockedSince);
   });
 

--- a/packages/dashboard/__tests__/NeedsAttentionList.test.tsx
+++ b/packages/dashboard/__tests__/NeedsAttentionList.test.tsx
@@ -83,34 +83,43 @@ describe('NeedsAttentionList buildItems — PR gating (issue #844)', () => {
     expect(items.filter(i => i.issueOrPR === '#100')).toHaveLength(1);
   });
 
-  it('surfaces a BUGFIX PR whose builder has no gate (Issue #872)', () => {
-    // BUGFIX has no `pr` gate — the v3.1.3 derivation (blocked === 'PR review')
-    // silently dropped these PRs. The canonical `prReady` signal fixes this.
-    const prs = [makePR({ id: '111', linkedIssue: '42' })];
+  it('surfaces a BUGFIX PR via the pr gate (post-#887, gate-authoritative shape)', () => {
+    // #887 gave BUGFIX a `pr` gate, so a prReady BUGFIX builder carries
+    // blocked='PR review' + blockedSince (gate-authoritative). The PR surfaces
+    // as a PR row, and its wait time is the gate-requested time — not createdAt.
+    const createdAt = new Date('2026-01-01T00:00:00Z').toISOString();
+    const blockedSince = new Date('2026-01-02T00:00:00Z').toISOString();
+    const prs = [makePR({ id: '111', linkedIssue: '42', createdAt })];
     const builders = [
       makeBuilder({
         issueId: '42',
         protocol: 'bugfix',
-        phase: 'verified',
-        blocked: null,
-        blockedGate: null,
-        blockedSince: null,
+        phase: 'review',
+        blocked: 'PR review',
+        blockedGate: 'pr',
+        blockedSince,
         prReady: true,
       }),
     ];
 
     const items = buildItems(prs, builders);
+    const row = items.find(i => i.key === 'pr-111');
 
-    expect(items.find(i => i.key === 'pr-111')).toBeDefined();
+    expect(row).toBeDefined();
+    expect(row!.waitingSince).toBe(blockedSince);
   });
 
-  it('surfaces a human-authored PR (no matching builder) only when reviewStatus is REVIEW_REQUIRED', () => {
-    const required = makePR({ id: '200', linkedIssue: null, reviewStatus: 'REVIEW_REQUIRED' });
+  it('surfaces a human-authored PR (no matching builder) only when reviewStatus is REVIEW_REQUIRED, using pr.createdAt', () => {
+    const createdAt = new Date('2026-01-03T00:00:00Z').toISOString();
+    const required = makePR({ id: '200', linkedIssue: null, reviewStatus: 'REVIEW_REQUIRED', createdAt });
     const approved = makePR({ id: '201', linkedIssue: null, reviewStatus: 'APPROVED' });
 
     const items = buildItems([required, approved], []);
+    const row = items.find(i => i.key === 'pr-200');
 
-    expect(items.find(i => i.key === 'pr-200')).toBeDefined();
+    expect(row).toBeDefined();
+    // Unaffiliated PR has no gate signal — wait time falls back to createdAt.
+    expect(row!.waitingSince).toBe(createdAt);
     expect(items.find(i => i.key === 'pr-201')).toBeUndefined();
   });
 
@@ -155,29 +164,6 @@ describe('NeedsAttentionList buildItems — PR gating (issue #844)', () => {
 
     expect(pr).toBeDefined();
     expect(pr!.waitingSince).toBe(blockedSince);
-  });
-
-  it('falls back to pr.createdAt for a prReady builder without blockedSince (BUGFIX shape)', () => {
-    // BUGFIX has no gate, so blockedSince is null even though prReady=true.
-    const createdAt = new Date('2026-01-01T00:00:00Z').toISOString();
-    const prs = [makePR({ id: '410', linkedIssue: '42', createdAt })];
-    const builders = [
-      makeBuilder({
-        issueId: '42',
-        protocol: 'bugfix',
-        phase: 'verified',
-        blocked: null,
-        blockedGate: null,
-        blockedSince: null,
-        prReady: true,
-      }),
-    ];
-
-    const items = buildItems(prs, builders);
-    const pr = items.find(i => i.key === 'pr-410');
-
-    expect(pr).toBeDefined();
-    expect(pr!.waitingSince).toBe(createdAt);
   });
 
   it('does NOT surface a prReady BUGFIX builder when its PR is missing from prs (#927: no builder stand-in)', () => {

--- a/packages/dashboard/src/components/NeedsAttentionList.tsx
+++ b/packages/dashboard/src/components/NeedsAttentionList.tsx
@@ -81,13 +81,20 @@ export function buildItems(
     const unaffiliatedNeedsReview = !hasBuilder && pr.reviewStatus === 'REVIEW_REQUIRED';
     if (!prReady && !unaffiliatedNeedsReview) continue;
 
+    // Affiliated pr-gate PRs measure wait from the gate-requested time the
+    // builder carries on `blockedSince` (#927: gate-authoritative ⇒ a prReady
+    // builder always has it). Unaffiliated / human-authored PRs have no gate
+    // signal, so they use the PR's createdAt. The `?? pr.createdAt` on the
+    // affiliated branch is an unreachable type guard — NOT the old gateless
+    // BUGFIX fallback (a prReady builder without blockedSince can no longer occur).
+    const waitingSince = prReady ? (readySince ?? pr.createdAt) : pr.createdAt;
     items.push({
       key: `pr-${pr.id}`,
       issueOrPR: `#${pr.id}`,
       title: pr.title,
       kind: 'PR review',
       kindClass: 'attention-kind--pr',
-      waitingSince: readySince || pr.createdAt,
+      waitingSince,
       url: pr.url,
     });
   }

--- a/packages/dashboard/src/components/NeedsAttentionList.tsx
+++ b/packages/dashboard/src/components/NeedsAttentionList.tsx
@@ -3,14 +3,6 @@ import type { OverviewPR, OverviewBuilder } from '../lib/api.js';
 interface NeedsAttentionListProps {
   prs: OverviewPR[];
   builders: OverviewBuilder[];
-  /**
-   * Issue IDs of recently-merged PRs (Issue #901). Used to distinguish
-   * "PR missing from `prs` because of cache miss / pagination" (surface
-   * the defensive row) from "PR missing because it has been merged"
-   * (skip — there is nothing left for the human to do). Defaults to an
-   * empty array for callers that haven't been wired up yet.
-   */
-  recentlyMergedIssueIds?: readonly string[];
 }
 
 interface AttentionItem {
@@ -34,6 +26,7 @@ function gateKindClass(blocked: string): string {
     case 'plan review': return 'attention-kind--plan';
     case 'code review': return 'attention-kind--code-review';
     case 'PR review': return 'attention-kind--pr';
+    case 'verify review': return 'attention-kind--verify';
     default: return 'attention-kind--plan';
   }
 }
@@ -51,19 +44,14 @@ function timeAgo(dateStr: string): string {
 export function buildItems(
   prs: OverviewPR[],
   builders: OverviewBuilder[],
-  recentlyMergedIssueIds: readonly string[] = [],
 ): AttentionItem[] {
   const items: AttentionItem[] = [];
-  const mergedIssueIdSet = new Set(recentlyMergedIssueIds);
 
-  // A PR is genuinely waiting on a human only after the builder finishes CMAP
-  // for the PR-creating phase. Issue #872 made this a canonical `prReady`
-  // boolean so consumers don't have to derive it from the protocol-specific
-  // gate shape (the v3.1.3 derivation `blocked === 'PR review'` silently
-  // dropped BUGFIX because BUGFIX has no `pr` gate). Track `blockedSince`
-  // when present so the waiting-time chip measures "how long since the human
-  // became the bottleneck", with a fallback to the PR's createdAt for
-  // BUGFIX-style protocols whose pr-ready state isn't a gate.
+  // A PR is waiting on a human exactly when its builder's `pr` gate is pending
+  // (#927) — surfaced as the gate-authoritative `prReady` flag from the
+  // overview server. Build issueId → prReady / blockedSince lookups so the PR
+  // loop can match open PRs to their builder and measure waiting time from the
+  // `pr` gate's `requested_at` (carried on `blockedSince`).
   const prReadySince = new Map<string, string>();
   const prReadyIssueIds = new Set<string>();
   const builderIssueIds = new Set<string>();
@@ -77,12 +65,12 @@ export function buildItems(
     }
   }
 
-  // Track which pr-ready builders had their PR successfully emitted. If a
-  // builder signals prReady but its PR is missing from `prs` (cache delay,
-  // pagination, transient API failure), the builder loop below still surfaces
-  // it so a real human-action signal isn't silently dropped.
-  const emittedPrReadyIssueIds = new Set<string>();
-
+  // (A) PR rows: open PRs whose linked builder has a pending `pr` gate, plus
+  // unaffiliated/human-authored PRs with an outstanding GitHub review. A PR is
+  // surfaced ONLY as a PR row — never as a builder standing in for it. If a
+  // pr-ready builder's PR is absent from `prs` (cache miss / pagination /
+  // merged), nothing is emitted here; the next refresh surfaces it once
+  // `pendingPRs` includes the open PR.
   for (const pr of prs) {
     const hasBuilder = pr.linkedIssue !== null && builderIssueIds.has(pr.linkedIssue);
     const prReady = pr.linkedIssue !== null && prReadyIssueIds.has(pr.linkedIssue);
@@ -93,7 +81,6 @@ export function buildItems(
     const unaffiliatedNeedsReview = !hasBuilder && pr.reviewStatus === 'REVIEW_REQUIRED';
     if (!prReady && !unaffiliatedNeedsReview) continue;
 
-    if (prReady && pr.linkedIssue) emittedPrReadyIssueIds.add(pr.linkedIssue);
     items.push({
       key: `pr-${pr.id}`,
       issueOrPR: `#${pr.id}`,
@@ -105,41 +92,15 @@ export function buildItems(
     });
   }
 
-  // Surface prReady builders and gate-blocked builders. Two independent
-  // signals — they share a loop but the prReady check must come BEFORE the
-  // gate-blocked early-out, otherwise BUGFIX builders (blocked = null,
-  // blockedSince = null) are filtered out before the prReady path fires and
-  // the missing-PR defense quietly drops them.
+  // (B) Gate rows: builders blocked on a genuine human-approval gate
+  // (spec/plan/dev/verify-approval). PR-ready builders are excluded — they
+  // surface ONLY as PR rows above (the dashboard-local "no builder stand-in"
+  // rule, #927). Skipping them here also keeps the `pr` gate out of the
+  // gate-row path: `pr` remains in the shared GATE_LABELS (VSCode depends on
+  // it), but a pr-gate-pending builder is `prReady`, so it never reaches the
+  // gate-row emission below.
   for (const b of builders) {
-    // Already surfaced as a PR row above — skip to avoid double-counting.
-    if (b.prReady && b.issueId && emittedPrReadyIssueIds.has(b.issueId)) continue;
-
-    // prReady builder whose PR didn't appear in `prs` (cache miss, pagination,
-    // transient API failure). Surface anyway so we don't silently drop a real
-    // human-action signal. blockedSince may be absent for gateless protocols
-    // (BUGFIX) — fall back to startedAt so the waiting chip still renders.
-    //
-    // Skip when the builder's PR has been MERGED (Issue #901): pendingPRs
-    // lists open PRs only, so a merged PR is correctly absent — emitting the
-    // defensive row would surface a stale "PR review" item for work that's
-    // already shipped. The data hazard from v3.1.4 → v3.1.5 left some
-    // in-flight builders with stale `pr_ready_for_human: true` in
-    // status.yaml; this filter masks them without a one-shot migration.
-    if (b.prReady) {
-      if (b.issueId && mergedIssueIdSet.has(b.issueId)) continue;
-      const label = b.issueId ? `#${b.issueId}` : b.id;
-      items.push({
-        key: `gate-${b.id}`,
-        issueOrPR: label,
-        title: b.issueTitle || b.id,
-        kind: 'PR review',
-        kindClass: 'attention-kind--pr',
-        waitingSince: b.blockedSince || b.startedAt || new Date().toISOString(),
-      });
-      continue;
-    }
-
-    // Gate-blocked (non-PR) builders.
+    if (b.prReady) continue;
     if (!b.blocked || !b.blockedSince) continue;
     const label = b.issueId ? `#${b.issueId}` : b.id;
     items.push({
@@ -160,8 +121,8 @@ export function buildItems(
   return items;
 }
 
-export function NeedsAttentionList({ prs, builders, recentlyMergedIssueIds }: NeedsAttentionListProps) {
-  const items = buildItems(prs, builders, recentlyMergedIssueIds);
+export function NeedsAttentionList({ prs, builders }: NeedsAttentionListProps) {
+  const items = buildItems(prs, builders);
 
   if (items.length === 0) {
     return <p className="work-empty">Nothing needs attention</p>;

--- a/packages/dashboard/src/components/WorkView.tsx
+++ b/packages/dashboard/src/components/WorkView.tsx
@@ -121,7 +121,6 @@ export function WorkView({ state, onRefresh, onSelectTab }: WorkViewProps) {
             <NeedsAttentionList
               prs={overview?.pendingPRs ?? []}
               builders={overview?.builders ?? []}
-              recentlyMergedIssueIds={overview?.recentlyMergedIssueIds ?? []}
             />
           )}
         </section>

--- a/packages/dashboard/src/index.css
+++ b/packages/dashboard/src/index.css
@@ -1390,6 +1390,12 @@ a.attention-row {
   color: var(--status-waiting);
 }
 
+/* verify-approval — post-merge human gate (#927). Review-style wait, grouped
+   visually with PR / code review rather than the urgent pre-PR error gates. */
+.attention-kind--verify {
+  color: var(--status-waiting);
+}
+
 .attention-row-age {
   font-size: 13px;
   color: var(--text-muted);

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -249,16 +249,6 @@ export interface OverviewData {
   pendingPRs: OverviewPR[];
   backlog: OverviewBacklogItem[];
   recentlyClosed: OverviewRecentlyClosed[];
-  /**
-   * Issue IDs of PRs merged in the recent window (matches the
-   * `fetchRecentMergedPRs` 24h window in the overview server). Consumers
-   * cross-reference this against a builder's `issueId` to detect post-merge
-   * builders whose status.yaml may still carry stale `prReady: true` — used
-   * by `NeedsAttentionList` to skip the cache-miss defensive emit when the
-   * PR is correctly absent from `pendingPRs` because it has been merged
-   * (Issue #901). Empty array when the forge call fails or returns no rows.
-   */
-  recentlyMergedIssueIds: string[];
   /** Auto-detected GitHub login of the current user (via the user-identity forge concept). */
   currentUser?: string;
   errors?: { prs?: string; issues?: string };

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -181,16 +181,18 @@ export interface OverviewBuilder {
    */
   area: string;
   /**
-   * Canonical "PR is waiting on a human reviewer" signal (Issue #872). True the
-   * moment porch transitions out of the CMAP-emitting state for the PR-creating
-   * phase, for ALL bundled protocols. Computed from `pr_ready_for_human` in
-   * status.yaml when present; otherwise falls back to the v3.1.3 derived logic
-   * (`blocked === 'PR review'` || BUGFIX `phase === 'verified'`) so in-flight
-   * projects from before this field shipped continue to surface correctly.
+   * Canonical "PR is waiting on a human reviewer" signal. Gate-authoritative
+   * (#927): true exactly when the builder's `pr` gate is genuinely pending
+   * (`status: pending` + `requested_at`). Porch requests the `pr` gate after
+   * the PR phase / CMAP for EVERY bundled PR-producing protocol (BUGFIX, AIR,
+   * SPIR, ASPIR, PIR — #887 gave BUGFIX a `pr` gate), so the pending `pr` gate
+   * is the uniform post-CMAP signal.
    *
    * Consumers gate on this single boolean instead of deriving from the
-   * protocol-specific gate shape (the v3.1.3 derivation silently dropped
-   * BUGFIX PRs because BUGFIX has no `pr` gate).
+   * protocol-specific gate shape. (Earlier revisions read `pr_ready_for_human`
+   * plus a `bugfix && phase === 'verified'` fallback; #927 dropped both in
+   * favor of reading the `pr` gate directly — the field is coincident with the
+   * gate, and the gate read avoids the sticky-`false` rollback hazard.)
    */
   prReady: boolean;
 }

--- a/packages/vscode/src/test/builders.test.ts
+++ b/packages/vscode/src/test/builders.test.ts
@@ -10,6 +10,8 @@ function builder(
   id: string,
   opts: {
     blocked?: boolean;
+    /** Explicit `blocked` label (e.g. 'verify review', 'PR review'); implies blocked. */
+    blockedLabel?: string;
     blockedSince?: string;
     phase?: string;
     lastDataAt?: string | null;
@@ -17,7 +19,7 @@ function builder(
 ): OverviewBuilder {
   return {
     id,
-    blocked: opts.blocked ? 'gate-x' : null,
+    blocked: opts.blockedLabel ?? (opts.blocked ? 'gate-x' : null),
     blockedSince: opts.blockedSince ?? null,
     phase: opts.phase ?? 'implement',
     lastDataAt: opts.lastDataAt === undefined ? null : opts.lastDataAt,
@@ -105,6 +107,34 @@ suite('orderForDisplay', () => {
 			builder('d', { phase: 'complete', lastDataAt: iso(NOW - 10 * 60_000) }),
 		];
 		assert.strictEqual(orderForDisplay(bs, NOW).length, bs.length);
+	});
+});
+
+// #927 — shared GATE_LABELS blast radius. The dashboard surfaces the `pr` gate
+// as a PR row, but VSCode is builder-centric and surfaces every pending human
+// gate (including the newly-added `verify-approval`) as a blocked builder in
+// the tree. orderForDisplay is label-agnostic — it must place ANY blocked
+// builder in the blocked bucket regardless of which gate it is blocked on.
+suite('orderForDisplay — #927 gate blast radius', () => {
+	test('a verify-approval-blocked builder lands in the blocked bucket', () => {
+		const verify = builder('verify', { blockedLabel: 'verify review', blockedSince: iso(NOW - 60_000) });
+		const active = builder('active', { lastDataAt: iso(NOW - 1000) });
+		const out = orderForDisplay([active, verify], NOW);
+		assert.deepStrictEqual(out.map(x => x.id), ['verify', 'active']);
+	});
+
+	test('a PR-review-blocked builder still lands in the blocked bucket (unchanged)', () => {
+		const pr = builder('pr', { blockedLabel: 'PR review', blockedSince: iso(NOW - 60_000) });
+		const active = builder('active', { lastDataAt: iso(NOW - 1000) });
+		const out = orderForDisplay([active, pr], NOW);
+		assert.deepStrictEqual(out.map(x => x.id), ['pr', 'active']);
+	});
+
+	test('verify-review and PR-review blocked builders sort together by blockedSince (longest-waiting first)', () => {
+		const pr = builder('pr', { blockedLabel: 'PR review', blockedSince: iso(NOW - 60_000) });
+		const verify = builder('verify', { blockedLabel: 'verify review', blockedSince: iso(NOW - 3600_000) });
+		const out = orderForDisplay([pr, verify], NOW);
+		assert.deepStrictEqual(out.map(x => x.id), ['verify', 'pr']);
 	});
 });
 


### PR DESCRIPTION
Closes #927.

## What

Reworks the dashboard's **Needs Attention** surface so PR-readiness keys on the **universal `pr` gate** instead of fragile builder-state derivations. Net **−45 LOC** (3 SPIR phases) — mostly deletion.

**Needs Attention = (A) ∪ (B):**
- **(A)** open PRs whose linked builder has a pending `pr` gate → **PR rows only** (never a builder standing in for a PR; a cache-missed/merged PR yields no row).
- **(B)** gate rows for genuine human gates: spec / plan / dev / **verify**-approval.
- plus the existing unaffiliated/human-PR (`REVIEW_REQUIRED`) fallback.

## How (by phase)

1. **server-derivation** (`packages/codev`, `packages/types`): `derivePrReady` reduced to the `requested_at`-aware `pr`-gate-pending check (drops the `bugfix && verified` fallback and the `pr_ready_for_human` field dependency — kills the #919 sticky-field hazard). `verify-approval → "verify review"` added to `GATE_LABELS`; `detectBlockedSince` unified on `Object.keys(GATE_LABELS)`.
2. **dashboard-surfacing** (`packages/dashboard`): deleted the builder-emit branch; `if (b.prReady) continue;` makes PR-ready builders surface only as PR rows; affiliated PRs use the gate timestamp (`createdAt` only for unaffiliated); `verify` styling (`gateKindClass` + `.attention-kind--verify`).
3. **remove-dead-projection** (`packages/codev`, `packages/types`): removed `recentlyMergedIssueIds` end-to-end. **Retained** `fetchRecentMergedPRs` (still feeds the recentlyClosed PR-link map).

## Shared-infra / VSCode blast radius (cc area/vscode — @Amr)

`pr` **stays** in the shared `GATE_LABELS`/`detectBlocked*` so VSCode (tree/toast/status-bar) is unchanged; the "no builder stand-in" rule is **dashboard-local**. New: `verify-approval` now surfaces as a blocked builder in VSCode via the gate-toast generic fallback (added a `builders.test.ts` regression-guard). **Open question for Amr**: is that the desired VSCode UX, or do you want a dedicated `GATE_ACTIONS` "Verify" action? (additive follow-up — not a blocker.)

## Verification

- porch `build` + `tests` green at every phase; dashboard `NeedsAttentionList` 13/13; VSCode `builders.test.ts` type-checks (Electron run = area CI).
- **Render-verified** the new `--verify` styling in headless chromium against the built CSS: `.attention-kind--verify` → `rgb(234,179,8)` (`--status-waiting`, == PR row), distinct from spec and from an unstyled control.
- 3-way CMAP per phase (Gemini/Codex/Claude); all REQUEST_CHANGES addressed.

## Relationships

- **#919**: this supersedes its Needs-Attention / `derivePrReady` parts — recommend descoping #919 to just the `verified → complete` rename.
- **#902 / #901**: `recentlyMergedIssueIds` retired.

See `codev/reviews/927-needs-attention-surface-prs-vi.md` for the full review, consultation history, and lessons.