### PR TITLE
vscode: builder row legibility — phase prefix + gate-specific icons

### DIFF
--- a/codev/plans/810-vscode-builder-row-legibility.md
+++ b/codev/plans/810-vscode-builder-row-legibility.md
@@ -1,0 +1,149 @@
+# PIR Plan: VSCode builder row legibility — phase prefix + gate-specific icons
+
+## Understanding
+
+The Builders tree (`packages/vscode/src/views/builders.ts`) renders each builder as a row with a state-dispatched label and a state-dispatched icon. Issue #810 identifies two at-a-glance legibility gaps and asks for two compositional fixes in the same file:
+
+- **Gap 1 — phase not visible at a glance.** The phase name (`[implement]`) only appears for *active* builders, as a trailing suffix that long titles truncate off-screen. Blocked and idle rows hide the phase entirely.
+- **Gap 2 — gate type not visible at a glance.** Every blocked row shows the same `bell` icon regardless of which gate (`spec-approval`, `plan-approval`, `dev-approval`, `pr`) is pending. The icon — the most pre-attentive signal in the row — carries zero gate-type information.
+
+The fix:
+- **Change A** — move the phase from a trailing suffix to a leading prefix right after the issue number, so it survives end-truncation and shows across all three states.
+- **Change B** — dispatch the blocked-row codicon by gate name (color stays uniform warning-yellow), with a `bell` fallback for unknown/future gates.
+
+### Critical finding — the issue's proposed icon-map key is wrong
+
+The issue's Change B snippet keys the gate-icon map off `b.blocked`:
+
+```ts
+const blockedIcon = (b.blocked && GATE_ICONS[b.blocked]) || 'bell';
+```
+
+This is a **defect**. Per `packages/codev/src/agent-farm/servers/overview.ts:410-455` and the type docs at `packages/types/src/api.ts:148-160`:
+
+- `b.blocked` is a **human-readable label** — `detectBlocked()` returns values like `"plan review"`, `"dev review"`, `"PR review"` (from the `GATE_LABELS` map).
+- `b.blockedGate` is the **canonical gate name** — `detectBlockedGate()` returns `"plan-approval"`, `"dev-approval"`, `"pr"`, etc.
+
+So `GATE_ICONS['plan-approval']` would never match `b.blocked === 'plan review'`; every blocked row would fall through to `bell` and Change B would silently do nothing. The icon map **must key off `b.blockedGate`**, not `b.blocked`. (The issue's label examples like `blocked on plan-approval` are also inaccurate — the actual rendered label is `blocked on plan review` — but that's pre-existing display text I am not changing.)
+
+### Second finding — `verify-approval` gate is missing from the issue's map
+
+The issue's `GATE_ICONS` map lists only `spec-approval`, `plan-approval`, `dev-approval`, `pr`. But `GATE_LABELS` in `overview.ts` includes a fifth gate, `verify-approval` (the post-merge SPIR/ASPIR verify gate, #927). A `verify-approval`-blocked builder would fall through to `bell`. That's acceptable as a fallback, but since it's a known, real gate I'll add an explicit mapping so the signal is complete.
+
+## Proposed Change
+
+Both changes land in `packages/vscode/src/views/builders.ts:166-211` (`makeBuilderRow`). For testability (the acceptance criteria require unit tests on the label variants, the empty-phase edge case, and the gate-icon mapping), I'll extract two **pure, vscode-free helpers** into a new module `packages/vscode/src/views/builder-row.ts`, mirroring the existing `backlog-filter.ts` pattern (pure helpers tested under `__tests__/` with vitest, no Electron harness needed):
+
+```ts
+// packages/vscode/src/views/builder-row.ts
+import type { OverviewBuilder } from '@cluesmith/codev-types';
+import { isIdleWaiting } from '@cluesmith/codev-core/builder-helpers';
+import { timeSince } from '...';   // wherever timeSince currently lives
+
+/**
+ * Gate → codicon name. Keyed off the CANONICAL gate name (`b.blockedGate`),
+ * NOT the human-readable `b.blocked` label. Color is applied by the caller
+ * and stays uniform warning-yellow across all gates — the shape encodes WHAT
+ * kind of review, the color stays "needs your attention". Unknown / future
+ * gates fall back to `bell` so new protocols never break rendering.
+ *
+ * To add a new gate: add one entry here. Keep in sync with GATE_LABELS in
+ * packages/codev/src/agent-farm/servers/overview.ts (the source of gate names).
+ */
+const GATE_ICONS: Record<string, string> = {
+  'spec-approval': 'book',
+  'plan-approval': 'checklist',
+  'dev-approval': 'play',
+  'pr': 'git-pull-request',
+  'verify-approval': 'verified',
+};
+
+export function gateIconFor(blockedGate: string | null): string {
+  return (blockedGate && GATE_ICONS[blockedGate]) || 'bell';
+}
+
+/**
+ * The row label, with the phase as a LEADING prefix (survives end-truncation)
+ * and the existing state-dispatched suffix for blocked/idle duration.
+ */
+export function builderRowLabel(b: OverviewBuilder, now: number): string {
+  const isBlocked = !!b.blocked;
+  const isIdle = !isBlocked && isIdleWaiting(b, now);
+  const waitTime = isBlocked && b.blockedSince ? ` [${timeSince(b.blockedSince)}]` : '';
+  const idleTime = isIdle && b.lastDataAt ? ` [${timeSince(b.lastDataAt)} silent]` : '';
+  const stateLabel = isBlocked
+    ? ` blocked on ${b.blocked}${waitTime}`
+    : isIdle
+    ? ` waiting on input${idleTime}`
+    : '';
+  const phasePrefix = b.phase ? `[${b.phase}] ` : '';
+  return `#${b.issueId ?? b.id} ${phasePrefix}${b.issueTitle ?? ''}${stateLabel}`;
+}
+```
+
+`makeBuilderRow` then consumes them:
+
+```ts
+const item = new BuilderTreeItem(b.id, builderRowLabel(b, now));
+...
+item.iconPath = isBlocked
+  ? new vscode.ThemeIcon(gateIconFor(b.blockedGate), new vscode.ThemeColor('notificationsWarningIcon.foreground'))
+  : isIdle
+  ? new vscode.ThemeIcon('comment-discussion', new vscode.ThemeColor('notificationsInfoIcon.foreground'))
+  : new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('testing.iconPassed'));
+```
+
+Note: `isBlocked` / `isIdle` are still computed inline in `makeBuilderRow` (they're needed for `contextValue` family dispatch and the icon ternary). The label helper recomputes them internally — a tiny, cheap duplication that keeps the label fully pure and independently testable. The alternative (threading the booleans in) couples the helper's signature to the caller's internals for no real gain.
+
+### Why extract rather than inline (deviation from the issue's ~15 LOC sketch)
+
+The issue sketches inline edits (~15 LOC). I'm extracting two helpers instead because the acceptance criteria explicitly require unit tests covering label variants, the empty-phase edge case, and the gate-icon mapping — and `makeBuilderRow` returns a `vscode.TreeItem`, which can only be exercised under the heavier `src/test/` Electron harness. Pulling the pure logic into a vscode-free module lets a vitest `__tests__/` test assert on plain strings, exactly as `backlog-filter.test.ts` does today. Net new LOC is modestly higher but the testing requirement makes extraction the right call.
+
+## Files to Change
+
+- `packages/vscode/src/views/builder-row.ts` — **new file**. Pure helpers `gateIconFor(blockedGate)` and `builderRowLabel(b, now)` plus the `GATE_ICONS` map. No `vscode` import.
+- `packages/vscode/src/views/builders.ts:166-211` — `makeBuilderRow`: replace inline label construction with `builderRowLabel(b, now)`; replace the blocked-icon `'bell'` literal with `gateIconFor(b.blockedGate)`. Add the import. Remove the now-dead inline `phaseLabel`/`waitTime`/`idleTime` locals that moved into the helper (keep `isBlocked`/`isIdle` — still used by `contextValue` + icon ternary).
+- `packages/vscode/src/__tests__/builder-row.test.ts` — **new file**. Vitest unit tests (see Test Plan).
+
+I'll confirm where `timeSince` is defined during implement and import it into `builder-row.ts` from the same place `builders.ts` gets it (it's used at `builders.ts:168-169`).
+
+## Risks & Alternatives Considered
+
+- **Risk: keying the icon map off `b.blocked` (as the issue wrote it) would no-op Change B.** Mitigated by keying off `b.blockedGate` — the documented finding above. I'll add a test asserting `gateIconFor` maps the canonical gate names, which would catch any regression back to the label-string key.
+- **Risk: `timeSince` import location.** If `timeSince` is a local (non-exported) helper in `builders.ts`, I'll export it (or lift it alongside the new helpers). Minor; resolved at implement time.
+- **Risk: `b.phase` empty-string transient.** Handled by `b.phase ? ... : ''` — row reads `#<id> <title>` with no `[] ` literal. Covered by a test.
+- **Alternative: inline everything per the issue sketch (no extraction).** Rejected — can't satisfy the unit-test acceptance criteria without the Electron harness; extraction matches the existing `backlog-filter.ts` precedent.
+- **Alternative: a single combined helper returning `{label, iconName}`.** Rejected — two narrowly-scoped pure functions are easier to test in isolation and read more clearly at the call site.
+- **Out of scope (per issue):** `FileDecorationProvider` badge, color-coding the phase prefix or per-gate icon colors, idle/active icon changes, tooltip changes, localization. The tooltip, `contextValue`, and stable `b.id` are all left untouched.
+
+## Test Plan
+
+### Unit (vitest, `packages/vscode/src/__tests__/builder-row.test.ts`)
+
+`builderRowLabel`:
+- **Active** builder (`phase: 'implement'`, not blocked, not idle) → `#882 [implement] <title>` (no trailing state label).
+- **Blocked** builder (`blocked: 'plan review'`, `blockedSince` set, `phase: 'plan'`) → `#791 [plan] <title> blocked on plan review [<elapsed>]`.
+- **Idle** builder (`isIdleWaiting` true, `phase: 'implement'`) → `#794 [implement] <title> waiting on input [<elapsed> silent]`.
+- **Empty-phase** edge (`phase: ''`) → no `[] ` literal; row is `#<id> <title>`.
+- Falls back to `b.id` when `issueId`/`issueTitle` are null.
+
+`gateIconFor`:
+- `'spec-approval'` → `'book'`
+- `'plan-approval'` → `'checklist'`
+- `'dev-approval'` → `'play'`
+- `'pr'` → `'git-pull-request'`
+- `'verify-approval'` → `'verified'`
+- unknown gate (`'some-future-gate'`) → `'bell'`
+- `null` → `'bell'`
+- **Regression guard for the issue's bug:** assert `gateIconFor('plan review')` (the human-readable *label*, not the gate name) → `'bell'`, documenting that the function keys off the canonical gate name.
+
+### Build / lint
+- `pnpm --filter @cluesmith/codev-vscode build` (or the package's configured build) passes with no TS errors.
+- Existing vitest suite still green.
+
+### Manual (at the `dev-approval` gate — reviewer runs VSCode against the worktree)
+- Open the Codev Builders sidebar. Confirm every row shows `[<phase>]` immediately after `#<id>`, before the title.
+- Confirm a blocked row's phase stays visible when the sidebar is narrowed (truncation cuts the title tail, not the phase).
+- Confirm blocked-row icons differ by gate: a `plan-approval` builder shows the checklist glyph, a `pr`-gate builder shows the pull-request glyph, both in warning-yellow.
+- Confirm idle rows still show `comment-discussion` (info color) and active rows still show `circle-filled` (passed color).
+- Confirm a row's phase prefix and icon both re-render on an SSE tick when the underlying field changes (e.g. a builder transitioning into a gate).

--- a/codev/projects/810-vscode-builder-row-legibility-/status.yaml
+++ b/codev/projects/810-vscode-builder-row-legibility-/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-05-30T00:28:32.693Z'
     approved_at: '2026-05-30T02:02:06.186Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-05-30T02:32:46.611Z'
+    approved_at: '2026-05-30T02:35:28.593Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-29T23:59:51.417Z'
-updated_at: '2026-05-30T02:32:46.613Z'
+updated_at: '2026-05-30T02:35:28.595Z'
 pr_history:
   - phase: review
     pr_number: 941
     branch: builder/pir-810
     created_at: '2026-05-30T02:04:26.798Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/810-vscode-builder-row-legibility-/status.yaml
+++ b/codev/projects/810-vscode-builder-row-legibility-/status.yaml
@@ -1,7 +1,7 @@
 id: '810'
 title: vscode-builder-row-legibility-
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:59:51.417Z'
-updated_at: '2026-05-30T02:02:06.187Z'
+updated_at: '2026-05-30T02:02:13.225Z'

--- a/codev/projects/810-vscode-builder-row-legibility-/status.yaml
+++ b/codev/projects/810-vscode-builder-row-legibility-/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-05-30T00:02:32.837Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:59:51.417Z'
-updated_at: '2026-05-29T23:59:51.418Z'
+updated_at: '2026-05-30T00:02:32.837Z'

--- a/codev/projects/810-vscode-builder-row-legibility-/status.yaml
+++ b/codev/projects/810-vscode-builder-row-legibility-/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-05-30T00:22:40.465Z'
   dev-approval:
     status: pending
+    requested_at: '2026-05-30T00:28:32.693Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:59:51.417Z'
-updated_at: '2026-05-30T00:22:46.270Z'
+updated_at: '2026-05-30T00:28:32.694Z'

--- a/codev/projects/810-vscode-builder-row-legibility-/status.yaml
+++ b/codev/projects/810-vscode-builder-row-legibility-/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:59:51.417Z'
-updated_at: '2026-05-30T02:02:13.225Z'
+updated_at: '2026-05-30T02:04:26.799Z'
+pr_history:
+  - phase: review
+    pr_number: 941
+    branch: builder/pir-810
+    created_at: '2026-05-30T02:04:26.798Z'

--- a/codev/projects/810-vscode-builder-row-legibility-/status.yaml
+++ b/codev/projects/810-vscode-builder-row-legibility-/status.yaml
@@ -1,7 +1,7 @@
 id: '810'
 title: vscode-builder-row-legibility-
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:59:51.417Z'
-updated_at: '2026-05-30T00:22:40.466Z'
+updated_at: '2026-05-30T00:22:46.270Z'

--- a/codev/projects/810-vscode-builder-row-legibility-/status.yaml
+++ b/codev/projects/810-vscode-builder-row-legibility-/status.yaml
@@ -1,0 +1,18 @@
+id: '810'
+title: vscode-builder-row-legibility-
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-29T23:59:51.417Z'
+updated_at: '2026-05-29T23:59:51.418Z'

--- a/codev/projects/810-vscode-builder-row-legibility-/status.yaml
+++ b/codev/projects/810-vscode-builder-row-legibility-/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-05-30T00:02:32.837Z'
     approved_at: '2026-05-30T00:22:40.465Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-05-30T00:28:32.693Z'
+    approved_at: '2026-05-30T02:02:06.186Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:59:51.417Z'
-updated_at: '2026-05-30T00:28:32.694Z'
+updated_at: '2026-05-30T02:02:06.187Z'

--- a/codev/projects/810-vscode-builder-row-legibility-/status.yaml
+++ b/codev/projects/810-vscode-builder-row-legibility-/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-05-30T00:02:32.837Z'
+    approved_at: '2026-05-30T00:22:40.465Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:59:51.417Z'
-updated_at: '2026-05-30T00:02:32.837Z'
+updated_at: '2026-05-30T00:22:40.466Z'

--- a/codev/projects/810-vscode-builder-row-legibility-/status.yaml
+++ b/codev/projects/810-vscode-builder-row-legibility-/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-05-30T02:02:06.186Z'
   pr:
     status: pending
+    requested_at: '2026-05-30T02:32:46.611Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-29T23:59:51.417Z'
-updated_at: '2026-05-30T02:04:34.798Z'
+updated_at: '2026-05-30T02:32:46.613Z'
 pr_history:
   - phase: review
     pr_number: 941
     branch: builder/pir-810
     created_at: '2026-05-30T02:04:26.798Z'
+pr_ready_for_human: true

--- a/codev/projects/810-vscode-builder-row-legibility-/status.yaml
+++ b/codev/projects/810-vscode-builder-row-legibility-/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-05-29T23:59:51.417Z'
-updated_at: '2026-05-30T02:04:26.799Z'
+updated_at: '2026-05-30T02:04:34.798Z'
 pr_history:
   - phase: review
     pr_number: 941

--- a/codev/resources/lessons-learned.md
+++ b/codev/resources/lessons-learned.md
@@ -65,6 +65,7 @@ Generalizable wisdom extracted from review documents, ordered by impact. Updated
 
 ## Architecture
 
+- [From 810] The builder-overview shape is defined twice — the `OverviewBuilder` wire type (`packages/types`) and a structurally-identical local `BuilderOverview` interface in `overview.ts`, kept in sync by hand. Adding a field to only the wire type compiles for clients (vscode/dashboard) but breaks the codev build at the server-side `builders.push({...})` sites. Compounding footgun: the codev package has no `check-types` script, so the mismatch is invisible until a full `pnpm build` runs `tsc` over `codev/src` — vscode/dashboard type-checks pass meanwhile. When touching the overview projection, build the codev package, not just the client type-check.
 - [From 0395] Prompt-based instructions beat programmatic file manipulation for flexible document generation — the Builder already has context and can write natural responses, while code would need fragile parsing and placeholder logic
 - [From 0395] Keep specs and plans clean as forward-looking documents — append review history (consultation feedback, lessons learned) to review files, not to the documents being reviewed
 - [From 0031] SQLite with WAL mode handles concurrency better than JSON files for shared state

--- a/codev/reviews/810-vscode-builder-row-legibility.md
+++ b/codev/reviews/810-vscode-builder-row-legibility.md
@@ -1,0 +1,64 @@
+# PIR Review: VSCode builder row legibility — phase prefix + gate-specific icons
+
+Fixes #810
+
+## Summary
+
+The Builders tree now leads each row with the coarse protocol phase (`[plan]` / `[implement]` / `[review]`) immediately after the icon, and dispatches a gate-specific codicon for blocked builders (book / checklist / play / git-pull-request / verified, with a `bell` fallback) while keeping the warning-yellow color uniform. Both changes make protocol state legible at a glance — phase across all three row states (not just active rows, where it was previously a truncation-prone trailing suffix), and gate type via icon shape (previously a single generic bell for every gate). A new `protocolPhase` wire field was added so the prefix shows the true high-level phase instead of the low-level plan sub-phase id that the collapsed `phase` field carries.
+
+## Files Changed
+
+- `packages/vscode/src/views/builder-row.ts` (+90 / -0) — new pure, vscode-free module: `gateIconFor`, `builderRowLabel`, `timeSince`
+- `packages/vscode/src/views/builders.ts` (+7 / -21) — `makeBuilderRow` delegates to the helpers; local `timeSince` removed
+- `packages/vscode/src/__tests__/builder-row.test.ts` (+134 / -0) — new unit suite (label states, empty-phase edge, sub-phase→implement, gate mapping, regression guards)
+- `packages/types/src/api.ts` (+15 / -0) — `OverviewBuilder.protocolPhase` field + docs
+- `packages/codev/src/agent-farm/servers/overview.ts` (+18 / -0) — populate `protocolPhase` at the 3 push sites; add it to the local `BuilderOverview` interface
+- `packages/dashboard/__tests__/BuilderCard.test.tsx` (+1 / -0) — fixture field
+- `packages/dashboard/__tests__/NeedsAttentionList.test.tsx` (+1 / -0) — fixture field
+- `packages/codev/src/agent-farm/__tests__/e2e/spec-823-builder-attribution.test.ts` (+1 / -0) — mock field
+- `codev/resources/lessons-learned.md` — dual-type footgun entry (see Lessons Learned)
+- `codev/plans/810-vscode-builder-row-legibility.md`, `codev/state/pir-810_thread.md` — plan + thread
+
+## Commits
+
+- `82aeff84` [PIR #810] Phase prefix + gate-specific icons for builder rows
+- `1535e4c2` [PIR #810] Show coarse protocolPhase in row prefix, not plan sub-phase id
+- `a77a4b4a` [PIR #810] Lead the row label with the phase prefix, before the issue id
+- `8e69aa48` [PIR #810] Add protocolPhase to the local BuilderOverview interface
+
+## Test Results
+
+- Build: `pnpm --filter @cluesmith/codev build` ✓; vscode `check-types` ✓, `lint` ✓, `esbuild` ✓
+- `pnpm test:unit` (vscode): ✓ 123 passed (10 new in `builder-row.test.ts`)
+- `pnpm test` (dashboard): 314 passed, **1 pre-existing unrelated failure** (`scrollController.test.ts`, Issue #630) — see Flaky Tests
+- Manual verification (human, `dev-approval` gate): ran the worktree dev server, confirmed phase prefix renders the coarse phase and gate icons dispatch per gate. The reviewer drove two design refinements during this gate (see Things to Look At).
+
+## Architecture Updates
+
+No `arch.md` changes needed. `arch.md` documents `status.yaml` fields (`current_plan_phase`) but not the `/api/overview` projection shape, so the new `protocolPhase` field doesn't intersect any documented architectural boundary or pattern — it's an additive field on an existing wire type, not a structural change.
+
+## Lessons Learned Updates
+
+Added one entry to `codev/resources/lessons-learned.md` (Architecture): the builder-overview shape is defined twice — the `OverviewBuilder` wire type and a hand-synced local `BuilderOverview` interface in `overview.ts` — and the codev package has no `check-types` script, so a field added only to the wire type passes client type-checks but breaks the codev build at the server push sites, invisible until a full `pnpm build`. This bit this PR directly (the dev-approval build error). Recording it so the next person touching the overview projection builds the codev package, not just the client type-check.
+
+## Things to Look At During PR Review
+
+- **`protocolPhase` vs `phase` (the core design decision).** The issue assumed the prefix could use `b.phase`, but `phase` is *collapsed* in `overview.ts` — it prefers `current_plan_phase` (a free-form plan sub-phase id like `phase_0_rebase_onto_ci`) over the protocol phase, because the dashboard matches that id against `planPhases` to render sub-phase progress (`BuilderCard.tsx:23`). So the prefix would have leaked low-level slugs. The fix exposes the protocol phase as its own field (`protocolPhase = parsed.phase`), leaving `phase` untouched so the dashboard is unaffected. A rejected alternative — a vscode-only heuristic mapping `phase`→`implement` when it matches a `planPhases` id — was discarded because it encodes an unproven protocol invariant in the view layer. Verify the dashboard's `(1/4)` progress still reads `phase` and is unchanged.
+- **Label order is phase-first** (`[<phase>] #<id> <title>`), not the issue's written "immediately after the issue number." This was a deliberate reviewer call at the dev-approval gate: phase-first pins the phase bracket to a fixed offset after the icon so the phase column scans straight down (issue ids vary in width, which would otherwise make it jiggle). Noted that the "icon represents phase" rationale only strictly holds for blocked rows (active/idle icons are generic).
+- **Icon map keys off `b.blockedGate`, not `b.blocked`.** `b.blocked` is a human-readable label (`"plan review"`); `b.blockedGate` is the canonical gate name (`"plan-approval"`). Keying off the label would silently no-op (every row → bell). There's a regression test asserting `gateIconFor('plan review') === 'bell'`. The `verify-approval` gate (#927) was added to the map (the issue's draft omitted it).
+- **Helper purity.** `builderRowLabel` takes `isIdle` as a parameter rather than importing `isIdleWaiting` from codev-core, so the unit suite runs under vitest against source without needing codev-core built. The caller already computes `isIdle`.
+
+## How to Test Locally
+
+- **View diff**: VSCode sidebar → right-click builder `pir-810` → **View Diff**
+- **Run dev server**: VSCode sidebar → **Run Dev Server**, or `afx dev pir-810` (reload the VSCode window after a rebuild to pick up the extension)
+- **What to verify** (maps to the plan's Test Plan):
+  - Every row shows `[<protocol-phase>]` right after the icon — `plan` / `implement` / `review`, never a `phase_*` slug
+  - Narrowing the sidebar clips the title tail, not the phase
+  - Blocked rows show gate-specific glyphs (checklist=plan, play=dev, git-pull-request=pr), all warning-yellow; idle (`comment-discussion`) and active (`circle-filled`) icons unchanged
+  - Empty-phase rows render `#<id> <title>` with no stray `[]`
+  - Dashboard builder cards still show sub-phase progress `(n/m)` (the `phase` field is untouched)
+
+## Flaky Tests
+
+- `packages/dashboard/__tests__/scrollController.test.ts` — "warns on unexpected scroll-to-top but does not auto-correct (Issue #630)" fails on this branch. **Pre-existing and unrelated**: it fails identically with this PR's entire diff stashed on a clean tree, and touches nothing in this change (scroll behavior / `console.warn` spying, no `OverviewBuilder` usage). Not skipped or modified — left as-is per PIR's out-of-scope guidance. Porch's `tests` check runs the codev package only (not the dashboard suite), so it is unaffected.

--- a/codev/reviews/810-vscode-builder-row-legibility.md
+++ b/codev/reviews/810-vscode-builder-row-legibility.md
@@ -4,7 +4,7 @@ Fixes #810
 
 ## Summary
 
-The Builders tree now leads each row with the coarse protocol phase (`[plan]` / `[implement]` / `[review]`) immediately after the icon, and dispatches a gate-specific codicon for blocked builders (book / checklist / play / git-pull-request / verified, with a `bell` fallback) while keeping the warning-yellow color uniform. Both changes make protocol state legible at a glance — phase across all three row states (not just active rows, where it was previously a truncation-prone trailing suffix), and gate type via icon shape (previously a single generic bell for every gate). A new `protocolPhase` wire field was added so the prefix shows the true high-level phase instead of the low-level plan sub-phase id that the collapsed `phase` field carries.
+The Builders tree now leads each row with the coarse protocol phase (`[plan]` / `[implement]` / `[review]`) immediately after the icon, and dispatches a gate-specific codicon for blocked builders (book / checklist / code / git-pull-request / verified, with a `bell` fallback) while keeping the warning-yellow color uniform. Both changes make protocol state legible at a glance — phase across all three row states (not just active rows, where it was previously a truncation-prone trailing suffix), and gate type via icon shape (previously a single generic bell for every gate). A new `protocolPhase` wire field was added so the prefix shows the true high-level phase instead of the low-level plan sub-phase id that the collapsed `phase` field carries.
 
 ## Files Changed
 
@@ -55,7 +55,7 @@ Added one entry to `codev/resources/lessons-learned.md` (Architecture): the buil
 - **What to verify** (maps to the plan's Test Plan):
   - Every row shows `[<protocol-phase>]` right after the icon — `plan` / `implement` / `review`, never a `phase_*` slug
   - Narrowing the sidebar clips the title tail, not the phase
-  - Blocked rows show gate-specific glyphs (checklist=plan, play=dev, git-pull-request=pr), all warning-yellow; idle (`comment-discussion`) and active (`circle-filled`) icons unchanged
+  - Blocked rows show gate-specific glyphs (checklist=plan, code=dev, git-pull-request=pr), all warning-yellow; idle (`comment-discussion`) and active (`circle-filled`) icons unchanged
   - Empty-phase rows render `#<id> <title>` with no stray `[]`
   - Dashboard builder cards still show sub-phase progress `(n/m)` (the `phase` field is untouched)
 

--- a/codev/state/pir-810_thread.md
+++ b/codev/state/pir-810_thread.md
@@ -15,4 +15,24 @@ Two changes in `packages/vscode/src/views/builders.ts` (`makeBuilderRow`):
 ### Design decision
 Extracting two pure vscode-free helpers (`gateIconFor`, `builderRowLabel`) into new `builder-row.ts` (mirrors `backlog-filter.ts`) so the acceptance-criteria unit tests run under vitest `__tests__/` instead of the heavier Electron `src/test/` harness. Slightly more LOC than the issue's inline sketch, but the testing requirement makes extraction the right call.
 
-Awaiting `plan-approval` gate.
+Plan approved.
+
+## Implement phase
+
+Extracted two pure helpers into new `packages/vscode/src/views/builder-row.ts`:
+- `gateIconFor(blockedGate)` — gate→codicon, keyed off canonical `b.blockedGate`, bell fallback. Includes `verify-approval`→`verified`.
+- `builderRowLabel(b, isIdle, now)` — phase-prefix label.
+- `timeSince(isoDate, now)` — moved here, now takes `now` param for deterministic tests.
+
+`builders.ts` `makeBuilderRow` now calls both; removed its local `timeSince`.
+
+### Deviation from plan
+`builderRowLabel` takes `isIdle` as a **parameter** rather than importing `isIdleWaiting` from `@cluesmith/codev-core`. Reason: the vitest `__tests__/` harness runs against source with codev-core unbuilt, so a runtime import of `@cluesmith/codev-core/builder-helpers` (subpath → `dist/`) fails to resolve. Injecting `isIdle` (which the caller already computes for icon/contextValue dispatch) keeps the helper genuinely pure + test-runnable with no build step, and avoids a double `isIdleWaiting` call. Cleaner separation overall.
+
+### Checks
+- `pnpm check-types` ✓ (after building codev-types + codev-core, which the fresh worktree `pnpm install` had left without `dist/`)
+- `pnpm lint` ✓
+- `node esbuild.js` ✓
+- `pnpm test:unit` ✓ 122 passed (9 new in `builder-row.test.ts`)
+
+Awaiting `dev-approval` gate.

--- a/codev/state/pir-810_thread.md
+++ b/codev/state/pir-810_thread.md
@@ -61,3 +61,7 @@ Reviewer asked for `[<phase>] #<id> <title>` (phase first, right after the icon)
 - `builder-row.ts` — label is now `${phasePrefix}#${id} ${title}${state}`; doc comment updated.
 - `builder-row.test.ts` — all label assertions flipped to phase-first order.
 - vscode `test:unit` ✓ 123, `lint` ✓, `esbuild` ✓.
+
+## Build fix: BuilderOverview local interface also needed the field
+
+`pnpm build` failed (TS2353) — `overview.ts` defines a **local `BuilderOverview` interface duplicating** codev-types' `OverviewBuilder`, and the `builders.push({...})` sites are typed as the local one. Added `protocolPhase` there too. The codev package has **no `check-types` script**, so vscode check-types passed while this stayed hidden until a full `pnpm build` ran `tsc` over codev/src. Lesson: when touching the overview shape, build the codev package, not just vscode check-types. `pnpm --filter @cluesmith/codev build` ✓ now.

--- a/codev/state/pir-810_thread.md
+++ b/codev/state/pir-810_thread.md
@@ -53,3 +53,11 @@ Considered a vscode-only heuristic (map `b.phase` → `implement` if it's a `pla
 - vscode `check-types` ✓, `lint` ✓, `esbuild` ✓; `test:unit` ✓ 123 passed (10 in builder-row).
 - dashboard `tsc -b --force` ✓; `pnpm test` 314 passed, **1 pre-existing failure** in `scrollController.test.ts` (Issue #630, console.warn spy) — **proven unrelated**: fails identically with my entire diff stashed on a clean tree. Out of scope per PIR flaky-test guidance; noted here + for the review file. (Porch's `tests` check runs the codev package only, not dashboard, so it's green.)
 - codev-types + codev-core rebuilt (fresh-worktree `pnpm install` had left them without `dist/`).
+
+## Dev-approval feedback #2: phase prefix moved before the issue id
+
+Reviewer asked for `[<phase>] #<id> <title>` (phase first, right after the icon) instead of `#<id> [<phase>] <title>`. Agreed — strongest reason is **column alignment**: issue ids vary in width, so an id-first order makes the phase bracket jiggle row-to-row; phase-first pins it to a fixed offset after the icon, so the phase column scans straight down. (Noted the "icon represents phase" premise is only strictly true for blocked rows — active/idle icons are generic — but the alignment win holds regardless.) This diverges from the issue's written "immediately after the issue number" spec; reviewer's call.
+
+- `builder-row.ts` — label is now `${phasePrefix}#${id} ${title}${state}`; doc comment updated.
+- `builder-row.test.ts` — all label assertions flipped to phase-first order.
+- vscode `test:unit` ✓ 123, `lint` ✓, `esbuild` ✓.

--- a/codev/state/pir-810_thread.md
+++ b/codev/state/pir-810_thread.md
@@ -1,0 +1,18 @@
+# PIR #810 — vscode builder row legibility
+
+## Plan phase
+
+Wrote `codev/plans/810-vscode-builder-row-legibility.md`.
+
+Two changes in `packages/vscode/src/views/builders.ts` (`makeBuilderRow`):
+- **A** — phase as leading prefix `#<id> [<phase>] <title>...` (was trailing suffix, truncated off-screen).
+- **B** — blocked-row codicon dispatched by gate (uniform warning-yellow), bell fallback.
+
+### Key findings (corrections to the issue's proposed code)
+1. **Icon map must key off `b.blockedGate`, not `b.blocked`.** `b.blocked` is a human-readable label (`"plan review"`) per `overview.ts:410-455`; `b.blockedGate` is the canonical name (`"plan-approval"`). The issue's snippet (`GATE_ICONS[b.blocked]`) would never match → Change B would silently no-op. Added a regression test asserting `gateIconFor('plan review') === 'bell'`.
+2. **Added `verify-approval` → `verified`** to the icon map (a real gate from #927 the issue's map omitted).
+
+### Design decision
+Extracting two pure vscode-free helpers (`gateIconFor`, `builderRowLabel`) into new `builder-row.ts` (mirrors `backlog-filter.ts`) so the acceptance-criteria unit tests run under vitest `__tests__/` instead of the heavier Electron `src/test/` harness. Slightly more LOC than the issue's inline sketch, but the testing requirement makes extraction the right call.
+
+Awaiting `plan-approval` gate.

--- a/codev/state/pir-810_thread.md
+++ b/codev/state/pir-810_thread.md
@@ -62,6 +62,12 @@ Reviewer asked for `[<phase>] #<id> <title>` (phase first, right after the icon)
 - `builder-row.test.ts` — all label assertions flipped to phase-first order.
 - vscode `test:unit` ✓ 123, `lint` ✓, `esbuild` ✓.
 
+## Review phase
+
+dev-approval approved. Wrote `codev/reviews/810-vscode-builder-row-legibility.md` (PR body). Added one lessons-learned entry (dual BuilderOverview/OverviewBuilder type + codev-no-check-types footgun). No arch.md change (overview projection shape isn't documented there). Opening PR next, then porch's single-pass 3-way consult, then `pr` gate.
+
+---
+
 ## Build fix: BuilderOverview local interface also needed the field
 
 `pnpm build` failed (TS2353) — `overview.ts` defines a **local `BuilderOverview` interface duplicating** codev-types' `OverviewBuilder`, and the `builders.push({...})` sites are typed as the local one. Added `protocolPhase` there too. The codev package has **no `check-types` script**, so vscode check-types passed while this stayed hidden until a full `pnpm build` ran `tsc` over codev/src. Lesson: when touching the overview shape, build the codev package, not just vscode check-types. `pnpm --filter @cluesmith/codev build` ✓ now.

--- a/codev/state/pir-810_thread.md
+++ b/codev/state/pir-810_thread.md
@@ -36,3 +36,20 @@ Extracted two pure helpers into new `packages/vscode/src/views/builder-row.ts`:
 - `pnpm test:unit` ✓ 122 passed (9 new in `builder-row.test.ts`)
 
 Awaiting `dev-approval` gate.
+
+## Dev-approval feedback: phase prefix showed low-level plan sub-phase ids
+
+Reviewer caught that some rows displayed `[phase_0_rebase_onto_ci]` / `[phase_1_schema]` instead of `[implement]`. Root cause: `OverviewBuilder.phase` is **collapsed** in `overview.ts:714` — it prefers `current_plan_phase` (a free-form plan sub-phase id) over the protocol phase, because the **dashboard intentionally** matches that id against `planPhases` to render `(1/4)` sub-phase progress (`BuilderCard.tsx:23`). So `b.phase` is the wrong field for a high-level prefix.
+
+Considered a vscode-only heuristic (map `b.phase` → `implement` if it's a `planPhases` id) but rejected it: it relies on an unproven "sub-phase ⟹ implement" invariant and would silently rot. Reviewer agreed — went with exposing ground truth instead.
+
+### Fix: new `protocolPhase` wire field (expands beyond the vscode-only plan)
+- `packages/types/src/api.ts` — added `OverviewBuilder.protocolPhase` (= raw `parsed.phase`: plan/implement/review). `phase` documented as the collapsed/sub-phase field; unchanged.
+- `packages/codev/src/agent-farm/servers/overview.ts` — set `protocolPhase: parsed.phase` at the active push site, `''` at the two soft fallbacks. **`phase` left untouched → dashboard `(1/4)` unaffected.**
+- `builder-row.ts` — prefix reads `b.protocolPhase`.
+- Fixtures updated for the new required field: `builder-row.test.ts` (+ new test: sub-phase id in `phase` still renders `[implement]`), dashboard `BuilderCard`/`NeedsAttentionList` tests, codev e2e `spec-823` mock.
+
+### Checks (re-run)
+- vscode `check-types` ✓, `lint` ✓, `esbuild` ✓; `test:unit` ✓ 123 passed (10 in builder-row).
+- dashboard `tsc -b --force` ✓; `pnpm test` 314 passed, **1 pre-existing failure** in `scrollController.test.ts` (Issue #630, console.warn spy) — **proven unrelated**: fails identically with my entire diff stashed on a clean tree. Out of scope per PIR flaky-test guidance; noted here + for the review file. (Porch's `tests` check runs the codev package only, not dashboard, so it's green.)
+- codev-types + codev-core rebuilt (fresh-worktree `pnpm install` had left them without `dist/`).

--- a/codev/state/pir-810_thread.md
+++ b/codev/state/pir-810_thread.md
@@ -62,6 +62,12 @@ Reviewer asked for `[<phase>] #<id> <title>` (phase first, right after the icon)
 - `builder-row.test.ts` — all label assertions flipped to phase-first order.
 - vscode `test:unit` ✓ 123, `lint` ✓, `esbuild` ✓.
 
+## Post-PR tweak: dev-approval gate icon play → code
+
+Reviewer asked for an icon reflecting "coding" rather than "run". Switched `dev-approval` → `code` (`</>` glyph) — more consistent with the other phase-reflecting icons (book=spec, checklist=plan, git-pull-request=pr). Lost the `play` "run-and-verify" hint, accepted. Updated test + review file. vscode unit ✓ 123, lint ✓, esbuild ✓. (Made during the pr-gate consult window; PR updates automatically.)
+
+---
+
 ## Review phase
 
 dev-approval approved. Wrote `codev/reviews/810-vscode-builder-row-legibility.md` (PR body). Added one lessons-learned entry (dual BuilderOverview/OverviewBuilder type + codev-no-check-types footgun). No arch.md change (overview projection shape isn't documented there). Opening PR next, then porch's single-pass 3-way consult, then `pr` gate.

--- a/packages/codev/src/agent-farm/__tests__/e2e/spec-823-builder-attribution.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/spec-823-builder-attribution.test.ts
@@ -64,6 +64,7 @@ function makeBuilder(
     issueId,
     issueTitle: `Test ${issueId}`,
     phase: 'implement',
+    protocolPhase: 'implement',
     mode: 'strict' as const,
     gates: {},
     worktreePath: `/tmp/.builders/${id}`,

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -38,7 +38,20 @@ export interface BuilderOverview {
   id: string;
   issueId: string | null;
   issueTitle: string | null;
+  /**
+   * Display phase. Collapsed: prefers the active plan sub-phase id
+   * (`current_plan_phase`) over the protocol phase so the dashboard can match
+   * it against `planPhases` for sub-phase progress. Read `protocolPhase` for
+   * the coarse protocol phase.
+   */
   phase: string;
+  /**
+   * Coarse protocol phase (`plan` / `implement` / `review`, …) — the raw
+   * `phase:` from `status.yaml` before the `phase` field's sub-phase collapse.
+   * Surfaces the high-level phase for at-a-glance UIs (#810) without leaking
+   * plan sub-phase ids. Empty string when no live status exists.
+   */
+  protocolPhase: string;
   mode: 'strict' | 'soft';
   gates: Record<string, string>;
   worktreePath: string;

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -657,6 +657,7 @@ export function discoverBuilders(workspaceRoot: string): BuilderOverview[] {
         issueId: null,
         issueTitle: null,
         phase: '',
+        protocolPhase: '',
         mode: 'soft',
         gates: {},
         worktreePath,
@@ -714,6 +715,9 @@ export function discoverBuilders(workspaceRoot: string): BuilderOverview[] {
             phase: (parsed.currentPlanPhase && parsed.currentPlanPhase !== 'null')
               ? parsed.currentPlanPhase
               : parsed.phase,
+            // Coarse protocol phase, uncollapsed — high-level UIs (#810) read
+            // this so they never surface plan sub-phase ids.
+            protocolPhase: parsed.phase,
             mode: 'strict',
             gates: parsed.gates,
             worktreePath,
@@ -748,6 +752,7 @@ export function discoverBuilders(workspaceRoot: string): BuilderOverview[] {
         issueId,
         issueTitle: null,
         phase: '',
+        protocolPhase: '',
         mode: 'soft',
         gates: {},
         worktreePath,

--- a/packages/dashboard/__tests__/BuilderCard.test.tsx
+++ b/packages/dashboard/__tests__/BuilderCard.test.tsx
@@ -13,6 +13,7 @@ function makeBuilder(overrides: Partial<OverviewBuilder> = {}): OverviewBuilder 
     issueId: '823',
     issueTitle: 'Multi-architect coordination',
     phase: 'implement',
+    protocolPhase: 'implement',
     mode: 'strict',
     gates: {},
     worktreePath: '/tmp/.builders/spir-823',

--- a/packages/dashboard/__tests__/NeedsAttentionList.test.tsx
+++ b/packages/dashboard/__tests__/NeedsAttentionList.test.tsx
@@ -20,6 +20,7 @@ function makeBuilder(overrides: Partial<OverviewBuilder> = {}): OverviewBuilder 
     issueId: '42',
     issueTitle: 'Issue 42',
     phase: 'review',
+    protocolPhase: 'review',
     mode: 'strict',
     gates: {},
     worktreePath: '/path',

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -130,7 +130,22 @@ export interface OverviewBuilder {
   id: string;
   issueId: string | null;
   issueTitle: string | null;
+  /**
+   * Display phase. Collapsed: prefers the active plan sub-phase id
+   * (`current_plan_phase`, e.g. `phase_5`) over the protocol phase, so the
+   * dashboard can match it against `planPhases` to render sub-phase progress
+   * (`(1/4)`). NOT the coarse protocol phase — read `protocolPhase` for that.
+   */
   phase: string;
+  /**
+   * Coarse *protocol* phase — `plan` / `implement` / `review` (and `specify` /
+   * `verify` for SPIR/ASPIR). The raw `phase:` from `status.yaml`, before the
+   * `phase` field's sub-phase collapse. Surfaces the high-level phase for
+   * at-a-glance UIs (the VSCode builders-tree row prefix, #810) without leaking
+   * free-form plan sub-phase ids like `phase_0_rebase_onto_ci`. Empty string
+   * when no live status exists.
+   */
+  protocolPhase: string;
   mode: 'strict' | 'soft';
   gates: Record<string, string>;
   worktreePath: string;

--- a/packages/vscode/src/__tests__/builder-row.test.ts
+++ b/packages/vscode/src/__tests__/builder-row.test.ts
@@ -25,6 +25,7 @@ function builder(overrides: Partial<OverviewBuilder>): OverviewBuilder {
     issueId: '810',
     issueTitle: 'builder row legibility',
     phase: 'implement',
+    protocolPhase: 'implement',
     mode: 'strict',
     gates: {},
     worktreePath: '/tmp/wt',
@@ -46,16 +47,32 @@ function builder(overrides: Partial<OverviewBuilder>): OverviewBuilder {
 }
 
 describe('builderRowLabel', () => {
-  it('active builder: phase prefix after the issue number, no trailing state label', () => {
-    const b = builder({ issueId: '882', issueTitle: 'refactor extract', phase: 'implement' });
+  it('active builder: protocol-phase prefix after the issue number, no trailing state label', () => {
+    const b = builder({
+      issueId: '882',
+      issueTitle: 'refactor extract',
+      protocolPhase: 'implement',
+    });
     expect(builderRowLabel(b, false, NOW)).toBe('#882 [implement] refactor extract');
+  });
+
+  it('renders the coarse protocolPhase, NOT the collapsed sub-phase id in `phase`', () => {
+    // The defining case: a builder mid-implementation has `phase` overwritten
+    // with a plan sub-phase id, but the prefix must show the protocol phase.
+    const b = builder({
+      issueId: '1190',
+      issueTitle: 'Audit and unify',
+      phase: 'phase_0_rebase_onto_ci',
+      protocolPhase: 'implement',
+    });
+    expect(builderRowLabel(b, false, NOW)).toBe('#1190 [implement] Audit and unify');
   });
 
   it('blocked builder: phase prefix + trailing "blocked on <label> [<elapsed>]"', () => {
     const b = builder({
       issueId: '791',
       issueTitle: 'Startup preflight',
-      phase: 'plan',
+      protocolPhase: 'plan',
       blocked: 'plan review',
       blockedSince: TWELVE_MIN_AGO,
     });
@@ -69,7 +86,7 @@ describe('builderRowLabel', () => {
     const b = builder({
       issueId: '794',
       issueTitle: 'Notification refactor',
-      phase: 'implement',
+      protocolPhase: 'implement',
       blocked: null,
       lastDataAt: SIX_MIN_AGO,
     });
@@ -78,13 +95,13 @@ describe('builderRowLabel', () => {
     );
   });
 
-  it('empty phase: no "[] " literal prefix', () => {
-    const b = builder({ issueId: '810', issueTitle: 'x', phase: '' });
+  it('empty protocolPhase: no "[] " literal prefix', () => {
+    const b = builder({ issueId: '810', issueTitle: 'x', protocolPhase: '' });
     expect(builderRowLabel(b, false, NOW)).toBe('#810 x');
   });
 
   it('falls back to id when issueId/issueTitle are null', () => {
-    const b = builder({ id: 'pir-999', issueId: null, issueTitle: null, phase: 'plan' });
+    const b = builder({ id: 'pir-999', issueId: null, issueTitle: null, protocolPhase: 'plan' });
     expect(builderRowLabel(b, false, NOW)).toBe('#pir-999 [plan] ');
   });
 });

--- a/packages/vscode/src/__tests__/builder-row.test.ts
+++ b/packages/vscode/src/__tests__/builder-row.test.ts
@@ -53,7 +53,7 @@ describe('builderRowLabel', () => {
       issueTitle: 'refactor extract',
       protocolPhase: 'implement',
     });
-    expect(builderRowLabel(b, false, NOW)).toBe('#882 [implement] refactor extract');
+    expect(builderRowLabel(b, false, NOW)).toBe('[implement] #882 refactor extract');
   });
 
   it('renders the coarse protocolPhase, NOT the collapsed sub-phase id in `phase`', () => {
@@ -65,7 +65,7 @@ describe('builderRowLabel', () => {
       phase: 'phase_0_rebase_onto_ci',
       protocolPhase: 'implement',
     });
-    expect(builderRowLabel(b, false, NOW)).toBe('#1190 [implement] Audit and unify');
+    expect(builderRowLabel(b, false, NOW)).toBe('[implement] #1190 Audit and unify');
   });
 
   it('blocked builder: phase prefix + trailing "blocked on <label> [<elapsed>]"', () => {
@@ -78,7 +78,7 @@ describe('builderRowLabel', () => {
     });
     // isIdle is false: blocked takes precedence (caller computes !isBlocked && ...).
     expect(builderRowLabel(b, false, NOW)).toBe(
-      '#791 [plan] Startup preflight blocked on plan review [12m]',
+      '[plan] #791 Startup preflight blocked on plan review [12m]',
     );
   });
 
@@ -91,7 +91,7 @@ describe('builderRowLabel', () => {
       lastDataAt: SIX_MIN_AGO,
     });
     expect(builderRowLabel(b, true, NOW)).toBe(
-      '#794 [implement] Notification refactor waiting on input [6m silent]',
+      '[implement] #794 Notification refactor waiting on input [6m silent]',
     );
   });
 
@@ -102,7 +102,7 @@ describe('builderRowLabel', () => {
 
   it('falls back to id when issueId/issueTitle are null', () => {
     const b = builder({ id: 'pir-999', issueId: null, issueTitle: null, protocolPhase: 'plan' });
-    expect(builderRowLabel(b, false, NOW)).toBe('#pir-999 [plan] ');
+    expect(builderRowLabel(b, false, NOW)).toBe('[plan] #pir-999 ');
   });
 });
 

--- a/packages/vscode/src/__tests__/builder-row.test.ts
+++ b/packages/vscode/src/__tests__/builder-row.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for the pure helpers that back a builder row's label and icon
+ * in the Builders tree (#810):
+ * - `builderRowLabel` — phase-prefix label across active / blocked / idle
+ *   states plus the empty-phase edge case.
+ * - `gateIconFor` — gate → codicon mapping, keyed off the CANONICAL gate name.
+ *
+ * Lives in `__tests__/` (vitest) rather than `src/test/` (vscode-test Electron
+ * harness) because the helpers touch no `vscode` APIs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { OverviewBuilder } from '@cluesmith/codev-types';
+import { builderRowLabel, gateIconFor } from '../views/builder-row.js';
+
+// A fixed clock so elapsed-time suffixes are deterministic.
+const NOW = new Date('2026-05-30T12:00:00Z').getTime();
+const TWELVE_MIN_AGO = new Date(NOW - 12 * 60_000).toISOString();
+// Strictly past IDLE_WAITING_THRESHOLD_MS (5m), so isIdleWaiting() is true.
+const SIX_MIN_AGO = new Date(NOW - 6 * 60_000).toISOString();
+
+function builder(overrides: Partial<OverviewBuilder>): OverviewBuilder {
+  return {
+    id: 'pir-810',
+    issueId: '810',
+    issueTitle: 'builder row legibility',
+    phase: 'implement',
+    mode: 'strict',
+    gates: {},
+    worktreePath: '/tmp/wt',
+    roleId: null,
+    protocol: 'pir',
+    planPhases: [],
+    progress: 0,
+    blocked: null,
+    blockedGate: null,
+    blockedSince: null,
+    startedAt: null,
+    idleMs: 0,
+    lastDataAt: null,
+    spawnedByArchitect: null,
+    area: 'Uncategorized',
+    prReady: false,
+    ...overrides,
+  } as OverviewBuilder;
+}
+
+describe('builderRowLabel', () => {
+  it('active builder: phase prefix after the issue number, no trailing state label', () => {
+    const b = builder({ issueId: '882', issueTitle: 'refactor extract', phase: 'implement' });
+    expect(builderRowLabel(b, false, NOW)).toBe('#882 [implement] refactor extract');
+  });
+
+  it('blocked builder: phase prefix + trailing "blocked on <label> [<elapsed>]"', () => {
+    const b = builder({
+      issueId: '791',
+      issueTitle: 'Startup preflight',
+      phase: 'plan',
+      blocked: 'plan review',
+      blockedSince: TWELVE_MIN_AGO,
+    });
+    // isIdle is false: blocked takes precedence (caller computes !isBlocked && ...).
+    expect(builderRowLabel(b, false, NOW)).toBe(
+      '#791 [plan] Startup preflight blocked on plan review [12m]',
+    );
+  });
+
+  it('idle builder: phase prefix + trailing "waiting on input [<elapsed> silent]"', () => {
+    const b = builder({
+      issueId: '794',
+      issueTitle: 'Notification refactor',
+      phase: 'implement',
+      blocked: null,
+      lastDataAt: SIX_MIN_AGO,
+    });
+    expect(builderRowLabel(b, true, NOW)).toBe(
+      '#794 [implement] Notification refactor waiting on input [6m silent]',
+    );
+  });
+
+  it('empty phase: no "[] " literal prefix', () => {
+    const b = builder({ issueId: '810', issueTitle: 'x', phase: '' });
+    expect(builderRowLabel(b, false, NOW)).toBe('#810 x');
+  });
+
+  it('falls back to id when issueId/issueTitle are null', () => {
+    const b = builder({ id: 'pir-999', issueId: null, issueTitle: null, phase: 'plan' });
+    expect(builderRowLabel(b, false, NOW)).toBe('#pir-999 [plan] ');
+  });
+});
+
+describe('gateIconFor', () => {
+  it('maps each canonical gate name to its codicon', () => {
+    expect(gateIconFor('spec-approval')).toBe('book');
+    expect(gateIconFor('plan-approval')).toBe('checklist');
+    expect(gateIconFor('dev-approval')).toBe('play');
+    expect(gateIconFor('pr')).toBe('git-pull-request');
+    expect(gateIconFor('verify-approval')).toBe('verified');
+  });
+
+  it('falls back to bell for unknown / future gates', () => {
+    expect(gateIconFor('some-future-gate')).toBe('bell');
+  });
+
+  it('falls back to bell when not blocked (null gate)', () => {
+    expect(gateIconFor(null)).toBe('bell');
+  });
+
+  it('regression: keys off the canonical gate name, NOT the human-readable label', () => {
+    // `b.blocked` holds "plan review"; `b.blockedGate` holds "plan-approval".
+    // Passing the label must NOT match the map — guards against reverting to
+    // keying the icon off `b.blocked` (which would no-op the whole feature).
+    expect(gateIconFor('plan review')).toBe('bell');
+    expect(gateIconFor('dev review')).toBe('bell');
+    expect(gateIconFor('PR review')).toBe('bell');
+  });
+});

--- a/packages/vscode/src/__tests__/builder-row.test.ts
+++ b/packages/vscode/src/__tests__/builder-row.test.ts
@@ -110,7 +110,7 @@ describe('gateIconFor', () => {
   it('maps each canonical gate name to its codicon', () => {
     expect(gateIconFor('spec-approval')).toBe('book');
     expect(gateIconFor('plan-approval')).toBe('checklist');
-    expect(gateIconFor('dev-approval')).toBe('play');
+    expect(gateIconFor('dev-approval')).toBe('code');
     expect(gateIconFor('pr')).toBe('git-pull-request');
     expect(gateIconFor('verify-approval')).toBe('verified');
   });

--- a/packages/vscode/src/views/builder-row.ts
+++ b/packages/vscode/src/views/builder-row.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure, vscode-free helpers backing a builder row's label and icon in the
+ * Builders tree (`builders.ts`). Kept here (no `vscode` import) so the
+ * legibility logic can be unit-tested under the vitest `__tests__/` harness
+ * instead of the heavier Electron `src/test/` one — mirroring `backlog-filter.ts`.
+ */
+
+import type { OverviewBuilder } from '@cluesmith/codev-types';
+
+/**
+ * Blocked-gate → codicon name. Keyed off the CANONICAL gate name
+ * (`OverviewBuilder.blockedGate`, e.g. `"plan-approval"`), NOT the
+ * human-readable `blocked` label (e.g. `"plan review"`) — those are distinct
+ * strings (see `detectBlocked` vs `detectBlockedGate` in
+ * `packages/codev/src/agent-farm/servers/overview.ts`). Keying off the label
+ * would never match and every blocked row would fall through to `bell`.
+ *
+ * Color is applied by the caller and stays uniform warning-yellow across all
+ * gates — the shape encodes WHAT kind of review is needed, the color stays the
+ * constant "needs your attention" signal.
+ *
+ * To add a new gate: add one entry here, keeping the key in sync with
+ * `GATE_LABELS` in `overview.ts` (the source of gate names). Unknown / future
+ * gates fall back to `bell` so new protocols never render without an icon.
+ */
+const GATE_ICONS: Record<string, string> = {
+  'spec-approval': 'book',
+  'plan-approval': 'checklist',
+  'dev-approval': 'play',
+  'pr': 'git-pull-request',
+  'verify-approval': 'verified',
+};
+
+/** Codicon name for a blocked builder's gate, with a `bell` fallback. */
+export function gateIconFor(blockedGate: string | null): string {
+  return (blockedGate && GATE_ICONS[blockedGate]) || 'bell';
+}
+
+/**
+ * Compact elapsed-time label (`<1m`, `42m`, `3h`, `2d`) from `isoDate` to
+ * `now`. `now` is passed in (not read from `Date.now()`) so callers and tests
+ * compute deterministically.
+ */
+export function timeSince(isoDate: string, now: number): string {
+  const ms = now - new Date(isoDate).getTime();
+  const minutes = Math.floor(ms / 60000);
+  if (minutes < 1) { return '<1m'; }
+  if (minutes < 60) { return `${minutes}m`; }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) { return `${hours}h`; }
+  return `${Math.floor(hours / 24)}d`;
+}
+
+/**
+ * The builder row's label. The phase is a LEADING prefix immediately after the
+ * issue number (`#<id> [<phase>] <title>`) so it survives end-truncation in a
+ * narrow sidebar and shows across all three states — not the old trailing
+ * `[<phase>]` suffix that only active rows carried and long titles clipped.
+ *
+ * The state-dispatched suffix is preserved for blocked/idle duration:
+ *  - blocked: ` blocked on <label> [<elapsed>]`
+ *  - idle:    ` waiting on input [<elapsed> silent]`
+ *  - active:  (empty — the phase prefix already covers it)
+ *
+ * Empty `phase` (rare transient init state) omits the prefix entirely — the row
+ * reads `#<id> <title>` rather than carrying a literal `[] `.
+ *
+ * `isIdle` is injected by the caller (which already computes it via
+ * `isIdleWaiting` for the icon + contextValue dispatch) rather than recomputed
+ * here — keeps this helper pure (no `@cluesmith/codev-core` runtime import) and
+ * unit-testable without a build step.
+ */
+export function builderRowLabel(b: OverviewBuilder, isIdle: boolean, now: number): string {
+  const isBlocked = !!b.blocked;
+  const waitTime = isBlocked && b.blockedSince ? ` [${timeSince(b.blockedSince, now)}]` : '';
+  const idleTime = isIdle && b.lastDataAt ? ` [${timeSince(b.lastDataAt, now)} silent]` : '';
+  const stateLabel = isBlocked
+    ? ` blocked on ${b.blocked}${waitTime}`
+    : isIdle
+    ? ` waiting on input${idleTime}`
+    : '';
+  const phasePrefix = b.phase ? `[${b.phase}] ` : '';
+  return `#${b.issueId ?? b.id} ${phasePrefix}${b.issueTitle ?? ''}${stateLabel}`;
+}

--- a/packages/vscode/src/views/builder-row.ts
+++ b/packages/vscode/src/views/builder-row.ts
@@ -52,10 +52,13 @@ export function timeSince(isoDate: string, now: number): string {
 }
 
 /**
- * The builder row's label. The phase is a LEADING prefix immediately after the
- * issue number (`#<id> [<phase>] <title>`) so it survives end-truncation in a
- * narrow sidebar and shows across all three states — not the old trailing
- * `[<phase>]` suffix that only active rows carried and long titles clipped.
+ * The builder row's label. The phase leads the label, before the issue number
+ * (`[<phase>] #<id> <title>`), so it sits at a FIXED offset right after the
+ * row's icon — letting the eye scan the phase column straight down the tree
+ * (issue ids vary in width, so an id-first order would make the phase bracket
+ * jiggle row-to-row). It also survives end-truncation in a narrow sidebar and
+ * shows across all three states — unlike the old trailing `[<phase>]` suffix
+ * that only active rows carried and long titles clipped.
  *
  * The state-dispatched suffix is preserved for blocked/idle duration:
  *  - blocked: ` blocked on <label> [<elapsed>]`
@@ -83,5 +86,5 @@ export function builderRowLabel(b: OverviewBuilder, isIdle: boolean, now: number
     ? ` waiting on input${idleTime}`
     : '';
   const phasePrefix = b.protocolPhase ? `[${b.protocolPhase}] ` : '';
-  return `#${b.issueId ?? b.id} ${phasePrefix}${b.issueTitle ?? ''}${stateLabel}`;
+  return `${phasePrefix}#${b.issueId ?? b.id} ${b.issueTitle ?? ''}${stateLabel}`;
 }

--- a/packages/vscode/src/views/builder-row.ts
+++ b/packages/vscode/src/views/builder-row.ts
@@ -62,8 +62,11 @@ export function timeSince(isoDate: string, now: number): string {
  *  - idle:    ` waiting on input [<elapsed> silent]`
  *  - active:  (empty — the phase prefix already covers it)
  *
- * Empty `phase` (rare transient init state) omits the prefix entirely — the row
- * reads `#<id> <title>` rather than carrying a literal `[] `.
+ * The prefix uses the coarse `protocolPhase` (`plan` / `implement` / `review`),
+ * NOT the collapsed `phase` field — `phase` prefers free-form plan sub-phase
+ * ids (e.g. `phase_0_rebase_onto_ci`) which are too low-level for the row.
+ * Empty `protocolPhase` (rare transient init state) omits the prefix entirely —
+ * the row reads `#<id> <title>` rather than carrying a literal `[] `.
  *
  * `isIdle` is injected by the caller (which already computes it via
  * `isIdleWaiting` for the icon + contextValue dispatch) rather than recomputed
@@ -79,6 +82,6 @@ export function builderRowLabel(b: OverviewBuilder, isIdle: boolean, now: number
     : isIdle
     ? ` waiting on input${idleTime}`
     : '';
-  const phasePrefix = b.phase ? `[${b.phase}] ` : '';
+  const phasePrefix = b.protocolPhase ? `[${b.protocolPhase}] ` : '';
   return `#${b.issueId ?? b.id} ${phasePrefix}${b.issueTitle ?? ''}${stateLabel}`;
 }

--- a/packages/vscode/src/views/builder-row.ts
+++ b/packages/vscode/src/views/builder-row.ts
@@ -26,7 +26,7 @@ import type { OverviewBuilder } from '@cluesmith/codev-types';
 const GATE_ICONS: Record<string, string> = {
   'spec-approval': 'book',
   'plan-approval': 'checklist',
-  'dev-approval': 'play',
+  'dev-approval': 'code',
   'pr': 'git-pull-request',
   'verify-approval': 'verified',
 };

--- a/packages/vscode/src/views/builders.ts
+++ b/packages/vscode/src/views/builders.ts
@@ -12,6 +12,7 @@ import { BuilderFolderTreeItem } from './builder-folder-tree-item.js';
 import { buildFilePathTree, type FilePathNode } from './file-path-tree.js';
 import type { BuilderDiffCache } from './builder-diff-cache.js';
 import { AreaGroupExpansionStore } from './area-group-expansion.js';
+import { builderRowLabel, gateIconFor } from './builder-row.js';
 
 /**
  * Order builders for the Builders tree: three buckets, top-down.
@@ -166,14 +167,7 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
   private makeBuilderRow(b: OverviewBuilder, now: number): BuilderTreeItem {
     const isBlocked = !!b.blocked;
     const isIdle = !isBlocked && isIdleWaiting(b, now);
-    const waitTime = isBlocked && b.blockedSince ? ` [${timeSince(b.blockedSince)}]` : '';
-    const idleTime = isIdle && b.lastDataAt ? ` [${timeSince(b.lastDataAt)} silent]` : '';
-    const phaseLabel = isBlocked
-      ? `blocked on ${b.blocked}${waitTime}`
-      : isIdle
-      ? `waiting on input${idleTime}`
-      : `[${b.phase}]`;
-    const item = new BuilderTreeItem(b.id, `#${b.issueId ?? b.id} ${b.issueTitle ?? ''} ${phaseLabel}`);
+    const item = new BuilderTreeItem(b.id, builderRowLabel(b, isIdle, now));
     // Stable id (not the churning label) so VSCode persists expansion across
     // the frequent overview-poll refreshes, and so the accordion's
     // collapseAll+reveal can target this row reliably.
@@ -201,10 +195,12 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
     const protocol = b.protocol || 'unknown';
     const reviewSuffix = builderHasReviewFile(b) ? '-review' : '';
     item.contextValue = `${family}-${protocol}${reviewSuffix}`;
-    // Three icons for three states: bell (gate), comment-discussion
-    // (silent, likely waiting on a question), circle-filled (live/active).
+    // Three icons for three states: gate-specific codicon (blocked, shape
+    // varies by gate via `gateIconFor` — color stays warning-yellow),
+    // comment-discussion (silent, likely waiting on a question), circle-filled
+    // (live/active).
     item.iconPath = isBlocked
-      ? new vscode.ThemeIcon('bell', new vscode.ThemeColor('notificationsWarningIcon.foreground'))
+      ? new vscode.ThemeIcon(gateIconFor(b.blockedGate), new vscode.ThemeColor('notificationsWarningIcon.foreground'))
       : isIdle
       ? new vscode.ThemeIcon('comment-discussion', new vscode.ThemeColor('notificationsInfoIcon.foreground'))
       : new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('testing.iconPassed'));
@@ -323,14 +319,4 @@ function placeholder(label: string): vscode.TreeItem {
   item.contextValue = 'builder-file-none';
   item.iconPath = new vscode.ThemeIcon('circle-slash', new vscode.ThemeColor('disabledForeground'));
   return item;
-}
-
-function timeSince(isoDate: string): string {
-  const ms = Date.now() - new Date(isoDate).getTime();
-  const minutes = Math.floor(ms / 60000);
-  if (minutes < 1) { return '<1m'; }
-  if (minutes < 60) { return `${minutes}m`; }
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) { return `${hours}h`; }
-  return `${Math.floor(hours / 24)}d`;
 }


### PR DESCRIPTION
# PIR Review: VSCode builder row legibility — phase prefix + gate-specific icons

Fixes #810

## Summary

The Builders tree now leads each row with the coarse protocol phase (`[plan]` / `[implement]` / `[review]`) immediately after the icon, and dispatches a gate-specific codicon for blocked builders (book / checklist / play / git-pull-request / verified, with a `bell` fallback) while keeping the warning-yellow color uniform. Both changes make protocol state legible at a glance — phase across all three row states (not just active rows, where it was previously a truncation-prone trailing suffix), and gate type via icon shape (previously a single generic bell for every gate). A new `protocolPhase` wire field was added so the prefix shows the true high-level phase instead of the low-level plan sub-phase id that the collapsed `phase` field carries.

## Preview
<img width="364" height="345" alt="image" src="https://github.com/user-attachments/assets/8fd7dcbb-9166-4797-bcbf-5c87bc877254" />


## Files Changed

- `packages/vscode/src/views/builder-row.ts` (+90 / -0) — new pure, vscode-free module: `gateIconFor`, `builderRowLabel`, `timeSince`
- `packages/vscode/src/views/builders.ts` (+7 / -21) — `makeBuilderRow` delegates to the helpers; local `timeSince` removed
- `packages/vscode/src/__tests__/builder-row.test.ts` (+134 / -0) — new unit suite (label states, empty-phase edge, sub-phase→implement, gate mapping, regression guards)
- `packages/types/src/api.ts` (+15 / -0) — `OverviewBuilder.protocolPhase` field + docs
- `packages/codev/src/agent-farm/servers/overview.ts` (+18 / -0) — populate `protocolPhase` at the 3 push sites; add it to the local `BuilderOverview` interface
- `packages/dashboard/__tests__/BuilderCard.test.tsx` (+1 / -0) — fixture field
- `packages/dashboard/__tests__/NeedsAttentionList.test.tsx` (+1 / -0) — fixture field
- `packages/codev/src/agent-farm/__tests__/e2e/spec-823-builder-attribution.test.ts` (+1 / -0) — mock field
- `codev/resources/lessons-learned.md` — dual-type footgun entry (see Lessons Learned)
- `codev/plans/810-vscode-builder-row-legibility.md`, `codev/state/pir-810_thread.md` — plan + thread

## Commits

- `82aeff84` [PIR #810] Phase prefix + gate-specific icons for builder rows
- `1535e4c2` [PIR #810] Show coarse protocolPhase in row prefix, not plan sub-phase id
- `a77a4b4a` [PIR #810] Lead the row label with the phase prefix, before the issue id
- `8e69aa48` [PIR #810] Add protocolPhase to the local BuilderOverview interface

## Test Results

- Build: `pnpm --filter @cluesmith/codev build` ✓; vscode `check-types` ✓, `lint` ✓, `esbuild` ✓
- `pnpm test:unit` (vscode): ✓ 123 passed (10 new in `builder-row.test.ts`)
- `pnpm test` (dashboard): 314 passed, **1 pre-existing unrelated failure** (`scrollController.test.ts`, Issue #630) — see Flaky Tests
- Manual verification (human, `dev-approval` gate): ran the worktree dev server, confirmed phase prefix renders the coarse phase and gate icons dispatch per gate. The reviewer drove two design refinements during this gate (see Things to Look At).

## Architecture Updates

No `arch.md` changes needed. `arch.md` documents `status.yaml` fields (`current_plan_phase`) but not the `/api/overview` projection shape, so the new `protocolPhase` field doesn't intersect any documented architectural boundary or pattern — it's an additive field on an existing wire type, not a structural change.

## Lessons Learned Updates

Added one entry to `codev/resources/lessons-learned.md` (Architecture): the builder-overview shape is defined twice — the `OverviewBuilder` wire type and a hand-synced local `BuilderOverview` interface in `overview.ts` — and the codev package has no `check-types` script, so a field added only to the wire type passes client type-checks but breaks the codev build at the server push sites, invisible until a full `pnpm build`. This bit this PR directly (the dev-approval build error). Recording it so the next person touching the overview projection builds the codev package, not just the client type-check.

## Things to Look At During PR Review

- **`protocolPhase` vs `phase` (the core design decision).** The issue assumed the prefix could use `b.phase`, but `phase` is *collapsed* in `overview.ts` — it prefers `current_plan_phase` (a free-form plan sub-phase id like `phase_0_rebase_onto_ci`) over the protocol phase, because the dashboard matches that id against `planPhases` to render sub-phase progress (`BuilderCard.tsx:23`). So the prefix would have leaked low-level slugs. The fix exposes the protocol phase as its own field (`protocolPhase = parsed.phase`), leaving `phase` untouched so the dashboard is unaffected. A rejected alternative — a vscode-only heuristic mapping `phase`→`implement` when it matches a `planPhases` id — was discarded because it encodes an unproven protocol invariant in the view layer. Verify the dashboard's `(1/4)` progress still reads `phase` and is unchanged.
- **Label order is phase-first** (`[<phase>] #<id> <title>`), not the issue's written "immediately after the issue number." This was a deliberate reviewer call at the dev-approval gate: phase-first pins the phase bracket to a fixed offset after the icon so the phase column scans straight down (issue ids vary in width, which would otherwise make it jiggle). Noted that the "icon represents phase" rationale only strictly holds for blocked rows (active/idle icons are generic).
- **Icon map keys off `b.blockedGate`, not `b.blocked`.** `b.blocked` is a human-readable label (`"plan review"`); `b.blockedGate` is the canonical gate name (`"plan-approval"`). Keying off the label would silently no-op (every row → bell). There's a regression test asserting `gateIconFor('plan review') === 'bell'`. The `verify-approval` gate (#927) was added to the map (the issue's draft omitted it).
- **Helper purity.** `builderRowLabel` takes `isIdle` as a parameter rather than importing `isIdleWaiting` from codev-core, so the unit suite runs under vitest against source without needing codev-core built. The caller already computes `isIdle`.

## How to Test Locally

- **View diff**: VSCode sidebar → right-click builder `pir-810` → **View Diff**
- **Run dev server**: VSCode sidebar → **Run Dev Server**, or `afx dev pir-810` (reload the VSCode window after a rebuild to pick up the extension)
- **What to verify** (maps to the plan's Test Plan):
  - Every row shows `[<protocol-phase>]` right after the icon — `plan` / `implement` / `review`, never a `phase_*` slug
  - Narrowing the sidebar clips the title tail, not the phase
  - Blocked rows show gate-specific glyphs (checklist=plan, play=dev, git-pull-request=pr), all warning-yellow; idle (`comment-discussion`) and active (`circle-filled`) icons unchanged
  - Empty-phase rows render `#<id> <title>` with no stray `[]`
  - Dashboard builder cards still show sub-phase progress `(n/m)` (the `phase` field is untouched)

## Flaky Tests

- `packages/dashboard/__tests__/scrollController.test.ts` — "warns on unexpected scroll-to-top but does not auto-correct (Issue #630)" fails on this branch. **Pre-existing and unrelated**: it fails identically with this PR's entire diff stashed on a clean tree, and touches nothing in this change (scroll behavior / `console.warn` spying, no `OverviewBuilder` usage). Not skipped or modified — left as-is per PIR's out-of-scope guidance. Porch's `tests` check runs the codev package only (not the dashboard suite), so it is unaffected.
