### PR TITLE
[AIR #943] codev doctor/update: warn on PR-producing protocol overrides missing a `pr` gate

### DIFF
--- a/codev/projects/943-codev-doctor-update-warn-on-pr/status.yaml
+++ b/codev/projects/943-codev-doctor-update-warn-on-pr/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-05-30T04:11:01.899Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-30T03:51:33.844Z'
-updated_at: '2026-05-30T04:08:14.232Z'
+updated_at: '2026-05-30T04:11:01.899Z'
+pr_ready_for_human: true

--- a/codev/projects/943-codev-doctor-update-warn-on-pr/status.yaml
+++ b/codev/projects/943-codev-doctor-update-warn-on-pr/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-05-30T04:11:01.899Z'
+    approved_at: '2026-05-30T17:43:37.606Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-30T03:51:33.844Z'
-updated_at: '2026-05-30T04:11:01.899Z'
-pr_ready_for_human: true
+updated_at: '2026-05-30T17:43:37.607Z'
+pr_ready_for_human: false

--- a/codev/projects/943-codev-doctor-update-warn-on-pr/status.yaml
+++ b/codev/projects/943-codev-doctor-update-warn-on-pr/status.yaml
@@ -1,0 +1,14 @@
+id: '943'
+title: codev-doctor-update-warn-on-pr
+protocol: air
+phase: implement
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-30T03:51:33.844Z'
+updated_at: '2026-05-30T03:51:33.845Z'

--- a/codev/projects/943-codev-doctor-update-warn-on-pr/status.yaml
+++ b/codev/projects/943-codev-doctor-update-warn-on-pr/status.yaml
@@ -1,7 +1,7 @@
 id: '943'
 title: codev-doctor-update-warn-on-pr
 protocol: air
-phase: implement
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-30T03:51:33.844Z'
-updated_at: '2026-05-30T03:51:33.845Z'
+updated_at: '2026-05-30T04:08:14.232Z'

--- a/codev/state/air-943_thread.md
+++ b/codev/state/air-943_thread.md
@@ -1,0 +1,48 @@
+# air-943 — codev doctor/update: warn on PR-producing protocol overrides missing a `pr` gate
+
+## Context
+AIR builder, strict mode. Issue #943: post-#927 guardrail. #927 made Needs Attention
+surface PRs via the universal `pr` gate (`derivePrReady` = `gates['pr'] === 'pending'`).
+A tier-1/2 protocol override that lacks a `pr` gate silently loses PR surfacing.
+
+## Investigation findings
+- `derivePrReady` (overview.ts:508): PR surfaces iff the `pr` gate goes pending. Porch
+  requests the `pr` gate only when `isPrCreatingPhase` (phase.gate === 'pr') is true
+  (protocol.ts:434, index.ts:498). No `pr` gate anywhere → never requested → never surfaces.
+- Bundled PR-producing protocols (all carry `gate: pr` on their PR-creating phase in stock):
+  bugfix, air, spir, aspir, pir. experiment/maintain are NOT PR-producing.
+- 4-tier resolver = `resolveCodevFile` (skeleton.ts): .codev/ → codev/ → cache → package skeleton.
+- This repo has tier-2 copies under `codev/protocols/*` — all correctly pr-gated, so the
+  check is clean (no output) when run here.
+
+## Plan
+1. New lib `lib/pr-gate-audit.ts`: `auditPrGates(root)` resolves each bundled PR-producing
+   protocol via the 4-tier resolver, flags any whose resolved JSON has no phase gated `pr`.
+   `formatPrGateWarning(w)` builds the loud message.
+2. `doctor.ts`: add a "Protocol PR Gates" section (non-fatal warning, exit code unchanged).
+3. `update.ts`: print the same warnings after the summary; expose via `result.prGateWarnings`.
+4. Tests: unit (pr-gate-audit) + doctor integration + update integration.
+
+## Implementation (done)
+- `lib/pr-gate-audit.ts`: `auditPrGates()` + `formatPrGateWarning()`, `PR_PRODUCING_PROTOCOLS`.
+- `doctor.ts`: new "Protocol PR Gates" section (non-fatal warning, exit code unchanged).
+- `update.ts`: prints warnings after summary + `result.prGateWarnings`.
+- Tests: pr-gate-audit.test.ts (8), doctor.test.ts (+2), update.test.ts (+2). All pass.
+
+## Verification
+- tsc --noEmit: clean (0 errors) after building codev-core.
+- pr-gate-audit + doctor + update suites: 50/50 pass.
+- Full unit suite: 3198 pass. 6 session-manager "real shellper" failures were a stale-`dist`
+  artifact (shellper = `dist/terminal/shellper-main.js`); after `tsc` emit they pass 67/67.
+  Porch's build check emits dist before the tests check, so no impact.
+- Headline path (real CLI, built dist): `codev doctor` shows "✓ All PR-producing protocols
+  are pr-gated" in this repo; against a gateless bugfix override it prints the loud warning.
+  `codev update --dry-run` prints the same warning after the summary.
+- Env note: fresh worktree needed `pnpm install` + core build + `pnpm copy-skeleton` before
+  update.test.ts/doctor could resolve the skeleton dir.
+
+## Status
+- [x] Investigation complete
+- [x] Implementation
+- [x] Tests
+- [ ] PR

--- a/codev/state/air-943_thread.md
+++ b/codev/state/air-943_thread.md
@@ -41,8 +41,15 @@ A tier-1/2 protocol override that lacks a `pr` gate silently loses PR surfacing.
 - Env note: fresh worktree needed `pnpm install` + core build + `pnpm copy-skeleton` before
   update.test.ts/doctor could resolve the skeleton dir.
 
+## PR
+- PR #944 open: https://github.com/cluesmith/codev/pull/944
+- Review embedded in PR body (AIR convention — no separate review file).
+- Implementation ~166 LOC (pr-gate-audit 127 + doctor 22 + update 17); tests ~245 LOC.
+- Porch implement checks passed (build ✓, tests ✓). Advancing through PR phase → `pr` gate.
+
 ## Status
 - [x] Investigation complete
 - [x] Implementation
 - [x] Tests
-- [ ] PR
+- [x] PR #944 open
+- [ ] `pr` gate (awaiting human approval)

--- a/packages/codev/src/__tests__/doctor.test.ts
+++ b/packages/codev/src/__tests__/doctor.test.ts
@@ -589,6 +589,80 @@ describe('doctor command', () => {
     });
   });
 
+  describe('protocol PR-gate audit (#943)', () => {
+    const testBaseDir = path.join(tmpdir(), `codev-doctor-prgate-${Date.now()}`);
+    let originalCwd: string;
+
+    beforeEach(() => {
+      originalCwd = process.cwd();
+      fs.mkdirSync(path.join(testBaseDir, 'codev'), { recursive: true });
+    });
+
+    afterEach(() => {
+      process.chdir(originalCwd);
+      if (fs.existsSync(testBaseDir)) {
+        fs.rmSync(testBaseDir, { recursive: true });
+      }
+    });
+
+    function mockDepsPresent() {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd.includes('which')) return Buffer.from('/usr/bin/command');
+        if (cmd.includes('gh auth status')) return Buffer.from('Logged in');
+        return Buffer.from('');
+      });
+      vi.mocked(spawnSync).mockImplementation((cmd: string) => {
+        const responses: Record<string, string> = {
+          node: 'v20.0.0', git: 'git version 2.40.0', claude: '1.0.0',
+        };
+        return {
+          status: 0, stdout: responses[cmd] || 'working', stderr: '',
+          signal: null, output: [null, responses[cmd] || 'working', ''], pid: 0,
+        } as never;
+      });
+    }
+
+    it('warns when a PR-producing override lacks a pr gate', async () => {
+      const bugfixDir = path.join(testBaseDir, 'codev', 'protocols', 'bugfix');
+      fs.mkdirSync(bugfixDir, { recursive: true });
+      fs.writeFileSync(path.join(bugfixDir, 'protocol.json'), JSON.stringify({
+        name: 'bugfix',
+        phases: [{ id: 'fix' }, { id: 'pr', steps: ['create_pr'] }],
+      }));
+
+      process.chdir(testBaseDir);
+      mockDepsPresent();
+      vi.resetModules();
+
+      const logOutput: string[] = [];
+      vi.spyOn(console, 'log').mockImplementation((...args) => { logOutput.push(args.join(' ')); });
+
+      const { doctor } = await import('../commands/doctor.js');
+      await doctor();
+
+      const hasWarning = logOutput.some(line =>
+        line.includes('Protocol `bugfix`') && line.includes('no `pr` gate'));
+      expect(hasWarning).toBe(true);
+    });
+
+    it('shows clean when no PR-producing override is gateless', async () => {
+      // codev/ exists but no protocol overrides — bundled protocols resolve from
+      // the always-gated skeleton (or not at all), so the section is clean.
+      process.chdir(testBaseDir);
+      mockDepsPresent();
+      vi.resetModules();
+
+      const logOutput: string[] = [];
+      vi.spyOn(console, 'log').mockImplementation((...args) => { logOutput.push(args.join(' ')); });
+
+      const { doctor } = await import('../commands/doctor.js');
+      await doctor();
+
+      const hasClean = logOutput.some(line => line.includes('All PR-producing protocols are pr-gated'));
+      expect(hasClean).toBe(true);
+    });
+  });
+
   describe('AI model verification (Issue #128)', () => {
     const testBaseDir = path.join(tmpdir(), `codev-doctor-ai-test-${Date.now()}`);
     let originalCwd: string;

--- a/packages/codev/src/__tests__/pr-gate-audit.test.ts
+++ b/packages/codev/src/__tests__/pr-gate-audit.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for the PR-gate audit (#943).
+ *
+ * Verifies that PR-producing protocol overrides missing a `pr` gate are flagged,
+ * and correctly-gated / unparseable / absent protocols are not.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import { auditPrGates, formatPrGateWarning, PR_PRODUCING_PROTOCOLS } from '../lib/pr-gate-audit.js';
+
+/** Write a tier-2 protocol override (codev/protocols/<name>/protocol.json). */
+function writeOverride(root: string, name: string, json: unknown): void {
+  const dir = path.join(root, 'codev', 'protocols', name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'protocol.json'), JSON.stringify(json, null, 2));
+}
+
+const gatelessBugfix = {
+  name: 'bugfix',
+  phases: [
+    { id: 'investigate' },
+    { id: 'fix' },
+    { id: 'pr', steps: ['create_pr', 'link_issue'] }, // create_pr but NO `pr` gate
+  ],
+};
+
+const gatedBugfix = {
+  name: 'bugfix',
+  phases: [
+    { id: 'investigate' },
+    { id: 'fix' },
+    { id: 'pr', gate: 'pr', steps: ['create_pr', 'link_issue'] },
+  ],
+};
+
+describe('pr-gate-audit', () => {
+  let baseDir: string;
+
+  beforeEach(() => {
+    baseDir = fs.mkdtempSync(path.join(tmpdir(), 'pr-gate-audit-'));
+    // A bare codev/ dir so findWorkspaceRoot anchors here even if not passed.
+    fs.mkdirSync(path.join(baseDir, 'codev'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  it('flags a gateless bugfix override', () => {
+    writeOverride(baseDir, 'bugfix', gatelessBugfix);
+
+    const warnings = auditPrGates(baseDir);
+    const bugfix = warnings.find(w => w.protocol === 'bugfix');
+
+    expect(bugfix).toBeDefined();
+    expect(bugfix!.source).toBe('override');
+    expect(bugfix!.displayPath).toBe(path.join('codev', 'protocols', 'bugfix', 'protocol.json'));
+  });
+
+  it('does not flag a correctly pr-gated override', () => {
+    writeOverride(baseDir, 'bugfix', gatedBugfix);
+
+    const warnings = auditPrGates(baseDir);
+    expect(warnings.find(w => w.protocol === 'bugfix')).toBeUndefined();
+  });
+
+  it('recognizes the object gate form ({ name: "pr" })', () => {
+    writeOverride(baseDir, 'air', {
+      name: 'air',
+      phases: [
+        { id: 'implement' },
+        { id: 'pr', gate: { name: 'pr', next: null } },
+      ],
+    });
+
+    const warnings = auditPrGates(baseDir);
+    expect(warnings.find(w => w.protocol === 'air')).toBeUndefined();
+  });
+
+  it('skips an unparseable override rather than crashing', () => {
+    const dir = path.join(baseDir, 'codev', 'protocols', 'spir');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'protocol.json'), '{ this is not json');
+
+    expect(() => auditPrGates(baseDir)).not.toThrow();
+    const warnings = auditPrGates(baseDir);
+    expect(warnings.find(w => w.protocol === 'spir')).toBeUndefined();
+  });
+
+  it('returns empty when no PR-producing protocols are overridden', () => {
+    // No codev/protocols/ overrides at all; bundled protocols resolve from the
+    // (always-gated) package skeleton or not at all — either way, no warning.
+    const warnings = auditPrGates(baseDir);
+    expect(warnings).toEqual([]);
+  });
+
+  it('flags multiple offending overrides independently', () => {
+    writeOverride(baseDir, 'bugfix', gatelessBugfix);
+    writeOverride(baseDir, 'pir', {
+      name: 'pir',
+      phases: [{ id: 'plan' }, { id: 'implement' }, { id: 'review' }],
+    });
+
+    const warnings = auditPrGates(baseDir);
+    const names = warnings.map(w => w.protocol).sort();
+    expect(names).toContain('bugfix');
+    expect(names).toContain('pir');
+  });
+
+  it('only audits the bundled PR-producing set', () => {
+    expect([...PR_PRODUCING_PROTOCOLS].sort()).toEqual(['air', 'aspir', 'bugfix', 'pir', 'spir']);
+    // experiment / maintain are intentionally excluded.
+    expect(PR_PRODUCING_PROTOCOLS).not.toContain('experiment' as never);
+    expect(PR_PRODUCING_PROTOCOLS).not.toContain('maintain' as never);
+  });
+
+  describe('formatPrGateWarning', () => {
+    it('produces a loud, actionable message naming the protocol and fix', () => {
+      writeOverride(baseDir, 'bugfix', gatelessBugfix);
+      const [warning] = auditPrGates(baseDir);
+      const msg = formatPrGateWarning(warning);
+
+      expect(msg).toContain('Protocol `bugfix`');
+      expect(msg).toContain('local override at');
+      expect(msg).toContain('no `pr` gate');
+      expect(msg).toContain('Needs Attention');
+      expect(msg).toContain('"gate": "pr"');
+    });
+  });
+});

--- a/packages/codev/src/__tests__/update.test.ts
+++ b/packages/codev/src/__tests__/update.test.ts
@@ -119,6 +119,44 @@ describe('update command', () => {
     });
   });
 
+  describe('PR-gate audit surfacing (#943)', () => {
+    it('surfaces a gateless PR-producing override after the update summary', async () => {
+      const projectDir = path.join(testBaseDir, 'prgate-warn');
+      const bugfixDir = path.join(projectDir, 'codev', 'protocols', 'bugfix');
+      fs.mkdirSync(bugfixDir, { recursive: true });
+      fs.writeFileSync(path.join(bugfixDir, 'protocol.json'), JSON.stringify({
+        name: 'bugfix',
+        phases: [{ id: 'fix' }, { id: 'pr', steps: ['create_pr'] }],
+      }));
+
+      process.chdir(projectDir);
+
+      const { update } = await import('../commands/update.js');
+      const result = await update({ dryRun: true });
+
+      expect(result.prGateWarnings).toBeDefined();
+      expect(result.prGateWarnings!.some(w =>
+        w.includes('Protocol `bugfix`') && w.includes('no `pr` gate'))).toBe(true);
+    });
+
+    it('reports no PR-gate warnings when overrides are correctly gated', async () => {
+      const projectDir = path.join(testBaseDir, 'prgate-clean');
+      const bugfixDir = path.join(projectDir, 'codev', 'protocols', 'bugfix');
+      fs.mkdirSync(bugfixDir, { recursive: true });
+      fs.writeFileSync(path.join(bugfixDir, 'protocol.json'), JSON.stringify({
+        name: 'bugfix',
+        phases: [{ id: 'fix' }, { id: 'pr', gate: 'pr', steps: ['create_pr'] }],
+      }));
+
+      process.chdir(projectDir);
+
+      const { update } = await import('../commands/update.js');
+      const result = await update({ dryRun: true });
+
+      expect(result.prGateWarnings).toEqual([]);
+    });
+  });
+
   describe('agent mode', () => {
     it('should return result without throwing when codev dir missing', async () => {
       const projectDir = path.join(testBaseDir, 'agent-no-codev');

--- a/packages/codev/src/commands/doctor.ts
+++ b/packages/codev/src/commands/doctor.ts
@@ -12,6 +12,7 @@ import chalk from 'chalk';
 import { query as claudeQuery } from '@anthropic-ai/claude-agent-sdk';
 import { executeForgeCommandSync, loadForgeConfig, validateForgeConfig, resolveAllConcepts, type ConceptResolution } from '../lib/forge.js';
 import { detectHarnessFromCommand } from '../agent-farm/utils/harness.js';
+import { auditPrGates, formatPrGateWarning } from '../lib/pr-gate-audit.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -639,6 +640,27 @@ export async function doctor(): Promise<number> {
         warningDetails.push({
           name: 'Project structure',
           issue: warning,
+        });
+      }
+    }
+    console.log('');
+
+    // Protocol PR-gate audit (#943): a PR-producing protocol whose resolved
+    // definition (local override included) lost its `pr` gate will silently
+    // stop surfacing PRs in Needs Attention (post-#927). Warn loudly; non-fatal.
+    console.log(chalk.bold('Protocol PR Gates') + ' (Needs Attention surfacing)');
+    console.log('');
+    const prGateWarnings = auditPrGates(workspaceRoot);
+    if (prGateWarnings.length === 0) {
+      console.log(`  ${chalk.green('✓')} All PR-producing protocols are pr-gated`);
+    } else {
+      for (const w of prGateWarnings) {
+        console.log(`  ${chalk.yellow('⚠')} ${formatPrGateWarning(w)}`);
+        warnings++;
+        warningDetails.push({
+          name: `Protocol ${w.protocol}`,
+          issue: 'no `pr` gate on PR-creating phase — PRs will not surface in Needs Attention',
+          recommendation: 'Add "gate": "pr" to its PR-creating phase, or remove the local override',
         });
       }
     }

--- a/packages/codev/src/commands/update.ts
+++ b/packages/codev/src/commands/update.ts
@@ -30,6 +30,7 @@ import {
   backfillGitignore,
   CODEV_GITIGNORE_ENTRIES,
 } from '../lib/gitignore.js';
+import { auditPrGates, formatPrGateWarning } from '../lib/pr-gate-audit.js';
 
 export interface UpdateOptions {
   dryRun?: boolean;
@@ -54,6 +55,8 @@ export interface UpdateResult {
   preservedFiles?: string[];
   gitignoreAdded?: string[];
   gitignoreSkipped?: boolean;
+  /** Loud warnings for PR-producing protocol overrides missing a `pr` gate (#943). */
+  prGateWarnings?: string[];
   error?: string;
 }
 
@@ -293,6 +296,20 @@ export async function update(options: UpdateOptions = {}): Promise<UpdateResult>
       (!result.gitignoreAdded || result.gitignoreAdded.length === 0)
     ) {
       log(chalk.dim('  Already up to date!'));
+    }
+
+    // PR-gate audit (#943): warn loudly if any PR-producing protocol override
+    // lost its `pr` gate. `codev update` preserves user-modified files as local
+    // overrides, so it neither fixes nor flags this without an explicit check —
+    // surfacing it here turns a silent post-#927 breakage into a migration prompt.
+    const prGateWarnings = auditPrGates(targetDir);
+    result.prGateWarnings = prGateWarnings.map(formatPrGateWarning);
+    if (prGateWarnings.length > 0) {
+      log('');
+      log(chalk.bold('Protocol PR-gate warnings:'));
+      for (const w of prGateWarnings) {
+        log(`  ${chalk.yellow('⚠')} ${formatPrGateWarning(w)}`);
+      }
     }
 
     if (dryRun) {

--- a/packages/codev/src/lib/pr-gate-audit.ts
+++ b/packages/codev/src/lib/pr-gate-audit.ts
@@ -1,0 +1,127 @@
+/**
+ * PR-gate audit (#943) — guardrail enforcing #927's universal `pr` gate contract.
+ *
+ * #927 made Needs Attention surface PRs via the universal `pr` gate: porch
+ * requests the `pr` gate when a protocol's PR-creating phase completes
+ * (`isPrCreatingPhase`, i.e. `phase.gate === 'pr'`), and the dashboard / VSCode
+ * surface the PR from that pending gate (`derivePrReady`). A PR-producing
+ * protocol whose resolved definition carries NO `pr` gate is therefore never
+ * requested, and its PRs silently vanish from Needs Attention.
+ *
+ * `codev update` deliberately preserves user-modified files as local overrides
+ * (tier-1 `.codev/` / tier-2 `codev/`), so a customized override that predates
+ * #927 — and lacks a `pr` gate — keeps winning the 4-tier resolution while
+ * silently breaking surfacing. This module detects exactly that case so doctor
+ * and update can turn the silent breakage into an actionable migration prompt.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { resolveCodevFile, findWorkspaceRoot } from './skeleton.js';
+
+/**
+ * Bundled PR-producing protocols — the set whose PR-creating phase carries a
+ * `pr` gate in the stock skeleton (mirrors `derivePrReady`'s documented set in
+ * overview.ts). experiment/maintain are NOT PR-producing (their completion
+ * gates are `experiment-complete` / `maintain-complete`, not `pr`) and are
+ * excluded by design. A new PR-producing protocol must be added here.
+ */
+export const PR_PRODUCING_PROTOCOLS = ['bugfix', 'air', 'spir', 'aspir', 'pir'] as const;
+
+/** Resolution tier the offending protocol.json was resolved from. */
+export type PrGateSource = 'override' | 'cache' | 'skeleton';
+
+export interface PrGateWarning {
+  /** Protocol name (e.g. "bugfix"). */
+  protocol: string;
+  /** Absolute path to the resolved protocol.json. */
+  resolvedPath: string;
+  /** Path relative to the workspace root, for display. */
+  displayPath: string;
+  /** Which resolution tier the offending file came from. */
+  source: PrGateSource;
+}
+
+/**
+ * Extract a phase's gate name, accepting both the string form (`"gate": "pr"`)
+ * and the object form (`"gate": { "name": "pr", ... }`). Mirrors the gate
+ * parsing in porch's `normalizePhase` (commands/porch/protocol.ts) so this
+ * check stays faithful to how porch actually reads gates.
+ */
+function gateName(phase: unknown): string | undefined {
+  if (!phase || typeof phase !== 'object') return undefined;
+  const gate = (phase as Record<string, unknown>).gate;
+  if (typeof gate === 'string') return gate;
+  if (gate && typeof gate === 'object') {
+    const name = (gate as Record<string, unknown>).name;
+    return typeof name === 'string' ? name : undefined;
+  }
+  return undefined;
+}
+
+/** Classify which resolution tier a resolved path belongs to. */
+function classifySource(root: string, resolvedPath: string): PrGateSource {
+  const dotCodev = path.join(root, '.codev') + path.sep;
+  const localCodev = path.join(root, 'codev') + path.sep;
+  if (resolvedPath.startsWith(dotCodev) || resolvedPath.startsWith(localCodev)) {
+    return 'override';
+  }
+  if (resolvedPath.includes(`${path.sep}skeleton${path.sep}`)) return 'skeleton';
+  return 'cache';
+}
+
+/**
+ * Audit the bundled PR-producing protocols for a missing `pr` gate.
+ *
+ * Each protocol is resolved through the 4-tier resolver (local overrides win),
+ * and any whose resolved definition has no phase gated `pr` is flagged. Returns
+ * one entry per offending protocol; an empty array means every PR-producing
+ * protocol is correctly gated.
+ *
+ * Protocols that don't resolve at all, or whose override is unparseable, are
+ * skipped — neither is the "lost pr gate" condition this guardrail targets.
+ */
+export function auditPrGates(workspaceRoot?: string): PrGateWarning[] {
+  const root = workspaceRoot || findWorkspaceRoot();
+  const warnings: PrGateWarning[] = [];
+
+  for (const protocol of PR_PRODUCING_PROTOCOLS) {
+    const resolvedPath = resolveCodevFile(`protocols/${protocol}/protocol.json`, root);
+    if (!resolvedPath) continue;
+
+    let phases: unknown[];
+    try {
+      const json = JSON.parse(fs.readFileSync(resolvedPath, 'utf-8'));
+      phases = Array.isArray(json?.phases) ? json.phases : [];
+    } catch {
+      continue; // Unparseable override — out of scope for the pr-gate check.
+    }
+
+    if (phases.some(p => gateName(p) === 'pr')) continue;
+
+    warnings.push({
+      protocol,
+      resolvedPath,
+      displayPath: path.relative(root, resolvedPath) || resolvedPath,
+      source: classifySource(root, resolvedPath),
+    });
+  }
+
+  return warnings;
+}
+
+/**
+ * Format a PR-gate warning into a single loud, actionable line (no icon/indent
+ * — callers add those). Shared by doctor and update so the wording stays in sync.
+ */
+export function formatPrGateWarning(w: PrGateWarning): string {
+  const where =
+    w.source === 'override'
+      ? `local override at \`${w.displayPath}\``
+      : `resolved from ${w.source} at \`${w.displayPath}\``;
+  return (
+    `Protocol \`${w.protocol}\` (${where}) has no \`pr\` gate on its PR-creating phase. ` +
+    `Its PRs will not surface in Needs Attention (Codev ≥ 3.1.5). ` +
+    `Add \`"gate": "pr"\` to that phase, or remove the override to use the stock pr-gated protocol.`
+  );
+}


### PR DESCRIPTION
Closes #943.

## Summary

Post-#927 guardrail. #927 made Needs Attention surface PRs via the **universal `pr` gate**: porch requests the `pr` gate when a protocol's PR-creating phase completes, and `derivePrReady` surfaces the PR from that pending gate. A PR-producing protocol whose resolved definition (a tier-1/2 local override) carries **no `pr` gate** is therefore never requested, and its PRs silently vanish from Needs Attention. Because `codev update` deliberately preserves user-modified files as local overrides, it neither fixes nor flags such an override — the breakage is silent (an adopter's gateless `bugfix` override caused exactly this).

This adds a check that resolves each bundled PR-producing protocol through the 4-tier resolver and warns loudly — with the fix — when one lacks a `pr` gate, surfaced in both `codev doctor` and `codev update`.

## What changed

- **`packages/codev/src/lib/pr-gate-audit.ts`** (new) — `auditPrGates(root)` resolves each protocol in `PR_PRODUCING_PROTOCOLS` (`bugfix`, `air`, `spir`, `aspir`, `pir`) via `resolveCodevFile` (tier-1/2 override wins) and flags any whose resolved JSON has no phase gated `pr` (handles both the string `"gate": "pr"` and object `"gate": { "name": "pr" }` forms, mirroring porch's `normalizePhase`). `formatPrGateWarning(w)` builds the shared, loud message. `experiment`/`maintain` are excluded — not PR-producing.
- **`doctor.ts`** — new **"Protocol PR Gates"** section. Clean repos show `✓ All PR-producing protocols are pr-gated`; offenders get a `⚠` line and appear in the summary. **Non-fatal** — exit code unchanged (warnings never set exit 1).
- **`update.ts`** — prints the same warnings after the update summary and exposes them on `UpdateResult.prGateWarnings`. **Does not auto-modify** the override (consistent with update's preserve-customizations behavior) — warn + instruct only.

## Example output

Against a `bugfix` override whose PR phase lost its gate:

> ⚠ Protocol \`bugfix\` (local override at \`codev/protocols/bugfix/protocol.json\`) has no \`pr\` gate on its PR-creating phase. Its PRs will not surface in Needs Attention (Codev ≥ 3.1.5). Add \`"gate": "pr"\` to that phase, or remove the override to use the stock pr-gated protocol.

## Key decisions

- **Bundled set, not dynamic discovery.** The PR-producing set is hardcoded to the five bundled protocols (as the issue prescribes), mirroring `derivePrReady`'s documented set. A new PR-producing protocol adds itself to the constant.
- **"Has a `pr` gate at all" is the correct check.** Surfacing requires porch to request the `pr` gate, which it only does for a phase with `gate === 'pr'`. If no phase carries it, surfacing is broken — that's exactly what's flagged. (Stock skeletons always carry it, so in practice this only fires for overrides.)
- **Faithful to porch's gate parsing.** `gateName()` accepts both gate shapes so the audit stays in sync with how porch actually reads gates.

## Test plan

- **`pr-gate-audit.test.ts`** (unit): flags a gateless override; passes a correctly-gated one; recognizes the object gate form; skips unparseable/absent protocols without crashing; flags multiple offenders independently; asserts the bundled set excludes experiment/maintain; verifies the message wording.
- **`doctor.test.ts`** / **`update.test.ts`** (integration): a gateless override surfaces in doctor output and in `result.prGateWarnings`; clean overrides produce the `✓` / empty result.
- **Headline path (real built CLI):** `codev doctor` in this repo prints `✓ All PR-producing protocols are pr-gated`; against a gateless fixture it prints the warning; `codev update --dry-run` prints it after the summary.
- `tsc --noEmit` clean. Porch `build` + `tests` checks pass.

## Out of scope (per issue)

Auto-fixing/migrating overrides; any change to #927's surfacing logic; experiment/maintain completion-gate surfacing.