### PR TITLE
[Bugfix #931] dashboard: map dev-approval gate to attention-kind--dev

### DIFF
--- a/codev/projects/bugfix-931-dashboard-gatekindclass-missin/status.yaml
+++ b/codev/projects/bugfix-931-dashboard-gatekindclass-missin/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-05-30T00:09:20.583Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:50:15.664Z'
-updated_at: '2026-05-29T23:59:53.091Z'
+updated_at: '2026-05-30T00:09:20.583Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-931-dashboard-gatekindclass-missin/status.yaml
+++ b/codev/projects/bugfix-931-dashboard-gatekindclass-missin/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-931
 title: dashboard-gatekindclass-missin
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:50:15.664Z'
-updated_at: '2026-05-29T23:50:15.665Z'
+updated_at: '2026-05-29T23:52:17.272Z'

--- a/codev/projects/bugfix-931-dashboard-gatekindclass-missin/status.yaml
+++ b/codev/projects/bugfix-931-dashboard-gatekindclass-missin/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-05-30T00:09:20.583Z'
+    approved_at: '2026-05-30T21:23:28.721Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:50:15.664Z'
-updated_at: '2026-05-30T00:09:20.583Z'
-pr_ready_for_human: true
+updated_at: '2026-05-30T21:23:28.722Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-931-dashboard-gatekindclass-missin/status.yaml
+++ b/codev/projects/bugfix-931-dashboard-gatekindclass-missin/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-931
 title: dashboard-gatekindclass-missin
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:50:15.664Z'
-updated_at: '2026-05-29T23:52:17.272Z'
+updated_at: '2026-05-29T23:59:53.091Z'

--- a/codev/projects/bugfix-931-dashboard-gatekindclass-missin/status.yaml
+++ b/codev/projects/bugfix-931-dashboard-gatekindclass-missin/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-931
+title: dashboard-gatekindclass-missin
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-29T23:50:15.664Z'
+updated_at: '2026-05-29T23:50:15.665Z'

--- a/codev/state/bugfix-931_thread.md
+++ b/codev/state/bugfix-931_thread.md
@@ -1,0 +1,61 @@
+# bugfix-931 — dashboard: gateKindClass missing 'dev review' case
+
+Issue #931 (cosmetic, dashboard-only). Deferred from #927.
+
+## Investigate (2026-05-29)
+
+Confirmed the bug by reading the code path. Three relevant files:
+
+1. **`packages/codev/src/agent-farm/servers/overview.ts:421`** — `GATE_LABELS` maps
+   `dev-approval → 'dev review'`. This is the human-facing label that `detectBlocked`
+   stamps onto `OverviewBuilder.blocked` for a PIR builder paused at its `dev-approval` gate.
+
+2. **`packages/dashboard/src/components/NeedsAttentionList.tsx:23-32`** — `gateKindClass`
+   switches on that label to pick a CSS class. Cases present: `spec review`, `plan review`,
+   `code review`, `PR review`, `verify review`. **No `case 'dev review'`** → falls through
+   to `default: 'attention-kind--plan'`. So a PIR dev-approval gate row renders with the
+   **plan** color, not its own.
+
+   Also: `case 'code review'` is **dead** — no `GATE_LABELS` value is `'code review'`
+   (verified by grep). Its only references are this case + the `.attention-kind--code-review`
+   CSS rule + one stale comment. The issue flags it as optional-to-remove.
+
+3. **`packages/dashboard/src/index.css:1377-1397`** — CSS rules for `--pr/--spec/--plan/
+   --code-review/--verify`. **No `.attention-kind--dev`.**
+
+VSCode handles `dev review` independently (gate-toast.ts), so the dashboard `gateKindClass`
+is the only consumer missing it.
+
+## Fix plan
+- Add `case 'dev review': return 'attention-kind--dev';` to `gateKindClass`.
+- Remove the dead `case 'code review'` (and its orphaned `.attention-kind--code-review` CSS
+  rule + fix the stale comment that references "code review").
+- Add `.attention-kind--dev` to `index.css`. dev-approval is a **pre-PR** human gate (PIR),
+  so group it with the urgent pre-PR error gates (spec/plan) → `var(--status-error)`,
+  not the review-style waits (PR/verify) → `var(--status-waiting)`.
+- Regression test in `__tests__/NeedsAttentionList.test.tsx`: a dev-approval-pending builder
+  yields `kindClass === 'attention-kind--dev'` (fails pre-fix: would be `--plan`).
+
+## Fix (2026-05-29)
+
+Applied all four changes above. Verified:
+- `NeedsAttentionList.test.tsx`: **14/14 pass** (13 original + new `--dev` regression test).
+- New test is a genuine regression guard — pre-fix it asserts `--dev` while the code returned
+  the `--plan` fallback.
+- `tsc --noEmit -p tsconfig.app.json`: clean (exit 0).
+- Full dashboard suite after building `@cluesmith/codev-core`: **30/31 files, 315 pass, 1 skip,
+  1 fail**.
+
+### Environment note (not a code issue)
+Fresh worktree had no `node_modules` and `@cluesmith/codev-core` was unbuilt. The first full
+suite run showed 12 files with `(0 test)` — all `Failed to resolve import
+"@cluesmith/codev-core/<subpath>"` (Terminal.*, BuilderCard, VirtualKeyboard, escapeBuffer,
+architect-toolbar). Ran `pnpm install` + `pnpm --filter "...@cluesmith/codev-core" build` and
+all 12 cleared. Pure setup gap, unrelated to #931.
+
+### Pre-existing unrelated failure (flagged to architect, NOT fixed — out of scope)
+`__tests__/scrollController.test.ts > ... > warns on unexpected scroll-to-top (Issue #630)`
+fails **consistently** (3/3 runs), 1 test. It concerns terminal scroll-to-top warning behavior
+and imports nothing from the attention-row path. Not flaky, not caused by #931. Per BUGFIX
+protocol (unrelated test failures are out of scope) I am leaving it untouched and surfacing it
+to the architect rather than modifying an unrelated test file.

--- a/codev/state/bugfix-931_thread.md
+++ b/codev/state/bugfix-931_thread.md
@@ -59,3 +59,22 @@ fails **consistently** (3/3 runs), 1 test. It concerns terminal scroll-to-top wa
 and imports nothing from the attention-row path. Not flaky, not caused by #931. Per BUGFIX
 protocol (unrelated test failures are out of scope) I am leaving it untouched and surfacing it
 to the architect rather than modifying an unrelated test file.
+
+## PR + CMAP (2026-05-29)
+
+Opened **PR #935**. First 3-way CMAP (`--type pr`):
+- **Claude**: APPROVE (HIGH) — full review with worktree file access.
+- **Codex**: REQUEST_CHANGES (HIGH) — *valid, substantive*: I'd set `.attention-kind--dev`
+  to `var(--status-error)`, the SAME color as `.attention-kind--plan`. So renaming the class
+  left dev rows visually identical to plan rows — the user-visible symptom of #931 ("renders
+  with the plan color instead of their own") was NOT resolved by the rename alone.
+- **Gemini**: blind APPROVE — could not read the diff (`Path not in workspace`: consult wrote
+  the diff to `/tmp/...`, outside Gemini's sandbox `~/.gemini/tmp/bugfix-931`). Known consult/
+  Gemini lane environmental bug, not a real review. Flagging to architect.
+
+**Resolution (commit 8c666c2):** changed `.attention-kind--dev` to `var(--status-implementing)`
+(orange). Rationale: dev-approval is PIR's gate at the END of the implement phase, so the orange
+"implementing" palette color is semantically apt AND makes dev rows visually distinct — a 3-tier
+design(red spec/plan) → implement(orange dev) → review(yellow PR/verify) progression. This
+directly resolves Codex's finding. Strengthened the regression test to also assert dev never
+maps to the plan class. Re-running the 3-way CMAP to confirm Codex flips to APPROVE.

--- a/packages/dashboard/__tests__/NeedsAttentionList.test.tsx
+++ b/packages/dashboard/__tests__/NeedsAttentionList.test.tsx
@@ -266,6 +266,36 @@ describe('NeedsAttentionList buildItems — PR gating (issue #844)', () => {
     expect(row!.waitingSince).toBe(blockedSince);
   });
 
+  it('surfaces a dev-approval-pending builder as a gate row with --dev styling (#931, PIR)', () => {
+    // PIR's pre-PR human gate. The overview server's GATE_LABELS maps
+    // dev-approval → "dev review"; gateKindClass must map that label to
+    // attention-kind--dev so the row renders with its own color. Before #931
+    // there was no `case 'dev review'`, so it fell through to the default
+    // attention-kind--plan (the plan gate's color) — this guards against that.
+    const prs: OverviewPR[] = [];
+    const blockedSince = new Date('2026-01-06T08:00:00Z').toISOString();
+    const builders = [
+      makeBuilder({
+        id: 'pir-88',
+        issueId: '88',
+        protocol: 'pir',
+        phase: 'implement',
+        blocked: 'dev review',
+        blockedGate: 'dev-approval',
+        blockedSince,
+        prReady: false,
+      }),
+    ];
+
+    const items = buildItems(prs, builders);
+    const row = items.find(i => i.key === 'gate-pir-88');
+
+    expect(row).toBeDefined();
+    expect(row!.kind).toBe('dev review');
+    expect(row!.kindClass).toBe('attention-kind--dev');
+    expect(row!.waitingSince).toBe(blockedSince);
+  });
+
   it('does NOT double-emit when both the PR and the builder are present', () => {
     // Regression guard for the dedupe invariant after the missing-PR fallback
     // was added: when the PR IS emitted, the builder loop must skip.

--- a/packages/dashboard/__tests__/NeedsAttentionList.test.tsx
+++ b/packages/dashboard/__tests__/NeedsAttentionList.test.tsx
@@ -293,6 +293,11 @@ describe('NeedsAttentionList buildItems — PR gating (issue #844)', () => {
     expect(row).toBeDefined();
     expect(row!.kind).toBe('dev review');
     expect(row!.kindClass).toBe('attention-kind--dev');
+    // The user-visible symptom of #931 was dev rows being indistinguishable
+    // from plan rows. Guard that dev maps to its OWN class, never the plan
+    // class (the old default fallthrough). The class carries a distinct color
+    // (--status-implementing vs plan's --status-error) defined in index.css.
+    expect(row!.kindClass).not.toBe('attention-kind--plan');
     expect(row!.waitingSince).toBe(blockedSince);
   });
 

--- a/packages/dashboard/src/components/NeedsAttentionList.tsx
+++ b/packages/dashboard/src/components/NeedsAttentionList.tsx
@@ -24,7 +24,7 @@ function gateKindClass(blocked: string): string {
   switch (blocked) {
     case 'spec review': return 'attention-kind--spec';
     case 'plan review': return 'attention-kind--plan';
-    case 'code review': return 'attention-kind--code-review';
+    case 'dev review': return 'attention-kind--dev';
     case 'PR review': return 'attention-kind--pr';
     case 'verify review': return 'attention-kind--verify';
     default: return 'attention-kind--plan';

--- a/packages/dashboard/src/index.css
+++ b/packages/dashboard/src/index.css
@@ -1386,11 +1386,15 @@ a.attention-row {
   color: var(--status-error);
 }
 
-/* dev-approval — pre-PR human gate (PIR, #931). The human reviews the running
-   worktree before the PR exists, so it's grouped with the urgent pre-PR error
-   gates (spec/plan) rather than the review-style PR/verify waits. */
+/* dev-approval — PIR's human gate at the END of the implement phase, where the
+   human reviews the running worktree before the PR exists (#931). Uses the
+   orange "implementing" color so dev-review rows are visually DISTINCT from the
+   red spec/plan design gates and the yellow PR/verify review waits — a 3-tier
+   design → implement → review progression. (Reusing plan's --status-error would
+   leave dev rows indistinguishable from plan rows, which is the very symptom
+   #931 reports.) */
 .attention-kind--dev {
-  color: var(--status-error);
+  color: var(--status-implementing);
 }
 
 /* verify-approval — post-merge human gate (#927). Review-style wait, grouped

--- a/packages/dashboard/src/index.css
+++ b/packages/dashboard/src/index.css
@@ -1386,12 +1386,15 @@ a.attention-row {
   color: var(--status-error);
 }
 
-.attention-kind--code-review {
-  color: var(--status-waiting);
+/* dev-approval — pre-PR human gate (PIR, #931). The human reviews the running
+   worktree before the PR exists, so it's grouped with the urgent pre-PR error
+   gates (spec/plan) rather than the review-style PR/verify waits. */
+.attention-kind--dev {
+  color: var(--status-error);
 }
 
 /* verify-approval — post-merge human gate (#927). Review-style wait, grouped
-   visually with PR / code review rather than the urgent pre-PR error gates. */
+   visually with the PR review row rather than the urgent pre-PR error gates. */
 .attention-kind--verify {
   color: var(--status-waiting);
 }


### PR DESCRIPTION
## Summary
Fixes #931

PIR `dev-approval` gate rows in the dashboard's **Needs Attention** list rendered with the **plan** gate's color instead of their own, because `gateKindClass` had no case for the `dev review` label.

## Root Cause
`GATE_LABELS` in `packages/codev/src/agent-farm/servers/overview.ts` maps `dev-approval → 'dev review'`, and the overview server stamps that label onto `OverviewBuilder.blocked`. But `gateKindClass` in `packages/dashboard/src/components/NeedsAttentionList.tsx` had **no `case 'dev review'`**, so the label fell through to `default: 'attention-kind--plan'` — every PIR dev-approval row got the plan styling.

The switch also carried a **dead `case 'code review'`** returning `attention-kind--code-review`: no `GATE_LABELS` value is `'code review'` (verified by grep across the repo), so that case (and its CSS rule) matched nothing.

## Fix
- `NeedsAttentionList.tsx`: replace the dead `case 'code review'` with `case 'dev review': return 'attention-kind--dev';`.
- `index.css`: add `.attention-kind--dev` using **`var(--status-implementing)`** (orange) and remove the orphaned `.attention-kind--code-review` rule + its stale comment reference.
  - **Color rationale:** `dev-approval` is PIR's gate at the *end of the implement phase* (the human reviews the running worktree before the PR exists). Orange "implementing" is semantically apt and makes dev rows **visually distinct** from the red spec/plan design gates and the yellow PR/verify review waits — a 3-tier **design → implement → review** progression. (An earlier revision used `--status-error`, which left dev rows the same red as plan rows; the CMAP review correctly flagged that as not actually resolving the visible symptom.)

Dashboard-only. No behavior change beyond the row color.

## Test Plan
- [x] Added regression test (`NeedsAttentionList.test.tsx`): a `dev-approval`-pending builder yields `kindClass === 'attention-kind--dev'` **and** `!== 'attention-kind--plan'`. Fails pre-fix (would be `attention-kind--plan`).
- [x] `NeedsAttentionList` suite passes (14/14).
- [x] Dashboard typecheck clean (`tsc --noEmit -p tsconfig.app.json`).
- [x] `porch check` build + tests pass.

## Net Diff
~45 LOC across 3 files — well under the 300 BUGFIX threshold.

## CMAP Review (3-way)
| Model | Verdict | Notes |
|-------|---------|-------|
| **Claude** | ✅ APPROVE (HIGH) | "Clean, well-scoped fix … solid regression test"; endorsed the 3-tier color hierarchy. |
| **Codex** | ✅ APPROVE (HIGH) | Initially **REQUEST_CHANGES** — correctly caught that `--dev` mapped to `var(--status-error)`, identical to plan, so the visible symptom wasn't resolved. Addressed by switching to `var(--status-implementing)` + strengthening the test; re-review flipped to APPROVE. |
| **Gemini** | ⚠️ blind APPROVE | Could not read the diff: `Path not in workspace` (consult wrote the diff to `/tmp/...`, outside Gemini's sandbox `~/.gemini/tmp/bugfix-931`). Environmental consult/Gemini-lane issue, **not** a real review — see note below. |

## Notes for the architect (out of scope, not touched)
1. **Pre-existing unrelated test failure:** `__tests__/scrollController.test.ts > … > warns on unexpected scroll-to-top (Issue #630)` fails **consistently** (3/3 runs) on this branch and is unrelated to #931 (terminal scroll behavior; imports nothing from the attention-row path — looks like a stale test where the prod code no longer emits that warning). Left untouched per the BUGFIX "unrelated failures are out of scope" rule. It's outside porch's `tests` check scope (which passes). Worth a separate issue.
2. **Gemini consult lane:** the Gemini reviewer can't read the PR diff because consult writes it under `/tmp/...`, outside Gemini's allowed workspace. Reproduced across multiple runs. This is the consult tooling, not this PR.