### PR TITLE
Fix #799: builder changed-file rows render grey instead of SCM colors

### DIFF
--- a/codev/plans/799-vscode-builder-changed-file-ro.md
+++ b/codev/plans/799-vscode-builder-changed-file-ro.md
@@ -131,8 +131,23 @@ leading hypothesis was a grey *color value*. The flicker disproves that (the
 colors render correctly before being overridden), so **`contributes.colors` is
 not part of this fix** — the borrowed `gitDecoration.*` tokens resolve fine.
 
+### Coloring stays automatic — no per-row work, no new colors
+
+This fix does **not** introduce manual per-row coloring or any new color
+definitions. `BuilderFileDecorationProvider.provideFileDecoration`
+(`builder-file-decoration.ts:35-46`) already colors every row automatically:
+VSCode queries it per URI, it looks up the status from the cache and returns the
+matching `gitDecoration.*ResourceForeground` ThemeColor. That provider is
+unchanged. Those theme-color *tokens* are registered by the built-in Git
+extension at activation and resolve from the active theme **regardless of whether
+Git's decorator fires on any given URI** (token definition ≠ decorator) — the
+flicker already proves they render. The synthetic-path change only stops Git's
+*competing* grey decoration; it does not change where our color comes from.
+
 ### What this does NOT touch (already correct)
 
+- The decoration provider — `provideFileDecoration` and the `DECO` color map are
+  unchanged; coloring remains automatic per status.
 - Provider registration — one `registerFileDecorationProvider` at
   `extension.ts:267`; no competing Codev provider.
 - Cache keying — `decorationFor`/`syncDecorations` key by `uri.toString()` via the

--- a/codev/plans/799-vscode-builder-changed-file-ro.md
+++ b/codev/plans/799-vscode-builder-changed-file-ro.md
@@ -3,9 +3,9 @@
 ## Understanding
 
 Builder changed-file rows in the VSCode Builders view (list and tree mode) render
-their filenames in flat grey instead of SCM colors — Added should be green,
-Modified yellow, Deleted red. The `A`/`M`/`D` status badge on the right still
-renders correctly; only the label *color* is missing.
+their filenames in grey instead of SCM colors — Added should be green, Modified
+yellow, Deleted red. The `A`/`M`/`D` status badge on the right stays correct;
+only the label *color* is wrong.
 
 **Critical context the issue body did not have: the issue's own "proposed fix"
 was already implemented and shipped, and it did not work.**
@@ -14,222 +14,220 @@ was already implemented and shipped, and it did not work.**
   resourceUri"` switched `builderFileResourceUri` to the custom
   `codev-builder-diff:` scheme (`builder-file-tree-item.ts:43-45`), shipped in
   v3.1.4.
-- The architect **reopened** the issue on 2026-05-29, confirming via a fresh
-  screenshot that rows are **still grey** — the fix is present in the bundled
-  code but the user-visible behavior is unchanged.
+- The architect **reopened** the issue on 2026-05-29, confirming via fresh
+  screenshot that rows are **still grey** — the fix is in the bundled code but the
+  behavior is unchanged.
 
-So the issue body's root-cause theory ("the built-in Git decorator wins the
-color merge on the `file:` URI") is wrong, or at best a second-order effect. We
-re-investigated from scratch (3-lens parallel investigation + adversarial
-synthesis, run `wf_7b1f578b-c4b`).
+### The decisive symptom
 
-### Root cause
+The reviewer reports that the correct colors render **for a split second, then are
+instantly overridden by grey**. That flicker is the whole diagnosis: it rules out
+a static wrong-color (the SCM color tokens clearly *do* resolve to visible
+green/yellow/red) and points squarely at a **late-arriving grey decoration winning
+a re-merge** after the first paint.
 
-VSCode's tree-label color pipeline is **entirely scheme-agnostic**. No layer
-(`treeView.ts` `TreeRenderer`, `labels.ts`, `decorationsService.getDecoration`)
-inspects the URI scheme when deciding the label color. The badge and the color
-are derived from the **same** `FileDecoration` returned by
-`provideFileDecoration`, and applied as **two independent CSS classes**
-(`badgeClassName` for the badge, `labelClassName` for the color), each gated only
-on the sibling booleans of the `explorer.decorations` setting (both default
-`true`).
+### Root cause (high confidence, VSCode-source-backed)
 
-The decisive evidence is the **badge-yes / color-no symptom**: because the badge
-renders, our provider *is* being invoked for the `codev-builder-diff:` scheme,
-the decoration *does* reach the label renderer, and the color path *is*
-reachable. The only variable left that can be wrong is the **color value**.
+The shipped fix's premise — *"the built-in Git decorator only acts on
+`scheme === 'file'`, so the custom scheme stops it from firing"* — **is false.**
 
-`BuilderFileDecorationProvider` (`builder-file-decoration.ts:18-26`) sets each
-status color to a borrowed `gitDecoration.*ResourceForeground` ThemeColor token,
-but the extension's `package.json` ships **no `contributes.colors` block**
-(confirmed: `contributes` keys are `commands, menus, snippets, keybindings,
-viewsContainers, views, configuration` — no `colors`). We depend on theme tokens
-we do not own resolving to a saturated, distinguishable value in the user's
-active theme. They instead resolve to something at or near the default tree-label
-foreground → grey.
+Verified against `microsoft/vscode` source:
 
-This explains **both** the original intermittent grey (when the Git decorator was
-also firing on the `file:` URI and could win the merge) **and** the persistent
-grey after the scheme swap (Git no longer fires, but our own color token still
-resolves near-foreground). The scheme swap fixed a real but *different* defect
-and left the color-value defect untouched.
+1. **Git's decorators do not check `uri.scheme`.** In
+   `extensions/git/src/decorationProvider.ts`, `GitDecorationProvider` is a pure
+   `this.decorations.get(uri.toString())` lookup, and `GitIgnoreDecorationProvider`
+   does `getRepository(uri)` (path-based) then `repository.checkIgnore(paths)`
+   (shells out to `git check-ignore` on the URI's path) — **neither inspects the
+   scheme.** Our `codev-builder-diff:` URI is built as
+   `vscode.Uri.file(path.join(worktreePath, rel)).with({ scheme })`, so its
+   `.path`/`.fsPath` still point at the real, gitignored `.builders/<id>/…` file.
+   Git resolves the repo by that path and `git check-ignore` matches → Git emits
+   its grey `gitDecoration.ignoredResourceForeground` decoration on our row.
 
-This is a `medium`-confidence diagnosis. It is robust to the two most likely
-failure modes of the borrowed token (undefined, or resolving near-foreground),
-but unit tests cannot render labels or resolve theme tokens, so it **must be
-confirmed on the running extension** before we commit. That confirmation is the
-`dev-approval` gate's job — and is exactly why this is a PIR.
+2. **Extensions cannot outrank Git in the merge.**
+   `src/vs/workbench/api/browser/mainThreadDecorations.ts` pins *every*
+   extension-provided decoration (Git's and ours) to a hardcoded `weight: 10`. In
+   `src/vs/workbench/services/decorations/browser/decorationsService.ts` the merge
+   sorts by weight desc (a no-op tie at equal weight) and takes
+   `data.find(d => !!d.color) ?? data[0]` — the **first colored entry in
+   non-deterministic registration/merge order**.
+
+3. **Timing produces the flicker.** Our decoration resolves synchronously (cache
+   lookup) and paints first → correct color. Git's `GitIgnoreDecorationProvider`
+   resolves on a **500 ms debounce**, then fires a decoration-change that triggers
+   a re-merge; when Git's equal-weight grey lands first in the merge order, it
+   wins → grey. This is the open, unresolved VSCode issue
+   [#187756](https://github.com/microsoft/vscode/issues/187756) ("FileDecoration
+   color overrides gitDecoration color … all decoration providers have the same
+   weight").
+
+So the scheme swap was orthogonal to the actual mechanism. There is **no API to
+set decoration weight or to suppress another extension's provider**. The only
+lever an extension controls is the **URI shape**: if the URI's path does not
+resolve to a real tracked/ignored file inside an open repo, `getRepository(uri)`
+returns undefined, Git's provider returns nothing, and ours becomes the sole
+colored decoration — winning by default.
 
 ### Why the prior unit tests passed while the bug shipped
 
-`builder-file-tree-item.test.ts` asserts only URI *shapes* (scheme is non-`file`)
-and cache lookups. It never asserts the decoration carries a color, and cannot
-observe rendering. It passed while the color stayed broken.
+`builder-file-tree-item.test.ts` asserts only that the scheme is non-`file`. It
+never asserts the URI path is un-resolvable by Git, and cannot observe rendering.
+It passed while the bug shipped — and would still pass against the broken code.
 
 ## Proposed Change
 
-**Diagnostic-first, then fix.** Because a guess-fix already shipped and failed,
-the implement phase opens with a live A/B diagnostic the human verifies at the
-`dev-approval` gate, *then* lands the fix.
+Keep the `codev-builder-diff:` scheme, but **stop deriving the URI from the real
+worktree filesystem path.** Build a synthetic path that (a) Git cannot resolve to
+a repo-tracked/ignored file, while (b) still ending in the real basename so the
+file-type icon resolves, and (c) carrying the real worktree path in the query so
+our own decoration provider and command handlers can recover it.
 
-### Step 0 — Live diagnostic (confirm root cause before committing the fix)
+### The change
 
-Temporary instrumentation, reverted before PR:
+In `builder-file-tree-item.ts`, change `builderFileResourceUri`:
 
-1. In `provideFileDecoration`, hard-code a maximally-saturated, definitely-defined
-   color for **all** statuses: `color: new vscode.ThemeColor('charts.red')` (or
-   `'errorForeground'`).
-2. Add `console.log(uri.toString(), uri.scheme, this.cache.decorationFor(uri))`
-   at the top of `provideFileDecoration`.
-3. `pnpm --filter @cluesmith/codev compile`, launch the Extension Development
-   Host (F5 / "Run Extension"), open a workspace with a spawned builder worktree,
-   **reload the window** (FileDecoration color caching can require a reload —
-   microsoft/vscode#209907), expand a builder, look at the rows.
+```ts
+export function builderFileResourceUri(worktreePath: string, rel: string): vscode.Uri {
+  // Synthetic path ('/' + rel), NOT the real worktree fsPath. The built-in Git
+  // decorators resolve a repository by PATH and run `git check-ignore` on it
+  // (scheme-agnostic) — with the real `.builders/<id>/…` path they fire their
+  // grey "ignored" decoration and, at equal weight, win the color merge on a
+  // 500ms debounce (#799, vscode#187756). A path that doesn't resolve into any
+  // open repo makes Git's getRepository() return undefined, so it never fires
+  // and our SCM color is the sole (winning) decoration. The basename at the tail
+  // still drives the file-type icon; the real worktree path rides in the query
+  // for our provider/handlers to read back.
+  return vscode.Uri.from({
+    scheme: BUILDER_FILE_SCHEME,
+    path: '/' + rel,
+    query: `wt=${encodeURIComponent(worktreePath)}`,
+  });
+}
+```
 
-Interpretation:
-- **Rows turn red** → the scheme, provider invocation, `explorer.decorations.colors`,
-  and the color CSS path are all healthy; the only defect was the borrowed
-  `gitDecoration.*` tokens resolving near-foreground. **Root cause confirmed** →
-  proceed to Step 1.
-- **Rows stay grey** → the color CSS class is not being applied at all (value was
-  never the issue). Switch to the fallback path (Risks section).
-- The `console.log` independently confirms the provider fires once per row for the
-  custom scheme (re-falsifying the "provider not invoked for custom scheme"
-  hypothesis live).
+Why this satisfies every constraint:
 
-### Step 1 — The fix (most-likely branch): own the colors
+- **Git no longer fires.** `/src/components/Foo.tsx` does not start with any open
+  repo root (the workspace repo root is an absolute path like
+  `/Users/…/codev`), so `getRepository(uri)` → undefined and `checkIgnore` is
+  never called. `GitDecorationProvider` also returns undefined (it has no entry
+  keyed by this URI's `toString()`). Git contributes nothing → our decoration
+  wins. No flicker.
+- **Uniqueness across builders is preserved.** Two builders can share the same
+  `rel`; the `wt=<worktree>` query keeps `uri.toString()` distinct per builder, so
+  the per-builder decoration cache (keyed by `uri.toString()`) does not collide.
+  This is the role the full worktree path played in the old `file:`-based URI.
+- **The file-type icon still resolves** — `IFileIconTheme` keys off the last path
+  segment (the real basename), which is unchanged.
+- **The cache and the tree item stay in lockstep** — both call this one helper, so
+  their URIs match exactly (`builder-diff-cache.ts:107` and
+  `builder-file-tree-item.ts:78`). No cache/keying changes needed; the map already
+  keys by `uri.toString()`.
 
-Keep the custom `codev-builder-diff:` scheme (it correctly and permanently stops
-the built-in Git decorator from firing on the gitignored worktree paths;
-reverting to `file:` would regress to the intermittent Git-ignored grey). Stop
-borrowing `gitDecoration.*` tokens; register first-class, self-owned colors so the
-tint is deterministic and theme-independent.
+### What this drops vs. the medium-confidence draft
 
-1. Add a `contributes.colors` array to `packages/vscode/package.json` with one
-   entry per status:
-   - `codev.builderDiff.addedForeground`
-   - `codev.builderDiff.modifiedForeground`
-   - `codev.builderDiff.deletedForeground`
-   - `codev.builderDiff.renamedForeground` (also used for Copied)
-   - `codev.builderDiff.conflictingForeground` (Unmerged)
-
-   Each with an explicit `defaults` block for `light`, `dark`, and
-   `highContrast`, seeded from the Git extension's known-saturated values so they
-   never collapse to foreground (added ≈ `#587c0c`/`#81b88b`, modified ≈
-   `#895503`/`#e2c08d`, deleted ≈ `#ad0707`/`#c74e39`, renamed/copied ≈ the
-   "modified/added" family, conflicting ≈ `#6c6cc4`/`#e4676b`). Final exact hexes
-   chosen during implementation to match VSCode's current Git defaults.
-
-2. In `builder-file-decoration.ts`, change the `DECO` map's `color` strings from
-   `gitDecoration.*ResourceForeground` to the new `codev.builderDiff.*Foreground`
-   ids. No other logic changes — `new vscode.ThemeColor(d.color)` already wraps
-   whatever id is supplied. `T` (type-changed) keeps mapping to the modified
-   token; `C` (copied) keeps mapping to the renamed token.
-
-3. Add regression tests (see Test Plan).
-
-4. Bump version + add an *unreleased* VSCode CHANGELOG entry **only after** the
-   live diagnostic confirms color renders. (The reopen comment removed the prior
-   premature CHANGELOG entry; do not re-add until genuinely confirmed.)
+The earlier draft proposed registering own `contributes.colors` because the
+leading hypothesis was a grey *color value*. The flicker disproves that (the
+colors render correctly before being overridden), so **`contributes.colors` is
+not part of this fix** — the borrowed `gitDecoration.*` tokens resolve fine.
 
 ### What this does NOT touch (already correct)
 
-- Cache keying — `decorationFor`/`syncDecorations` both key by `uri.toString()`
-  via the shared `builderFileResourceUri` helper; the tree-item URI and the
-  decoration-map key match exactly. (`builder-diff-cache.ts:56,103,108`)
-- Provider registration — exactly one `registerFileDecorationProvider` at
-  `extension.ts:267`; no competing Codev provider exists.
-- The custom scheme itself — kept.
+- Provider registration — one `registerFileDecorationProvider` at
+  `extension.ts:267`; no competing Codev provider.
+- Cache keying — `decorationFor`/`syncDecorations` key by `uri.toString()` via the
+  shared helper (`builder-diff-cache.ts:56,103,108`).
+- The diff command — `codev.openBuilderFileDiff` receives the `BuilderFileTreeItem`
+  itself (`arguments: [this]`) and builds diff URIs from `worktreePath`/`baseRef`/
+  `plan`, never from `resourceUri`. Unaffected by the synthetic path.
 
 ## Files to Change
 
-- `packages/vscode/src/views/builder-file-decoration.ts:18-26` — repoint the
-  `DECO` map `color` values from `gitDecoration.*ResourceForeground` to the new
-  `codev.builderDiff.*Foreground` token ids. (Step 0 also temporarily edits
-  `provideFileDecoration` at `:35-46` for the diagnostic; reverted before PR.)
-- `packages/vscode/package.json` — add a `contributes.colors` array (new key) with
-  the five `codev.builderDiff.*Foreground` color definitions + light/dark/highContrast
-  defaults. Version bump after confirmation.
-- `packages/vscode/src/test/builder-file-tree-item.test.ts` (or a new
-  `builder-file-decoration.test.ts`) — add tests asserting the decoration *content*
-  (color id + badge), plus a `package.json` contract test (every DECO color id is
-  declared in `contributes.colors`).
-- `packages/vscode/CHANGELOG.md` (or the worktrees changelog path used for the
-  VSCode extension) — unreleased entry, added last, only after live confirmation.
+- `packages/vscode/src/views/builder-file-tree-item.ts:43-45` — rewrite
+  `builderFileResourceUri` to build a synthetic-path URI (worktree in the query),
+  per above. Update the surrounding doc comment (lines 20-34, 75-78) to describe
+  the path-resolution mechanism, not the (false) scheme-gating one.
+- `packages/vscode/src/views/builder-diff-cache.ts` — **no logic change** (it uses
+  the helper); only verify the comment at `:96-100` still reads correctly.
+- `packages/vscode/src/test/builder-file-tree-item.test.ts` — replace the
+  shape-only assertions with ones that would actually catch this class of bug
+  (see Test Plan).
+- `packages/vscode/package.json` — verify whether the `builder-file` contextValue
+  exposes any built-in fsPath-based menu items (see Risks); add a CHANGELOG/version
+  bump **only after** live confirmation. The VSCode CHANGELOG entry goes in the
+  path used for this repo's extension changelog.
 
 ## Risks & Alternatives Considered
 
-- **Risk: diagnostic shows rows stay grey even with a hard-coded bright color.**
-  Then the color CSS class is not applied at all and `contributes.colors` won't
-  help. Fallback, in order: (a) verify `explorer.decorations.colors` is `true` in
-  the test profile (it gates the color class independently of badges; if a profile
-  disabled it, badges show but colors never do — that's a config/UX issue, not a
-  code bug); (b) open Developer Tools, inspect the row label DOM — is the decoration
-  color class *absent* (would contradict the badge → unlikely) or *present-but-
-  overridden* by a higher-specificity rule (TreeView selection/focus foreground, or
-  a custom-view label foreground)? If overridden, the fix shifts to CSS specificity;
-  (c) last resort — encode status via a colored `ThemeIcon`/`iconPath` glyph on the
-  TreeItem (rendered through a more deterministic path), accepting the loss of the
-  SCM-label look.
-
-- **Risk: the borrowed `gitDecoration.*` tokens are actually defined (the built-in
-  Git extension is usually active).** True — so "undefined token" is not certain.
-  But our own `contributes.colors` with saturated explicit defaults is robust
-  *regardless* of whether the cause is "undefined" or "resolves near-foreground":
-  no theme overrides our `codev.builderDiff.*` ids, so our saturated defaults
-  always win. The diagnostic disambiguates which it was, but the fix covers both.
-
-- **Alternative: revert to the `file:` scheme.** Rejected. The scheme swap was a
-  genuine, separate win (stops the intermittent Git-ignored-grey on the gitignored
-  worktree path). Reverting re-introduces that bug to fix nothing — the color
-  pipeline is scheme-agnostic, so `file:` would not restore color either.
-
-- **Alternative: add a second FileDecorationProvider / change cache keying.**
-  Rejected. Both are already correct; the synthesis explicitly ruled out a
-  colorless-provider-wins-merge race (single provider) and a cache key mismatch.
-
-- **Risk noted in the original issue: third-party extensions that filter
-  `resourceUri.scheme === 'file'` skip our rows.** Unchanged by this plan (we keep
-  the custom scheme); built-in `revealFileInOS`/`copyFilePath` accept the fsPath
-  regardless, so the right-click menu stays intact.
+- **Risk: `resourceUri.fsPath` is now synthetic, so any built-in command that
+  reveals/copies the file path (`revealFileInOS`, `copyFilePath`) would point at
+  the fake path.** Must verify during implement whether the `builder-file`
+  contextValue actually contributes such items. If it does: either remove them for
+  this row type, or back them with a small custom command that reads the real path
+  from `wt=` (query) + the rel (path) and calls the underlying action. The custom
+  diff command is unaffected (it uses the item, not the URI). The original issue
+  already flagged this scheme-vs-fsPath trade-off as acceptable.
+- **Risk: a synthetic path accidentally resolves into a repo** (e.g. if a repo were
+  rooted at `/`). Not possible in practice — repo roots are absolute workspace
+  paths; `/src/...` never matches. The live diagnostic confirms Git no longer
+  fires.
+- **Alternative: register own `contributes.colors` / saturated tokens.** Rejected
+  as the fix — the flicker proves the color value is fine; it would not stop Git's
+  grey from winning the merge.
+- **Alternative: revert to the `file:` scheme.** Rejected — same root cause
+  (Git path-resolves it), plus it re-introduces nothing useful.
+- **Alternative: try to outrank Git via decoration weight.** Impossible — the
+  extension `FileDecoration` API exposes no weight; `mainThreadDecorations` pins
+  all extensions to `weight: 10` (vscode#187756, unresolved).
+- **Alternative (fallback if synthetic path somehow still flickers): a colored
+  `ThemeIcon`/`iconPath` status glyph instead of a label tint** — rendered through
+  a path that doesn't participate in the FileDecoration merge at all. Loses the
+  SCM-label look; only if the URI-shape fix is somehow insufficient.
 
 ## Test Plan
 
 The `dev-approval` gate is the real verification — unit tests cannot render labels
-or resolve theme tokens.
+or run the decoration merge.
+
+### Live confirmation of the root cause (cheap, do first)
+
+Already strongly indicated by the flicker, but to nail it before/at the gate:
+**disable the built-in Git extension** (Extensions → Git → Disable) and reload with
+the *current* (broken) build. If the rows then render the correct colors with no
+flicker, Git is confirmed as the overrider → the URI-shape fix is the right lever.
 
 ### Manual (at the dev-approval gate — the killer move)
 
 1. `pnpm --filter @cluesmith/codev compile` in the worktree.
 2. Launch the Extension Development Host (F5 "Run Extension", or install the built
-   `.vsix`). Open a workspace that has at least one spawned builder worktree with
+   `.vsix`) on a workspace with at least one spawned builder worktree containing
    Added, Modified, and Deleted files.
-3. **Reload the window** (Developer: Reload Window) — FileDecoration color caching
-   can require a reload.
-4. Expand a builder row in the Builders view. Confirm in **both list and tree
-   mode**:
-   - Added file label is green, Modified is yellow, Deleted is red (badges
-     unchanged).
-   - Try a light theme, a dark theme, and a high-contrast theme — colors stay
-     distinguishable in all three.
-5. Run the Step 0 diagnostic first if there is any doubt the fix took effect.
+3. Developer: Reload Window. Expand a builder row. Confirm in **both list and tree
+   mode**, with the Git extension **enabled**:
+   - Added is green, Modified yellow, Deleted red — and the color is **stable** (no
+     flash-then-grey).
+   - Badges still correct.
+   - Repeat across light, dark, and high-contrast themes.
+4. Confirm the per-file diff still opens (click a row) and the right-click menu
+   behaves (per the fsPath risk above).
 
-### Unit / contract (regression guards)
+### Unit / regression (guards that would actually catch this class of bug)
 
-- Assert decoration **content**: instantiate `BuilderFileDecorationProvider` with a
-  seeded cache, call `provideFileDecoration` per status, assert the returned
-  decoration carries a defined `color` whose `ThemeColor` id is the expected
-  `codev.builderDiff.*` token (not a borrowed `gitDecoration.*` one) and a
-  non-empty badge. This would have caught the original "borrowed-token" defect that
-  the shape-only tests missed.
-- `package.json` contract test: parse `contributes.colors`, assert every color id
-  referenced by the `DECO` map is declared with `light`/`dark`/`highContrast`
-  defaults.
+- Assert the URI path is **not Git-resolvable**: `uri.path` must not contain the
+  worktree absolute path; the real worktree path must be recoverable from the
+  query (`wt=`). This is the assertion that would have caught the shipped bug,
+  which the old scheme-only test missed.
+- Assert **uniqueness**: two builders with the same `rel` produce distinct
+  `uri.toString()` (so the decoration cache doesn't collide).
+- Keep: scheme is `BUILDER_FILE_SCHEME` (non-`file`); basename is preserved at the
+  path tail (icon resolution).
+- Assert the decoration **content**: `provideFileDecoration` returns a defined
+  `color` + badge per status (cheap guard against a future regression dropping the
+  color).
 
 ### Optional (rendering-layer smoke)
 
-- If feasible per `codev/resources/testing-guide.md`, a VSCode integration /
-  Playwright test that launches the extension against a fixture worktree and reads
-  the computed label color, asserting it is the contributed status color and not
-  the default tree foreground. This is the only layer that can actually observe the
-  grey-vs-colored regression.
+If feasible per `codev/resources/testing-guide.md`, a VSCode integration test that
+launches against a fixture worktree and asserts the changed-file row's computed
+label color is the status color, not the default/ignored grey — the only layer
+that can observe the merge outcome.

--- a/codev/plans/799-vscode-builder-changed-file-ro.md
+++ b/codev/plans/799-vscode-builder-changed-file-ro.md
@@ -68,6 +68,33 @@ resolve to a real tracked/ignored file inside an open repo, `getRepository(uri)`
 returns undefined, Git's provider returns nothing, and ours becomes the sole
 colored decoration — winning by default.
 
+### Confirming evidence (the "sometimes it's correct" case)
+
+Reviewers occasionally see the rows render *correctly* and stably. Verified why:
+each `.builders/<id>/` worktree is **its own git repository**, and the main repo
+**gitignores `.builders/`**:
+
+- main repo: `git check-ignore` → `.gitignore:3:.builders/` matches
+  `.builders/pir-799/codev/plans/799-…md` (ignored).
+- worktree repo: `git -C .builders/pir-799 rev-parse --show-toplevel` returns the
+  worktree itself, and the same file is ` M` (tracked & modified) there.
+
+VSCode's Git extension associates a path with the **closest** containing repo. So:
+
+- When VSCode **has** detected the nested worktree as a repo, these paths resolve
+  to the *worktree* repo, where they're modified/added (not ignored) → Git applies
+  its modified/added color (which matches ours) → **stable, correct**. (Notably,
+  in this state the color may actually be coming from *Git's worktree-repo
+  decoration*, not ours — they coincide because we reuse the same tokens.)
+- When VSCode has **not** (fresh spawn, scan depth/timing, Tower restart), the path
+  resolves to the *main* repo, where `.builders/` is ignored → Git's grey
+  "ignored" decoration wins the equal-weight merge → **grey / flicker**.
+
+This is exactly the repo-detection sensitivity the issue body described, and it
+confirms the path-based mechanism. The synthetic-path fix makes `getRepository`
+return undefined for **both** repos, so Git contributes nothing in *either* state
+and our provider's color applies deterministically — eliminating the flip.
+
 ### Why the prior unit tests passed while the bug shipped
 
 `builder-file-tree-item.test.ts` asserts only that the scheme is non-`file`. It

--- a/codev/plans/799-vscode-builder-changed-file-ro.md
+++ b/codev/plans/799-vscode-builder-changed-file-ro.md
@@ -1,0 +1,235 @@
+# PIR Plan: Builder changed-file rows render grey instead of SCM colors (#799)
+
+## Understanding
+
+Builder changed-file rows in the VSCode Builders view (list and tree mode) render
+their filenames in flat grey instead of SCM colors — Added should be green,
+Modified yellow, Deleted red. The `A`/`M`/`D` status badge on the right still
+renders correctly; only the label *color* is missing.
+
+**Critical context the issue body did not have: the issue's own "proposed fix"
+was already implemented and shipped, and it did not work.**
+
+- Commit `0301b7fa "Fix #799: use custom scheme for builder changed-file
+  resourceUri"` switched `builderFileResourceUri` to the custom
+  `codev-builder-diff:` scheme (`builder-file-tree-item.ts:43-45`), shipped in
+  v3.1.4.
+- The architect **reopened** the issue on 2026-05-29, confirming via a fresh
+  screenshot that rows are **still grey** — the fix is present in the bundled
+  code but the user-visible behavior is unchanged.
+
+So the issue body's root-cause theory ("the built-in Git decorator wins the
+color merge on the `file:` URI") is wrong, or at best a second-order effect. We
+re-investigated from scratch (3-lens parallel investigation + adversarial
+synthesis, run `wf_7b1f578b-c4b`).
+
+### Root cause
+
+VSCode's tree-label color pipeline is **entirely scheme-agnostic**. No layer
+(`treeView.ts` `TreeRenderer`, `labels.ts`, `decorationsService.getDecoration`)
+inspects the URI scheme when deciding the label color. The badge and the color
+are derived from the **same** `FileDecoration` returned by
+`provideFileDecoration`, and applied as **two independent CSS classes**
+(`badgeClassName` for the badge, `labelClassName` for the color), each gated only
+on the sibling booleans of the `explorer.decorations` setting (both default
+`true`).
+
+The decisive evidence is the **badge-yes / color-no symptom**: because the badge
+renders, our provider *is* being invoked for the `codev-builder-diff:` scheme,
+the decoration *does* reach the label renderer, and the color path *is*
+reachable. The only variable left that can be wrong is the **color value**.
+
+`BuilderFileDecorationProvider` (`builder-file-decoration.ts:18-26`) sets each
+status color to a borrowed `gitDecoration.*ResourceForeground` ThemeColor token,
+but the extension's `package.json` ships **no `contributes.colors` block**
+(confirmed: `contributes` keys are `commands, menus, snippets, keybindings,
+viewsContainers, views, configuration` — no `colors`). We depend on theme tokens
+we do not own resolving to a saturated, distinguishable value in the user's
+active theme. They instead resolve to something at or near the default tree-label
+foreground → grey.
+
+This explains **both** the original intermittent grey (when the Git decorator was
+also firing on the `file:` URI and could win the merge) **and** the persistent
+grey after the scheme swap (Git no longer fires, but our own color token still
+resolves near-foreground). The scheme swap fixed a real but *different* defect
+and left the color-value defect untouched.
+
+This is a `medium`-confidence diagnosis. It is robust to the two most likely
+failure modes of the borrowed token (undefined, or resolving near-foreground),
+but unit tests cannot render labels or resolve theme tokens, so it **must be
+confirmed on the running extension** before we commit. That confirmation is the
+`dev-approval` gate's job — and is exactly why this is a PIR.
+
+### Why the prior unit tests passed while the bug shipped
+
+`builder-file-tree-item.test.ts` asserts only URI *shapes* (scheme is non-`file`)
+and cache lookups. It never asserts the decoration carries a color, and cannot
+observe rendering. It passed while the color stayed broken.
+
+## Proposed Change
+
+**Diagnostic-first, then fix.** Because a guess-fix already shipped and failed,
+the implement phase opens with a live A/B diagnostic the human verifies at the
+`dev-approval` gate, *then* lands the fix.
+
+### Step 0 — Live diagnostic (confirm root cause before committing the fix)
+
+Temporary instrumentation, reverted before PR:
+
+1. In `provideFileDecoration`, hard-code a maximally-saturated, definitely-defined
+   color for **all** statuses: `color: new vscode.ThemeColor('charts.red')` (or
+   `'errorForeground'`).
+2. Add `console.log(uri.toString(), uri.scheme, this.cache.decorationFor(uri))`
+   at the top of `provideFileDecoration`.
+3. `pnpm --filter @cluesmith/codev compile`, launch the Extension Development
+   Host (F5 / "Run Extension"), open a workspace with a spawned builder worktree,
+   **reload the window** (FileDecoration color caching can require a reload —
+   microsoft/vscode#209907), expand a builder, look at the rows.
+
+Interpretation:
+- **Rows turn red** → the scheme, provider invocation, `explorer.decorations.colors`,
+  and the color CSS path are all healthy; the only defect was the borrowed
+  `gitDecoration.*` tokens resolving near-foreground. **Root cause confirmed** →
+  proceed to Step 1.
+- **Rows stay grey** → the color CSS class is not being applied at all (value was
+  never the issue). Switch to the fallback path (Risks section).
+- The `console.log` independently confirms the provider fires once per row for the
+  custom scheme (re-falsifying the "provider not invoked for custom scheme"
+  hypothesis live).
+
+### Step 1 — The fix (most-likely branch): own the colors
+
+Keep the custom `codev-builder-diff:` scheme (it correctly and permanently stops
+the built-in Git decorator from firing on the gitignored worktree paths;
+reverting to `file:` would regress to the intermittent Git-ignored grey). Stop
+borrowing `gitDecoration.*` tokens; register first-class, self-owned colors so the
+tint is deterministic and theme-independent.
+
+1. Add a `contributes.colors` array to `packages/vscode/package.json` with one
+   entry per status:
+   - `codev.builderDiff.addedForeground`
+   - `codev.builderDiff.modifiedForeground`
+   - `codev.builderDiff.deletedForeground`
+   - `codev.builderDiff.renamedForeground` (also used for Copied)
+   - `codev.builderDiff.conflictingForeground` (Unmerged)
+
+   Each with an explicit `defaults` block for `light`, `dark`, and
+   `highContrast`, seeded from the Git extension's known-saturated values so they
+   never collapse to foreground (added ≈ `#587c0c`/`#81b88b`, modified ≈
+   `#895503`/`#e2c08d`, deleted ≈ `#ad0707`/`#c74e39`, renamed/copied ≈ the
+   "modified/added" family, conflicting ≈ `#6c6cc4`/`#e4676b`). Final exact hexes
+   chosen during implementation to match VSCode's current Git defaults.
+
+2. In `builder-file-decoration.ts`, change the `DECO` map's `color` strings from
+   `gitDecoration.*ResourceForeground` to the new `codev.builderDiff.*Foreground`
+   ids. No other logic changes — `new vscode.ThemeColor(d.color)` already wraps
+   whatever id is supplied. `T` (type-changed) keeps mapping to the modified
+   token; `C` (copied) keeps mapping to the renamed token.
+
+3. Add regression tests (see Test Plan).
+
+4. Bump version + add an *unreleased* VSCode CHANGELOG entry **only after** the
+   live diagnostic confirms color renders. (The reopen comment removed the prior
+   premature CHANGELOG entry; do not re-add until genuinely confirmed.)
+
+### What this does NOT touch (already correct)
+
+- Cache keying — `decorationFor`/`syncDecorations` both key by `uri.toString()`
+  via the shared `builderFileResourceUri` helper; the tree-item URI and the
+  decoration-map key match exactly. (`builder-diff-cache.ts:56,103,108`)
+- Provider registration — exactly one `registerFileDecorationProvider` at
+  `extension.ts:267`; no competing Codev provider exists.
+- The custom scheme itself — kept.
+
+## Files to Change
+
+- `packages/vscode/src/views/builder-file-decoration.ts:18-26` — repoint the
+  `DECO` map `color` values from `gitDecoration.*ResourceForeground` to the new
+  `codev.builderDiff.*Foreground` token ids. (Step 0 also temporarily edits
+  `provideFileDecoration` at `:35-46` for the diagnostic; reverted before PR.)
+- `packages/vscode/package.json` — add a `contributes.colors` array (new key) with
+  the five `codev.builderDiff.*Foreground` color definitions + light/dark/highContrast
+  defaults. Version bump after confirmation.
+- `packages/vscode/src/test/builder-file-tree-item.test.ts` (or a new
+  `builder-file-decoration.test.ts`) — add tests asserting the decoration *content*
+  (color id + badge), plus a `package.json` contract test (every DECO color id is
+  declared in `contributes.colors`).
+- `packages/vscode/CHANGELOG.md` (or the worktrees changelog path used for the
+  VSCode extension) — unreleased entry, added last, only after live confirmation.
+
+## Risks & Alternatives Considered
+
+- **Risk: diagnostic shows rows stay grey even with a hard-coded bright color.**
+  Then the color CSS class is not applied at all and `contributes.colors` won't
+  help. Fallback, in order: (a) verify `explorer.decorations.colors` is `true` in
+  the test profile (it gates the color class independently of badges; if a profile
+  disabled it, badges show but colors never do — that's a config/UX issue, not a
+  code bug); (b) open Developer Tools, inspect the row label DOM — is the decoration
+  color class *absent* (would contradict the badge → unlikely) or *present-but-
+  overridden* by a higher-specificity rule (TreeView selection/focus foreground, or
+  a custom-view label foreground)? If overridden, the fix shifts to CSS specificity;
+  (c) last resort — encode status via a colored `ThemeIcon`/`iconPath` glyph on the
+  TreeItem (rendered through a more deterministic path), accepting the loss of the
+  SCM-label look.
+
+- **Risk: the borrowed `gitDecoration.*` tokens are actually defined (the built-in
+  Git extension is usually active).** True — so "undefined token" is not certain.
+  But our own `contributes.colors` with saturated explicit defaults is robust
+  *regardless* of whether the cause is "undefined" or "resolves near-foreground":
+  no theme overrides our `codev.builderDiff.*` ids, so our saturated defaults
+  always win. The diagnostic disambiguates which it was, but the fix covers both.
+
+- **Alternative: revert to the `file:` scheme.** Rejected. The scheme swap was a
+  genuine, separate win (stops the intermittent Git-ignored-grey on the gitignored
+  worktree path). Reverting re-introduces that bug to fix nothing — the color
+  pipeline is scheme-agnostic, so `file:` would not restore color either.
+
+- **Alternative: add a second FileDecorationProvider / change cache keying.**
+  Rejected. Both are already correct; the synthesis explicitly ruled out a
+  colorless-provider-wins-merge race (single provider) and a cache key mismatch.
+
+- **Risk noted in the original issue: third-party extensions that filter
+  `resourceUri.scheme === 'file'` skip our rows.** Unchanged by this plan (we keep
+  the custom scheme); built-in `revealFileInOS`/`copyFilePath` accept the fsPath
+  regardless, so the right-click menu stays intact.
+
+## Test Plan
+
+The `dev-approval` gate is the real verification — unit tests cannot render labels
+or resolve theme tokens.
+
+### Manual (at the dev-approval gate — the killer move)
+
+1. `pnpm --filter @cluesmith/codev compile` in the worktree.
+2. Launch the Extension Development Host (F5 "Run Extension", or install the built
+   `.vsix`). Open a workspace that has at least one spawned builder worktree with
+   Added, Modified, and Deleted files.
+3. **Reload the window** (Developer: Reload Window) — FileDecoration color caching
+   can require a reload.
+4. Expand a builder row in the Builders view. Confirm in **both list and tree
+   mode**:
+   - Added file label is green, Modified is yellow, Deleted is red (badges
+     unchanged).
+   - Try a light theme, a dark theme, and a high-contrast theme — colors stay
+     distinguishable in all three.
+5. Run the Step 0 diagnostic first if there is any doubt the fix took effect.
+
+### Unit / contract (regression guards)
+
+- Assert decoration **content**: instantiate `BuilderFileDecorationProvider` with a
+  seeded cache, call `provideFileDecoration` per status, assert the returned
+  decoration carries a defined `color` whose `ThemeColor` id is the expected
+  `codev.builderDiff.*` token (not a borrowed `gitDecoration.*` one) and a
+  non-empty badge. This would have caught the original "borrowed-token" defect that
+  the shape-only tests missed.
+- `package.json` contract test: parse `contributes.colors`, assert every color id
+  referenced by the `DECO` map is declared with `light`/`dark`/`highContrast`
+  defaults.
+
+### Optional (rendering-layer smoke)
+
+- If feasible per `codev/resources/testing-guide.md`, a VSCode integration /
+  Playwright test that launches the extension against a fixture worktree and reads
+  the computed label color, asserting it is the contributed status color and not
+  the default tree foreground. This is the only layer that can actually observe the
+  grey-vs-colored regression.

--- a/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
+++ b/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-05-30T02:44:01.581Z'
     approved_at: '2026-05-30T02:47:31.008Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-05-30T02:51:59.924Z'
+    approved_at: '2026-05-30T02:52:49.863Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-30T00:23:40.118Z'
-updated_at: '2026-05-30T02:51:59.925Z'
+updated_at: '2026-05-30T02:52:49.866Z'
 pr_history:
   - phase: review
     pr_number: 942
     branch: builder/pir-799
     created_at: '2026-05-30T02:49:32.198Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
+++ b/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-05-30T00:23:40.118Z'
-updated_at: '2026-05-30T02:49:32.199Z'
+updated_at: '2026-05-30T02:49:42.772Z'
 pr_history:
   - phase: review
     pr_number: 942

--- a/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
+++ b/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
@@ -1,0 +1,18 @@
+id: '799'
+title: vscode-builder-changed-file-ro
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-30T00:23:40.118Z'
+updated_at: '2026-05-30T00:23:40.119Z'

--- a/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
+++ b/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-05-30T02:33:53.130Z'
   dev-approval:
     status: pending
+    requested_at: '2026-05-30T02:44:01.581Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-30T00:23:40.118Z'
-updated_at: '2026-05-30T02:34:48.710Z'
+updated_at: '2026-05-30T02:44:01.582Z'

--- a/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
+++ b/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-05-30T01:41:54.727Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-30T00:23:40.118Z'
-updated_at: '2026-05-30T00:23:40.119Z'
+updated_at: '2026-05-30T01:41:54.728Z'

--- a/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
+++ b/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
@@ -1,7 +1,7 @@
 id: '799'
 title: vscode-builder-changed-file-ro
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-30T00:23:40.118Z'
-updated_at: '2026-05-30T02:33:53.130Z'
+updated_at: '2026-05-30T02:34:48.710Z'

--- a/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
+++ b/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-05-30T01:41:54.727Z'
+    approved_at: '2026-05-30T02:33:53.130Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-30T00:23:40.118Z'
-updated_at: '2026-05-30T01:41:54.728Z'
+updated_at: '2026-05-30T02:33:53.130Z'

--- a/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
+++ b/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
@@ -1,7 +1,7 @@
 id: '799'
 title: vscode-builder-changed-file-ro
 protocol: pir
-phase: review
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -21,7 +21,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-30T00:23:40.118Z'
-updated_at: '2026-05-30T02:52:49.866Z'
+updated_at: '2026-05-30T02:52:59.161Z'
 pr_history:
   - phase: review
     pr_number: 942

--- a/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
+++ b/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
@@ -1,7 +1,7 @@
 id: '799'
 title: vscode-builder-changed-file-ro
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-30T00:23:40.118Z'
-updated_at: '2026-05-30T02:47:31.009Z'
+updated_at: '2026-05-30T02:47:37.839Z'

--- a/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
+++ b/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-05-30T01:41:54.727Z'
     approved_at: '2026-05-30T02:33:53.130Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-05-30T02:44:01.581Z'
+    approved_at: '2026-05-30T02:47:31.008Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-30T00:23:40.118Z'
-updated_at: '2026-05-30T02:44:01.582Z'
+updated_at: '2026-05-30T02:47:31.009Z'

--- a/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
+++ b/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-30T00:23:40.118Z'
-updated_at: '2026-05-30T02:47:37.839Z'
+updated_at: '2026-05-30T02:49:32.199Z'
+pr_history:
+  - phase: review
+    pr_number: 942
+    branch: builder/pir-799
+    created_at: '2026-05-30T02:49:32.198Z'

--- a/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
+++ b/codev/projects/799-vscode-builder-changed-file-ro/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-05-30T02:47:31.008Z'
   pr:
     status: pending
+    requested_at: '2026-05-30T02:51:59.924Z'
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-05-30T00:23:40.118Z'
-updated_at: '2026-05-30T02:49:42.772Z'
+updated_at: '2026-05-30T02:51:59.925Z'
 pr_history:
   - phase: review
     pr_number: 942
     branch: builder/pir-799
     created_at: '2026-05-30T02:49:32.198Z'
+pr_ready_for_human: true

--- a/codev/resources/lessons-learned.md
+++ b/codev/resources/lessons-learned.md
@@ -294,6 +294,7 @@ Generalizable wisdom extracted from review documents, ordered by impact. Updated
 - [From 0099] Differentiate error types in CLI commands. CLI commands that call APIs must distinguish connection-level failures (server not running) from application-level errors (server returned an error) and show different user-facing messages.
 - [From 0126] Building the overview endpoint to work in degraded mode (showing builders but empty PR/backlog sections with error messages when `gh` is unavailable) is a good default pattern for features that depend on external services.
 - [From 0364] Use `onPointerDown` with `preventDefault()` and `tabIndex={-1}` to prevent focus stealing from terminal widgets -- this pattern translates directly to any floating controls rendered alongside interactive widgets.
+- [From 799] VSCode's built-in Git `FileDecorationProvider` matches resources by repository **path**, not by URI scheme, and every extension-provided decoration shares a fixed `weight: 10` — so an extension cannot outrank Git in the decoration color merge. To stop Git from tinting a custom TreeView row's label (e.g. grey "ignored" on gitignored worktree paths), the row's `resourceUri` must use a **synthetic path that resolves into no open repository**; a non-`file` scheme alone is insufficient because Git never checks the scheme. The file-type icon still resolves off the basename at the path tail.
 
 ## Documentation
 
@@ -378,6 +379,8 @@ Generalizable wisdom extracted from review documents, ordered by impact. Updated
 - [From 627] When multiple bugfix patches compete over the same state, consolidate them into a single owner (e.g., a state machine) rather than adding more guards. Three scroll mechanisms fighting each other created more bugs than they fixed.
 - [From 627] Lifecycle phases (initial-load → buffer-replay → interactive) eliminate magic thresholds. Instead of asking "is this scroll event real?", ask "what phase am I in?" to determine behavior.
 - [From 627] Always add a `reset()` method to state machines that persist across reconnections. The ScrollController's phase transitions were one-way until reconnection revealed the need to return to initial-load.
+
+- [From 799] A plausible fix that ships without live verification can mask the real root cause for a full release. The first #799 attempt (custom URI scheme) was logically appealing, passed unit tests, and shipped — but the tests only asserted URI *shape*, never rendering, and the scheme was the wrong layer entirely. Two things broke the deadlock: the precise user symptom ("correct color flashes, then goes grey" — a *late override*, not a static wrong value) and reading the actual VSCode source rather than trusting the API docs' implied behavior. For rendering/theme bugs, assert behavior at the layer that actually fails, and treat a one-line repro symptom as gold.
 
 ---
 

--- a/codev/reviews/799-vscode-builder-changed-file-ro.md
+++ b/codev/reviews/799-vscode-builder-changed-file-ro.md
@@ -1,0 +1,58 @@
+# PIR Review: Builder changed-file rows render grey instead of SCM colors (#799)
+
+Fixes #799
+
+## Summary
+
+Builder changed-file rows in the VSCode Builders view rendered grey instead of SCM colors (Added green / Modified yellow / Deleted red). A prior fix (v3.1.4) switched the row's `resourceUri` to a custom scheme on the theory that VSCode's built-in Git decorator gates on `scheme === 'file'` — but it does not: Git's decorators resolve a repository by **path** and `git check-ignore` the path, scheme-agnostically. Since the URI's path was still the real gitignored `.builders/<id>/…` worktree path, Git kept emitting its grey "ignored" decoration and won the equal-weight color merge (all extension decorations are pinned to `weight: 10`) on a ~500 ms debounce — the "correct color flashes, then grey" symptom. The fix builds the `resourceUri` from a **synthetic path** that resolves into no open repository, so Git never decorates these rows and our SCM color stands uncontested. Coloring itself is unchanged (same provider, same theme tokens).
+
+## Files Changed
+
+- `packages/vscode/src/views/builder-file-tree-item.ts` (+33 / -10) — `builderFileResourceUri` now returns a synthetic-path URI; doc comments rewritten to the real (path-based) mechanism.
+- `packages/vscode/src/test/builder-file-tree-item.test.ts` (+74 / -9) — regression tests that assert the path is not Git-resolvable, the worktree is recoverable, URIs are unique per builder, and the decoration carries a color + badge per status.
+
+(Plan, thread, and porch state files also ship with the branch: `codev/plans/799-…md`, `codev/state/pir-799_thread.md`, `codev/projects/799-…/status.yaml`, plus the `codev/resources/lessons-learned.md` updates below.)
+
+## Commits
+
+- `bf9ee0a9` [PIR #799] Fix grey builder file rows: synthetic-path resourceUri so Git can't decorate them
+- `7c36ce17` [PIR #799] thread: implement complete, pausing at dev-approval
+- (plan-phase commits: `22f30291`, `8f6f0447`, `bff8bc84`, `5a409910`)
+
+## Test Results
+
+- `pnpm --filter codev-vscode compile` (check-types + lint + esbuild): ✓ pass
+- `pnpm --filter codev-vscode test`: ✓ pass (105 tests, 7 new for #799)
+- porch `build` ✓ / `tests` ✓
+- Manual verification: confirmed at the `dev-approval` gate by running the Extension Development Host with the built-in Git extension enabled — builder file rows render stably colored (no flash-then-grey) in both list and tree mode.
+
+## Architecture Updates
+
+No `arch.md` changes needed — this fix changes the construction of one `resourceUri` inside an existing view; it introduces no new module, boundary, or architectural pattern. The decoration provider, cache, and registration are unchanged.
+
+## Lessons Learned Updates
+
+Two entries added to `codev/resources/lessons-learned.md`:
+
+- **UI/UX**: VSCode's built-in Git `FileDecorationProvider` matches resources by repository *path*, not URI scheme, and all extension decorations share a fixed `weight: 10` (an extension can't outrank Git in the color merge). To keep Git off a custom TreeView row, the `resourceUri` needs a synthetic path that resolves into no open repo — a non-`file` scheme alone is insufficient.
+- **Debugging and Root Cause Analysis**: a plausible fix that ships without live verification can mask the real root cause for a release. The prior #799 fix passed unit tests that only checked URI *shape* (never rendering) and addressed the wrong layer. The precise user symptom (late override, not static wrong value) plus reading the actual VSCode source — not the API docs — cracked it.
+
+## Things to Look At During PR Review
+
+- **The crux is one line**: `builderFileResourceUri` now uses `vscode.Uri.from({ scheme, path: '/' + rel, query: 'wt=' + encodeURIComponent(worktreePath) })`. The invariant is that `uri.path` must NOT be a real path inside any open repo (so Git's `getRepository` returns undefined). The worktree rides in the query purely to keep `uri.toString()` unique per builder (the global decoration cache keys by `uri.toString()`); nothing in production parses it back.
+- **fsPath is now synthetic.** Verified safe: no menu contributes to the `builder-file` contextValue, and `codev.openBuilderFileDiff` (extension.ts:626) reads the tree-item's `plan`/`worktreePath`/`baseRef`, never `resourceUri`/`fsPath`. So open-diff and the right-click menu are unaffected. A future `revealFileInOS`/`copyFilePath` contribution on these rows would need the real path recovered from the `wt` query.
+- **Why not contributes.colors / a different scheme?** The colors render correctly (the flicker proved it) — the borrowed `gitDecoration.*` tokens are fine; the only defect was Git winning the merge. Reverting the scheme would regress nothing useful. Extensions cannot set decoration weight, so out-ranking Git is not an option (vscode#187756, open).
+
+## How to Test Locally
+
+- **View diff**: VSCode sidebar → right-click builder `pir-799` → **View Diff**.
+- **Run the extension**: build it (`pnpm --filter codev-vscode compile`) and launch the Extension Development Host (F5 "Run Extension") on a workspace with at least one spawned builder worktree containing Added/Modified/Deleted files.
+- **What to verify** (with the built-in Git extension *enabled*):
+  - Changed-file rows show stable SCM colors (Added green, Modified yellow, Deleted red) with no flash-then-grey, in **both list and tree mode**.
+  - Holds across light, dark, and high-contrast themes.
+  - Clicking a row still opens the per-file diff; the file-type icon still renders.
+  - Root-cause sanity check on the *old* build: disabling the Git extension makes the grey disappear — confirming Git was the overrider.
+
+## Note for reviewers
+
+This was a fresh worktree with no `node_modules` (this repo has no `worktree.postSpawn` configured), so building required `pnpm install` + building the upstream `@cluesmith/codev-types` / `-core` packages first. Not part of the change; flagged so the build steps reproduce.

--- a/codev/state/pir-799_thread.md
+++ b/codev/state/pir-799_thread.md
@@ -47,3 +47,26 @@ Targeted source investigation (background agent, microsoft/vscode) confirmed, hi
 Live confirmation at dev-approval: disable the built-in Git extension → flicker should stop on the *current* build (proves Git is the overrider). Then verify the fix gives stable color with Git enabled.
 
 Recommitting plan v2.
+
+### plan-approval APPROVED → implement phase
+
+Plan approved (after reviewer Q&A that strengthened it: the flicker symptom, the "works in codev not shannon" question — both explained by the path→repo→decoration chain and worktree-as-own-repo detection state; the fix is robust to all of it).
+
+Pre-implementation de-risking confirmed:
+- No menu item uses the `builder-file` contextValue → no built-in fsPath right-click actions to break.
+- `codev.openBuilderFileDiff` (extension.ts:626-631) uses `arg.plan`/`worktreePath`/`baseRef`, never `resourceUri`/`fsPath` → synthetic path is safe for the diff command.
+
+Implementing: synthetic-path `builderFileResourceUri` + updated doc comments + regression tests.
+
+### Implement complete — pausing at dev-approval
+
+Change (1 source file + 1 test file):
+- `builder-file-tree-item.ts`: `builderFileResourceUri` now returns `vscode.Uri.from({ scheme: BUILDER_FILE_SCHEME, path: '/'+rel, query: 'wt='+encodeURIComponent(worktreePath) })` — synthetic path so Git's path-based `getRepository` returns undefined and it never decorates these rows. Doc comments rewritten to the real (path-based, not scheme-based) mechanism.
+- `builder-file-tree-item.test.ts`: replaced scheme-only assertions with ones that catch this bug class — path is NOT Git-resolvable (no worktree path), basename preserved (icon), worktree recoverable from query, unique per builder; plus a `BuilderFileDecorationProvider` suite asserting a defined color+badge per status.
+
+Verification (correct pnpm commands — porch's generic `npm run build`/`npm test` checks target the CLI package and fail at the monorepo root, unrelated to this change):
+- Fresh worktree had NO node_modules (no `worktree.postSpawn` configured) → `pnpm install` + build upstream `@cluesmith/codev-types`/`-core`.
+- `pnpm --filter codev-vscode compile` (check-types + lint + esbuild) ✓
+- `pnpm --filter codev-vscode test` → **105 passing**, incl. all #799 regression tests ✓
+
+Pausing at `dev-approval`. Reviewer's killer move: run the Extension Dev Host with the Git extension enabled and confirm builder file rows are stably colored (no flash-then-grey); the disable-Git-extension test on the OLD build confirms Git was the overrider.

--- a/codev/state/pir-799_thread.md
+++ b/codev/state/pir-799_thread.md
@@ -29,6 +29,21 @@ The two lead lenses disagreed; synthesis reconciled it decisively:
 
 **Recommended fix**: KEEP the custom scheme (reverting re-introduces the intermittent Git-ignored grey). REPLACE borrowed tokens with first-class `contributes.colors` (`codev.builderDiff.*Foreground`) with saturated light/dark/highContrast defaults; point the DECO map at them. Robust to both "token undefined" and "token resolves near-foreground".
 
-**PIR fit**: confidence is medium and unit tests can't render — so the plan is **diagnostic-first at the dev-approval gate**: hard-code a bright color + log provideFileDecoration, reload the Extension Dev Host, confirm rows turn red (→ value problem, our fix works) vs stay grey (→ fallback: check `explorer.decorations.colors`, CSS specificity via DevTools, or iconPath approach). The human runs the extension before any PR exists — exactly why PIR was chosen.
+**PIR fit**: confidence is medium and unit tests can't render — so the plan is diagnostic-first at the dev-approval gate. The human runs the extension before any PR exists — exactly why PIR was chosen.
 
-Writing the plan now.
+Plan v1 committed (`22f30291`), plan-approval gate requested.
+
+### Plan v2 — reviewer feedback flipped the diagnosis (high confidence now)
+
+Reviewer reported the decisive symptom: **correct colors render for a split second, then are instantly overridden by grey.** That flicker disproves the v1 "color value resolves to grey" theory (the SCM tokens clearly DO render) and points at a late grey decoration winning a re-merge.
+
+Targeted source investigation (background agent, microsoft/vscode) confirmed, high confidence:
+- The built-in Git decorators (`GitDecorationProvider`, `GitIgnoreDecorationProvider` in `extensions/git/src/decorationProvider.ts`) do **NOT** check `uri.scheme`. They resolve the repo by **path** and run `git check-ignore` on the fsPath. Our `Uri.file(worktreePath/rel).with({scheme})` keeps the real gitignored `.builders/<id>/…` path → Git STILL fires its grey `ignoredResourceForeground` decoration. **The shipped scheme swap was cosmetic.**
+- Extensions can't set decoration weight; `mainThreadDecorations.ts` pins all extensions (Git + ours) to `weight: 10`. Merge picks `data.find(d=>!!d.color)` in non-deterministic order. Git's `checkIgnore` resolves on a **500ms debounce** → after our synchronous paint → re-merge → grey wins. Exactly the flicker. (Open vscode issue #187756.)
+- Only lever: **URI shape**. A path that doesn't resolve into any open repo → `getRepository(uri)` undefined → Git never fires → ours is the sole colored decoration.
+
+**Revised fix**: keep the custom scheme but build the URI from a **synthetic path** (`path: '/'+rel`, worktree carried in `query: wt=…`). Git can't path-resolve it; basename at the tail still drives the file icon; the query keeps `uri.toString()` unique per builder (cache no longer collides). Dropped the `contributes.colors` work (color value is fine). Diff command uses the item not the URI, so unaffected. New risk: synthetic fsPath breaks any built-in fsPath menu item (revealFileInOS/copyFilePath) — verify the `builder-file` contextValue menu during implement.
+
+Live confirmation at dev-approval: disable the built-in Git extension → flicker should stop on the *current* build (proves Git is the overrider). Then verify the fix gives stable color with Git enabled.
+
+Recommitting plan v2.

--- a/codev/state/pir-799_thread.md
+++ b/codev/state/pir-799_thread.md
@@ -1,0 +1,34 @@
+# PIR #799 — vscode: builder changed-file rows render grey instead of SCM colors
+
+## Builder thread (pir-799)
+
+### Plan phase — opening
+
+Key discovery on first investigation: **the fix described in the issue body was already implemented and shipped.**
+
+- Commit `0301b7fa "Fix #799: use custom scheme for builder changed-file resourceUri"` already switched `builderFileResourceUri` to the custom `codev-builder-diff:` scheme (v3.1.4).
+- Registration (`extension.ts:267`), cache keying (`resourcePath === c.path`, so tree-item URI and decoration map key match), and `onDidChangeDecorations` firing are all correct on paper. Unit tests in `builder-file-tree-item.test.ts` pass — but they only assert URI *shapes* and cache lookups, never actual *rendering*.
+- The architect **reopened** the issue (2026-05-29) confirming via fresh screenshot that rows are STILL grey. So the custom-scheme theory in the issue body did NOT solve the visible bug.
+
+Conclusion: the issue body's root-cause analysis is wrong or incomplete. This is now a genuine multi-hypothesis investigation — and a guess-fix already failed once, so the next fix must be confirmed on the *running* extension (exactly why PIR/dev-approval gate fits).
+
+Central open question: when a custom TreeView TreeItem's `resourceUri` uses a NON-`file` scheme, does VSCode apply the FileDecorationProvider's `color` to the label, or only the badge?
+
+Launched a 3-lens parallel investigation workflow (run `wf_7b1f578b-c4b`):
+1. VSCode rendering semantics (does label color apply for non-file schemes? authoritative, from vscode source).
+2. Code-path audit (timing/race/keying defects unit tests miss).
+3. Alternative hypotheses + a definitive live diagnostic for the dev-approval gate.
+
+### Investigation result (workflow wf_7b1f578b-c4b, 4 agents)
+
+The two lead lenses disagreed; synthesis reconciled it decisively:
+
+- **Falsified**: "VSCode doesn't invoke FileDecorationProvider for custom schemes." The badge (`A`/`M`/`D`) and the color come from the **same** `provideFileDecoration` return, rendered as two independent CSS classes (`badgeClassName`, `labelClassName`) in vscode `labels.ts`. A visible badge proves the provider IS invoked for `codev-builder-diff:` and the decoration reaches the renderer. `decorationsService.getDecoration` is scheme-agnostic — no layer inspects the scheme.
+- **Therefore**: the prior custom-scheme fix could never have changed the label *color*. It correctly stopped the Git decorator from competing (a real, separate win), but the remaining grey is a **color-value** defect, masked by the first.
+- **Root cause (medium confidence)**: `builder-file-decoration.ts:18-26` reuses `gitDecoration.*ResourceForeground` tokens, but `package.json` ships **no `contributes.colors`** (confirmed: contributes keys = commands/menus/snippets/keybindings/viewsContainers/views/configuration). We depend on tokens we don't own resolving to a saturated value in every theme — they resolve near-foreground/grey.
+
+**Recommended fix**: KEEP the custom scheme (reverting re-introduces the intermittent Git-ignored grey). REPLACE borrowed tokens with first-class `contributes.colors` (`codev.builderDiff.*Foreground`) with saturated light/dark/highContrast defaults; point the DECO map at them. Robust to both "token undefined" and "token resolves near-foreground".
+
+**PIR fit**: confidence is medium and unit tests can't render — so the plan is **diagnostic-first at the dev-approval gate**: hard-code a bright color + log provideFileDecoration, reload the Extension Dev Host, confirm rows turn red (→ value problem, our fix works) vs stay grey (→ fallback: check `explorer.decorations.colors`, CSS specificity via DevTools, or iconPath approach). The human runs the extension before any PR exists — exactly why PIR was chosen.
+
+Writing the plan now.

--- a/codev/state/pir-799_thread.md
+++ b/codev/state/pir-799_thread.md
@@ -70,3 +70,11 @@ Verification (correct pnpm commands — porch's generic `npm run build`/`npm tes
 - `pnpm --filter codev-vscode test` → **105 passing**, incl. all #799 regression tests ✓
 
 Pausing at `dev-approval`. Reviewer's killer move: run the Extension Dev Host with the Git extension enabled and confirm builder file rows are stably colored (no flash-then-grey); the disable-Git-extension test on the OLD build confirms Git was the overrider.
+
+### dev-approval APPROVED → review phase → PR #942 → pr gate pending
+
+- Wrote `codev/reviews/799-vscode-builder-changed-file-ro.md` (retrospective: Summary/Files/Commits/Tests/Architecture Updates [none]/Lessons Learned/Things to Look At/How to Test).
+- Added 2 lessons to `codev/resources/lessons-learned.md` (UI/UX: Git decorator matches by path + weight:10; Debugging: a plausible unverified fix can mask root cause).
+- PR #942 opened with review as body (`Fixes #799`), recorded with porch.
+- 3-way consultation (single advisory pass): **gemini=APPROVE (HIGH), codex=APPROVE (MEDIUM), claude=APPROVE (HIGH)** — no REQUEST_CHANGES, no KEY_ISSUES.
+- Architect notified. **Waiting at `pr` gate** — merge is gated by porch state (`porch approve 799 pr --a-human-explicitly-approved-this`), not pane prose. After approval: verify gate, `gh pr merge --merge`, `porch done --merged 942`, final cleanup notification.

--- a/packages/vscode/src/test/builder-file-tree-item.test.ts
+++ b/packages/vscode/src/test/builder-file-tree-item.test.ts
@@ -6,6 +6,7 @@ import {
   builderFileResourceUri,
 } from '../views/builder-file-tree-item.js';
 import { BuilderDiffCache, type BuilderFileChange } from '../views/builder-diff-cache.js';
+import { BuilderFileDecorationProvider } from '../views/builder-file-decoration.js';
 import {
   planResources,
   type ChangeEntry,
@@ -15,12 +16,18 @@ import {
 
 /**
  * Regression tests for #799: the changed-file rows under each builder in
- * the Builders view were rendering with grey filenames because VSCode's
- * built-in Git FileDecorationProvider was firing on the `file:` URIs
- * (which point into gitignored `.builders/<id>/…`) and tinting the label
- * with `gitDecoration.ignoredResourceForeground`, winning the color merge
- * over our `BuilderFileDecorationProvider`. The fix is to use a custom
- * scheme on `resourceUri` so the built-in Git decorator skips these rows.
+ * the Builders view rendered with grey filenames because VSCode's built-in
+ * Git FileDecorationProvider was also firing on these rows and winning the
+ * color merge with `gitDecoration.ignoredResourceForeground`.
+ *
+ * The first shipped attempt (v3.1.4) only changed the URI *scheme*, on the
+ * theory that Git gates on `scheme === 'file'`. It does not: Git's
+ * decorators resolve a repository by *path* and `git check-ignore` the path,
+ * scheme-agnostically — so a custom-scheme URI whose path was still the real
+ * gitignored `.builders/<id>/…` path kept getting Git's grey decoration. The
+ * real fix is a **synthetic path** that resolves into no open repository, so
+ * `getRepository(uri)` returns undefined and Git never fires. These tests
+ * assert that path-shape property, which the scheme-only tests missed.
  */
 
 const WT = '/repo/.builders/0042';
@@ -32,17 +39,38 @@ function makeFileChange(path: string, status: ChangeStatus = 'M'): BuilderFileCh
 }
 
 suite('builderFileResourceUri', () => {
-  test('returns a non-file scheme so the built-in Git decorator skips it', () => {
+  test('uses the custom scheme, not file:', () => {
     const uri = builderFileResourceUri(WT, 'src/a.ts');
-    // The whole point of the fix — Git only decorates `file:` URIs.
     assert.notStrictEqual(uri.scheme, 'file');
     assert.strictEqual(uri.scheme, BUILDER_FILE_SCHEME);
   });
 
-  test('preserves the worktree-relative fs path (so the file-type icon resolves by basename)', () => {
+  test('path is synthetic — does NOT contain the worktree fs path (so Git cannot resolve a repo for it)', () => {
+    // The crux of the fix. If the path were the real worktree path, the
+    // built-in Git decorators would path-resolve it (main repo → gitignored,
+    // or the worktree's own repo) and win the color merge with grey (#799).
+    const uri = builderFileResourceUri(WT, 'src/a.ts');
+    assert.ok(!uri.path.includes(WT), `path must not contain the worktree fs path; got ${uri.path}`);
+    assert.strictEqual(uri.path, '/src/a.ts');
+  });
+
+  test('preserves the basename at the path tail (so the file-type icon resolves)', () => {
     const uri = builderFileResourceUri(WT, 'src/components/Foo.tsx');
-    // basename drives the icon — it must come through unchanged.
-    assert.ok(uri.path.endsWith('/src/components/Foo.tsx'), `path = ${uri.path}`);
+    // IFileIconTheme keys off the basename — it must come through unchanged.
+    assert.strictEqual(uri.path.split('/').pop(), 'Foo.tsx');
+  });
+
+  test('carries the worktree path in the query so it stays recoverable', () => {
+    const uri = builderFileResourceUri(WT, 'src/a.ts');
+    assert.strictEqual(new URLSearchParams(uri.query).get('wt'), WT);
+  });
+
+  test('is unique per builder for the same relative path (decoration cache keys by uri.toString())', () => {
+    // Two builders can have the same changed file; without the worktree in
+    // the query their URIs would collide in the global decoration map.
+    const a = builderFileResourceUri('/repo/.builders/0042', 'src/a.ts');
+    const b = builderFileResourceUri('/repo/.builders/0099', 'src/a.ts');
+    assert.notStrictEqual(a.toString(), b.toString());
   });
 });
 
@@ -109,6 +137,39 @@ suite('BuilderDiffCache decorations (#799)', () => {
       } finally {
         sub.dispose();
       }
+    } finally {
+      cache.dispose();
+    }
+  });
+});
+
+suite('BuilderFileDecorationProvider (#799)', () => {
+  test('returns a defined color + status badge per status (guards against a future color drop)', () => {
+    const cache = new BuilderDiffCache();
+    try {
+      const statuses: ChangeStatus[] = ['A', 'M', 'D'];
+      (cache as unknown as { syncDecorations: (id: string, wt: string, r: { baseRef: string; files: BuilderFileChange[] }) => void })
+        .syncDecorations('0042', WT, { baseRef: 'main', files: statuses.map(s => makeFileChange(`src/${s}.ts`, s)) });
+
+      const provider = new BuilderFileDecorationProvider(cache);
+      for (const s of statuses) {
+        const deco = provider.provideFileDecoration(builderFileResourceUri(WT, `src/${s}.ts`));
+        assert.ok(deco, `expected a decoration for status ${s}`);
+        assert.strictEqual(deco!.badge, s, `badge for ${s}`);
+        // The bug was a missing/overridden *color*, not a missing badge — so
+        // assert the color is present, the thing the scheme-only tests ignored.
+        assert.ok(deco!.color, `expected a color for status ${s}`);
+      }
+    } finally {
+      cache.dispose();
+    }
+  });
+
+  test('returns undefined for an untracked URI', () => {
+    const cache = new BuilderDiffCache();
+    try {
+      const provider = new BuilderFileDecorationProvider(cache);
+      assert.strictEqual(provider.provideFileDecoration(builderFileResourceUri(WT, 'not/tracked.ts')), undefined);
     } finally {
       cache.dispose();
     }

--- a/packages/vscode/src/views/builder-file-tree-item.ts
+++ b/packages/vscode/src/views/builder-file-tree-item.ts
@@ -18,14 +18,9 @@ import type { ChangeEntry, ChangeStatus, ResourcePlan } from '../commands/view-d
  */
 
 /**
- * Scheme for builder changed-file `resourceUri`s. Deliberately NOT `file:`
- * so VSCode's built-in Git FileDecorationProvider — which fires for every
- * `file:` URI rendered in the editor — does not also decorate these rows.
- * With a `file:` URI, Git sees the gitignored `.builders/<id>/…` path and
- * tints the label with `gitDecoration.ignoredResourceForeground` (grey),
- * winning the color merge over our SCM-style status colors (#799). The
- * file-type icon still resolves because `IFileIconTheme` keys off
- * basename, not scheme.
+ * Scheme for builder changed-file `resourceUri`s. Deliberately NOT `file:`,
+ * though — as #799 proved — the scheme alone is not what keeps VSCode's
+ * built-in Git decorator off these rows. See `builderFileResourceUri`.
  *
  * No TextDocumentContentProvider is registered for this scheme — these
  * URIs are markers for the tree row only; the diff is opened via
@@ -39,9 +34,35 @@ export const BUILDER_FILE_SCHEME = 'codev-builder-diff';
  * `BuilderDiffCache` (when firing decoration-change events) so the two
  * URIs match exactly — VSCode keys decoration cache entries by URI, so a
  * mismatch would leave stale decorations on screen.
+ *
+ * The path is **synthetic** (`/` + the worktree-relative path), NOT the real
+ * worktree fs path. This is the crux of the #799 fix: VSCode's built-in Git
+ * decorators (`GitDecorationProvider`, `GitIgnoreDecorationProvider`) do NOT
+ * gate on `uri.scheme` — they resolve a repository by *path* and run
+ * `git check-ignore` on it. With the real `.builders/<id>/…` path, Git
+ * resolves the repo (main repo → path is gitignored; or the worktree's own
+ * repo → tracked) and contributes a decoration that competes with ours. At
+ * equal weight (the extension API exposes no weight; VSCode pins every
+ * extension decoration to `weight: 10`), the color merge winner is
+ * non-deterministic, and Git's grey `ignoredResourceForeground` — resolved
+ * on a ~500ms debounce, after our synchronous decoration paints — overrides
+ * our SCM color (the "correct color flashes, then grey" symptom; cf.
+ * microsoft/vscode#187756). A path that resolves into *no* open repository
+ * makes `getRepository(uri)` return undefined, so Git never fires and our
+ * decoration is the sole (winning) color.
+ *
+ * The real worktree path rides in the query so our own provider / handlers
+ * can recover it, and it keeps `uri.toString()` distinct per builder (two
+ * builders can share the same relative path) so the decoration cache — keyed
+ * by `uri.toString()` — doesn't collide. The file-type icon still resolves
+ * because `IFileIconTheme` keys off the basename at the path tail.
  */
 export function builderFileResourceUri(worktreePath: string, rel: string): vscode.Uri {
-  return vscode.Uri.file(path.join(worktreePath, rel)).with({ scheme: BUILDER_FILE_SCHEME });
+  return vscode.Uri.from({
+    scheme: BUILDER_FILE_SCHEME,
+    path: '/' + rel,
+    query: `wt=${encodeURIComponent(worktreePath)}`,
+  });
 }
 
 const STATUS_LABEL: Record<ChangeStatus, string> = {
@@ -73,8 +94,8 @@ export class BuilderFileTreeItem extends vscode.TreeItem {
         : dirLabel;
 
     // resourceUri → native file-type icon + our decoration-provider badge.
-    // Custom scheme keeps the built-in Git decorator from firing on the
-    // gitignored worktree path and tinting the label grey (#799).
+    // Synthetic path (see builderFileResourceUri) keeps the built-in Git
+    // decorator from path-resolving these rows and tinting the label grey (#799).
     this.resourceUri = builderFileResourceUri(worktreePath, rel);
     this.tooltip = `${STATUS_LABEL[change.status] ?? 'Changed'} · ${rel}`;
     this.contextValue = 'builder-file';


### PR DESCRIPTION
# PIR Review: Builder changed-file rows render grey instead of SCM colors (#799)

Fixes #799

## Summary

Builder changed-file rows in the VSCode Builders view rendered grey instead of SCM colors (Added green / Modified yellow / Deleted red). A prior fix (v3.1.4) switched the row's `resourceUri` to a custom scheme on the theory that VSCode's built-in Git decorator gates on `scheme === 'file'` — but it does not: Git's decorators resolve a repository by **path** and `git check-ignore` the path, scheme-agnostically. Since the URI's path was still the real gitignored `.builders/<id>/…` worktree path, Git kept emitting its grey "ignored" decoration and won the equal-weight color merge (all extension decorations are pinned to `weight: 10`) on a ~500 ms debounce — the "correct color flashes, then grey" symptom. The fix builds the `resourceUri` from a **synthetic path** that resolves into no open repository, so Git never decorates these rows and our SCM color stands uncontested. Coloring itself is unchanged (same provider, same theme tokens).

## Files Changed

- `packages/vscode/src/views/builder-file-tree-item.ts` (+33 / -10) — `builderFileResourceUri` now returns a synthetic-path URI; doc comments rewritten to the real (path-based) mechanism.
- `packages/vscode/src/test/builder-file-tree-item.test.ts` (+74 / -9) — regression tests that assert the path is not Git-resolvable, the worktree is recoverable, URIs are unique per builder, and the decoration carries a color + badge per status.

(Plan, thread, and porch state files also ship with the branch: `codev/plans/799-…md`, `codev/state/pir-799_thread.md`, `codev/projects/799-…/status.yaml`, plus the `codev/resources/lessons-learned.md` updates below.)

## Commits

- `bf9ee0a9` [PIR #799] Fix grey builder file rows: synthetic-path resourceUri so Git can't decorate them
- `7c36ce17` [PIR #799] thread: implement complete, pausing at dev-approval
- (plan-phase commits: `22f30291`, `8f6f0447`, `bff8bc84`, `5a409910`)

## Test Results

- `pnpm --filter codev-vscode compile` (check-types + lint + esbuild): ✓ pass
- `pnpm --filter codev-vscode test`: ✓ pass (105 tests, 7 new for #799)
- porch `build` ✓ / `tests` ✓
- Manual verification: confirmed at the `dev-approval` gate by running the Extension Development Host with the built-in Git extension enabled — builder file rows render stably colored (no flash-then-grey) in both list and tree mode.

## Architecture Updates

No `arch.md` changes needed — this fix changes the construction of one `resourceUri` inside an existing view; it introduces no new module, boundary, or architectural pattern. The decoration provider, cache, and registration are unchanged.

## Lessons Learned Updates

Two entries added to `codev/resources/lessons-learned.md`:

- **UI/UX**: VSCode's built-in Git `FileDecorationProvider` matches resources by repository *path*, not URI scheme, and all extension decorations share a fixed `weight: 10` (an extension can't outrank Git in the color merge). To keep Git off a custom TreeView row, the `resourceUri` needs a synthetic path that resolves into no open repo — a non-`file` scheme alone is insufficient.
- **Debugging and Root Cause Analysis**: a plausible fix that ships without live verification can mask the real root cause for a release. The prior #799 fix passed unit tests that only checked URI *shape* (never rendering) and addressed the wrong layer. The precise user symptom (late override, not static wrong value) plus reading the actual VSCode source — not the API docs — cracked it.

## Things to Look At During PR Review

- **The crux is one line**: `builderFileResourceUri` now uses `vscode.Uri.from({ scheme, path: '/' + rel, query: 'wt=' + encodeURIComponent(worktreePath) })`. The invariant is that `uri.path` must NOT be a real path inside any open repo (so Git's `getRepository` returns undefined). The worktree rides in the query purely to keep `uri.toString()` unique per builder (the global decoration cache keys by `uri.toString()`); nothing in production parses it back.
- **fsPath is now synthetic.** Verified safe: no menu contributes to the `builder-file` contextValue, and `codev.openBuilderFileDiff` (extension.ts:626) reads the tree-item's `plan`/`worktreePath`/`baseRef`, never `resourceUri`/`fsPath`. So open-diff and the right-click menu are unaffected. A future `revealFileInOS`/`copyFilePath` contribution on these rows would need the real path recovered from the `wt` query.
- **Why not contributes.colors / a different scheme?** The colors render correctly (the flicker proved it) — the borrowed `gitDecoration.*` tokens are fine; the only defect was Git winning the merge. Reverting the scheme would regress nothing useful. Extensions cannot set decoration weight, so out-ranking Git is not an option (vscode#187756, open).

## How to Test Locally

- **View diff**: VSCode sidebar → right-click builder `pir-799` → **View Diff**.
- **Run the extension**: build it (`pnpm --filter codev-vscode compile`) and launch the Extension Development Host (F5 "Run Extension") on a workspace with at least one spawned builder worktree containing Added/Modified/Deleted files.
- **What to verify** (with the built-in Git extension *enabled*):
  - Changed-file rows show stable SCM colors (Added green, Modified yellow, Deleted red) with no flash-then-grey, in **both list and tree mode**.
  - Holds across light, dark, and high-contrast themes.
  - Clicking a row still opens the per-file diff; the file-type icon still renders.
  - Root-cause sanity check on the *old* build: disabling the Git extension makes the grey disappear — confirming Git was the overrider.

## Note for reviewers

This was a fresh worktree with no `node_modules` (this repo has no `worktree.postSpawn` configured), so building required `pnpm install` + building the upstream `@cluesmith/codev-types` / `-core` packages first. Not part of the change; flagged so the build steps reproduce.
