### PR TITLE
vscode: lint rule banning bare vscode.commands.registerCommand (enforce #791)

### DIFF
--- a/codev/plans/956-vscode-lint-rule-banning-bare-.md
+++ b/codev/plans/956-vscode-lint-rule-banning-bare-.md
@@ -77,6 +77,20 @@ The `--` suffix on each disable comment is ESLint's built-in description syntax,
 
 No production logic changes. No bundle change (comments and lint config don't ship). Net diff well under 50 LOC.
 
+## Enforcement scope (decided)
+
+CI does **not** lint `packages/vscode` today — none of the four workflows
+(`test.yml`, `e2e.yml`, `dashboard-e2e.yml`, `post-release-e2e.yml`) run `pnpm lint`,
+build, or package the extension; they cover only `packages/core` and `packages/codev`.
+A bare `registerCommand` therefore will **not** fail a GitHub PR check.
+
+This is an accepted, deliberate boundary for #956 (confirmed with the reviewer): the rule
+is enforced via **`pnpm lint` locally and at VSIX packaging / publish time** — `pnpm package`
+(and `vscode:prepublish` → `pnpm package`) runs `check-types && lint && esbuild`, so a bare
+call blocks the extension from being packaged or published. Adding a vscode lint job to CI
+is explicitly **out of scope** here (would be a separate issue). The acceptance criterion
+"fails `pnpm lint`" is fully met.
+
 ## Risks & Alternatives Considered
 
 - **Risk — selector misses aliased forms.** The selector only matches the `vscode.commands.registerCommand(...)` member-expression. A contributor who does `const { registerCommand } = vscode.commands; registerCommand(...)` is not caught. Mitigation: accepted as out of scope — that form is contrived and unidiomatic in this codebase (zero instances today); the rule targets the realistic copy-paste regression. Documented here so it's a known limit, not a surprise.

--- a/codev/plans/956-vscode-lint-rule-banning-bare-.md
+++ b/codev/plans/956-vscode-lint-rule-banning-bare-.md
@@ -1,0 +1,98 @@
+# PIR Plan: Lint rule banning bare `vscode.commands.registerCommand`
+
+Issue: #956 — enforce the `reg`/`regCli` registrar convention from #791 with a lint rule.
+
+## Understanding
+
+#791 introduced two command registrars in `packages/vscode/src/extension.ts`:
+
+- `reg(id, handler)` — registers with no guard (CLI-independent commands)
+- `regCli(id, handler)` — wraps the handler in `guard()` (CLI-preflight + "run setup" toast)
+
+The registrar name at each call site *is* the guard policy. A future contributor who writes a bare `vscode.commands.registerCommand('codev.foo', …)` silently bypasses both guards, and the only review-time signal is grep. The issue asks for a lint rule that makes this a hard `pnpm lint` failure, with a message that names the helpers and cites #791.
+
+The issue suggests a built-in `no-restricted-syntax` selector rather than a custom rule package — zero extra plumbing, precise enough. I agree.
+
+### Investigation finding the issue did not anticipate
+
+The issue assumed bare `vscode.commands.registerCommand` exists in exactly two places — the two helper definitions in `extension.ts`. It does not. A repo grep of `packages/vscode/src/` finds **four** call sites:
+
+| File | Lines | What it is |
+|---|---|---|
+| `extension.ts` | 485, 487 | the `reg` / `regCli` helper definitions (the intended escape hatch) |
+| `comments/plan-review.ts` | 120, 131 | `codev.submitReviewComment` and `codev.deleteReviewComment`, registered in `registerPlanReviewComments()` — a **separate module** with no access to the `activate`-scoped `reg`/`regCli` closures |
+
+The two `plan-review.ts` commands are CLI-independent (they edit `<!-- REVIEW… -->` markers in local files; `submitReviewComment` reads an author handle from Tower's overview cache but **falls back to `"architect"`** when Tower hasn't fetched yet — it never hard-requires the CLI). They are effectively `reg`-style (unguarded) registrations that predate / sit outside the helper pattern.
+
+A repo-wide ban therefore flags four sites, not two. The plan must decide how to reconcile the two `plan-review.ts` sites — this is the one judgement call worth a gate.
+
+## Proposed Change
+
+Add a `no-restricted-syntax` rule to `packages/vscode/eslint.config.mjs` banning the `vscode.commands.registerCommand` member-call form, and place a visible `eslint-disable-next-line` escape hatch on each of the **four** legitimate existing call sites.
+
+Rationale for repo-wide (not `extension.ts`-scoped):
+- The whole point is to catch the *future* contributor, who may add a command in a new file, not just in `extension.ts`. Scoping to `extension.ts` would leave new modules unguarded — exactly the gap #791 is trying to close.
+- The two `plan-review.ts` calls are real, intentional, unguarded registrations. Making them visible escape hatches (with a one-line justification each) is *more* honest than hiding them behind a file-scoped rule — the next reader sees "yes, these bypass the helpers, on purpose, here's why."
+
+### Rule (added to the `rules` block in `eslint.config.mjs`)
+
+```js
+"no-restricted-syntax": ["error", {
+  selector:
+    "CallExpression[callee.object.object.name='vscode'][callee.object.property.name='commands'][callee.property.name='registerCommand']",
+  message:
+    "Use reg(...) or regCli(...) from extension.ts instead of bare vscode.commands.registerCommand — regCli adds the CLI-preflight guard (#791). If a registration legitimately can't use the helpers, add an eslint-disable-next-line with a one-line reason.",
+}],
+```
+
+Note: the config's existing rules are all `"warn"`. This rule is `"error"` deliberately — a silent guard-bypass is a correctness regression, not a style nit, and the acceptance criterion is that it **fails** `pnpm lint`. (`eslint src` exits non-zero on any error; warnings alone exit 0.)
+
+### Escape hatches (4 total)
+
+`extension.ts` — on the two helper definitions:
+```ts
+// eslint-disable-next-line no-restricted-syntax -- this IS the reg helper (#791)
+vscode.commands.registerCommand(id, handler);
+...
+// eslint-disable-next-line no-restricted-syntax -- this IS the regCli helper (#791)
+vscode.commands.registerCommand(id, guard(handler));
+```
+
+`comments/plan-review.ts` — on the two existing command registrations:
+```ts
+// eslint-disable-next-line no-restricted-syntax -- separate module, CLI-independent review-comment command (no access to extension.ts reg/regCli)
+vscode.commands.registerCommand(
+  'codev.submitReviewComment',
+  ...
+```
+(same for `codev.deleteReviewComment`).
+
+The `--` suffix on each disable comment is ESLint's built-in description syntax, so the *reason* travels with the escape hatch.
+
+## Files to Change
+
+- `packages/vscode/eslint.config.mjs` — add the `no-restricted-syntax` entry to the `rules` object (~5 lines).
+- `packages/vscode/src/extension.ts:484-487` — add two `eslint-disable-next-line` comments on the helper bodies.
+- `packages/vscode/src/comments/plan-review.ts:119-126,128-137` — add two `eslint-disable-next-line` comments on the existing registrations.
+
+No production logic changes. No bundle change (comments and lint config don't ship). Net diff well under 50 LOC.
+
+## Risks & Alternatives Considered
+
+- **Risk — selector misses aliased forms.** The selector only matches the `vscode.commands.registerCommand(...)` member-expression. A contributor who does `const { registerCommand } = vscode.commands; registerCommand(...)` is not caught. Mitigation: accepted as out of scope — that form is contrived and unidiomatic in this codebase (zero instances today); the rule targets the realistic copy-paste regression. Documented here so it's a known limit, not a surprise.
+- **Risk — `error` severity could block an unrelated lint run** if there were other latent `registerCommand` calls. Mitigation: the grep above is exhaustive (4 sites, all exempted); I'll re-run `pnpm lint` after the change to confirm a clean pass.
+- **Alternative — scope the rule to `extension.ts` only** (via a `files: ["**/extension.ts"]` override). Rejected: leaves new modules (and the existing `plan-review.ts`) unguarded, defeating the future-proofing goal. The acceptance criterion explicitly says "anywhere in `packages/vscode/src/`".
+- **Alternative — refactor `plan-review.ts` to import shared `reg`/`regCli`.** Rejected for this issue: `reg`/`regCli` are closures inside `activate()` (they capture `isCliReady`, `guard`, `showSetupRequiredToast`). Exporting them means extracting a registrar factory — a real refactor with its own blast radius, and it would change whether those two commands become guarded (a runtime-behavior change the issue forbids). The visible escape hatch is the minimal, in-scope reconciliation. Worth a follow-up issue if we want every command funneled through the helpers.
+- **Alternative — full custom ESLint rule package.** Rejected per the issue: `no-restricted-syntax` is built-in and precise enough; a custom plugin is overkill.
+
+## Test Plan
+
+Acceptance is verifiable purely via `pnpm lint` (no runtime/UI to exercise — this is config + comments).
+
+- **Baseline**: `cd packages/vscode && pnpm lint` exits 0 after the change (the four exemptions keep it clean).
+- **Negative test (proves the rule bites)**: temporarily add `vscode.commands.registerCommand('codev.foo', () => {});` to a `src/` file → `pnpm lint` exits non-zero with the #791 message → remove it. I'll do this transiently during implement and report the exact error output in the dev-approval summary (it will **not** be committed).
+- **Positive test (proves helpers lint clean)**: temporarily add `reg('codev.foo', () => {})` → `pnpm lint` stays clean → remove it.
+- **Helper sites still clean**: confirm the two `extension.ts` helpers and the two `plan-review.ts` commands produce no lint error.
+- **No bundle change**: `node esbuild.js` (or `pnpm compile`) output is byte-unaffected by comments/lint config; `pnpm check-types` still passes.
+
+Manual / cross-platform: none — no UI, no runtime path touched.

--- a/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
+++ b/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-06-02T00:05:06.891Z'
+    approved_at: '2026-06-02T00:22:50.800Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-02T00:02:08.542Z'
-updated_at: '2026-06-02T00:05:06.892Z'
+updated_at: '2026-06-02T00:22:50.800Z'

--- a/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
+++ b/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-06-02T00:05:06.891Z'
     approved_at: '2026-06-02T00:22:50.800Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-06-02T00:26:02.253Z'
+    approved_at: '2026-06-02T00:46:17.012Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-02T00:02:08.542Z'
-updated_at: '2026-06-02T00:26:02.254Z'
+updated_at: '2026-06-02T00:46:17.013Z'

--- a/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
+++ b/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-06-02T00:46:17.012Z'
   pr:
     status: pending
+    requested_at: '2026-06-02T00:49:34.927Z'
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-06-02T00:02:08.542Z'
-updated_at: '2026-06-02T00:48:03.467Z'
+updated_at: '2026-06-02T00:49:34.928Z'
 pr_history:
   - phase: review
     pr_number: 958
     branch: builder/pir-956
     created_at: '2026-06-02T00:47:53.541Z'
+pr_ready_for_human: true

--- a/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
+++ b/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-06-02T00:22:50.800Z'
   dev-approval:
     status: pending
+    requested_at: '2026-06-02T00:26:02.253Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-02T00:02:08.542Z'
-updated_at: '2026-06-02T00:22:56.107Z'
+updated_at: '2026-06-02T00:26:02.254Z'

--- a/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
+++ b/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-02T00:02:08.542Z'
-updated_at: '2026-06-02T00:46:30.976Z'
+updated_at: '2026-06-02T00:47:53.542Z'
+pr_history:
+  - phase: review
+    pr_number: 958
+    branch: builder/pir-956
+    created_at: '2026-06-02T00:47:53.541Z'

--- a/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
+++ b/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
@@ -1,0 +1,18 @@
+id: '956'
+title: vscode-lint-rule-banning-bare-
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-06-02T00:02:08.542Z'
+updated_at: '2026-06-02T00:02:08.542Z'

--- a/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
+++ b/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-06-02T00:02:08.542Z'
-updated_at: '2026-06-02T00:47:53.542Z'
+updated_at: '2026-06-02T00:48:03.467Z'
 pr_history:
   - phase: review
     pr_number: 958

--- a/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
+++ b/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-06-02T00:05:06.891Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-02T00:02:08.542Z'
-updated_at: '2026-06-02T00:02:08.542Z'
+updated_at: '2026-06-02T00:05:06.892Z'

--- a/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
+++ b/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
@@ -1,7 +1,7 @@
 id: '956'
 title: vscode-lint-rule-banning-bare-
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-02T00:02:08.542Z'
-updated_at: '2026-06-02T00:22:50.800Z'
+updated_at: '2026-06-02T00:22:56.107Z'

--- a/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
+++ b/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
@@ -1,7 +1,7 @@
 id: '956'
 title: vscode-lint-rule-banning-bare-
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-02T00:02:08.542Z'
-updated_at: '2026-06-02T00:46:17.013Z'
+updated_at: '2026-06-02T00:46:30.976Z'

--- a/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
+++ b/codev/projects/956-vscode-lint-rule-banning-bare-/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-06-02T00:26:02.253Z'
     approved_at: '2026-06-02T00:46:17.012Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-06-02T00:49:34.927Z'
+    approved_at: '2026-06-02T00:51:38.946Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-02T00:02:08.542Z'
-updated_at: '2026-06-02T00:49:34.928Z'
+updated_at: '2026-06-02T00:51:38.948Z'
 pr_history:
   - phase: review
     pr_number: 958
     branch: builder/pir-956
     created_at: '2026-06-02T00:47:53.541Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/reviews/956-vscode-lint-rule-banning-bare-.md
+++ b/codev/reviews/956-vscode-lint-rule-banning-bare-.md
@@ -1,0 +1,56 @@
+# PIR Review: Lint rule banning bare `vscode.commands.registerCommand`
+
+Fixes #956
+
+## Summary
+
+Adds a built-in `no-restricted-syntax` ESLint rule to `packages/vscode/eslint.config.mjs` that bans bare `vscode.commands.registerCommand(...)` calls, enforcing the `reg`/`regCli` registrar convention introduced in #791. The rule fires at `error` severity so a bare call fails `pnpm lint` (and therefore `pnpm compile` / `pnpm package`); the four legitimate existing call sites opt out with inline `eslint-disable-next-line … -- <reason>` comments. This closes a silent-regression class: a future contributor who registers a command the old way would otherwise bypass the CLI-preflight guard `regCli` provides, with grep as the only review-time signal.
+
+## Files Changed
+
+- `packages/vscode/eslint.config.mjs` (+12 / -0) — the `no-restricted-syntax` rule
+- `packages/vscode/src/extension.ts` (+2 / -0) — `eslint-disable-next-line` on the two `reg`/`regCli` helper definitions
+- `packages/vscode/src/comments/plan-review.ts` (+2 / -0) — `eslint-disable-next-line` on the two CLI-independent review-comment commands
+
+## Commits
+
+- `d3d700bc` [PIR #956] Add no-restricted-syntax rule banning bare vscode.commands.registerCommand
+- `6beca0ce` [PIR #956] Reword plan-review disable reasons to lead with policy (intentionally unguarded)
+
+(Plus thread-file updates and porch phase-transition commits.)
+
+## Test Results
+
+- `npm run build` (root → core + codev): ✓ pass (porch gate check, 6.8s)
+- `npm test` (codev): ✓ pass (porch gate check, 20.7s)
+- `packages/vscode` `pnpm lint`: ✓ clean with all four exemptions
+- `packages/vscode` `pnpm check-types`: ✓ pass (after building core/types — see "Things to Look At")
+- `node esbuild.js`: ✓ bundle builds; no shipped-bundle change (comments + lint config don't ship)
+- **Rule-bites verification** (transient probe files, not committed):
+  - Negative: a bare `vscode.commands.registerCommand('codev.foo', …)` → `1 error` at the call site with the #791 message → confirms enforcement.
+  - Positive: `reg('codev.foo', …)` → lints clean → confirms the helpers are allowed.
+- Manual verification (human, dev-approval gate): reviewed the running worktree; approved.
+
+## Architecture Updates
+
+No `arch.md` changes needed — this PR adds a lint guardrail around an existing, already-documented pattern (the #791 `reg`/`regCli` registrar split). It introduces no new module boundary, data flow, or architectural concept; it only mechanically enforces a convention that already exists in the codebase.
+
+## Lessons Learned Updates
+
+No `lessons-learned.md` update needed — the change is a small, self-contained lint addition. One worth-noting-but-not-durable observation (recorded here, not promoted to `lessons-learned.md` to keep it lean): a repo-wide AST selector surfaces *every* real call site, including ones outside the convention's home module. Here it revealed two `registerCommand` calls in `comments/plan-review.ts` that the issue hadn't anticipated. The honest reconciliation was a visible `eslint-disable-next-line … -- <policy reason>` per site rather than silently scoping the rule to `extension.ts` (which would have left new files unguarded) — the escape hatch documents intent at the call site instead of hiding the exception in config.
+
+## Things to Look At During PR Review
+
+- **The two `plan-review.ts` exemptions** are the only non-obvious part. These commands (`codev.submitReviewComment`, `codev.deleteReviewComment`) live in a separate module from `activate()`, so they can't reach the `activate`-scoped `reg`/`regCli` closures. They're intentionally unguarded (CLI-independent local-file edits), so the disable comments lead with that policy rather than the mechanical "no access". Refactoring them to share the helpers was rejected as out of scope — it would change whether they're guarded (a runtime-behavior change #956 forbids).
+- **Severity is `error`, not `warn`** like the rest of the config — deliberate, because the acceptance criterion is that a bare call *fails* lint (`eslint` exits 0 on warnings).
+- **Enforcement is local + packaging-time, not CI**: no GitHub workflow lints `packages/vscode`, so a bad PR won't fail a GitHub check — it fails `pnpm lint` / `pnpm package` locally and at VSIX publish. Confirmed sufficient with the reviewer; a CI lint job is explicitly out of scope (possible follow-up).
+- **Known selector limitation**: only the `vscode.commands.registerCommand(...)` member form is matched. An aliased form (`const { registerCommand } = vscode.commands`) would not be caught — accepted, since there are zero such instances today and the form is unidiomatic here.
+
+## How to Test Locally
+
+- **View diff**: VSCode sidebar → right-click builder pir-956 → **View Diff**
+- **What to verify** (maps to the plan's Test Plan):
+  - `cd packages/vscode && pnpm lint` → clean (exit 0)
+  - Add `vscode.commands.registerCommand('codev.foo', () => {});` to any `src/` file → `pnpm lint` fails with the #791 message → remove it
+  - Add `reg('codev.foo', () => {})` instead → lints clean
+- The change is config + comments only — no dev server needed to exercise it.

--- a/codev/state/pir-956_thread.md
+++ b/codev/state/pir-956_thread.md
@@ -64,3 +64,8 @@ Wrote `codev/reviews/956-vscode-lint-rule-banning-bare-.md` (retrospective, beco
 No arch.md / lessons-learned.md changes (lint guardrail around existing #791 pattern; sections
 explain why). Next: PR, record with porch, `porch done` triggers single-pass 3-way consult,
 then pr gate.
+
+PR #958 opened. 3-way consult (single advisory pass) all clear:
+gemini=APPROVE, codex=APPROVE, claude=APPROVE — KEY_ISSUES: None on all three.
+Architect notified. **At `pr` gate** — waiting for human merge approval. Merge is gated by
+porch state (gate_status: approved), never typed prose.

--- a/codev/state/pir-956_thread.md
+++ b/codev/state/pir-956_thread.md
@@ -54,4 +54,13 @@ Verification:
 Note for porch checks: root `npm run build` / `npm test` target core+codev, not vscode, so
 they pass independent of this change. The real verification for this change is vscode `pnpm lint`.
 
-Awaiting dev-approval gate.
+Dev-approval gate: APPROVED (after rewording plan-review disable reasons to lead with
+policy — "intentionally unguarded: CLI-independent command" rather than "no access to
+reg/regCli").
+
+## Review phase
+
+Wrote `codev/reviews/956-vscode-lint-rule-banning-bare-.md` (retrospective, becomes PR body).
+No arch.md / lessons-learned.md changes (lint guardrail around existing #791 pattern; sections
+explain why). Next: PR, record with porch, `porch done` triggers single-pass 3-way consult,
+then pr gate.

--- a/codev/state/pir-956_thread.md
+++ b/codev/state/pir-956_thread.md
@@ -1,0 +1,28 @@
+# PIR #956 — vscode lint rule banning bare `vscode.commands.registerCommand`
+
+## Plan phase
+
+Issue asks for a `no-restricted-syntax` ESLint rule enforcing the #791 `reg`/`regCli`
+registrar convention.
+
+**Key investigation finding the issue missed**: bare `vscode.commands.registerCommand`
+exists at **four** sites in `packages/vscode/src/`, not two:
+- `extension.ts:485,487` — the `reg`/`regCli` helper definitions (expected escape hatch)
+- `comments/plan-review.ts:120,131` — `codev.submitReviewComment` / `codev.deleteReviewComment`,
+  registered in a separate module with no access to the `activate`-scoped helpers. They're
+  CLI-independent (local-file review-marker commands, graceful Tower fallback).
+
+Plan decision: repo-wide ban + 4 visible `eslint-disable-next-line ... -- reason` escape
+hatches (2 helpers + 2 plan-review commands). Rejected `extension.ts`-only scoping (leaves
+new modules unguarded) and refactoring plan-review.ts to share the helpers (closure capture
++ would change guard behavior = runtime change the issue forbids). Flagged the 2 extra
+exemptions for human review at the plan-approval gate.
+
+Rule severity = `error` (not `warn` like the rest of the config) so `pnpm lint` actually fails.
+
+Plan file: `codev/plans/956-vscode-lint-rule-banning-bare-.md` (exact name required by
+`plan_exists` check: `test -f codev/plans/${PROJECT_TITLE}.md`).
+
+`pnpm install` run (node_modules was missing in fresh worktree) so implement phase can run lint.
+
+Awaiting plan-approval gate.

--- a/codev/state/pir-956_thread.md
+++ b/codev/state/pir-956_thread.md
@@ -25,4 +25,9 @@ Plan file: `codev/plans/956-vscode-lint-rule-banning-bare-.md` (exact name requi
 
 `pnpm install` run (node_modules was missing in fresh worktree) so implement phase can run lint.
 
+**CI check**: confirmed no workflow lints/builds/packages `packages/vscode` (test.yml covers
+core+codev only). Reviewer confirmed lint-only enforcement is enough — NO CI job added.
+Enforcement = local `pnpm lint` + VSIX packaging/publish gate (`pnpm package` runs lint).
+Documented as deliberate scope boundary in the plan's "Enforcement scope" section.
+
 Awaiting plan-approval gate.

--- a/codev/state/pir-956_thread.md
+++ b/codev/state/pir-956_thread.md
@@ -30,4 +30,28 @@ core+codev only). Reviewer confirmed lint-only enforcement is enough — NO CI j
 Enforcement = local `pnpm lint` + VSIX packaging/publish gate (`pnpm package` runs lint).
 Documented as deliberate scope boundary in the plan's "Enforcement scope" section.
 
-Awaiting plan-approval gate.
+Plan-approval gate: APPROVED.
+
+## Implement phase
+
+Applied 3 edits per plan:
+- `eslint.config.mjs` — `no-restricted-syntax` rule (`error` severity), selector on
+  `vscode.commands.registerCommand`, message names reg/regCli + cites #791.
+- `extension.ts:484-489` — 2 `eslint-disable-next-line ... -- this IS the reg/regCli helper (#791)`.
+- `comments/plan-review.ts` — 2 `eslint-disable-next-line ... -- CLI-independent review-comment command in a separate module`.
+
+Verification:
+- `pnpm lint` → clean (exit 0) with all 4 exemptions.
+- Negative probe (transient temp file, removed): bare `registerCommand` → 1 error at the
+  call site with the #791 message. Positive probe `reg(...)` → clean. Confirms the rule bites
+  only unjustified bare calls.
+- `pnpm check-types` → clean (after building core+types first; the fresh-worktree failures
+  were all pre-existing `@cluesmith/codev-core/workspace` missing-module + implicit-any in
+  `views/*.ts`, none in files I touched — NOT my change).
+- `node esbuild.js` → bundle builds clean. No bundle content change (comments + lint config
+  don't ship).
+
+Note for porch checks: root `npm run build` / `npm test` target core+codev, not vscode, so
+they pass independent of this change. The real verification for this change is vscode `pnpm lint`.
+
+Awaiting dev-approval gate.

--- a/packages/vscode/eslint.config.mjs
+++ b/packages/vscode/eslint.config.mjs
@@ -23,5 +23,17 @@ export default [{
         eqeqeq: "warn",
         "no-throw-literal": "warn",
         semi: "warn",
+
+        // Enforce the #791 command-registrar convention: every VS Code command
+        // must register through `reg(...)` (no guard) or `regCli(...)` (CLI-preflight
+        // guard) from extension.ts, never a bare `vscode.commands.registerCommand`.
+        // A bare call silently bypasses the guard. `error` (not `warn`) so it fails
+        // `pnpm lint` / `pnpm compile` / `pnpm package`. Legitimate low-level call
+        // sites (the two helper definitions; CLI-independent registrations in
+        // separate modules) opt out with `eslint-disable-next-line ... -- <reason>`.
+        "no-restricted-syntax": ["error", {
+            selector: "CallExpression[callee.object.object.name='vscode'][callee.object.property.name='commands'][callee.property.name='registerCommand']",
+            message: "Use reg(...) or regCli(...) from extension.ts instead of bare vscode.commands.registerCommand — regCli adds the CLI-preflight guard (#791). If a registration legitimately can't use the helpers, add an eslint-disable-next-line with a one-line reason.",
+        }],
     },
 }];

--- a/packages/vscode/src/comments/plan-review.ts
+++ b/packages/vscode/src/comments/plan-review.ts
@@ -117,6 +117,7 @@ export function activateReviewComments(
 
   // Command: submit a new review comment from an empty thread.
   context.subscriptions.push(
+    // eslint-disable-next-line no-restricted-syntax -- CLI-independent review-comment command in a separate module (no access to extension.ts reg/regCli)
     vscode.commands.registerCommand(
       'codev.submitReviewComment',
       async (reply: vscode.CommentReply) => {
@@ -128,6 +129,7 @@ export function activateReviewComments(
   // Command: delete an inline review comment (removes the `<!-- REVIEW... -->`
   // line from the file).
   context.subscriptions.push(
+    // eslint-disable-next-line no-restricted-syntax -- CLI-independent review-comment command in a separate module (no access to extension.ts reg/regCli)
     vscode.commands.registerCommand(
       'codev.deleteReviewComment',
       async (thread: vscode.CommentThread) => {

--- a/packages/vscode/src/comments/plan-review.ts
+++ b/packages/vscode/src/comments/plan-review.ts
@@ -117,7 +117,7 @@ export function activateReviewComments(
 
   // Command: submit a new review comment from an empty thread.
   context.subscriptions.push(
-    // eslint-disable-next-line no-restricted-syntax -- CLI-independent review-comment command in a separate module (no access to extension.ts reg/regCli)
+    // eslint-disable-next-line no-restricted-syntax -- intentionally unguarded: CLI-independent command (edits local review markers), so no regCli guard is wanted (#791)
     vscode.commands.registerCommand(
       'codev.submitReviewComment',
       async (reply: vscode.CommentReply) => {
@@ -129,7 +129,7 @@ export function activateReviewComments(
   // Command: delete an inline review comment (removes the `<!-- REVIEW... -->`
   // line from the file).
   context.subscriptions.push(
-    // eslint-disable-next-line no-restricted-syntax -- CLI-independent review-comment command in a separate module (no access to extension.ts reg/regCli)
+    // eslint-disable-next-line no-restricted-syntax -- intentionally unguarded: CLI-independent command (edits local review markers), so no regCli guard is wanted (#791)
     vscode.commands.registerCommand(
       'codev.deleteReviewComment',
       async (thread: vscode.CommentThread) => {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -482,8 +482,10 @@ export async function activate(context: vscode.ExtensionContext) {
 			return undefined;
 		};
 	const reg = <A extends unknown[]>(id: string, handler: (...args: A) => unknown) =>
+		// eslint-disable-next-line no-restricted-syntax -- this IS the reg helper (#791)
 		vscode.commands.registerCommand(id, handler);
 	const regCli = <A extends unknown[]>(id: string, handler: (...args: A) => unknown) =>
+		// eslint-disable-next-line no-restricted-syntax -- this IS the regCli helper (#791)
 		vscode.commands.registerCommand(id, guard(handler));
 
 	// Commands


### PR DESCRIPTION
# PIR Review: Lint rule banning bare `vscode.commands.registerCommand`

Fixes #956

## Summary

Adds a built-in `no-restricted-syntax` ESLint rule to `packages/vscode/eslint.config.mjs` that bans bare `vscode.commands.registerCommand(...)` calls, enforcing the `reg`/`regCli` registrar convention introduced in #791. The rule fires at `error` severity so a bare call fails `pnpm lint` (and therefore `pnpm compile` / `pnpm package`); the four legitimate existing call sites opt out with inline `eslint-disable-next-line … -- <reason>` comments. This closes a silent-regression class: a future contributor who registers a command the old way would otherwise bypass the CLI-preflight guard `regCli` provides, with grep as the only review-time signal.

## Files Changed

- `packages/vscode/eslint.config.mjs` (+12 / -0) — the `no-restricted-syntax` rule
- `packages/vscode/src/extension.ts` (+2 / -0) — `eslint-disable-next-line` on the two `reg`/`regCli` helper definitions
- `packages/vscode/src/comments/plan-review.ts` (+2 / -0) — `eslint-disable-next-line` on the two CLI-independent review-comment commands

## Commits

- `d3d700bc` [PIR #956] Add no-restricted-syntax rule banning bare vscode.commands.registerCommand
- `6beca0ce` [PIR #956] Reword plan-review disable reasons to lead with policy (intentionally unguarded)

(Plus thread-file updates and porch phase-transition commits.)

## Test Results

- `npm run build` (root → core + codev): ✓ pass (porch gate check, 6.8s)
- `npm test` (codev): ✓ pass (porch gate check, 20.7s)
- `packages/vscode` `pnpm lint`: ✓ clean with all four exemptions
- `packages/vscode` `pnpm check-types`: ✓ pass (after building core/types — see "Things to Look At")
- `node esbuild.js`: ✓ bundle builds; no shipped-bundle change (comments + lint config don't ship)
- **Rule-bites verification** (transient probe files, not committed):
  - Negative: a bare `vscode.commands.registerCommand('codev.foo', …)` → `1 error` at the call site with the #791 message → confirms enforcement.
  - Positive: `reg('codev.foo', …)` → lints clean → confirms the helpers are allowed.
- Manual verification (human, dev-approval gate): reviewed the running worktree; approved.

## Architecture Updates

No `arch.md` changes needed — this PR adds a lint guardrail around an existing, already-documented pattern (the #791 `reg`/`regCli` registrar split). It introduces no new module boundary, data flow, or architectural concept; it only mechanically enforces a convention that already exists in the codebase.

## Lessons Learned Updates

No `lessons-learned.md` update needed — the change is a small, self-contained lint addition. One worth-noting-but-not-durable observation (recorded here, not promoted to `lessons-learned.md` to keep it lean): a repo-wide AST selector surfaces *every* real call site, including ones outside the convention's home module. Here it revealed two `registerCommand` calls in `comments/plan-review.ts` that the issue hadn't anticipated. The honest reconciliation was a visible `eslint-disable-next-line … -- <policy reason>` per site rather than silently scoping the rule to `extension.ts` (which would have left new files unguarded) — the escape hatch documents intent at the call site instead of hiding the exception in config.

## Things to Look At During PR Review

- **The two `plan-review.ts` exemptions** are the only non-obvious part. These commands (`codev.submitReviewComment`, `codev.deleteReviewComment`) live in a separate module from `activate()`, so they can't reach the `activate`-scoped `reg`/`regCli` closures. They're intentionally unguarded (CLI-independent local-file edits), so the disable comments lead with that policy rather than the mechanical "no access". Refactoring them to share the helpers was rejected as out of scope — it would change whether they're guarded (a runtime-behavior change #956 forbids).
- **Severity is `error`, not `warn`** like the rest of the config — deliberate, because the acceptance criterion is that a bare call *fails* lint (`eslint` exits 0 on warnings).
- **Enforcement is local + packaging-time, not CI**: no GitHub workflow lints `packages/vscode`, so a bad PR won't fail a GitHub check — it fails `pnpm lint` / `pnpm package` locally and at VSIX publish. Confirmed sufficient with the reviewer; a CI lint job is explicitly out of scope (possible follow-up).
- **Known selector limitation**: only the `vscode.commands.registerCommand(...)` member form is matched. An aliased form (`const { registerCommand } = vscode.commands`) would not be caught — accepted, since there are zero such instances today and the form is unidiomatic here.

## How to Test Locally

- **View diff**: VSCode sidebar → right-click builder pir-956 → **View Diff**
- **What to verify** (maps to the plan's Test Plan):
  - `cd packages/vscode && pnpm lint` → clean (exit 0)
  - Add `vscode.commands.registerCommand('codev.foo', () => {});` to any `src/` file → `pnpm lint` fails with the #791 message → remove it
  - Add `reg('codev.foo', () => {})` instead → lints clean
- The change is config + comments only — no dev server needed to exercise it.
