### PR TITLE
vscode: mark recently-created backlog rows with [new] (<24h)

### DIFF
--- a/codev/plans/930-vscode-mark-recently-created-b.md
+++ b/codev/plans/930-vscode-mark-recently-created-b.md
@@ -29,14 +29,20 @@ clobbering the existing icon" problem:
 
 | #810 decision | #930 application |
 |---|---|
-| Bracket-text **prefix after the issue number** (`#<id> [<phase>] <title>`) | `#<id> [new] <title>` — `[new]` prefix after the id, before the title |
+| Bracket-text **prefix** (`#<id> [<phase>] <title>`) | `[new] #<id> <title>` — `[new]` leads the row label |
 | Prefix chosen because **truncation cuts the END, not the start** | `[new]` stays visible on narrow sidebars / long titles |
 | Prefix is **monochrome bracket text**; icons carry color | `[new]` is plain bracket text, no color |
 | **Icons untouched** where they already carry info | `account` / `issues` icons fully preserved |
 | Small **extracted, unit-tested helper with a fallback** | pure `recencyPrefix(createdAt, now)` → `'[new] '` or `''`, vitest-tested |
 
 The result coexists with assignment: a new+assigned row reads
-`👤 #911 [new] <title>  …  assigned to you` — account icon kept, `[new]` added.
+`👤 [new] #911 <title>  …  assigned to you` — account icon kept, `[new]` added.
+
+> **Revision (dev-approval gate):** the prefix was originally drafted to sit
+> *between* the id and title (`#911 [new] <title>`). At the `dev-approval` gate
+> the reviewer asked to move it to **lead the row** (`[new] #911 <title>`), so
+> the marker is the leftmost token. This plan, the implementation, and the
+> review file all reflect the leading-prefix placement.
 
 ## Proposed Change
 
@@ -70,10 +76,10 @@ deterministic — the existing `relativeTime` in `view-artifact.ts:135` hardcode
 Compute `const now = Date.now()` once per row (render-time "now", satisfying
 the "re-evaluated on every render" requirement). Then:
 
-- **Label**: insert the `[new]` prefix between the issue number and the title.
+- **Label**: lead the row with the `[new]` prefix (dev-approval-gate revision).
   Current label is
   `` `#${item.id} ${item.title}${author}` ``; becomes
-  `` `#${item.id} ${recencyPrefix(item.createdAt, now)}${item.title}${author}` ``.
+  `` `${recencyPrefix(item.createdAt, now)}#${item.id} ${item.title}${author}` ``.
   When not recent (or `createdAt` missing/malformed) `recencyPrefix` returns
   `''`, so the label is byte-identical to today.
 - **Icons unchanged**: keep `account` (assigned) / `issues` (otherwise). No

--- a/codev/plans/930-vscode-mark-recently-created-b.md
+++ b/codev/plans/930-vscode-mark-recently-created-b.md
@@ -10,123 +10,150 @@ per-user dismissal. After 24h the marker drops off naturally on the next
 render.
 
 The data is already present: `OverviewBacklogItem.createdAt` is a required
-`string` field (`packages/types/src/api.ts:227`) and flows through the
-existing overview pipeline to the extension. The entire change is confined to
-row construction in `BacklogProvider.makeRow` plus a small pure helper.
+`string` field (`packages/types/src/api.ts:227`) and flows through the existing
+overview pipeline to the extension. The entire change is confined to row
+construction in `BacklogProvider.makeRow` plus a small pure helper — no
+data-flow or type changes.
 
-The issue body resolves the UX choices to concrete defaults; I adopt them:
+**Design decision (resolved): follow the #810 pattern, not an icon swap.**
+The issue body proposed an icon-prefix marker (`$(sparkle)`). During plan
+review we rejected that because the backlog row icon is *already* dispatched by
+assignment (`account` when assigned-to-you, `issues` otherwise), so a "new"
+icon would collide with the assignment signal — making a *new issue assigned to
+you* indistinguishable from an *old* one. That defeats the feature's primary
+purpose (an engineer spotting fresh items assigned to them).
 
-1. **Marker location**: icon prefix (default 1a) — swap the per-row icon to a
-   "new" variant. Matches the existing visual language (`account` vs `issues`
-   icon based on assignment).
-2. **Icon**: `$(sparkle)` in `ThemeColor('list.highlightForeground')` so it
-   picks up the user's accent color (default proposal).
-3. **Threshold**: hardcoded 24h constant for v1 (no setting).
-4. **Tooltip**: append `Created <relativeTime>` to the row tooltip whenever
-   `createdAt` is present and parseable — regardless of whether the row is
-   marked new (useful info past the 24h window too).
-5. **Mine-only toggle (#809)**: filtered-out items aren't rendered, so the
-   marker question never arises for them. Confirmed: `orderedSpawnable` filters
-   first, then `makeRow` runs only on survivors — no special handling needed.
+Instead we adopt the design language established by #810 (builder-row
+legibility), which solved the same "encode an extra categorical state without
+clobbering the existing icon" problem:
+
+| #810 decision | #930 application |
+|---|---|
+| Bracket-text **prefix after the issue number** (`#<id> [<phase>] <title>`) | `#<id> [new] <title>` — `[new]` prefix after the id, before the title |
+| Prefix chosen because **truncation cuts the END, not the start** | `[new]` stays visible on narrow sidebars / long titles |
+| Prefix is **monochrome bracket text**; icons carry color | `[new]` is plain bracket text, no color |
+| **Icons untouched** where they already carry info | `account` / `issues` icons fully preserved |
+| Small **extracted, unit-tested helper with a fallback** | pure `recencyPrefix(createdAt, now)` → `'[new] '` or `''`, vitest-tested |
+
+The result coexists with assignment: a new+assigned row reads
+`👤 #911 [new] <title>  …  assigned to you` — account icon kept, `[new]` added.
 
 ## Proposed Change
 
 ### 1. New pure helper file: `packages/vscode/src/views/backlog-recency.ts`
 
 Vscode-free, mirroring the established `backlog-filter.ts` pattern so the logic
-is unit-testable under the vitest harness (`__tests__/`) without dragging in
-the `vscode` module. Two functions, both taking an injected `now` (ms) so tests
-are deterministic — the codebase's existing `relativeTime` in
-`view-artifact.ts:135` hardcodes `Date.now()` and isn't reusable for testing:
+is unit-testable under the vitest harness (`__tests__/`) without importing the
+`vscode` module. Both functions take an injected `now` (ms) so tests are
+deterministic — the existing `relativeTime` in `view-artifact.ts:135` hardcodes
+`Date.now()` and isn't reusable for testing.
 
-- `RECENT_THRESHOLD_MS = 24 * 60 * 60 * 1000` — the hardcoded window.
+- `RECENT_THRESHOLD_MS = 24 * 60 * 60 * 1000` — the hardcoded 24h window (no
+  setting, per issue default 3).
 - `isRecentlyCreated(createdAt: string | undefined, nowMs: number): boolean`
   — parses `createdAt` via `Date.parse`; returns `false` on
   missing/empty/malformed (`NaN`), on future timestamps (defensive), and when
-  the age is ≥ threshold. Returns `true` only when `0 ≤ age < threshold`.
+  age ≥ threshold. Returns `true` only when `0 ≤ age < threshold`.
+- `recencyPrefix(createdAt: string | undefined, nowMs: number): string`
+  — thin wrapper: returns `'[new] '` when `isRecentlyCreated`, else `''`.
+  This is the #810-analogous "categorical state → text prefix" helper, kept
+  tiny and testable with a graceful empty-string fallback (mirrors #810's
+  `GATE_ICONS[...] || 'bell'` fallback shape).
 - `relativeAge(createdAt: string | undefined, nowMs: number): string | null`
   — returns `null` when missing/malformed, else a relative string
   (`'3h ago'`, `'2d ago'`, `'45m ago'`, `'30s ago'`) using the same tiered
-  format as `view-artifact.ts:135` so the wording stays consistent across the
-  extension. Future timestamps clamp to `'0s ago'` rather than emitting a
-  negative number.
+  format as `view-artifact.ts:135` so wording stays consistent across the
+  extension. Future timestamps clamp to `'0s ago'`.
 
 ### 2. `BacklogProvider.makeRow` (`backlog.ts:116-134`)
 
 Compute `const now = Date.now()` once per row (render-time "now", satisfying
 the "re-evaluated on every render" requirement). Then:
 
-- **Icon precedence**: `account` (assigned) keeps priority — assignment is the
-  stronger, action-relevant signal and already drives the icon. For an
-  *unassigned* row that is recently created, use
-  `new vscode.ThemeIcon('sparkle', new vscode.ThemeColor('list.highlightForeground'))`.
-  Otherwise `issues`. A new+assigned row keeps the `account` icon but still
-  surfaces newness via the tooltip (`Created <age>`) and the existing
-  `assigned to you` description.
-  *(Flagged as a design call below — see Risks.)*
+- **Label**: insert the `[new]` prefix between the issue number and the title.
+  Current label is
+  `` `#${item.id} ${item.title}${author}` ``; becomes
+  `` `#${item.id} ${recencyPrefix(item.createdAt, now)}${item.title}${author}` ``.
+  When not recent (or `createdAt` missing/malformed) `recencyPrefix` returns
+  `''`, so the label is byte-identical to today.
+- **Icons unchanged**: keep `account` (assigned) / `issues` (otherwise). No
+  icon dispatch on recency at all — the whole icon-precedence design call from
+  the first draft disappears.
 - **Tooltip**: when `relativeAge(item.createdAt, now)` is non-null, set tooltip
-  to `${item.url}\nCreated <age>`; otherwise keep `item.url` as today. (Use a
-  `MarkdownString` or plain multi-line string — plain `\n` in a string tooltip
-  renders as a second line in VSCode.)
+  to `${item.url}\nCreated <age>`; otherwise keep `item.url` as today. (Plain
+  `\n` in a string tooltip renders as a second line in VSCode.)
 
-No change to `description`, sort order, grouping, or the mine-only path.
+No change to `description`, sort order, grouping, the mine-only path, or the
+icon dispatch.
 
 ### 3. Tests: `packages/vscode/src/__tests__/backlog-recency.test.ts`
 
-Vitest unit tests for the two pure helpers with a fixed `now`:
+Vitest unit tests for the pure helpers with a fixed `now`:
 - `isRecentlyCreated`: just-now, 1h ago, 23h59m ago → true; exactly 24h, 25h,
   2d ago → false; `undefined`, `''`, `'not-a-date'` → false; future → false.
+- `recencyPrefix`: recent → `'[new] '`; not-recent / malformed / undefined →
+  `''`.
 - `relativeAge`: seconds/minutes/hours/days tiers; `undefined`/malformed →
-  null; future → `'0s ago'`.
+  `null`; future → `'0s ago'`.
 
 ## Files to Change
 
 - `packages/vscode/src/views/backlog-recency.ts` — **new**, pure helpers
-  (`RECENT_THRESHOLD_MS`, `isRecentlyCreated`, `relativeAge`).
-- `packages/vscode/src/views/backlog.ts:116-134` — `makeRow`: compute
-  recency, swap icon for unassigned-new rows, enrich tooltip.
+  (`RECENT_THRESHOLD_MS`, `isRecentlyCreated`, `recencyPrefix`, `relativeAge`).
+- `packages/vscode/src/views/backlog.ts:116-134` — `makeRow`: insert `[new]`
+  label prefix, enrich tooltip. Icons untouched.
 - `packages/vscode/src/__tests__/backlog-recency.test.ts` — **new**, vitest
   unit tests for the helpers.
 
-Estimated net diff: ~40-60 LOC including tests. No type changes, no data-flow
-changes.
+Estimated net diff: ~45-65 LOC including tests. No type changes, no data-flow
+changes, no grouping/sorting changes.
 
 ## Risks & Alternatives Considered
 
-- **Icon precedence ambiguity (the one real design call left)**: a row that is
-  both *assigned to you* and *new*. I propose **assignment wins the icon**
-  (keep `account`), with newness conveyed by the tooltip. Rationale: assignment
-  is the durable, action-relevant signal; the sparkle is most valuable on
-  *unassigned* fresh items a reviewer is triaging. **Alternative**: new wins
-  the icon (sparkle), assignment stays in the description text. Reviewer can
-  redirect at this gate — it's a one-line change either way.
-- **`createdAt` missing/malformed**: helpers return `false`/`null`, so the row
-  renders exactly as today (issues/account icon, url-only tooltip), no thrown
-  error. Covered by tests. (Acceptance criterion #6.)
-- **No regression to #809 / #811 / #911**: the change is purely additive inside
-  `makeRow` (icon + tooltip). `orderedSpawnable` (mine-only), `groupByArea`
-  (#811), and `formatBacklogTitle`/`visibleBacklogCount` (#911) are untouched.
-  Existing `src/test/backlog.test.ts` and `__tests__/backlog-filter.test.ts`
-  should pass unchanged.
-- **Reusing the existing `relativeTime`**: rejected for the helper because it's
-  in a vscode-dependent module and hardcodes `Date.now()` (untestable). I
-  duplicate the ~6-line tiered format in the pure helper rather than refactor
-  `view-artifact.ts` (out of scope; would widen the diff for no behavioral
-  gain). The format strings match so wording stays consistent.
+- **Alternative — `$(sparkle)` icon swap (the issue's original default 1a)**:
+  rejected because the row icon already encodes assignment; a recency icon
+  would clobber the `account` signal and hide newness on exactly the rows that
+  matter most (new + assigned-to-you). The `[new]` text prefix coexists with
+  the icon. This is the same reasoning #810 used to reject letter-badges /
+  `FileDecorationProvider` in favor of a text prefix beside the untouched icon.
+- **Alternative — "Recent" group at the top of the backlog**: rejected as a
+  structural grouping change that the issue explicitly lists under *Out of
+  scope* ("Sorting changes — newly-created items don't get re-sorted to the
+  top") and that would force a duplication decision (item in both Recent and
+  its area group, or only in Recent). The `[new]` prefix surfaces newness
+  in-place without re-sorting; with the mine-only toggle on (the #809 default)
+  the list is already short and the prefix is plainly visible.
+- **`createdAt` missing/malformed**: `recencyPrefix` → `''` and `relativeAge`
+  → `null`, so the row renders exactly as today (no prefix, url-only tooltip),
+  no thrown error. Covered by tests (acceptance criterion #6).
+- **No regression to #809 / #811 / #911**: the change is additive inside
+  `makeRow` (label prefix + tooltip). `orderedSpawnable` (mine-only),
+  `groupByArea` (#811), and `formatBacklogTitle`/`visibleBacklogCount` (#911)
+  are untouched. The title-count formatter counts items, not label text, so the
+  prefix doesn't perturb it. Existing `src/test/backlog.test.ts` and
+  `__tests__/backlog-filter.test.ts` pass unchanged.
+- **Reusing `view-artifact.ts`'s `relativeTime`**: rejected for the helper
+  because it's in a vscode-dependent module and hardcodes `Date.now()`
+  (untestable). We duplicate the ~6-line tiered format in the pure helper; the
+  format strings match so wording stays consistent. Refactoring
+  `view-artifact.ts` to share it is out of scope (widens the diff for no
+  behavioral gain).
 
 ## Test Plan
 
-- **Unit (vitest)**: `pnpm --filter @cluesmith/codev-vscode test` (or the
-  package's vitest run) — new `backlog-recency.test.ts` covers threshold
-  boundaries, malformed input, and relative-age tiers deterministically.
-- **Build**: `pnpm --filter @cluesmith/codev-vscode build` (tsc) passes.
+- **Unit (vitest)**: run the vscode package's vitest suite — new
+  `backlog-recency.test.ts` covers threshold boundaries, malformed input,
+  prefix output, and relative-age tiers deterministically.
+- **Build**: the vscode package's `tsc` build passes.
 - **Manual (at dev-approval gate)**: open the Backlog view in the Extension
   Development Host. Verify:
-  - A freshly-filed issue (< 24h) shows the `$(sparkle)` icon (accent-colored)
-    when unassigned; hovering shows `Created <Xh ago>`.
-  - An older issue renders unchanged (issues/account icon), tooltip still shows
+  - A freshly-filed issue (< 24h) shows `[new]` immediately after its `#id`,
+    before the title; hovering shows `Created <Xh ago>`.
+  - A new issue **assigned to you** keeps its `account` icon **and** shows
+    `[new]` (the primary goal) plus `assigned to you` description.
+  - An older issue renders unchanged (no `[new]`), tooltip still shows
     `Created <Xd ago>`.
+  - Narrow the sidebar / use a long title → `[new]` stays visible while the
+    title truncates (the prefix-over-suffix rationale from #810).
   - The mine-only toggle, area grouping, and title count all still render
-    correctly with markers present.
-  - An item assigned to you keeps the `account` icon + `assigned to you`
-    description (per the proposed precedence), tooltip shows its age.
+    correctly with `[new]` prefixes present.

--- a/codev/plans/930-vscode-mark-recently-created-b.md
+++ b/codev/plans/930-vscode-mark-recently-created-b.md
@@ -1,0 +1,132 @@
+# PIR Plan: Mark recently-created backlog rows (< 24h)
+
+## Understanding
+
+The Backlog sidebar tree (`packages/vscode/src/views/backlog.ts`) gives no
+visual signal that an issue is freshly filed. Issue #930 asks for a
+lightweight "new" marker on rows whose `createdAt` is within the last 24
+hours of "now", re-evaluated on every tree render — no persistent state, no
+per-user dismissal. After 24h the marker drops off naturally on the next
+render.
+
+The data is already present: `OverviewBacklogItem.createdAt` is a required
+`string` field (`packages/types/src/api.ts:227`) and flows through the
+existing overview pipeline to the extension. The entire change is confined to
+row construction in `BacklogProvider.makeRow` plus a small pure helper.
+
+The issue body resolves the UX choices to concrete defaults; I adopt them:
+
+1. **Marker location**: icon prefix (default 1a) — swap the per-row icon to a
+   "new" variant. Matches the existing visual language (`account` vs `issues`
+   icon based on assignment).
+2. **Icon**: `$(sparkle)` in `ThemeColor('list.highlightForeground')` so it
+   picks up the user's accent color (default proposal).
+3. **Threshold**: hardcoded 24h constant for v1 (no setting).
+4. **Tooltip**: append `Created <relativeTime>` to the row tooltip whenever
+   `createdAt` is present and parseable — regardless of whether the row is
+   marked new (useful info past the 24h window too).
+5. **Mine-only toggle (#809)**: filtered-out items aren't rendered, so the
+   marker question never arises for them. Confirmed: `orderedSpawnable` filters
+   first, then `makeRow` runs only on survivors — no special handling needed.
+
+## Proposed Change
+
+### 1. New pure helper file: `packages/vscode/src/views/backlog-recency.ts`
+
+Vscode-free, mirroring the established `backlog-filter.ts` pattern so the logic
+is unit-testable under the vitest harness (`__tests__/`) without dragging in
+the `vscode` module. Two functions, both taking an injected `now` (ms) so tests
+are deterministic — the codebase's existing `relativeTime` in
+`view-artifact.ts:135` hardcodes `Date.now()` and isn't reusable for testing:
+
+- `RECENT_THRESHOLD_MS = 24 * 60 * 60 * 1000` — the hardcoded window.
+- `isRecentlyCreated(createdAt: string | undefined, nowMs: number): boolean`
+  — parses `createdAt` via `Date.parse`; returns `false` on
+  missing/empty/malformed (`NaN`), on future timestamps (defensive), and when
+  the age is ≥ threshold. Returns `true` only when `0 ≤ age < threshold`.
+- `relativeAge(createdAt: string | undefined, nowMs: number): string | null`
+  — returns `null` when missing/malformed, else a relative string
+  (`'3h ago'`, `'2d ago'`, `'45m ago'`, `'30s ago'`) using the same tiered
+  format as `view-artifact.ts:135` so the wording stays consistent across the
+  extension. Future timestamps clamp to `'0s ago'` rather than emitting a
+  negative number.
+
+### 2. `BacklogProvider.makeRow` (`backlog.ts:116-134`)
+
+Compute `const now = Date.now()` once per row (render-time "now", satisfying
+the "re-evaluated on every render" requirement). Then:
+
+- **Icon precedence**: `account` (assigned) keeps priority — assignment is the
+  stronger, action-relevant signal and already drives the icon. For an
+  *unassigned* row that is recently created, use
+  `new vscode.ThemeIcon('sparkle', new vscode.ThemeColor('list.highlightForeground'))`.
+  Otherwise `issues`. A new+assigned row keeps the `account` icon but still
+  surfaces newness via the tooltip (`Created <age>`) and the existing
+  `assigned to you` description.
+  *(Flagged as a design call below — see Risks.)*
+- **Tooltip**: when `relativeAge(item.createdAt, now)` is non-null, set tooltip
+  to `${item.url}\nCreated <age>`; otherwise keep `item.url` as today. (Use a
+  `MarkdownString` or plain multi-line string — plain `\n` in a string tooltip
+  renders as a second line in VSCode.)
+
+No change to `description`, sort order, grouping, or the mine-only path.
+
+### 3. Tests: `packages/vscode/src/__tests__/backlog-recency.test.ts`
+
+Vitest unit tests for the two pure helpers with a fixed `now`:
+- `isRecentlyCreated`: just-now, 1h ago, 23h59m ago → true; exactly 24h, 25h,
+  2d ago → false; `undefined`, `''`, `'not-a-date'` → false; future → false.
+- `relativeAge`: seconds/minutes/hours/days tiers; `undefined`/malformed →
+  null; future → `'0s ago'`.
+
+## Files to Change
+
+- `packages/vscode/src/views/backlog-recency.ts` — **new**, pure helpers
+  (`RECENT_THRESHOLD_MS`, `isRecentlyCreated`, `relativeAge`).
+- `packages/vscode/src/views/backlog.ts:116-134` — `makeRow`: compute
+  recency, swap icon for unassigned-new rows, enrich tooltip.
+- `packages/vscode/src/__tests__/backlog-recency.test.ts` — **new**, vitest
+  unit tests for the helpers.
+
+Estimated net diff: ~40-60 LOC including tests. No type changes, no data-flow
+changes.
+
+## Risks & Alternatives Considered
+
+- **Icon precedence ambiguity (the one real design call left)**: a row that is
+  both *assigned to you* and *new*. I propose **assignment wins the icon**
+  (keep `account`), with newness conveyed by the tooltip. Rationale: assignment
+  is the durable, action-relevant signal; the sparkle is most valuable on
+  *unassigned* fresh items a reviewer is triaging. **Alternative**: new wins
+  the icon (sparkle), assignment stays in the description text. Reviewer can
+  redirect at this gate — it's a one-line change either way.
+- **`createdAt` missing/malformed**: helpers return `false`/`null`, so the row
+  renders exactly as today (issues/account icon, url-only tooltip), no thrown
+  error. Covered by tests. (Acceptance criterion #6.)
+- **No regression to #809 / #811 / #911**: the change is purely additive inside
+  `makeRow` (icon + tooltip). `orderedSpawnable` (mine-only), `groupByArea`
+  (#811), and `formatBacklogTitle`/`visibleBacklogCount` (#911) are untouched.
+  Existing `src/test/backlog.test.ts` and `__tests__/backlog-filter.test.ts`
+  should pass unchanged.
+- **Reusing the existing `relativeTime`**: rejected for the helper because it's
+  in a vscode-dependent module and hardcodes `Date.now()` (untestable). I
+  duplicate the ~6-line tiered format in the pure helper rather than refactor
+  `view-artifact.ts` (out of scope; would widen the diff for no behavioral
+  gain). The format strings match so wording stays consistent.
+
+## Test Plan
+
+- **Unit (vitest)**: `pnpm --filter @cluesmith/codev-vscode test` (or the
+  package's vitest run) — new `backlog-recency.test.ts` covers threshold
+  boundaries, malformed input, and relative-age tiers deterministically.
+- **Build**: `pnpm --filter @cluesmith/codev-vscode build` (tsc) passes.
+- **Manual (at dev-approval gate)**: open the Backlog view in the Extension
+  Development Host. Verify:
+  - A freshly-filed issue (< 24h) shows the `$(sparkle)` icon (accent-colored)
+    when unassigned; hovering shows `Created <Xh ago>`.
+  - An older issue renders unchanged (issues/account icon), tooltip still shows
+    `Created <Xd ago>`.
+  - The mine-only toggle, area grouping, and title count all still render
+    correctly with markers present.
+  - An item assigned to you keeps the `account` icon + `assigned to you`
+    description (per the proposed precedence), tooltip shows its age.

--- a/codev/projects/930-vscode-mark-recently-created-b/status.yaml
+++ b/codev/projects/930-vscode-mark-recently-created-b/status.yaml
@@ -1,0 +1,18 @@
+id: '930'
+title: vscode-mark-recently-created-b
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-29T23:09:58.314Z'
+updated_at: '2026-05-29T23:09:58.315Z'

--- a/codev/projects/930-vscode-mark-recently-created-b/status.yaml
+++ b/codev/projects/930-vscode-mark-recently-created-b/status.yaml
@@ -1,7 +1,7 @@
 id: '930'
 title: vscode-mark-recently-created-b
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:09:58.314Z'
-updated_at: '2026-05-30T00:05:51.152Z'
+updated_at: '2026-05-30T00:05:57.332Z'

--- a/codev/projects/930-vscode-mark-recently-created-b/status.yaml
+++ b/codev/projects/930-vscode-mark-recently-created-b/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-05-29T23:11:52.790Z'
+    approved_at: '2026-05-30T00:05:51.151Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:09:58.314Z'
-updated_at: '2026-05-29T23:11:52.791Z'
+updated_at: '2026-05-30T00:05:51.152Z'

--- a/codev/projects/930-vscode-mark-recently-created-b/status.yaml
+++ b/codev/projects/930-vscode-mark-recently-created-b/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-05-29T23:11:52.790Z'
     approved_at: '2026-05-30T00:05:51.151Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-05-30T00:10:41.465Z'
+    approved_at: '2026-05-31T11:26:54.123Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:09:58.314Z'
-updated_at: '2026-05-30T00:10:41.466Z'
+updated_at: '2026-05-31T11:26:54.124Z'

--- a/codev/projects/930-vscode-mark-recently-created-b/status.yaml
+++ b/codev/projects/930-vscode-mark-recently-created-b/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-05-29T23:11:52.790Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:09:58.314Z'
-updated_at: '2026-05-29T23:09:58.315Z'
+updated_at: '2026-05-29T23:11:52.791Z'

--- a/codev/projects/930-vscode-mark-recently-created-b/status.yaml
+++ b/codev/projects/930-vscode-mark-recently-created-b/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-05-30T00:10:41.465Z'
     approved_at: '2026-05-31T11:26:54.123Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-05-31T11:33:52.469Z'
+    approved_at: '2026-05-31T11:35:08.645Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-29T23:09:58.314Z'
-updated_at: '2026-05-31T11:33:52.470Z'
+updated_at: '2026-05-31T11:35:08.647Z'
 pr_history:
   - phase: review
     pr_number: 949
     branch: builder/pir-930
     created_at: '2026-05-31T11:28:08.505Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/930-vscode-mark-recently-created-b/status.yaml
+++ b/codev/projects/930-vscode-mark-recently-created-b/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:09:58.314Z'
-updated_at: '2026-05-31T11:26:59.916Z'
+updated_at: '2026-05-31T11:28:08.505Z'
+pr_history:
+  - phase: review
+    pr_number: 949
+    branch: builder/pir-930
+    created_at: '2026-05-31T11:28:08.505Z'

--- a/codev/projects/930-vscode-mark-recently-created-b/status.yaml
+++ b/codev/projects/930-vscode-mark-recently-created-b/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-05-30T00:05:51.151Z'
   dev-approval:
     status: pending
+    requested_at: '2026-05-30T00:10:41.465Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:09:58.314Z'
-updated_at: '2026-05-30T00:05:57.332Z'
+updated_at: '2026-05-30T00:10:41.466Z'

--- a/codev/projects/930-vscode-mark-recently-created-b/status.yaml
+++ b/codev/projects/930-vscode-mark-recently-created-b/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-05-31T11:26:54.123Z'
   pr:
     status: pending
+    requested_at: '2026-05-31T11:33:52.469Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-29T23:09:58.314Z'
-updated_at: '2026-05-31T11:28:14.439Z'
+updated_at: '2026-05-31T11:33:52.470Z'
 pr_history:
   - phase: review
     pr_number: 949
     branch: builder/pir-930
     created_at: '2026-05-31T11:28:08.505Z'
+pr_ready_for_human: true

--- a/codev/projects/930-vscode-mark-recently-created-b/status.yaml
+++ b/codev/projects/930-vscode-mark-recently-created-b/status.yaml
@@ -1,7 +1,7 @@
 id: '930'
 title: vscode-mark-recently-created-b
 protocol: pir
-phase: review
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -21,7 +21,7 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-29T23:09:58.314Z'
-updated_at: '2026-05-31T11:35:08.647Z'
+updated_at: '2026-05-31T11:35:19.691Z'
 pr_history:
   - phase: review
     pr_number: 949

--- a/codev/projects/930-vscode-mark-recently-created-b/status.yaml
+++ b/codev/projects/930-vscode-mark-recently-created-b/status.yaml
@@ -1,7 +1,7 @@
 id: '930'
 title: vscode-mark-recently-created-b
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:09:58.314Z'
-updated_at: '2026-05-31T11:26:54.124Z'
+updated_at: '2026-05-31T11:26:59.916Z'

--- a/codev/projects/930-vscode-mark-recently-created-b/status.yaml
+++ b/codev/projects/930-vscode-mark-recently-created-b/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-05-29T23:09:58.314Z'
-updated_at: '2026-05-31T11:28:08.505Z'
+updated_at: '2026-05-31T11:28:14.439Z'
 pr_history:
   - phase: review
     pr_number: 949

--- a/codev/reviews/930-vscode-mark-recently-created-b.md
+++ b/codev/reviews/930-vscode-mark-recently-created-b.md
@@ -67,6 +67,28 @@ passed once core+types were built. This is pre-existing worktree build-ordering
 behavior (confirmed via `git stash` that the `status.ts`/`workspace.ts`/
 `terminal-adapter.ts` errors exist without this diff), not introduced here.
 
+## 3-Way Consultation Disposition (PIR single-pass)
+
+Verdicts: **gemini=REQUEST_CHANGES, codex=REQUEST_CHANGES, claude=APPROVE**
+(full text in `codev/projects/930-vscode-mark-recently-created-b/930-review-iter1-*.txt`).
+PIR consults once — this was not independently re-reviewed, so the human is the
+final check at the `pr` gate.
+
+- **`[new]` placement before `#id` (gemini + codex)** — *not a code defect.*
+  Both flagged that the shipped `[new] #<id> <title>` order deviates from the
+  plan's original `#<id> [new] <title>`. This was a **deliberate revision the
+  reviewer requested at the `dev-approval` gate** (commit `5ff73ac4`); Claude's
+  APPROVE explicitly recognized it as gate-approved. The legitimate kernel was
+  **plan↔code drift**: the approved plan still documented the old order. Fixed
+  by reconciling the plan to the shipped order (no code change — the placement
+  is the human's gate decision). Gemini's secondary note that leading the row
+  with `[new]` offsets the `#id` left-alignment for fresh rows is the inherent,
+  accepted tradeoff of the requested placement.
+- **"How to Test Locally" too generic for an extension UI change (codex)** —
+  *valid, addressed.* Rewrote that section with concrete Extension Development
+  Host steps (build subpath deps → `pnpm compile` → F5 → open Backlog tree)
+  instead of the web-oriented "Run Dev Server" instruction.
+
 ## Things to Look At During PR Review
 
 - **Marker coexists with the assignment icon** (`backlog.ts:124-130`): the
@@ -95,9 +117,21 @@ behavior (confirmed via `git stash` that the `status.ts`/`workspace.ts`/
 
 ## How to Test Locally
 
-- **View diff**: VSCode sidebar → right-click builder `pir-930` → **View Diff**
-- **Run dev server**: VSCode sidebar → **Run Dev Server**, or `afx dev pir-930`
-- **What to verify**:
+This is a VSCode **extension UI** change (the Backlog tree in the Codev
+sidebar), so verify it in the Extension Development Host rather than a web dev
+server:
+
+1. **View diff**: VSCode sidebar → right-click builder `pir-930` → **View Diff**.
+2. **Build the extension**: from the worktree, `pnpm --filter @cluesmith/codev-core build`
+   and `pnpm --filter @cluesmith/codev-types build` (subpath deps), then in
+   `packages/vscode` run `pnpm compile`.
+3. **Launch the Extension Development Host**: open `packages/vscode` in VSCode
+   and press **F5** (Run → Start Debugging), or pick the "Run Extension" launch
+   config. A second VSCode window opens with the dev build of the extension.
+4. **Open the Backlog tree**: in the EDH window, open the Codev sidebar and
+   expand the **Backlog** view (connect it to a Tower workspace if prompted, so
+   real backlog items load).
+5. **What to verify**:
   - A freshly-filed issue (< 24h) leads with `[new]` before its `#id`; hovering
     shows `Created <Xh ago>`.
   - A new issue **assigned to you** keeps its `account` icon **and** shows

--- a/codev/reviews/930-vscode-mark-recently-created-b.md
+++ b/codev/reviews/930-vscode-mark-recently-created-b.md
@@ -1,0 +1,110 @@
+# PIR Review: Mark recently-created backlog rows (< 24h)
+
+Fixes #930
+
+## Summary
+
+The Backlog sidebar tree now flags freshly-filed issues: any row whose
+`createdAt` is within the last 24 hours of render-time "now" leads with a
+monochrome `[new]` prefix, and every row with a parseable `createdAt` gains a
+`Created <age>` line on its hover tooltip. The marker is computed at render
+time against a fresh `Date.now()`, so an item ages out of `[new]` on the next
+tree refresh with no persistent state or per-user dismissal. The `[new]` text
+prefix (rather than an icon swap) was chosen so it coexists with the existing
+`account` / `issues` assignment icon — the primary goal was letting an engineer
+spot a *new issue assigned to them*, which an icon swap would have hidden.
+
+## Files Changed
+
+- `packages/vscode/src/views/backlog-recency.ts` (+65 / -0) — new, vscode-free
+  pure helpers
+- `packages/vscode/src/__tests__/backlog-recency.test.ts` (+82 / -0) — new,
+  vitest unit tests
+- `packages/vscode/src/views/backlog.ts` (+12 / -2) — `makeRow`: `[new]` label
+  prefix + `Created <age>` tooltip
+
+## Commits
+
+- `5ff73ac4` [PIR #930] Lead row with [new] prefix (before the issue number)
+- `54637402` [PIR #930] Update thread — implement phase
+- `0b03226b` [PIR #930] Render [new] prefix + Created-age tooltip on backlog rows
+- `417156f9` [PIR #930] Add backlog-recency pure helpers + unit tests
+- `04dcc581` [PIR #930] Plan revised — follow #810 [new]-prefix pattern
+- `93b5768a` [PIR #930] Plan draft
+
+## Test Results
+
+- `build` (porch check): ✓ pass
+- `tests` (porch check): ✓ pass
+- vitest unit suite: ✓ 122 pass (9 new in `backlog-recency.test.ts`)
+- `check-types` (`tsc --noEmit`): ✓ pass
+- `lint` (`eslint src`): ✓ pass
+- esbuild bundle: ✓ pass
+- Manual verification: approved by the human at the `dev-approval` gate via the
+  running worktree (Extension Development Host / dev server).
+
+## Architecture Updates
+
+No arch changes — this is a self-contained, additive change to one view's row
+construction (`BacklogProvider.makeRow`) plus a sibling pure-helper file. It
+introduces no new module boundary, data flow, or pattern: it reuses the
+established "pure logic in a vscode-free file, vitest-tested in `__tests__/`,
+consumed by the vscode-dependent provider" convention already set by
+`backlog-filter.ts`. `codev/resources/arch.md` already documents that
+convention; nothing to add.
+
+## Lessons Learned Updates
+
+No durable lessons captured — the implementation followed existing conventions
+end to end (the `backlog-filter.ts` pure-helper pattern for testability, and
+the #810 "monochrome bracket-text prefix coexisting with the row icon" design
+language for the marker). One process note worth recording inline rather than
+in `lessons-learned.md` (too situational to generalize): a fresh builder
+worktree needs `@cluesmith/codev-core` and `@cluesmith/codev-types` built
+before the vscode package's `tsc`/`esbuild` can resolve their subpath exports —
+the first `porch done` failed the `build` check for exactly this reason and
+passed once core+types were built. This is pre-existing worktree build-ordering
+behavior (confirmed via `git stash` that the `status.ts`/`workspace.ts`/
+`terminal-adapter.ts` errors exist without this diff), not introduced here.
+
+## Things to Look At During PR Review
+
+- **Marker coexists with the assignment icon** (`backlog.ts:124-130`): the
+  `[new]` prefix leads the label while `iconPath` still dispatches `account`
+  (assigned) vs `issues` (otherwise). A new + assigned row reads
+  `👤 [new] #N <title> … assigned to you`. This was the resolved design call —
+  an earlier draft proposed a `$(sparkle)` icon swap, rejected because it would
+  clobber the assignment icon and hide newness on exactly the rows that matter.
+- **Robustness of the age parse** (`backlog-recency.ts`): `isRecentlyCreated` /
+  `relativeAge` both guard `Date.parse` returning `NaN` (missing / empty /
+  malformed `createdAt`) and defensively treat future timestamps as
+  not-recent / `0s ago`. Malformed input yields no prefix and an unchanged
+  url-only tooltip — no thrown error. Covered by tests.
+- **Render-driven, not timer-driven**: the marker recomputes only when the
+  Backlog tree re-renders (SSE-driven `OverviewCache.onDidChange`, or a config
+  refresh). There is no 24h `setTimeout`; an item drops `[new]` on the next
+  refresh after crossing the threshold. This matches the issue's acceptance
+  criterion #3 ("lose the marker on the next refresh") and was explicitly
+  confirmed with the reviewer at the gate.
+- **Duplicated relative-time format**: `relativeAge` re-implements the ~6-line
+  tiered format from `view-artifact.ts:135` rather than importing it, because
+  that helper lives in a vscode-dependent module and hardcodes `Date.now()`
+  (not injectable for deterministic tests). The format strings match so wording
+  stays consistent. A future consolidation could extract a shared
+  `now`-injectable formatter, but that was out of scope here.
+
+## How to Test Locally
+
+- **View diff**: VSCode sidebar → right-click builder `pir-930` → **View Diff**
+- **Run dev server**: VSCode sidebar → **Run Dev Server**, or `afx dev pir-930`
+- **What to verify**:
+  - A freshly-filed issue (< 24h) leads with `[new]` before its `#id`; hovering
+    shows `Created <Xh ago>`.
+  - A new issue **assigned to you** keeps its `account` icon **and** shows
+    `[new]` plus the `assigned to you` description (the primary goal).
+  - An older issue renders unchanged (no `[new]`); its tooltip still shows
+    `Created <Xd ago>`.
+  - Mine-only toggle (#809), area grouping (#811), and the title-count
+    formatter (#911) all still render correctly with `[new]` prefixes present.
+  - An issue with missing/malformed `createdAt` renders with no prefix and a
+    url-only tooltip — no error.

--- a/codev/state/pir-930_thread.md
+++ b/codev/state/pir-930_thread.md
@@ -29,3 +29,24 @@ icons untouched. Survives truncation (leading position). Pure helper
 mirroring #810's extracted-testable-helper-with-fallback pattern.
 
 Plan rewritten, awaiting `plan-approval`.
+
+### Implement phase
+
+Implemented per the v2 plan:
+- New `packages/vscode/src/views/backlog-recency.ts` — pure helpers
+  `isRecentlyCreated`, `recencyPrefix` (`'[new] '`/`''`), `relativeAge` (tooltip),
+  all with injected `now`. Hardcoded 24h `RECENT_THRESHOLD_MS`.
+- `backlog.ts makeRow` — `[new]` prefix after `#id`, before title; tooltip
+  gains `Created <age>` when parseable. Icons untouched.
+- New vitest `__tests__/backlog-recency.test.ts` — 9 tests (boundaries,
+  malformed/missing, future-clamp, prefix output, age tiers).
+
+Build/test: `check-types` ✓, `lint` ✓, esbuild ✓, vitest 122/122 (9 new) ✓.
+
+Note: had to build `@cluesmith/codev-core` and `@cluesmith/codev-types` first —
+the worktree's tsc/esbuild couldn't resolve their subpath exports until built.
+Pre-existing env/build-ordering issue (confirmed via git-stash that the
+status.ts/workspace.ts/terminal-adapter.ts errors exist without my diff), not
+caused by this change.
+
+Awaiting `dev-approval` gate.

--- a/codev/state/pir-930_thread.md
+++ b/codev/state/pir-930_thread.md
@@ -57,3 +57,13 @@ dev-approval approved (reviewer asked to move `[new]` before the `#id` — done 
 5ff73ac4). Wrote retrospective `codev/reviews/930-vscode-mark-recently-created-b.md`.
 No arch/lessons file changes (additive, follows existing conventions). Opening PR
 next; porch verify runs the single 3-way advisory consult.
+
+### Consultation (single pass)
+
+Verdicts: gemini=REQUEST_CHANGES, codex=REQUEST_CHANGES, claude=APPROVE.
+Both RC's = the `[new]` placement-before-id "deviates from plan". Not a defect —
+it was the reviewer's explicit dev-approval-gate request (5ff73ac4); Claude
+recognized it as gate-approved. Real kernel = plan↔code drift. Disposition: no
+code change; reconciled the plan to the shipped `[new] #id` order, and tightened
+the review's "How to Test Locally" with concrete EDH steps (codex's 2nd point).
+Escalating to human at pr gate.

--- a/codev/state/pir-930_thread.md
+++ b/codev/state/pir-930_thread.md
@@ -16,4 +16,16 @@ One real design call surfaced and flagged in the plan: icon precedence for a
 row that is BOTH assigned-to-you AND new. Proposed assignment-wins (keep
 `account` icon), newness via tooltip. Reviewer can flip it at the gate.
 
-Plan written, committed, awaiting `plan-approval`.
+### Plan revised (v2) — follow #810 pattern
+
+Architect pushed back: the icon-swap approach hides newness on assigned rows,
+defeating the main purpose (engineer spotting NEW issues assigned to them).
+Considered a "Recent" top group (rejected — out-of-scope structural re-sort per
+the issue body). Settled on following #810's design language: a monochrome
+`[new]` **text prefix after the issue number** (`#911 [new] <title>`),
+analogous to #810's `[phase]` prefix. Coexists with the account/issues icon —
+icons untouched. Survives truncation (leading position). Pure helper
+`recencyPrefix(createdAt, now)` + `relativeAge` for tooltip, vitest-tested,
+mirroring #810's extracted-testable-helper-with-fallback pattern.
+
+Plan rewritten, awaiting `plan-approval`.

--- a/codev/state/pir-930_thread.md
+++ b/codev/state/pir-930_thread.md
@@ -1,0 +1,19 @@
+# PIR #930 — mark recently-created backlog rows (< 24h)
+
+## Plan phase
+
+Investigated `packages/vscode/src/views/backlog.ts`. The codebase already
+separates pure logic (`backlog-filter.ts`, vitest-tested in `__tests__/`) from
+vscode-dependent row construction (`backlog.ts`, vscode-test in `src/test/`).
+Following that pattern: new pure `backlog-recency.ts` for the age helpers,
+edit `makeRow` for icon + tooltip.
+
+`OverviewBacklogItem.createdAt` is required on the type (`api.ts:227`) and
+already plumbed to the extension — confirmed via the issue + type read. No
+data-flow change.
+
+One real design call surfaced and flagged in the plan: icon precedence for a
+row that is BOTH assigned-to-you AND new. Proposed assignment-wins (keep
+`account` icon), newness via tooltip. Reviewer can flip it at the gate.
+
+Plan written, committed, awaiting `plan-approval`.

--- a/codev/state/pir-930_thread.md
+++ b/codev/state/pir-930_thread.md
@@ -50,3 +50,10 @@ status.ts/workspace.ts/terminal-adapter.ts errors exist without my diff), not
 caused by this change.
 
 Awaiting `dev-approval` gate.
+
+### Review phase
+
+dev-approval approved (reviewer asked to move `[new]` before the `#id` — done in
+5ff73ac4). Wrote retrospective `codev/reviews/930-vscode-mark-recently-created-b.md`.
+No arch/lessons file changes (additive, follows existing conventions). Opening PR
+next; porch verify runs the single 3-way advisory consult.

--- a/packages/vscode/src/__tests__/backlog-recency.test.ts
+++ b/packages/vscode/src/__tests__/backlog-recency.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for the pure recency helpers behind the Backlog "new" marker (#930):
+ * - `isRecentlyCreated` (24h age threshold)
+ * - `recencyPrefix` (`'[new] '` vs `''`)
+ * - `relativeAge` (human-relative age string for the tooltip)
+ *
+ * Lives in `__tests__/` (vitest) rather than `src/test/` (vscode-test Electron
+ * harness) because the helpers touch no `vscode` APIs. `now` is injected so the
+ * assertions are deterministic.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  RECENT_THRESHOLD_MS,
+  isRecentlyCreated,
+  recencyPrefix,
+  relativeAge,
+} from '../views/backlog-recency.js';
+
+// Fixed reference "now" so every case is deterministic.
+const NOW = Date.parse('2026-05-30T12:00:00.000Z');
+const iso = (msAgo: number) => new Date(NOW - msAgo).toISOString();
+
+const HOUR = 60 * 60 * 1000;
+const MINUTE = 60 * 1000;
+const DAY = 24 * HOUR;
+
+describe('isRecentlyCreated', () => {
+  it('returns true for items created within the last 24h', () => {
+    expect(isRecentlyCreated(iso(0), NOW)).toBe(true); // just now
+    expect(isRecentlyCreated(iso(HOUR), NOW)).toBe(true); // 1h ago
+    expect(isRecentlyCreated(iso(23 * HOUR + 59 * MINUTE), NOW)).toBe(true); // 23h59m ago
+    expect(isRecentlyCreated(iso(RECENT_THRESHOLD_MS - 1), NOW)).toBe(true); // 1ms inside window
+  });
+
+  it('returns false at and beyond the 24h boundary', () => {
+    expect(isRecentlyCreated(iso(RECENT_THRESHOLD_MS), NOW)).toBe(false); // exactly 24h
+    expect(isRecentlyCreated(iso(25 * HOUR), NOW)).toBe(false);
+    expect(isRecentlyCreated(iso(2 * DAY), NOW)).toBe(false);
+  });
+
+  it('returns false for missing / empty / malformed input', () => {
+    expect(isRecentlyCreated(undefined, NOW)).toBe(false);
+    expect(isRecentlyCreated('', NOW)).toBe(false);
+    expect(isRecentlyCreated('not-a-date', NOW)).toBe(false);
+  });
+
+  it('returns false (defensively) for future timestamps', () => {
+    expect(isRecentlyCreated(iso(-HOUR), NOW)).toBe(false); // 1h in the future
+  });
+});
+
+describe('recencyPrefix', () => {
+  it("returns '[new] ' for recent items", () => {
+    expect(recencyPrefix(iso(HOUR), NOW)).toBe('[new] ');
+  });
+
+  it("returns '' for older / malformed / missing items", () => {
+    expect(recencyPrefix(iso(2 * DAY), NOW)).toBe('');
+    expect(recencyPrefix('not-a-date', NOW)).toBe('');
+    expect(recencyPrefix(undefined, NOW)).toBe('');
+  });
+});
+
+describe('relativeAge', () => {
+  it('formats seconds / minutes / hours / days tiers', () => {
+    expect(relativeAge(iso(30 * 1000), NOW)).toBe('30s ago');
+    expect(relativeAge(iso(45 * MINUTE), NOW)).toBe('45m ago');
+    expect(relativeAge(iso(3 * HOUR), NOW)).toBe('3h ago');
+    expect(relativeAge(iso(2 * DAY), NOW)).toBe('2d ago');
+  });
+
+  it('returns null for missing / malformed input', () => {
+    expect(relativeAge(undefined, NOW)).toBeNull();
+    expect(relativeAge('', NOW)).toBeNull();
+    expect(relativeAge('not-a-date', NOW)).toBeNull();
+  });
+
+  it("clamps future timestamps to '0s ago'", () => {
+    expect(relativeAge(iso(-HOUR), NOW)).toBe('0s ago');
+  });
+});

--- a/packages/vscode/src/views/backlog-recency.ts
+++ b/packages/vscode/src/views/backlog-recency.ts
@@ -7,9 +7,9 @@
  * (`backlog.ts`) imports these and applies them during row construction.
  *
  * The "new" signal follows the #810 design language: a monochrome `[new]`
- * text prefix after the issue number — coexisting with the existing
- * `account` / `issues` icon rather than clobbering it — so a freshly-filed
- * issue *assigned to you* keeps its account icon AND shows `[new]`.
+ * text prefix leading the row — coexisting with the existing `account` /
+ * `issues` icon rather than clobbering it — so a freshly-filed issue
+ * *assigned to you* keeps its account icon AND shows `[new]`.
  *
  * `now` is injected (ms) rather than read from `Date.now()` so tests are
  * deterministic. (The existing `relativeTime` in `view-artifact.ts` hardcodes
@@ -37,8 +37,8 @@ export function isRecentlyCreated(createdAt: string | undefined, nowMs: number):
 
 /**
  * The label prefix for a backlog row: `'[new] '` when recently created, else
- * `''`. Designed to splice between the issue number and the title
- * (`#${id} ${recencyPrefix(...)}${title}`) — when empty the label is
+ * `''`. Designed to lead the row label
+ * (`${recencyPrefix(...)}#${id} ${title}`) — when empty the label is
  * byte-identical to the pre-#930 form. Graceful empty-string fallback mirrors
  * #810's `GATE_ICONS[gate] || 'bell'` shape.
  */

--- a/packages/vscode/src/views/backlog-recency.ts
+++ b/packages/vscode/src/views/backlog-recency.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure recency helpers for the Backlog view (#930).
+ *
+ * Lives in its own vscode-free file (same rationale as `backlog-filter.ts`)
+ * so the age logic can be unit-tested under the vitest harness in
+ * `__tests__/` without importing the `vscode` module. `BacklogProvider`
+ * (`backlog.ts`) imports these and applies them during row construction.
+ *
+ * The "new" signal follows the #810 design language: a monochrome `[new]`
+ * text prefix after the issue number — coexisting with the existing
+ * `account` / `issues` icon rather than clobbering it — so a freshly-filed
+ * issue *assigned to you* keeps its account icon AND shows `[new]`.
+ *
+ * `now` is injected (ms) rather than read from `Date.now()` so tests are
+ * deterministic. (The existing `relativeTime` in `view-artifact.ts` hardcodes
+ * `Date.now()`, which is why it can't be reused here.)
+ */
+
+/** Items created within this window of "now" are marked `[new]`. Hardcoded
+ * for v1 — no `codev.*` setting until users ask (per #930 design call 3). */
+export const RECENT_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * True when `createdAt` parses to a timestamp between `now - 24h` (inclusive)
+ * and `now` (inclusive). Returns false — never throws — for missing, empty,
+ * or malformed input, and (defensively) for future timestamps. The threshold
+ * is re-evaluated against the caller's `now` on every render, so an item ages
+ * out of `[new]` on the next refresh with no persistent state.
+ */
+export function isRecentlyCreated(createdAt: string | undefined, nowMs: number): boolean {
+  if (!createdAt) { return false; }
+  const created = Date.parse(createdAt);
+  if (Number.isNaN(created)) { return false; }
+  const age = nowMs - created;
+  return age >= 0 && age < RECENT_THRESHOLD_MS;
+}
+
+/**
+ * The label prefix for a backlog row: `'[new] '` when recently created, else
+ * `''`. Designed to splice between the issue number and the title
+ * (`#${id} ${recencyPrefix(...)}${title}`) — when empty the label is
+ * byte-identical to the pre-#930 form. Graceful empty-string fallback mirrors
+ * #810's `GATE_ICONS[gate] || 'bell'` shape.
+ */
+export function recencyPrefix(createdAt: string | undefined, nowMs: number): string {
+  return isRecentlyCreated(createdAt, nowMs) ? '[new] ' : '';
+}
+
+/**
+ * Human-relative age string (`'30s ago'`, `'45m ago'`, `'3h ago'`, `'2d ago'`)
+ * for the row tooltip, or `null` when `createdAt` is missing/malformed (caller
+ * then leaves the tooltip unchanged). Future timestamps clamp to `'0s ago'`
+ * rather than emitting a negative number. Tiers match `view-artifact.ts`'s
+ * `relativeTime` so wording stays consistent across the extension.
+ */
+export function relativeAge(createdAt: string | undefined, nowMs: number): string | null {
+  if (!createdAt) { return null; }
+  const created = Date.parse(createdAt);
+  if (Number.isNaN(created)) { return null; }
+  const seconds = Math.max(0, Math.floor((nowMs - created) / 1000));
+  if (seconds < 60) { return `${seconds}s ago`; }
+  if (seconds < 3600) { return `${Math.floor(seconds / 60)}m ago`; }
+  if (seconds < 86400) { return `${Math.floor(seconds / 3600)}h ago`; }
+  return `${Math.floor(seconds / 86400)}d ago`;
+}

--- a/packages/vscode/src/views/backlog.ts
+++ b/packages/vscode/src/views/backlog.ts
@@ -122,11 +122,12 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
     const assigned = !!me && !!item.assignees?.some(a => a.toLowerCase() === me);
     const author = item.author ? ` @${item.author}` : '';
     // Render-time "now": items aging past the 24h window lose `[new]` on the
-    // next refresh, no persistent state (#930). The `[new]` prefix sits after
-    // the issue number and coexists with the assignment icon (following #810).
+    // next refresh, no persistent state (#930). The `[new]` prefix leads the
+    // row (before the issue number) and coexists with the assignment icon
+    // (following #810).
     const now = Date.now();
     const prefix = recencyPrefix(item.createdAt, now);
-    const ti = new BacklogTreeItem(item.id, item.url, item.title, `#${item.id} ${prefix}${item.title}${author}`);
+    const ti = new BacklogTreeItem(item.id, item.url, item.title, `${prefix}#${item.id} ${item.title}${author}`);
     const age = relativeAge(item.createdAt, now);
     ti.tooltip = age ? `${item.url}\nCreated ${age}` : item.url;
     ti.contextValue = 'backlog-item';

--- a/packages/vscode/src/views/backlog.ts
+++ b/packages/vscode/src/views/backlog.ts
@@ -6,6 +6,7 @@ import type { OverviewCache } from './overview-data.js';
 import { BacklogGroupTreeItem, BacklogTreeItem } from './backlog-tree-item.js';
 import { AreaGroupExpansionStore } from './area-group-expansion.js';
 import { filterMine, spawnableBacklog } from './backlog-filter.js';
+import { recencyPrefix, relativeAge } from './backlog-recency.js';
 
 // Re-export so existing call sites (extension.ts, src/test/backlog.test.ts)
 // keep their import path. The definition lives in `backlog-filter.ts` so
@@ -120,8 +121,14 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
     const me = data.currentUser?.toLowerCase();
     const assigned = !!me && !!item.assignees?.some(a => a.toLowerCase() === me);
     const author = item.author ? ` @${item.author}` : '';
-    const ti = new BacklogTreeItem(item.id, item.url, item.title, `#${item.id} ${item.title}${author}`);
-    ti.tooltip = item.url;
+    // Render-time "now": items aging past the 24h window lose `[new]` on the
+    // next refresh, no persistent state (#930). The `[new]` prefix sits after
+    // the issue number and coexists with the assignment icon (following #810).
+    const now = Date.now();
+    const prefix = recencyPrefix(item.createdAt, now);
+    const ti = new BacklogTreeItem(item.id, item.url, item.title, `#${item.id} ${prefix}${item.title}${author}`);
+    const age = relativeAge(item.createdAt, now);
+    ti.tooltip = age ? `${item.url}\nCreated ${age}` : item.url;
     ti.contextValue = 'backlog-item';
     ti.iconPath = new vscode.ThemeIcon(assigned ? 'account' : 'issues');
     if (assigned) { ti.description = 'assigned to you'; }


### PR DESCRIPTION
# PIR Review: Mark recently-created backlog rows (< 24h)

Fixes #930

## Summary

The Backlog sidebar tree now flags freshly-filed issues: any row whose
`createdAt` is within the last 24 hours of render-time "now" leads with a
monochrome `[new]` prefix, and every row with a parseable `createdAt` gains a
`Created <age>` line on its hover tooltip. The marker is computed at render
time against a fresh `Date.now()`, so an item ages out of `[new]` on the next
tree refresh with no persistent state or per-user dismissal. The `[new]` text
prefix (rather than an icon swap) was chosen so it coexists with the existing
`account` / `issues` assignment icon — the primary goal was letting an engineer
spot a *new issue assigned to them*, which an icon swap would have hidden.

## Files Changed

- `packages/vscode/src/views/backlog-recency.ts` (+65 / -0) — new, vscode-free
  pure helpers
- `packages/vscode/src/__tests__/backlog-recency.test.ts` (+82 / -0) — new,
  vitest unit tests
- `packages/vscode/src/views/backlog.ts` (+12 / -2) — `makeRow`: `[new]` label
  prefix + `Created <age>` tooltip

## Commits

- `5ff73ac4` [PIR #930] Lead row with [new] prefix (before the issue number)
- `54637402` [PIR #930] Update thread — implement phase
- `0b03226b` [PIR #930] Render [new] prefix + Created-age tooltip on backlog rows
- `417156f9` [PIR #930] Add backlog-recency pure helpers + unit tests
- `04dcc581` [PIR #930] Plan revised — follow #810 [new]-prefix pattern
- `93b5768a` [PIR #930] Plan draft

## Test Results

- `build` (porch check): ✓ pass
- `tests` (porch check): ✓ pass
- vitest unit suite: ✓ 122 pass (9 new in `backlog-recency.test.ts`)
- `check-types` (`tsc --noEmit`): ✓ pass
- `lint` (`eslint src`): ✓ pass
- esbuild bundle: ✓ pass
- Manual verification: approved by the human at the `dev-approval` gate via the
  running worktree (Extension Development Host / dev server).

## Architecture Updates

No arch changes — this is a self-contained, additive change to one view's row
construction (`BacklogProvider.makeRow`) plus a sibling pure-helper file. It
introduces no new module boundary, data flow, or pattern: it reuses the
established "pure logic in a vscode-free file, vitest-tested in `__tests__/`,
consumed by the vscode-dependent provider" convention already set by
`backlog-filter.ts`. `codev/resources/arch.md` already documents that
convention; nothing to add.

## Lessons Learned Updates

No durable lessons captured — the implementation followed existing conventions
end to end (the `backlog-filter.ts` pure-helper pattern for testability, and
the #810 "monochrome bracket-text prefix coexisting with the row icon" design
language for the marker). One process note worth recording inline rather than
in `lessons-learned.md` (too situational to generalize): a fresh builder
worktree needs `@cluesmith/codev-core` and `@cluesmith/codev-types` built
before the vscode package's `tsc`/`esbuild` can resolve their subpath exports —
the first `porch done` failed the `build` check for exactly this reason and
passed once core+types were built. This is pre-existing worktree build-ordering
behavior (confirmed via `git stash` that the `status.ts`/`workspace.ts`/
`terminal-adapter.ts` errors exist without this diff), not introduced here.

## 3-Way Consultation Disposition (PIR single-pass)

Verdicts: **gemini=REQUEST_CHANGES, codex=REQUEST_CHANGES, claude=APPROVE**
(full text in `codev/projects/930-vscode-mark-recently-created-b/930-review-iter1-*.txt`).
PIR consults once — this was not independently re-reviewed, so the human is the
final check at the `pr` gate.

- **`[new]` placement before `#id` (gemini + codex)** — *not a code defect.*
  Both flagged that the shipped `[new] #<id> <title>` order deviates from the
  plan's original `#<id> [new] <title>`. This was a **deliberate revision the
  reviewer requested at the `dev-approval` gate** (commit `5ff73ac4`); Claude's
  APPROVE explicitly recognized it as gate-approved. The legitimate kernel was
  **plan↔code drift**: the approved plan still documented the old order. Fixed
  by reconciling the plan to the shipped order (no code change — the placement
  is the human's gate decision). Gemini's secondary note that leading the row
  with `[new]` offsets the `#id` left-alignment for fresh rows is the inherent,
  accepted tradeoff of the requested placement.
- **"How to Test Locally" too generic for an extension UI change (codex)** —
  *valid, addressed.* Rewrote that section with concrete Extension Development
  Host steps (build subpath deps → `pnpm compile` → F5 → open Backlog tree)
  instead of the web-oriented "Run Dev Server" instruction.

## Things to Look At During PR Review

- **Marker coexists with the assignment icon** (`backlog.ts:124-130`): the
  `[new]` prefix leads the label while `iconPath` still dispatches `account`
  (assigned) vs `issues` (otherwise). A new + assigned row reads
  `👤 [new] #N <title> … assigned to you`. This was the resolved design call —
  an earlier draft proposed a `$(sparkle)` icon swap, rejected because it would
  clobber the assignment icon and hide newness on exactly the rows that matter.
- **Robustness of the age parse** (`backlog-recency.ts`): `isRecentlyCreated` /
  `relativeAge` both guard `Date.parse` returning `NaN` (missing / empty /
  malformed `createdAt`) and defensively treat future timestamps as
  not-recent / `0s ago`. Malformed input yields no prefix and an unchanged
  url-only tooltip — no thrown error. Covered by tests.
- **Render-driven, not timer-driven**: the marker recomputes only when the
  Backlog tree re-renders (SSE-driven `OverviewCache.onDidChange`, or a config
  refresh). There is no 24h `setTimeout`; an item drops `[new]` on the next
  refresh after crossing the threshold. This matches the issue's acceptance
  criterion #3 ("lose the marker on the next refresh") and was explicitly
  confirmed with the reviewer at the gate.
- **Duplicated relative-time format**: `relativeAge` re-implements the ~6-line
  tiered format from `view-artifact.ts:135` rather than importing it, because
  that helper lives in a vscode-dependent module and hardcodes `Date.now()`
  (not injectable for deterministic tests). The format strings match so wording
  stays consistent. A future consolidation could extract a shared
  `now`-injectable formatter, but that was out of scope here.

## How to Test Locally

This is a VSCode **extension UI** change (the Backlog tree in the Codev
sidebar), so verify it in the Extension Development Host rather than a web dev
server:

1. **View diff**: VSCode sidebar → right-click builder `pir-930` → **View Diff**.
2. **Build the extension**: from the worktree, `pnpm --filter @cluesmith/codev-core build`
   and `pnpm --filter @cluesmith/codev-types build` (subpath deps), then in
   `packages/vscode` run `pnpm compile`.
3. **Launch the Extension Development Host**: open `packages/vscode` in VSCode
   and press **F5** (Run → Start Debugging), or pick the "Run Extension" launch
   config. A second VSCode window opens with the dev build of the extension.
4. **Open the Backlog tree**: in the EDH window, open the Codev sidebar and
   expand the **Backlog** view (connect it to a Tower workspace if prompted, so
   real backlog items load).
5. **What to verify**:
  - A freshly-filed issue (< 24h) leads with `[new]` before its `#id`; hovering
    shows `Created <Xh ago>`.
  - A new issue **assigned to you** keeps its `account` icon **and** shows
    `[new]` plus the `assigned to you` description (the primary goal).
  - An older issue renders unchanged (no `[new]`); its tooltip still shows
    `Created <Xd ago>`.
  - Mine-only toggle (#809), area grouping (#811), and the title-count
    formatter (#911) all still render correctly with `[new]` prefixes present.
  - An issue with missing/malformed `createdAt` renders with no prefix and a
    url-only tooltip — no error.
