### PR TITLE
VSCode: area-header roll-up icons in Backlog & Builders views

### DIFF
--- a/codev/plans/926-vscode-area-header-roll-up-ico.md
+++ b/codev/plans/926-vscode-area-header-roll-up-ico.md
@@ -34,14 +34,14 @@ but the rollup *function* differs per view because the children differ:
   green filled dot vs. grey outline dot.
 - **Builders children are builders** → worst-of-three rollup over the three
   builder-row states (blocked / idle / active), reusing the exact icons + color
-  tokens already on individual builder rows (`builders.ts:206-210`).
+  tokens already on individual builder rows (`builders.ts:202-206`).
 
 No new colors or glyphs are introduced — every icon keeps its single existing
 meaning. The detail (counts) lives in the header tooltip.
 
 This is purely a VSCode-extension, client-side change. The overview payload
-already carries `builders[]` (each with `.area`, `api.ts:182`) alongside
-`backlog[]` (each with `.area`, `api.ts:222`), so both rollups are computed in
+already carries `builders[]` (each with `.area`, `api.ts:197`) alongside
+`backlog[]` (each with `.area`, `api.ts:237`), so both rollups are computed in
 the tree providers from data already in the `OverviewCache`. No server /
 overview-payload change is needed.
 
@@ -69,18 +69,35 @@ targets.
 
 In `builders.ts`, the provider already knows each group's builders and already
 classifies `isBlocked` / `isIdle` per builder (via `isIdleWaiting`,
-`builders.ts:168`). Compute a `{ blocked, idle, active }` count triple per group
+`builders.ts:169`). Compute a `{ blocked, idle, active }` count triple per group
 and pass it into `BuilderGroupTreeItem`; the subclass picks the **worst** state
-present and reuses the row icons from `builders.ts:206-210`:
+present:
 
 | If the area has… | Icon | Color token |
 |---|---|---|
-| any **blocked** builder | `bell` | `notificationsWarningIcon.foreground` (yellow) |
+| any **blocked** builder | `bell` (generic "attention pending") | `notificationsWarningIcon.foreground` (yellow) |
 | else any **idle/silent** builder | `comment-discussion` | `notificationsInfoIcon.foreground` (blue) |
 | else (all active) | `circle-filled` | `testing.iconPassed` (green) |
 
-This matches the existing within-group sort order (blocked → idle → active), so
-the header icon always equals the topmost row's icon in the group.
+**Note on the blocked icon (drift caught at rebase):** individual *blocked rows*
+no longer use a fixed `bell` — `builders.ts:203` now calls
+`gateIconFor(b.blockedGate)` (`builder-row.ts:35`), which maps each gate to a
+distinct shape (`book` / `checklist` / `code` / `git-pull-request` / `verified`,
+`bell` fallback) while holding the color uniform warning-yellow ("shape = which
+review, color = the constant attention signal"). The **group header
+deliberately uses the generic `bell`**, not `gateIconFor` of any one builder: a
+group can hold several blocked builders at *different* gates, so surfacing one
+builder's gate shape on the header would misread (it'd look like the whole area
+needs a plan review when only one builder does). The yellow color is the
+group-level signal; the specific gate shapes live on the rows when expanded.
+Consequence: for a blocked group the header icon (`bell`) intentionally **does
+not** pixel-match the topmost row's gate-specific icon — that earlier "header
+equals the top row" claim is dropped. The idle (`comment-discussion`) and active
+(`circle-filled`) headers still match their rows exactly, since those row icons
+aren't per-builder-specific.
+
+The worst-of ordering still mirrors the within-group sort (blocked → idle →
+active), so the header's *severity* always matches the topmost row's severity.
 
 Tooltip: `"<b> blocked · <i> waiting · <a> active"` — all three segments shown
 (matching the issue's example) so the format is predictable regardless of which
@@ -93,48 +110,58 @@ the consistency the scope decision is built on.
 
 ### Rollup logic placement & testability
 
-Mirror the existing exported-pure-helper pattern (`orderForDisplay`,
-`spawnableBacklog`) that's unit-tested directly:
+Put each rollup as a **pure, vscode-free helper** in the existing
+vscode-free modules so it's unit-testable under the lighter vitest `__tests__/`
+harness — the established pattern (`backlog-filter.ts` and `builder-row.ts`
+exist for exactly this reason; `spawnableBacklog`, `gateIconFor`, and
+`builderRowLabel` already live there and are tested under
+`__tests__/backlog-filter.test.ts` / `__tests__/builder-row.test.ts`):
 
-- `backlog.ts` — add exported `activeBuilderCountByArea(builders): Map<string, number>`.
-- `builders.ts` — add exported `rollupGroupState(builders, now): { blocked: number; idle: number; active: number }` (reuses `isIdleWaiting`).
+- `backlog-filter.ts` — add `activeBuilderCountByArea(builders): Map<string, number>`.
+- `builder-row.ts` — add `rollupGroupState(builders, now): { blocked: number; idle: number; active: number }` (reuses `isIdleWaiting` from `@cluesmith/codev-core`, already vscode-free).
 
-The providers call these and feed the result into the subclass constructors. The
-**icon/tooltip assignment lives in the subclasses** (`BacklogGroupTreeItem`,
-`BuilderGroupTreeItem`), per the issue's explicit instruction — *not* in the
-shared `AreaGroupTreeItem` base, because the rollup differs per view.
+The providers (`backlog.ts`, `builders.ts`) import these and feed the result
+into the subclass constructors. The **icon/tooltip assignment lives in the
+subclasses** (`BacklogGroupTreeItem`, `BuilderGroupTreeItem`), per the issue's
+explicit instruction — *not* in the shared `AreaGroupTreeItem` base, because the
+rollup differs per view.
 
 Both providers' degenerate single-`Uncategorized` flatten branch renders no
 headers, so it needs no rollup and is untouched.
 
 ## Files to Change
 
+- `packages/vscode/src/views/backlog-filter.ts` (vscode-free)
+  - Add `activeBuilderCountByArea(builders: OverviewBuilder[]): Map<string, number>`.
 - `packages/vscode/src/views/backlog.ts`
-  - Add exported `activeBuilderCountByArea(builders: OverviewBuilder[]): Map<string, number>`.
-  - In `rootChildren()` (L96-102), compute the map once from `data.builders` and
-    pass each group's count into
+  - In `rootChildren()` (L96-103), call `activeBuilderCountByArea(data.builders)`
+    once and pass each group's count into
     `new BacklogGroupTreeItem(g.area, g.items.length, state, activeCount)`.
 - `packages/vscode/src/views/backlog-tree-item.ts`
   - `BacklogGroupTreeItem` constructor gains `activeBuilderCount: number`; sets
     `this.iconPath` (circle-filled/green vs circle-outline/grey) and
     `this.tooltip`.
+- `packages/vscode/src/views/builder-row.ts` (vscode-free)
+  - Add `rollupGroupState(builders: OverviewBuilder[], now: number): { blocked: number; idle: number; active: number }` (reuses `isIdleWaiting`).
 - `packages/vscode/src/views/builders.ts`
-  - Add exported `rollupGroupState(builders, now): { blocked; idle; active }`.
-  - In `rootChildren()` (L141-151), compute the triple per group and pass into
+  - In `rootChildren()` (L140-152), call `rollupGroupState(g.items, now)` per
+    group and pass the triple into
     `new BuilderGroupTreeItem(g.area, g.items.length, state, rollup)`.
 - `packages/vscode/src/views/builder-tree-item.ts`
   - `BuilderGroupTreeItem` constructor gains the rollup-counts param; sets
-    `this.iconPath` (worst-of bell/comment-discussion/circle-filled) and
-    `this.tooltip`.
+    `this.iconPath` (worst-of `bell`/`comment-discussion`/`circle-filled` — the
+    blocked case uses the generic `bell`, not `gateIconFor`; see the Builders
+    subsection) and `this.tooltip`.
 - `packages/vscode/src/views/area-group-tree-item.ts` — **no change** (rollup
   stays in subclasses, per the issue).
-- Tests:
-  - `packages/vscode/src/test/backlog.test.ts` — unit-test
+- Tests (vitest, under `src/__tests__/`):
+  - `packages/vscode/src/__tests__/backlog-filter.test.ts` — unit-test
     `activeBuilderCountByArea` (empty, single area, multi-area, multiple builders
     same area summed, Uncategorized).
-  - `packages/vscode/src/test/builders.test.ts` — unit-test `rollupGroupState`
-    (all-active → active; one idle → idle beats active; one blocked → blocked
-    beats idle+active; mixed → counts correct).
+  - `packages/vscode/src/__tests__/builder-row.test.ts` — unit-test
+    `rollupGroupState` (all-active → active; one idle → idle beats active; one
+    blocked → blocked beats idle+active; mixed → counts correct). This file
+    already exists (tests `gateIconFor` / `builderRowLabel`) — extend it.
 
 ## Risks & Alternatives Considered
 
@@ -172,21 +199,26 @@ headers, so it needs no rollup and is untouched.
 
 ## Test Plan
 
-- **Unit (the existing `src/test` suite):**
+- **Unit (vitest `__tests__/` harness):**
   - `activeBuilderCountByArea`: empty → empty map; two areas → correct per-area
     counts; multiple builders same area → summed; Uncategorized counted.
   - `rollupGroupState`: all active → `{0,0,n}`; one idle → idle beats active;
     one blocked → blocked beats idle+active; mix → counts correct.
-  - Run: `cd packages/vscode && pnpm test`.
-- **Build:** `pnpm --filter @cluesmith/codev-vscode build` (and `pnpm build`
-  from root) — confirm no TS errors from the new constructor params.
+  - Run: `cd packages/vscode && pnpm test:unit`.
+- **Type-check / compile:** `cd packages/vscode && pnpm check-types` (tsc
+  `--noEmit`) catches TS errors from the new constructor params; `pnpm compile`
+  additionally lints + esbuilds. (The vscode extension is its own package — it is
+  *not* part of the root `pnpm build`, which covers core/codev/dashboard.)
 - **Manual (at the `dev-approval` gate, in the VSCode Extension Host):**
   - Backlog: an area with a spawnable issue **and** a live builder → green
     filled dot; an area with only spawnable issues → grey outline dot. Hover →
     builder count.
-  - Builders: a group with a builder blocked at a gate → yellow bell; worst-idle
-    group → blue comment-discussion; all-active group → green filled dot. Header
-    icon matches the topmost row. Hover → "b blocked · i waiting · a active".
+  - Builders: a group with a builder blocked at a gate → yellow `bell` on the
+    header (generic), regardless of which gate; worst-idle group → blue
+    comment-discussion; all-active group → green filled dot. Hover → "b blocked ·
+    i waiting · a active". Note the header's blocked `bell` intentionally differs
+    from the expanded row's gate-specific shape (e.g. `checklist` for
+    plan-approval) — only the severity/color matches, by design.
   - Both: collapse/expand still works; single-`Uncategorized` repos render flat
     rows with no header (unchanged); both views' headers consistently carry a
     dot.

--- a/codev/plans/926-vscode-area-header-roll-up-ico.md
+++ b/codev/plans/926-vscode-area-header-roll-up-ico.md
@@ -1,0 +1,171 @@
+# PIR Plan: VSCode area-header roll-up icons (Backlog & Builders views)
+
+## Understanding
+
+The Backlog and Builders sidebar trees group rows under `area/*` headers
+(e.g. `VSCODE (3)`). Today those headers carry **no icon** — the shared base
+`AreaGroupTreeItem` (`area-group-tree-item.ts`) sets only `id` and
+`contextValue`. An engineer scanning the collapsed tree can't tell, without
+expanding each group, which areas have live builders (Builders view) or which
+areas are open to spawn into vs. already being worked (Backlog view).
+
+Issue #926 asks for a **roll-up status icon on each area header** — a summary of
+the children's icons. The unifying rule is "the header summarizes what's
+inside it," but the rollup *function* differs per view because the children
+differ:
+
+- **Backlog children are issues** → binary question "is anyone working this
+  area?" → green filled dot vs. grey outline dot.
+- **Builders children are builders** → worst-of-three rollup over the existing
+  three builder-row states (blocked / idle / active), reusing the exact icons +
+  color tokens already on individual builder rows.
+
+No new colors or glyphs are introduced — every icon keeps the one meaning it
+already has on a builder row. The detail (counts) lives in the header tooltip.
+
+This is purely a VSCode-extension, client-side change. The overview payload
+already carries `builders[]` (each with `.area`, `api.ts:182`) alongside
+`backlog[]` (each with `.area`, `api.ts:222`), so both rollups are computed in
+the tree providers from data already in the `OverviewCache`. No server /
+overview-payload change is needed.
+
+## Proposed Change
+
+### Backlog view (binary rollup)
+
+In `backlog.ts`, derive a per-area **active-builder count** from
+`data.builders` (the same cache the provider already reads). A builder counts
+toward an area when its `.area` matches the header's area. Pass that count into
+`BacklogGroupTreeItem`; the subclass sets:
+
+| State | Icon | Color token |
+|---|---|---|
+| count ≥ 1 (area has a live builder) | `circle-filled` | `testing.iconPassed` (green) |
+| count = 0 (open to spawn) | `circle-outline` | `disabledForeground` (grey) |
+
+Tooltip: `"<n> builder(s) active in <area>"` when count ≥ 1; `"No active
+builders in <area>"` when count = 0.
+
+The green dot is the *same* dot that means "live builder" on a builder row, so
+its meaning is reinforced rather than overloaded; grey/idle areas stay muted so
+the eye skims for spawn targets.
+
+### Builders view (worst-of-three rollup)
+
+In `builders.ts`, the provider already knows each group's builders and already
+computes `isBlocked` / `isIdle` per builder (via `isIdleWaiting`,
+`builders.ts:168`). Compute a `{ blocked, idle, active }` count triple per group
+and pass it into `BuilderGroupTreeItem`; the subclass picks the **worst** state
+present and reuses the row icons from `builders.ts:206-210`:
+
+| If the area has… | Icon | Color token |
+|---|---|---|
+| any **blocked** builder | `bell` | `notificationsWarningIcon.foreground` (yellow) |
+| else any **idle/silent** builder | `comment-discussion` | `notificationsInfoIcon.foreground` (blue) |
+| else (all active) | `circle-filled` | `testing.iconPassed` (green) |
+
+This matches the existing within-group sort order (blocked → idle → active), so
+the header icon always equals the topmost row's icon in the group.
+
+Tooltip: `"<b> blocked · <i> waiting · <a> active"` (all three segments shown,
+matching the issue's example, so the format is predictable regardless of which
+states are present).
+
+### Rollup logic placement & testability
+
+Mirror the existing pattern of exported pure helpers (`orderForDisplay`,
+`spawnableBacklog`) that are unit-tested directly:
+
+- `backlog.ts` — add exported pure `activeBuilderCountByArea(builders): Map<string, number>`.
+- `builders.ts` — add exported pure `rollupGroupState(builders, now): { blocked: number; idle: number; active: number }` (reuses `isIdleWaiting`).
+
+The providers call these and feed the result into the subclass constructors.
+The **icon/tooltip assignment lives in the subclasses** (`BacklogGroupTreeItem`,
+`BuilderGroupTreeItem`), per the issue's explicit instruction — *not* in the
+shared `AreaGroupTreeItem` base, because the rollup differs per view.
+
+The degenerate single-`Uncategorized` flatten branch (both providers) renders
+no headers, so it needs no rollup and is untouched.
+
+## Files to Change
+
+- `packages/vscode/src/views/backlog.ts`
+  - Add exported `activeBuilderCountByArea(builders: OverviewBuilder[]): Map<string, number>`.
+  - In `rootChildren()` (L96-102), compute the map once and pass each group's
+    count into `new BacklogGroupTreeItem(g.area, g.items.length, state, activeCount)`.
+- `packages/vscode/src/views/backlog-tree-item.ts`
+  - `BacklogGroupTreeItem` constructor gains an `activeBuilderCount: number`
+    param; sets `this.iconPath` (circle-filled/green vs circle-outline/grey) and
+    `this.tooltip` from it.
+- `packages/vscode/src/views/builders.ts`
+  - Add exported `rollupGroupState(builders, now): { blocked; idle; active }`.
+  - In `rootChildren()` (L141-151), compute the triple per group and pass into
+    `new BuilderGroupTreeItem(g.area, g.items.length, state, rollup)`.
+- `packages/vscode/src/views/builder-tree-item.ts`
+  - `BuilderGroupTreeItem` constructor gains a rollup-counts param; sets
+    `this.iconPath` (worst-of bell/comment-discussion/circle-filled) and
+    `this.tooltip`.
+- `packages/vscode/src/views/area-group-tree-item.ts` — **no change** (rollup
+  stays in subclasses, per the issue).
+- Tests (new / extended):
+  - `packages/vscode/src/test/backlog.test.ts` — unit-test
+    `activeBuilderCountByArea` (empty, single area, multi-area, Uncategorized).
+  - `packages/vscode/src/test/builders.test.ts` — unit-test `rollupGroupState`
+    (all-active → active; one idle → idle; one blocked → blocked;
+    blocked-dominates-idle; mixed counts).
+
+## Risks & Alternatives Considered
+
+- **Risk: builder `.area` and backlog `.area` projected independently.** Both
+  use the same `parseArea` projection server-side (per the type docs), so an
+  area string from `builders[]` matches the header key from
+  `groupByArea(backlog)`. Mitigation: key the map on the raw `.area` wire value
+  (exactly what `groupByArea` keys on) — no re-normalization in the client.
+
+- **Risk: "active builder" semantics.** The Backlog rollup treats *any* builder
+  in the area as "active" (the issue's heading question is "is anyone working
+  this area?"). A builder blocked at a gate still counts — it's still occupying
+  that area. This matches the issue's binary intent; the Builders view is where
+  blocked/idle nuance is surfaced. Documented so a reviewer can object at the
+  plan gate if they want "active" to exclude blocked builders.
+
+- **Known limitation (accepted, from the issue):** an area that's busy but has
+  **no remaining spawnable backlog items** renders no Backlog header at all, so
+  it can't show "working" there. Fine for the "where do I spawn?" goal.
+
+- **Alternative: pass a boolean (not a count) into `BacklogGroupTreeItem`** (as
+  the issue's impl-notes suggest). Rejected: the tooltip needs the count, and
+  passing the count subsumes the boolean (`count > 0`) with no extra plumbing.
+
+- **Alternative: put rollup in the shared base.** Rejected per the issue — the
+  two rollups differ (binary vs worst-of-three), so they belong in the
+  subclasses.
+
+- **Alternative: omit zero-count tooltip segments** ("3 active" instead of
+  "0 blocked · 0 waiting · 3 active"). Rejected for predictability — the issue's
+  example shows the full triple; a fixed format is easier to scan.
+
+## Test Plan
+
+- **Unit (`vitest`/vscode-test, the existing suites):**
+  - `activeBuilderCountByArea`: empty builders → empty map; builders across two
+    areas → correct per-area counts; multiple builders same area → summed;
+    Uncategorized builders counted under `Uncategorized`.
+  - `rollupGroupState`: all active → `{0,0,n}`; contains one idle → idle wins
+    over active; contains one blocked → blocked wins over idle+active;
+    blocked+idle+active mix → counts correct and blocked is the worst.
+  - Run: `cd packages/vscode && pnpm test` (and/or `pnpm test:unit`).
+- **Build:** `pnpm --filter @cluesmith/codev-vscode build` (and the full
+  `pnpm build` from root) — confirm no TS errors from the new constructor params.
+- **Manual (at the `dev-approval` gate, in the VSCode Extension Host):**
+  - Backlog view: an area with a spawnable issue **and** a live builder shows a
+    green filled dot; an area with only spawnable issues shows a grey outline
+    dot. Hover → tooltip shows the builder count.
+  - Builders view: a group with a builder blocked at a gate shows the yellow
+    bell; a group whose worst builder is idle shows the blue comment-discussion;
+    an all-active group shows the green filled dot. Header icon matches the
+    topmost row in the group. Hover → "b blocked · i waiting · a active".
+  - Collapse/expand still works; single-`Uncategorized` repos render flat rows
+    with no header (unchanged).
+- **Cross-platform:** N/A (VSCode extension; web dashboard explicitly out of
+  scope per the issue).

--- a/codev/plans/926-vscode-area-header-roll-up-ico.md
+++ b/codev/plans/926-vscode-area-header-roll-up-ico.md
@@ -1,27 +1,43 @@
 # PIR Plan: VSCode area-header roll-up icons (Backlog & Builders views)
 
+## Scope (plan-gate discussion outcome)
+
+Both the Backlog and Builders area headers get a roll-up icon — the issue's
+original both-views design. We briefly considered shipping the Backlog rollup
+only, but reinstated the Builders rollup for **cross-view consistency**: the two
+trees are siblings in the same sidebar, both grouped by `area/*` and both built
+on the shared `AreaGroupTreeItem` base. Giving one header dots and the other
+none reads as unfinished. The objections to the Builders rollup
+(redundant-when-expanded, green-when-healthy) apply equally to the Backlog
+rollup we're keeping, so they don't justify an asymmetry. Net: **both views
+always carry a header dot from the same icon vocabulary**, computed per-view.
+
+A separate idea — keeping in-progress issues *in* the Backlog with the builder's
+state icon (instead of filtering them out) — was filed as a deliberate
+follow-up (#948) rather than folded in here, to keep #926 scoped and preserve
+the VSCode/dashboard backlog parity.
+
 ## Understanding
 
 The Backlog and Builders sidebar trees group rows under `area/*` headers
 (e.g. `VSCODE (3)`). Today those headers carry **no icon** — the shared base
 `AreaGroupTreeItem` (`area-group-tree-item.ts`) sets only `id` and
-`contextValue`. An engineer scanning the collapsed tree can't tell, without
-expanding each group, which areas have live builders (Builders view) or which
-areas are open to spawn into vs. already being worked (Backlog view).
+`contextValue`. An engineer scanning the collapsed tree can't tell which areas
+have live builders (Builders) or which are open to spawn into (Backlog) without
+expanding each group.
 
-Issue #926 asks for a **roll-up status icon on each area header** — a summary of
-the children's icons. The unifying rule is "the header summarizes what's
-inside it," but the rollup *function* differs per view because the children
-differ:
+Issue #926 adds a **roll-up status icon** to each area header — a summary of the
+children's icons. The unifying rule is "the header summarizes what's inside it,"
+but the rollup *function* differs per view because the children differ:
 
-- **Backlog children are issues** → binary question "is anyone working this
-  area?" → green filled dot vs. grey outline dot.
-- **Builders children are builders** → worst-of-three rollup over the existing
-  three builder-row states (blocked / idle / active), reusing the exact icons +
-  color tokens already on individual builder rows.
+- **Backlog children are issues** → binary "is anyone working this area?" →
+  green filled dot vs. grey outline dot.
+- **Builders children are builders** → worst-of-three rollup over the three
+  builder-row states (blocked / idle / active), reusing the exact icons + color
+  tokens already on individual builder rows (`builders.ts:206-210`).
 
-No new colors or glyphs are introduced — every icon keeps the one meaning it
-already has on a builder row. The detail (counts) lives in the header tooltip.
+No new colors or glyphs are introduced — every icon keeps its single existing
+meaning. The detail (counts) lives in the header tooltip.
 
 This is purely a VSCode-extension, client-side change. The overview payload
 already carries `builders[]` (each with `.area`, `api.ts:182`) alongside
@@ -33,27 +49,26 @@ overview-payload change is needed.
 
 ### Backlog view (binary rollup)
 
-In `backlog.ts`, derive a per-area **active-builder count** from
-`data.builders` (the same cache the provider already reads). A builder counts
-toward an area when its `.area` matches the header's area. Pass that count into
-`BacklogGroupTreeItem`; the subclass sets:
+In `backlog.ts`, derive a per-area **active-builder count** from `data.builders`.
+A builder counts toward an area when its `.area` matches the header's area. Pass
+that count into `BacklogGroupTreeItem`; the subclass sets:
 
 | State | Icon | Color token |
 |---|---|---|
 | count ≥ 1 (area has a live builder) | `circle-filled` | `testing.iconPassed` (green) |
 | count = 0 (open to spawn) | `circle-outline` | `disabledForeground` (grey) |
 
-Tooltip: `"<n> builder(s) active in <area>"` when count ≥ 1; `"No active
-builders in <area>"` when count = 0.
+Tooltip: `"<n> builder(s) active in <area>"` (count ≥ 1) / `"No active builders
+in <area>"` (count = 0).
 
 The green dot is the *same* dot that means "live builder" on a builder row, so
-its meaning is reinforced rather than overloaded; grey/idle areas stay muted so
-the eye skims for spawn targets.
+its meaning is reinforced; grey/idle areas stay muted so the eye skims for spawn
+targets.
 
 ### Builders view (worst-of-three rollup)
 
 In `builders.ts`, the provider already knows each group's builders and already
-computes `isBlocked` / `isIdle` per builder (via `isIdleWaiting`,
+classifies `isBlocked` / `isIdle` per builder (via `isIdleWaiting`,
 `builders.ts:168`). Compute a `{ blocked, idle, active }` count triple per group
 and pass it into `BuilderGroupTreeItem`; the subclass picks the **worst** state
 present and reuses the row icons from `builders.ts:206-210`:
@@ -67,105 +82,113 @@ present and reuses the row icons from `builders.ts:206-210`:
 This matches the existing within-group sort order (blocked → idle → active), so
 the header icon always equals the topmost row's icon in the group.
 
-Tooltip: `"<b> blocked · <i> waiting · <a> active"` (all three segments shown,
-matching the issue's example, so the format is predictable regardless of which
-states are present).
+Tooltip: `"<b> blocked · <i> waiting · <a> active"` — all three segments shown
+(matching the issue's example) so the format is predictable regardless of which
+states are present.
+
+Because every builder group has ≥1 builder, the Builders header never shows the
+grey "idle area" dot — it always shows green-or-worse. Combined with the Backlog
+rollup, **both views' headers always carry a dot from the same vocabulary** —
+the consistency the scope decision is built on.
 
 ### Rollup logic placement & testability
 
-Mirror the existing pattern of exported pure helpers (`orderForDisplay`,
-`spawnableBacklog`) that are unit-tested directly:
+Mirror the existing exported-pure-helper pattern (`orderForDisplay`,
+`spawnableBacklog`) that's unit-tested directly:
 
-- `backlog.ts` — add exported pure `activeBuilderCountByArea(builders): Map<string, number>`.
-- `builders.ts` — add exported pure `rollupGroupState(builders, now): { blocked: number; idle: number; active: number }` (reuses `isIdleWaiting`).
+- `backlog.ts` — add exported `activeBuilderCountByArea(builders): Map<string, number>`.
+- `builders.ts` — add exported `rollupGroupState(builders, now): { blocked: number; idle: number; active: number }` (reuses `isIdleWaiting`).
 
-The providers call these and feed the result into the subclass constructors.
-The **icon/tooltip assignment lives in the subclasses** (`BacklogGroupTreeItem`,
+The providers call these and feed the result into the subclass constructors. The
+**icon/tooltip assignment lives in the subclasses** (`BacklogGroupTreeItem`,
 `BuilderGroupTreeItem`), per the issue's explicit instruction — *not* in the
 shared `AreaGroupTreeItem` base, because the rollup differs per view.
 
-The degenerate single-`Uncategorized` flatten branch (both providers) renders
-no headers, so it needs no rollup and is untouched.
+Both providers' degenerate single-`Uncategorized` flatten branch renders no
+headers, so it needs no rollup and is untouched.
 
 ## Files to Change
 
 - `packages/vscode/src/views/backlog.ts`
   - Add exported `activeBuilderCountByArea(builders: OverviewBuilder[]): Map<string, number>`.
-  - In `rootChildren()` (L96-102), compute the map once and pass each group's
-    count into `new BacklogGroupTreeItem(g.area, g.items.length, state, activeCount)`.
+  - In `rootChildren()` (L96-102), compute the map once from `data.builders` and
+    pass each group's count into
+    `new BacklogGroupTreeItem(g.area, g.items.length, state, activeCount)`.
 - `packages/vscode/src/views/backlog-tree-item.ts`
-  - `BacklogGroupTreeItem` constructor gains an `activeBuilderCount: number`
-    param; sets `this.iconPath` (circle-filled/green vs circle-outline/grey) and
-    `this.tooltip` from it.
+  - `BacklogGroupTreeItem` constructor gains `activeBuilderCount: number`; sets
+    `this.iconPath` (circle-filled/green vs circle-outline/grey) and
+    `this.tooltip`.
 - `packages/vscode/src/views/builders.ts`
   - Add exported `rollupGroupState(builders, now): { blocked; idle; active }`.
   - In `rootChildren()` (L141-151), compute the triple per group and pass into
     `new BuilderGroupTreeItem(g.area, g.items.length, state, rollup)`.
 - `packages/vscode/src/views/builder-tree-item.ts`
-  - `BuilderGroupTreeItem` constructor gains a rollup-counts param; sets
+  - `BuilderGroupTreeItem` constructor gains the rollup-counts param; sets
     `this.iconPath` (worst-of bell/comment-discussion/circle-filled) and
     `this.tooltip`.
 - `packages/vscode/src/views/area-group-tree-item.ts` — **no change** (rollup
   stays in subclasses, per the issue).
-- Tests (new / extended):
+- Tests:
   - `packages/vscode/src/test/backlog.test.ts` — unit-test
-    `activeBuilderCountByArea` (empty, single area, multi-area, Uncategorized).
+    `activeBuilderCountByArea` (empty, single area, multi-area, multiple builders
+    same area summed, Uncategorized).
   - `packages/vscode/src/test/builders.test.ts` — unit-test `rollupGroupState`
-    (all-active → active; one idle → idle; one blocked → blocked;
-    blocked-dominates-idle; mixed counts).
+    (all-active → active; one idle → idle beats active; one blocked → blocked
+    beats idle+active; mixed → counts correct).
 
 ## Risks & Alternatives Considered
 
 - **Risk: builder `.area` and backlog `.area` projected independently.** Both
-  use the same `parseArea` projection server-side (per the type docs), so an
-  area string from `builders[]` matches the header key from
-  `groupByArea(backlog)`. Mitigation: key the map on the raw `.area` wire value
-  (exactly what `groupByArea` keys on) — no re-normalization in the client.
+  use the same `parseArea` projection server-side, so an area string from
+  `builders[]` matches the header key from `groupByArea(backlog)`. Mitigation:
+  key on the raw `.area` wire value (what `groupByArea` keys on) — no client
+  re-normalization.
 
-- **Risk: "active builder" semantics.** The Backlog rollup treats *any* builder
-  in the area as "active" (the issue's heading question is "is anyone working
-  this area?"). A builder blocked at a gate still counts — it's still occupying
-  that area. This matches the issue's binary intent; the Builders view is where
-  blocked/idle nuance is surfaced. Documented so a reviewer can object at the
-  plan gate if they want "active" to exclude blocked builders.
+- **Risk: "active builder" semantics (Backlog).** The Backlog rollup treats
+  *any* builder in the area as "active" (the heading question is "is anyone
+  working this area?"). A builder blocked at a gate still counts — it's still
+  occupying the area; the Builders view is where blocked/idle nuance shows.
+  Documented so a reviewer can object at the gate.
 
 - **Known limitation (accepted, from the issue):** an area that's busy but has
-  **no remaining spawnable backlog items** renders no Backlog header at all, so
-  it can't show "working" there. Fine for the "where do I spawn?" goal.
+  **no remaining spawnable backlog items** renders no Backlog header, so it
+  can't show "working" there. Fine for the "where do I spawn?" goal. (Follow-up
+  #948 would dissolve this by keeping in-progress issues in the Backlog.)
 
-- **Alternative: pass a boolean (not a count) into `BacklogGroupTreeItem`** (as
-  the issue's impl-notes suggest). Rejected: the tooltip needs the count, and
-  passing the count subsumes the boolean (`count > 0`) with no extra plumbing.
+- **Alternative: drop the Builders rollup (Backlog only).** Rejected for
+  cross-view consistency — see Scope. The objections to the Builders rollup
+  apply equally to the Backlog rollup we keep, so an asymmetry isn't justified.
+
+- **Alternative: exception-only Builders header** (icon only when attention
+  needed). Rejected: it makes the header intermittent, which is *less*
+  consistent with the always-on Backlog dot, not more.
+
+- **Alternative: pass a boolean into `BacklogGroupTreeItem`** (issue's impl
+  note). Rejected: the tooltip needs the count, and the count subsumes the
+  boolean (`count > 0`).
 
 - **Alternative: put rollup in the shared base.** Rejected per the issue — the
-  two rollups differ (binary vs worst-of-three), so they belong in the
-  subclasses.
-
-- **Alternative: omit zero-count tooltip segments** ("3 active" instead of
-  "0 blocked · 0 waiting · 3 active"). Rejected for predictability — the issue's
-  example shows the full triple; a fixed format is easier to scan.
+  two rollups differ, so they belong in the subclasses.
 
 ## Test Plan
 
-- **Unit (`vitest`/vscode-test, the existing suites):**
-  - `activeBuilderCountByArea`: empty builders → empty map; builders across two
-    areas → correct per-area counts; multiple builders same area → summed;
-    Uncategorized builders counted under `Uncategorized`.
-  - `rollupGroupState`: all active → `{0,0,n}`; contains one idle → idle wins
-    over active; contains one blocked → blocked wins over idle+active;
-    blocked+idle+active mix → counts correct and blocked is the worst.
-  - Run: `cd packages/vscode && pnpm test` (and/or `pnpm test:unit`).
-- **Build:** `pnpm --filter @cluesmith/codev-vscode build` (and the full
-  `pnpm build` from root) — confirm no TS errors from the new constructor params.
+- **Unit (the existing `src/test` suite):**
+  - `activeBuilderCountByArea`: empty → empty map; two areas → correct per-area
+    counts; multiple builders same area → summed; Uncategorized counted.
+  - `rollupGroupState`: all active → `{0,0,n}`; one idle → idle beats active;
+    one blocked → blocked beats idle+active; mix → counts correct.
+  - Run: `cd packages/vscode && pnpm test`.
+- **Build:** `pnpm --filter @cluesmith/codev-vscode build` (and `pnpm build`
+  from root) — confirm no TS errors from the new constructor params.
 - **Manual (at the `dev-approval` gate, in the VSCode Extension Host):**
-  - Backlog view: an area with a spawnable issue **and** a live builder shows a
-    green filled dot; an area with only spawnable issues shows a grey outline
-    dot. Hover → tooltip shows the builder count.
-  - Builders view: a group with a builder blocked at a gate shows the yellow
-    bell; a group whose worst builder is idle shows the blue comment-discussion;
-    an all-active group shows the green filled dot. Header icon matches the
-    topmost row in the group. Hover → "b blocked · i waiting · a active".
-  - Collapse/expand still works; single-`Uncategorized` repos render flat rows
-    with no header (unchanged).
-- **Cross-platform:** N/A (VSCode extension; web dashboard explicitly out of
-  scope per the issue).
+  - Backlog: an area with a spawnable issue **and** a live builder → green
+    filled dot; an area with only spawnable issues → grey outline dot. Hover →
+    builder count.
+  - Builders: a group with a builder blocked at a gate → yellow bell; worst-idle
+    group → blue comment-discussion; all-active group → green filled dot. Header
+    icon matches the topmost row. Hover → "b blocked · i waiting · a active".
+  - Both: collapse/expand still works; single-`Uncategorized` repos render flat
+    rows with no header (unchanged); both views' headers consistently carry a
+    dot.
+- **Cross-platform:** N/A (VSCode extension; web dashboard out of scope per the
+  issue).

--- a/codev/plans/926-vscode-area-header-roll-up-ico.md
+++ b/codev/plans/926-vscode-area-header-roll-up-ico.md
@@ -31,7 +31,7 @@ children's icons. The unifying rule is "the header summarizes what's inside it,"
 but the rollup *function* differs per view because the children differ:
 
 - **Backlog children are issues** → binary "is anyone working this area?" →
-  green filled dot vs. grey outline dot.
+  filled grey dot (has a builder) vs. outline grey dot (open to spawn).
 - **Builders children are builders** → worst-of-three rollup over the three
   builder-row states (blocked / idle / active), reusing the exact icons + color
   tokens already on individual builder rows (`builders.ts:202-206`).
@@ -55,15 +55,20 @@ that count into `BacklogGroupTreeItem`; the subclass sets:
 
 | State | Icon | Color token |
 |---|---|---|
-| count ≥ 1 (area has a live builder) | `circle-filled` | `testing.iconPassed` (green) |
+| count ≥ 1 (area has a builder) | `circle-filled` | `disabledForeground` (grey) |
 | count = 0 (open to spawn) | `circle-outline` | `disabledForeground` (grey) |
 
 Tooltip: `"<n> builder(s) active in <area>"` (count ≥ 1) / `"No active builders
 in <area>"` (count = 0).
 
-The green dot is the *same* dot that means "live builder" on a builder row, so
-its meaning is reinforced; grey/idle areas stay muted so the eye skims for spawn
-targets.
+> **Updated at the `dev-approval` gate:** the active-area dot was originally
+> planned as **green** (`testing.iconPassed`) to echo the live-builder dot on a
+> builder row. The reviewer asked to drop green here so it stays exclusive to
+> the Builders view's "agent actively building" signal — overloading green
+> across two sibling views was the concern. Both Backlog states now use the
+> muted `disabledForeground` and differ only in **fill** (filled = has a
+> builder, outline = open to spawn), keeping the Backlog a calm "where can I
+> spawn" surface. This section is updated to match what shipped.
 
 ### Builders view (worst-of-three rollup)
 
@@ -139,7 +144,7 @@ headers, so it needs no rollup and is untouched.
     `new BacklogGroupTreeItem(g.area, g.items.length, state, activeCount)`.
 - `packages/vscode/src/views/backlog-tree-item.ts`
   - `BacklogGroupTreeItem` constructor gains `activeBuilderCount: number`; sets
-    `this.iconPath` (circle-filled/green vs circle-outline/grey) and
+    `this.iconPath` (filled/outline `circle`, both grey `disabledForeground`) and
     `this.tooltip`.
 - `packages/vscode/src/views/builder-row.ts` (vscode-free)
   - Add `rollupGroupState(builders: OverviewBuilder[], now: number): { blocked: number; idle: number; active: number }` (reuses `isIdleWaiting`).
@@ -210,8 +215,8 @@ headers, so it needs no rollup and is untouched.
   additionally lints + esbuilds. (The vscode extension is its own package — it is
   *not* part of the root `pnpm build`, which covers core/codev/dashboard.)
 - **Manual (at the `dev-approval` gate, in the VSCode Extension Host):**
-  - Backlog: an area with a spawnable issue **and** a live builder → green
-    filled dot; an area with only spawnable issues → grey outline dot. Hover →
+  - Backlog: an area with a spawnable issue **and** a live builder → filled grey
+    dot; an area with only spawnable issues → outline grey dot. Hover →
     builder count.
   - Builders: a group with a builder blocked at a gate → yellow `bell` on the
     header (generic), regardless of which gate; worst-idle group → blue

--- a/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
+++ b/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
@@ -1,7 +1,7 @@
 id: '926'
 title: vscode-area-header-roll-up-ico
 protocol: pir
-phase: review
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -21,7 +21,7 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-29T23:15:30.202Z'
-updated_at: '2026-06-02T01:14:46.595Z'
+updated_at: '2026-06-02T01:14:54.059Z'
 pr_history:
   - phase: review
     pr_number: 959

--- a/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
+++ b/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
@@ -21,10 +21,12 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-29T23:15:30.202Z'
-updated_at: '2026-06-02T01:14:54.059Z'
+updated_at: '2026-06-02T01:15:07.063Z'
 pr_history:
   - phase: review
     pr_number: 959
     branch: builder/pir-926
     created_at: '2026-06-02T00:56:51.014Z'
+    merged: true
+    merged_at: '2026-06-02T01:15:07.062Z'
 pr_ready_for_human: false

--- a/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
+++ b/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-05-29T23:18:30.622Z'
     approved_at: '2026-06-02T00:00:00.276Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-06-02T00:28:22.507Z'
+    approved_at: '2026-06-02T00:55:06.695Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:15:30.202Z'
-updated_at: '2026-06-02T00:28:22.508Z'
+updated_at: '2026-06-02T00:55:06.696Z'

--- a/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
+++ b/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-06-02T00:00:00.276Z'
   dev-approval:
     status: pending
+    requested_at: '2026-06-02T00:28:22.507Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:15:30.202Z'
-updated_at: '2026-06-02T00:00:08.184Z'
+updated_at: '2026-06-02T00:28:22.508Z'

--- a/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
+++ b/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
@@ -1,7 +1,7 @@
 id: '926'
 title: vscode-area-header-roll-up-ico
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:15:30.202Z'
-updated_at: '2026-06-02T00:55:06.696Z'
+updated_at: '2026-06-02T00:55:18.906Z'

--- a/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
+++ b/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-05-29T23:15:30.202Z'
-updated_at: '2026-06-02T00:56:51.014Z'
+updated_at: '2026-06-02T00:57:04.835Z'
 pr_history:
   - phase: review
     pr_number: 959

--- a/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
+++ b/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-05-29T23:18:30.622Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:15:30.202Z'
-updated_at: '2026-05-29T23:15:30.203Z'
+updated_at: '2026-05-29T23:18:30.622Z'

--- a/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
+++ b/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-06-02T00:55:06.695Z'
   pr:
     status: pending
+    requested_at: '2026-06-02T01:13:29.307Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-29T23:15:30.202Z'
-updated_at: '2026-06-02T00:57:04.835Z'
+updated_at: '2026-06-02T01:13:29.308Z'
 pr_history:
   - phase: review
     pr_number: 959
     branch: builder/pir-926
     created_at: '2026-06-02T00:56:51.014Z'
+pr_ready_for_human: true

--- a/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
+++ b/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-06-02T00:28:22.507Z'
     approved_at: '2026-06-02T00:55:06.695Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-06-02T01:13:29.307Z'
+    approved_at: '2026-06-02T01:14:46.594Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-05-29T23:15:30.202Z'
-updated_at: '2026-06-02T01:13:29.308Z'
+updated_at: '2026-06-02T01:14:46.595Z'
 pr_history:
   - phase: review
     pr_number: 959
     branch: builder/pir-926
     created_at: '2026-06-02T00:56:51.014Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
+++ b/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-05-29T23:18:30.622Z'
+    approved_at: '2026-06-02T00:00:00.276Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:15:30.202Z'
-updated_at: '2026-05-29T23:18:30.622Z'
+updated_at: '2026-06-02T00:00:00.276Z'

--- a/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
+++ b/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
@@ -1,0 +1,18 @@
+id: '926'
+title: vscode-area-header-roll-up-ico
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-05-29T23:15:30.202Z'
+updated_at: '2026-05-29T23:15:30.203Z'

--- a/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
+++ b/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
@@ -1,7 +1,7 @@
 id: '926'
 title: vscode-area-header-roll-up-ico
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:15:30.202Z'
-updated_at: '2026-06-02T00:00:00.276Z'
+updated_at: '2026-06-02T00:00:08.184Z'

--- a/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
+++ b/codev/projects/926-vscode-area-header-roll-up-ico/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-05-29T23:15:30.202Z'
-updated_at: '2026-06-02T00:55:18.906Z'
+updated_at: '2026-06-02T00:56:51.014Z'
+pr_history:
+  - phase: review
+    pr_number: 959
+    branch: builder/pir-926
+    created_at: '2026-06-02T00:56:51.014Z'

--- a/codev/reviews/926-vscode-area-header-roll-up-ico.md
+++ b/codev/reviews/926-vscode-area-header-roll-up-ico.md
@@ -78,6 +78,29 @@ durable cross-cutting wisdom, and are captured in this review:
   rollup ships as filled/outline *grey* so green stays exclusive to live
   builders and the Backlog reads as a calm "where can I spawn" surface.
 
+## 3-Way Consultation (single advisory pass — PIR does not re-review)
+
+- **Claude: APPROVE** (HIGH).
+- **Codex: REQUEST_CHANGES** (HIGH) — two findings, both bookkeeping, no code defect:
+  1. *Backlog dot is grey, but the plan said green.* **Addressed by updating the
+     plan, not the code.** The grey was an explicit reviewer request at the
+     `dev-approval` gate (reserve green for the Builders "live agent" signal),
+     and the gate was approved with grey in place — reverting would contradict
+     the human decision. The plan's Backlog section is updated to match what
+     shipped, removing the drift. No code change, so no regression test applies.
+  2. *Plan lacks `approved`/`validated` frontmatter.* **Rebutted.** That
+     frontmatter is the architect-pre-approval convention (e.g. plan #925);
+     PIR builder-created plans approved via the porch `plan-approval` gate don't
+     carry it (siblings #920, #930, #932 have none), the approval record lives
+     in `status.yaml`, and `validated: [gemini, codex, claude]` would be
+     factually false — PIR's plan phase runs no consultation.
+- **Gemini: no verdict** — the run looped on a repeated file-search tool call
+  and exited without emitting a verdict file (infra issue, not a code finding).
+
+Net: one APPROVE, one REQUEST_CHANGES whose two findings are a plan-doc sync
+(done) and a frontmatter-convention rebut. Escalated to the human at the `pr`
+gate since PIR will not independently re-review.
+
 ## Things to Look At During PR Review
 
 - **Backlog "active builder" semantics.** `activeBuilderCountByArea` counts

--- a/codev/reviews/926-vscode-area-header-roll-up-ico.md
+++ b/codev/reviews/926-vscode-area-header-roll-up-ico.md
@@ -1,0 +1,120 @@
+# PIR Review: VSCode area-header roll-up icons (Backlog & Builders views)
+
+Fixes #926
+
+## Summary
+
+Adds a roll-up status icon to the `area/*` group headers in the VSCode sidebar's
+Backlog and Builders trees, so an engineer can triage at a glance without
+expanding each group. Both rollups are computed client-side from the overview
+cache (no server / payload change). The Backlog header is **binary** — filled
+vs. outline grey for "area has a builder" vs. "open to spawn"; the Builders
+header is a **worst-of-three** — `bell` (any blocked) → `comment-discussion`
+(any idle) → `circle-filled` (all active), reusing the builder-row icon
+vocabulary. Counts live in the tooltip.
+
+## Files Changed
+
+Code (anchored at merge-base `b6059d5b`):
+
+- `packages/vscode/src/views/backlog-filter.ts` (+24 / -0) — `activeBuilderCountByArea` (pure)
+- `packages/vscode/src/views/backlog-tree-item.ts` (+28 / -... ) — `BacklogGroupTreeItem` icon/tooltip
+- `packages/vscode/src/views/backlog.ts` (+5 / -...) — wire into `rootChildren()`
+- `packages/vscode/src/views/builder-row.ts` (+70 / -0) — `rollupGroupState`, `BUILDER_STATE_GLYPH`, `worstBuilderState`, `GroupRollup`/`BuilderState`
+- `packages/vscode/src/views/builder-tree-item.ts` (+21 / -...) — `BuilderGroupTreeItem` icon/tooltip
+- `packages/vscode/src/views/builders.ts` (+49 / -...) — wire rollup into `rootChildren()`; row icon/contextValue now sourced from the shared glyph
+- `packages/vscode/src/__tests__/backlog-filter.test.ts` (+38 / -0) — `activeBuilderCountByArea` tests
+- `packages/vscode/src/__tests__/builder-row.test.ts` (+53 / -0) — `rollupGroupState` + `worstBuilderState` tests
+
+8 files, +265 / -23.
+
+## Commits
+
+`git log main..HEAD --oneline` (implementation commits; porch chore commits omitted):
+
+- `3d07ae01` [PIR #926] Add area-header roll-up icons to Backlog & Builders views
+- `f846f6aa` [PIR #926] Unit-test activeBuilderCountByArea + rollupGroupState
+- `b6092ab8` [PIR #926] Backlog header: filled/outline grey instead of green (reserve green for live builders)
+- `845c0a45` [PIR #926] Centralize builder-state glyphs + worstBuilderState helper (drop nested ternaries)
+
+## Test Results
+
+- `pnpm check-types`: ✓ pass
+- `pnpm lint`: ✓ pass
+- `pnpm test:unit`: ✓ pass (211 tests, 14 new across the two helper suites)
+- `node esbuild.js`: ✓ pass (extension bundles)
+- porch `build` + `tests` checks: ✓ pass (at dev-approval)
+- Manual verification: reviewer approved the running worktree at the
+  `dev-approval` gate (VSCode Extension Host) — confirmed the Backlog
+  filled/outline-grey headers and the Builders worst-of-three headers render and
+  their tooltips carry the counts.
+
+## Architecture Updates
+
+No `arch.md` changes needed. This adds two pure helpers and sets `iconPath` on
+two existing `AreaGroupTreeItem` subclasses — no new module boundary, service,
+or data-flow. It stays within the established VSCode-view pattern (pure,
+vscode-free helpers in `backlog-filter.ts` / `builder-row.ts` tested under the
+vitest `__tests__/` harness; `ThemeIcon` construction at the tree-item call
+site). The one mild structural improvement — `BUILDER_STATE_GLYPH` as the single
+source of truth for the three builder-state glyphs shared by the row and the
+header — is a local DRY consolidation, not an architectural change.
+
+## Lessons Learned Updates
+
+No `lessons-learned.md` change — the insights here are PR-specific rather than
+durable cross-cutting wisdom, and are captured in this review:
+
+- **Issue specs referencing `file:line` icon vocabulary can go stale across a
+  rebase.** #926 specced the Builders blocked rollup as a static `bell` "reusing
+  the row icons." Between issue authoring and implementation, the row's blocked
+  icon became gate-specific (`gateIconFor` → `book`/`checklist`/`code`/…), so
+  `bell` is now only an unmapped-gate fallback. The rebase-time accuracy pass
+  caught this; the header keeps a *generic* `bell` as a deliberate group-level
+  "attention" glyph (a group can hold builders at different gates), documented at
+  `builder-tree-item.ts`.
+- **Reserve color semantics across sibling views.** Green = "live/active agent"
+  on builder rows; using a green dot in the Backlog overloaded it. The Backlog
+  rollup ships as filled/outline *grey* so green stays exclusive to live
+  builders and the Backlog reads as a calm "where can I spawn" surface.
+
+## Things to Look At During PR Review
+
+- **Backlog "active builder" semantics.** `activeBuilderCountByArea` counts
+  *any* builder in the area (including one blocked at a gate) as "active" — the
+  Backlog question is "is anyone working this area?". A consequence worth a
+  conscious nod: the same area can show a filled-grey Backlog header (has a
+  builder) while its Builders header is `bell`/yellow (that builder is blocked).
+  That's intended — the two views answer different questions.
+- **Known limitation (accepted).** An area whose only open issue is being built
+  has that issue filtered out of the backlog (`spawnableBacklog`), so it renders
+  no Backlog header at all and can't show "working" there. Fine for the "where
+  do I spawn?" goal; a follow-up (#948) tracks optionally keeping in-progress
+  issues in the Backlog with the builder's state icon.
+- **Builders worst-of-three is a severity summary, not a full picture.** One
+  glyph can't convey a mixed group; the full `{blocked, idle, active}` breakdown
+  is in the tooltip. This was discussed at the gate and kept deliberately.
+- **Shared-glyph refactor touched existing row code** (`builders.ts`
+  `makeBuilderRow`): the row now classifies once into a `BuilderState` driving
+  both `contextValue` family (`CONTEXT_FAMILY`) and icon (`BUILDER_STATE_GLYPH`),
+  with the blocked row still overriding the *glyph* via `gateIconFor` while
+  reusing the shared *color*. Behavior is identical; worth a glance to confirm
+  the contextValue strings (`blocked-builder`/`awaiting-builder`/`builder`) are
+  unchanged so menu `when`-clauses still match.
+
+## How to Test Locally
+
+For reviewers pulling the branch:
+
+- **View diff**: VSCode sidebar → right-click builder `pir-926` → **View Diff**
+- **Run dev server**: VSCode sidebar → **Run Dev Server**, or `afx dev pir-926`
+- **What to verify** (mapped to the plan's Test Plan):
+  - Backlog: an area with a spawnable issue **and** a live builder → filled grey
+    dot; an area with only spawnable issues → outline grey dot. Hover → builder
+    count.
+  - Builders: a group with a builder blocked at a gate → yellow `bell`;
+    worst-idle group → blue `comment-discussion`; all-active → green
+    `circle-filled`. Hover → "b blocked · i waiting · a active".
+  - Both: collapse/expand still works; a single-`Uncategorized` repo renders flat
+    rows with no header (unchanged).
+  - Unit: `cd packages/vscode && pnpm test:unit`.

--- a/codev/state/pir-926_thread.md
+++ b/codev/state/pir-926_thread.md
@@ -1,0 +1,29 @@
+# PIR #926 — VSCode area-header roll-up icons
+
+## Plan phase (start)
+
+Issue #926 (area/vscode): add roll-up status icons to area group headers in the
+Backlog and Builders sidebar views.
+
+Investigation findings:
+- `area-group-tree-item.ts` — shared base `AreaGroupTreeItem`; sets `id` +
+  `contextValue`, no `iconPath` today. Issue says: do NOT put rollup here.
+- `backlog-tree-item.ts` — `BacklogGroupTreeItem(areaName, count, state)`.
+- `builder-tree-item.ts` — `BuilderGroupTreeItem(areaName, count, state)`.
+- `backlog.ts` — `BacklogProvider.rootChildren()` builds group headers at L96-102.
+  Has `data.builders` (each with `.area`) on the same overview cache.
+- `builders.ts` — `BuildersProvider.rootChildren()` builds group headers L141-151.
+  Already computes blocked/idle/active per builder in `makeBuilderRow` via
+  `isIdleWaiting` (core helper) — within-group sort is blocked→idle→active.
+- Builder-row icon vocabulary lives at `builders.ts:206-210`:
+  bell/`notificationsWarningIcon.foreground`,
+  comment-discussion/`notificationsInfoIcon.foreground`,
+  circle-filled/`testing.iconPassed`.
+- Types: `OverviewBuilder.area` and `OverviewBacklogItem.area` both
+  required-with-default (`api.ts:182`, `:222`).
+- Tests: `src/test/*.test.ts` run under vscode-test (mocha suite/test). Pure
+  exported helpers (`orderForDisplay`, `spawnableBacklog`) are tested directly —
+  I'll mirror that for the rollup helpers.
+
+Plan written to `codev/plans/926-vscode-area-header-roll-up-ico.md`. Awaiting
+plan-approval gate.

--- a/codev/state/pir-926_thread.md
+++ b/codev/state/pir-926_thread.md
@@ -91,3 +91,15 @@ Implemented both rollups per the plan:
 Verified (worktree needed `pnpm install` + core/types build first):
 `pnpm check-types` ✓, `pnpm lint` ✓, `pnpm test:unit` ✓ (207 tests, 10 new),
 `node esbuild.js` ✓. Awaiting go-ahead to commit + push, then dev-approval gate.
+
+## dev-approval gate feedback
+
+Reviewer feedback at the dev-approval gate: the Backlog's **green** filled dot
+overloaded "green" — on the Builders side green means "agent actively building,"
+but the Backlog isn't a per-agent-activity surface. Changed the Backlog rollup
+to **filled-grey (has builder) vs. outline-grey (open to spawn)** — both
+`disabledForeground`, differing only in fill. Green is now exclusive to the
+Builders view's active signal; Backlog stays a calm "where can I spawn" surface.
+Deviation from the approved plan (which specced green) — will be recorded in the
+review file. Re-verified: check-types/lint/test:unit (207)/esbuild all ✓.
+Builders worst-of-three header left as-is (reviewer: "looks good").

--- a/codev/state/pir-926_thread.md
+++ b/codev/state/pir-926_thread.md
@@ -103,3 +103,17 @@ Builders view's active signal; Backlog stays a calm "where can I spawn" surface.
 Deviation from the approved plan (which specced green) — will be recorded in the
 review file. Re-verified: check-types/lint/test:unit (207)/esbuild all ✓.
 Builders worst-of-three header left as-is (reviewer: "looks good").
+
+Second dev-approval feedback: avoid the nested ternary in the header icon, and
+the row/header icons weren't centralized (duplicated literals in `builders.ts`
+row + header). Refactor:
+- `builder-row.ts` → new `BUILDER_STATE_GLYPH` (single source of truth for the
+  three state icon+color tokens), `BuilderState` type, `GroupRollup` interface,
+  and `worstBuilderState(rollup)` helper.
+- Header (`builder-tree-item.ts`) → `BUILDER_STATE_GLYPH[worstBuilderState(...)]`,
+  no ternary.
+- Row (`builders.ts`) → classify once into `BuilderState`, drive both the
+  contextValue family (new local `CONTEXT_FAMILY` map) and the icon from it;
+  blocked still overrides the glyph with `gateIconFor` (gate-specific) over the
+  shared color. Removes the duplicated literals + its own nested ternary.
+- +4 `worstBuilderState` unit tests. All green (211 tests).

--- a/codev/state/pir-926_thread.md
+++ b/codev/state/pir-926_thread.md
@@ -51,3 +51,26 @@ rollups — the issue's original both-views design.**
   (bell/comment-discussion/circle-filled). Tooltip carries counts in both.
 
 Plan rewritten to cover both views again.
+
+## Rebase on main + accuracy pass
+
+Rebased onto origin/main (4 commits replayed clean; #920 + #791 had landed).
+Re-verified every plan reference against the rebased code and fixed drift:
+
+- **Blocked-row icon is no longer a hardcoded `bell`.** `builders.ts:203` now
+  calls `gateIconFor(b.blockedGate)` (`builder-row.ts:35`) → gate-specific shape
+  (book/checklist/code/git-pull-request/verified, bell fallback), color held
+  uniform yellow. Plan's Builders rollup updated: header uses the **generic
+  `bell`** for any-blocked (a group can hold builders at different gates;
+  surfacing one gate's shape would misread). Dropped the "header pixel-matches
+  the topmost row" claim — only severity/color matches for blocked.
+- **Pure helpers relocated to the vscode-free modules** matching the
+  established pattern: `activeBuilderCountByArea` → `backlog-filter.ts`,
+  `rollupGroupState` → `builder-row.ts`. Tested under vitest `__tests__/`
+  (`backlog-filter.test.ts`, `builder-row.test.ts`), not the Electron
+  `src/test/` suite.
+- **Fixed test/build commands**: unit = `pnpm test:unit` (vitest); type-check =
+  `pnpm check-types`. The bogus `pnpm --filter @cluesmith/codev-vscode build`
+  (no such script; pkg is `codev-vscode`, not part of root `pnpm build`) removed.
+- Refreshed shifted line refs (api.ts area fields → 197/237; builders icon →
+  202-206; rootChildren blocks → backlog 96-103 / builders 140-152).

--- a/codev/state/pir-926_thread.md
+++ b/codev/state/pir-926_thread.md
@@ -27,3 +27,27 @@ Investigation findings:
 
 Plan written to `codev/plans/926-vscode-area-header-roll-up-ico.md`. Awaiting
 plan-approval gate.
+
+## Plan-gate discussion (resolved)
+
+Long design back-and-forth at the plan gate. Net outcome: **ship both views'
+rollups — the issue's original both-views design.**
+
+- Briefly descoped the Builders rollup as "redundant/noisy," then reversed:
+  those objections apply equally to the Backlog rollup we're keeping, so an
+  asymmetry (Backlog headers with dots, Builders without) would just look
+  unfinished. Consistency wins → both headers always carry a dot from the
+  shared icon vocabulary, computed per-view.
+- Confirmed the data model: issues with a builder are matched by `issueId`
+  (`overview.ts` `activeBuilderIssues`) and filtered out of the backlog by
+  `spawnableBacklog` (`!hasBuilder`). So the Backlog rollup must read
+  `data.builders` keyed by `.area`, not the visible issues (which are
+  builder-less by construction).
+- Filed **#948** (area/vscode): keep in-progress issues in the Backlog with the
+  builder's state icon instead of filtering them out — dissolves #926's known
+  limitation, but changes Backlog semantics + breaks dashboard parity, so it's
+  a deliberate follow-up, not folded into #926.
+- Backlog rollup stays binary (green/grey); Builders rollup is worst-of-three
+  (bell/comment-discussion/circle-filled). Tooltip carries counts in both.
+
+Plan rewritten to cover both views again.

--- a/codev/state/pir-926_thread.md
+++ b/codev/state/pir-926_thread.md
@@ -74,3 +74,20 @@ Re-verified every plan reference against the rebased code and fixed drift:
   (no such script; pkg is `codev-vscode`, not part of root `pnpm build`) removed.
 - Refreshed shifted line refs (api.ts area fields → 197/237; builders icon →
   202-206; rootChildren blocks → backlog 96-103 / builders 140-152).
+
+## Implement phase (plan-approval approved)
+
+Implemented both rollups per the plan:
+- `backlog-filter.ts` → `activeBuilderCountByArea(builders)` (pure, keyed on raw
+  `.area`).
+- `builder-row.ts` → `rollupGroupState(builders, now)` (pure, reuses
+  `isIdleWaiting`; blocked > idle > active).
+- `BacklogGroupTreeItem` → binary green/grey icon + count tooltip.
+- `BuilderGroupTreeItem` → worst-of-three icon (generic `bell` for blocked, not
+  gate-specific) + "b · i · a" tooltip.
+- Wired both into `backlog.ts` / `builders.ts` `rootChildren()`.
+- Tests: +5 `rollupGroupState`, +5 `activeBuilderCountByArea` (vitest __tests__).
+
+Verified (worktree needed `pnpm install` + core/types build first):
+`pnpm check-types` ✓, `pnpm lint` ✓, `pnpm test:unit` ✓ (207 tests, 10 new),
+`node esbuild.js` ✓. Awaiting go-ahead to commit + push, then dev-approval gate.

--- a/codev/state/pir-926_thread.md
+++ b/codev/state/pir-926_thread.md
@@ -117,3 +117,21 @@ row + header). Refactor:
   blocked still overrides the glyph with `gateIconFor` (gate-specific) over the
   shared color. Removes the duplicated literals + its own nested ternary.
 - +4 `worstBuilderState` unit tests. All green (211 tests).
+
+## Review phase → pr gate
+
+Wrote retrospective `codev/reviews/926-...md`, opened **PR #959** (Fixes #926),
+recorded with porch. 3-way consult (single advisory pass):
+- Gemini APPROVE (first run looped/no-verdict; re-ran → APPROVE).
+- Claude APPROVE.
+- Codex REQUEST_CHANGES — two bookkeeping findings, no code defect:
+  1. Backlog grey-vs-plan-green → ADDRESSED by syncing the plan to the shipped
+     grey (grey was the explicit dev-approval-gate request; gate approved with
+     it). Commit 939ed56d.
+  2. Plan missing approved/validated frontmatter → REBUTTED (architect-
+     pre-approval convention; PIR builder plans 920/930/932 carry none; approval
+     is in status.yaml; `validated:[3 models]` would be false — PIR plan phase
+     runs no consult).
+Rebuttal at `codev/projects/926-*/926-review-iter1-rebuttals.md`. Architect
+notified leading with the REQUEST_CHANGES + disposition. **At `pr` gate —
+awaiting human approval; merge is gated by porch state, not pane prose.**

--- a/packages/vscode/src/__tests__/backlog-filter.test.ts
+++ b/packages/vscode/src/__tests__/backlog-filter.test.ts
@@ -9,10 +9,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { OverviewBacklogItem, OverviewData, IssueSearchItem } from '@cluesmith/codev-types';
+import type { OverviewBacklogItem, OverviewBuilder, OverviewData, IssueSearchItem } from '@cluesmith/codev-types';
 import {
   filterMine,
   spawnableBacklog,
+  activeBuilderCountByArea,
   visibleBacklogCount,
   formatBacklogTitle,
   searchBacklog,
@@ -342,5 +343,40 @@ describe('formatAge', () => {
   });
   it('returns empty string for an unparseable date', () => {
     expect(formatAge('not-a-date', now)).toBe('');
+  });
+});
+
+describe('activeBuilderCountByArea', () => {
+  // The helper reads only `.area`; the rest of the shape is irrelevant.
+  const builderIn = (area: string): OverviewBuilder => ({ area } as unknown as OverviewBuilder);
+
+  it('empty builders → empty map', () => {
+    expect(activeBuilderCountByArea([]).size).toBe(0);
+  });
+
+  it('counts one builder under its area', () => {
+    const counts = activeBuilderCountByArea([builderIn('vscode')]);
+    expect(counts.get('vscode')).toBe(1);
+    expect(counts.get('tower')).toBeUndefined();
+  });
+
+  it('sums multiple builders in the same area', () => {
+    const counts = activeBuilderCountByArea([builderIn('vscode'), builderIn('vscode'), builderIn('vscode')]);
+    expect(counts.get('vscode')).toBe(3);
+  });
+
+  it('keeps per-area counts separate across areas', () => {
+    const counts = activeBuilderCountByArea([
+      builderIn('vscode'),
+      builderIn('tower'),
+      builderIn('vscode'),
+    ]);
+    expect(counts.get('vscode')).toBe(2);
+    expect(counts.get('tower')).toBe(1);
+  });
+
+  it('counts Uncategorized builders under the raw area value', () => {
+    const counts = activeBuilderCountByArea([builderIn('Uncategorized'), builderIn('Uncategorized')]);
+    expect(counts.get('Uncategorized')).toBe(2);
   });
 });

--- a/packages/vscode/src/__tests__/builder-row.test.ts
+++ b/packages/vscode/src/__tests__/builder-row.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, it, expect } from 'vitest';
 import type { OverviewBuilder } from '@cluesmith/codev-types';
-import { builderRowLabel, gateIconFor, rollupGroupState } from '../views/builder-row.js';
+import { builderRowLabel, gateIconFor, rollupGroupState, worstBuilderState } from '../views/builder-row.js';
 
 // A fixed clock so elapsed-time suffixes are deterministic.
 const NOW = new Date('2026-05-30T12:00:00Z').getTime();
@@ -163,5 +163,23 @@ describe('rollupGroupState', () => {
 
   it('empty group → all zero', () => {
     expect(rollupGroupState([], NOW)).toEqual({ blocked: 0, idle: 0, active: 0 });
+  });
+});
+
+describe('worstBuilderState', () => {
+  it('blocked beats everything', () => {
+    expect(worstBuilderState({ blocked: 1, idle: 5, active: 9 })).toBe('blocked');
+  });
+
+  it('idle beats active when nothing blocked', () => {
+    expect(worstBuilderState({ blocked: 0, idle: 1, active: 9 })).toBe('idle');
+  });
+
+  it('active when nothing blocked or idle', () => {
+    expect(worstBuilderState({ blocked: 0, idle: 0, active: 3 })).toBe('active');
+  });
+
+  it('all-zero (empty group) → active', () => {
+    expect(worstBuilderState({ blocked: 0, idle: 0, active: 0 })).toBe('active');
   });
 });

--- a/packages/vscode/src/__tests__/builder-row.test.ts
+++ b/packages/vscode/src/__tests__/builder-row.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, it, expect } from 'vitest';
 import type { OverviewBuilder } from '@cluesmith/codev-types';
-import { builderRowLabel, gateIconFor } from '../views/builder-row.js';
+import { builderRowLabel, gateIconFor, rollupGroupState } from '../views/builder-row.js';
 
 // A fixed clock so elapsed-time suffixes are deterministic.
 const NOW = new Date('2026-05-30T12:00:00Z').getTime();
@@ -130,5 +130,38 @@ describe('gateIconFor', () => {
     expect(gateIconFor('plan review')).toBe('bell');
     expect(gateIconFor('dev review')).toBe('bell');
     expect(gateIconFor('PR review')).toBe('bell');
+  });
+});
+
+describe('rollupGroupState', () => {
+  const blockedBuilder = () => builder({ blocked: 'plan review', blockedGate: 'plan-approval' });
+  const idleBuilder = () => builder({ blocked: null, lastDataAt: SIX_MIN_AGO });
+  const activeBuilder = () => builder({ blocked: null, lastDataAt: TWELVE_MIN_AGO, phase: 'verified' });
+
+  it('all active → only the active count', () => {
+    // `verified` phase makes isIdleWaiting false regardless of silence.
+    const state = rollupGroupState([activeBuilder(), activeBuilder(), activeBuilder()], NOW);
+    expect(state).toEqual({ blocked: 0, idle: 0, active: 3 });
+  });
+
+  it('one idle among actives → idle counted (idle beats active in the worst-of)', () => {
+    const state = rollupGroupState([activeBuilder(), idleBuilder(), activeBuilder()], NOW);
+    expect(state).toEqual({ blocked: 0, idle: 1, active: 2 });
+  });
+
+  it('one blocked → blocked counted (blocked beats idle + active)', () => {
+    const state = rollupGroupState([activeBuilder(), idleBuilder(), blockedBuilder()], NOW);
+    expect(state).toEqual({ blocked: 1, idle: 1, active: 1 });
+  });
+
+  it('blocked takes precedence over idle for the SAME builder', () => {
+    // A builder that is both blocked AND silent past the threshold counts as
+    // blocked only — mirrors the row classification (`!isBlocked && isIdle`).
+    const both = builder({ blocked: 'plan review', blockedGate: 'plan-approval', lastDataAt: SIX_MIN_AGO });
+    expect(rollupGroupState([both], NOW)).toEqual({ blocked: 1, idle: 0, active: 0 });
+  });
+
+  it('empty group → all zero', () => {
+    expect(rollupGroupState([], NOW)).toEqual({ blocked: 0, idle: 0, active: 0 });
   });
 });

--- a/packages/vscode/src/views/backlog-filter.ts
+++ b/packages/vscode/src/views/backlog-filter.ts
@@ -1,4 +1,4 @@
-import type { OverviewBacklogItem, OverviewData, IssueSearchItem } from '@cluesmith/codev-types';
+import type { OverviewBacklogItem, OverviewBuilder, OverviewData, IssueSearchItem } from '@cluesmith/codev-types';
 
 /**
  * Backlog rows the user can act on — exclude issues that already have an
@@ -12,6 +12,28 @@ import type { OverviewBacklogItem, OverviewData, IssueSearchItem } from '@cluesm
  */
 export function spawnableBacklog(items: OverviewBacklogItem[]): OverviewBacklogItem[] {
   return items.filter(i => !i.hasBuilder);
+}
+
+/**
+ * Count active builders per `area/*`, keyed on the raw `OverviewBuilder.area`
+ * wire value (the same value `groupByArea` keys on, so a Backlog group header's
+ * area matches without any client-side re-normalization).
+ *
+ * Backs the Backlog area-header roll-up icon (#926): a non-zero count means the
+ * area already has someone working it (green dot), zero means it's open to
+ * spawn into (grey dot). Reads from `OverviewData.builders` — NOT the visible
+ * backlog items — because issues with a builder are filtered out of the backlog
+ * (`spawnableBacklog`), so the "is this area active?" signal can only come from
+ * the builder list.
+ *
+ * Pure / vscode-free so it's unit-tested under the vitest `__tests__/` harness.
+ */
+export function activeBuilderCountByArea(builders: OverviewBuilder[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const b of builders) {
+    counts.set(b.area, (counts.get(b.area) ?? 0) + 1);
+  }
+  return counts;
 }
 
 /**

--- a/packages/vscode/src/views/backlog-tree-item.ts
+++ b/packages/vscode/src/views/backlog-tree-item.ts
@@ -31,14 +31,17 @@ export class BacklogTreeItem extends vscode.TreeItem {
  * `extension.ts` can scope to backlog groups via `instanceof`
  * (distinct from `BuilderGroupTreeItem`, which uses the same base).
  *
- * Carries a binary roll-up icon (#926): green `circle-filled` when the area
- * already has ≥1 active builder (someone's working it), grey `circle-outline`
- * when it's open to spawn into. The count comes from
- * `activeBuilderCountByArea` (computed from `OverviewData.builders`, not the
- * visible issues — those are builder-less by construction); the exact count
- * lives in the tooltip, the glyph stays glanceable. The rollup is set here in
- * the subclass, not the shared base, because the Builders view rolls up
- * differently.
+ * Carries a binary roll-up icon (#926): a filled grey `circle-filled` when the
+ * area already has ≥1 active builder (someone's working it) vs. an outline grey
+ * `circle-outline` when it's open to spawn into. Both use the muted
+ * `disabledForeground` token, differing only in fill — green is deliberately
+ * NOT used here so it stays exclusive to the Builders view's "agent actively
+ * building" signal; the Backlog is a calm "where can I spawn" surface, not an
+ * alert one. The count comes from `activeBuilderCountByArea` (computed from
+ * `OverviewData.builders`, not the visible issues — those are builder-less by
+ * construction); the exact count lives in the tooltip, the glyph stays
+ * glanceable. The rollup is set here in the subclass, not the shared base,
+ * because the Builders view rolls up differently.
  */
 export class BacklogGroupTreeItem extends AreaGroupTreeItem {
   constructor(
@@ -48,12 +51,13 @@ export class BacklogGroupTreeItem extends AreaGroupTreeItem {
     activeBuilderCount: number,
   ) {
     super(areaName, 'backlog', count, collapsibleState);
+    const grey = new vscode.ThemeColor('disabledForeground');
     if (activeBuilderCount > 0) {
-      this.iconPath = new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('testing.iconPassed'));
+      this.iconPath = new vscode.ThemeIcon('circle-filled', grey);
       const plural = activeBuilderCount === 1 ? 'builder' : 'builders';
       this.tooltip = `${activeBuilderCount} ${plural} active in ${areaName}`;
     } else {
-      this.iconPath = new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('disabledForeground'));
+      this.iconPath = new vscode.ThemeIcon('circle-outline', grey);
       this.tooltip = `No active builders in ${areaName}`;
     }
   }

--- a/packages/vscode/src/views/backlog-tree-item.ts
+++ b/packages/vscode/src/views/backlog-tree-item.ts
@@ -30,9 +30,31 @@ export class BacklogTreeItem extends vscode.TreeItem {
  * `AreaGroupTreeItem` so the per-view expand/collapse handler in
  * `extension.ts` can scope to backlog groups via `instanceof`
  * (distinct from `BuilderGroupTreeItem`, which uses the same base).
+ *
+ * Carries a binary roll-up icon (#926): green `circle-filled` when the area
+ * already has ≥1 active builder (someone's working it), grey `circle-outline`
+ * when it's open to spawn into. The count comes from
+ * `activeBuilderCountByArea` (computed from `OverviewData.builders`, not the
+ * visible issues — those are builder-less by construction); the exact count
+ * lives in the tooltip, the glyph stays glanceable. The rollup is set here in
+ * the subclass, not the shared base, because the Builders view rolls up
+ * differently.
  */
 export class BacklogGroupTreeItem extends AreaGroupTreeItem {
-  constructor(areaName: string, count: number, collapsibleState: vscode.TreeItemCollapsibleState) {
+  constructor(
+    areaName: string,
+    count: number,
+    collapsibleState: vscode.TreeItemCollapsibleState,
+    activeBuilderCount: number,
+  ) {
     super(areaName, 'backlog', count, collapsibleState);
+    if (activeBuilderCount > 0) {
+      this.iconPath = new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('testing.iconPassed'));
+      const plural = activeBuilderCount === 1 ? 'builder' : 'builders';
+      this.tooltip = `${activeBuilderCount} ${plural} active in ${areaName}`;
+    } else {
+      this.iconPath = new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('disabledForeground'));
+      this.tooltip = `No active builders in ${areaName}`;
+    }
   }
 }

--- a/packages/vscode/src/views/backlog.ts
+++ b/packages/vscode/src/views/backlog.ts
@@ -5,7 +5,7 @@ import { groupByArea } from '@cluesmith/codev-core/area-grouping';
 import type { OverviewCache } from './overview-data.js';
 import { BacklogGroupTreeItem, BacklogTreeItem } from './backlog-tree-item.js';
 import { AreaGroupExpansionStore } from './area-group-expansion.js';
-import { filterMine, spawnableBacklog } from './backlog-filter.js';
+import { activeBuilderCountByArea, filterMine, spawnableBacklog } from './backlog-filter.js';
 import { recencyPrefix, relativeAge } from './backlog-recency.js';
 
 // Re-export so existing call sites (extension.ts, src/test/backlog.test.ts)
@@ -94,12 +94,13 @@ export class BacklogProvider implements vscode.TreeDataProvider<vscode.TreeItem>
     }
 
     const expansion = this.expansion.read();
+    const activeByArea = activeBuilderCountByArea(data.builders);
     return groups.map(g => {
       const expanded = expansion[g.area] ?? true;
       const state = expanded
         ? vscode.TreeItemCollapsibleState.Expanded
         : vscode.TreeItemCollapsibleState.Collapsed;
-      return new BacklogGroupTreeItem(g.area, g.items.length, state);
+      return new BacklogGroupTreeItem(g.area, g.items.length, state, activeByArea.get(g.area) ?? 0);
     });
   }
 

--- a/packages/vscode/src/views/builder-row.ts
+++ b/packages/vscode/src/views/builder-row.ts
@@ -53,10 +53,7 @@ export function gateIconFor(blockedGate: string | null): string {
  *
  * Pure / vscode-free so it's unit-tested under the vitest `__tests__/` harness.
  */
-export function rollupGroupState(
-  builders: OverviewBuilder[],
-  now: number,
-): { blocked: number; idle: number; active: number } {
+export function rollupGroupState(builders: OverviewBuilder[], now: number): GroupRollup {
   let blocked = 0;
   let idle = 0;
   let active = 0;
@@ -70,6 +67,43 @@ export function rollupGroupState(
     }
   }
   return { blocked, idle, active };
+}
+
+export interface GroupRollup {
+  blocked: number;
+  idle: number;
+  active: number;
+}
+
+/** The three builder states, in worst-to-best severity order. */
+export type BuilderState = 'blocked' | 'idle' | 'active';
+
+/**
+ * Single source of truth for the three builder-state glyphs (codicon name +
+ * theme color token), shared by the builder ROW (`builders.ts`) and the
+ * area-group header rollup (`builder-tree-item.ts`) so the vocabulary is
+ * defined once. Strings only — no vscode `ThemeIcon`/`ThemeColor` — so this
+ * module stays vscode-free and unit-testable; call sites wrap them.
+ *
+ * NOTE: a blocked ROW overrides `icon` with the gate-specific `gateIconFor`
+ * shape (keeping `color`); the generic `bell` here is the group HEADER's
+ * blocked glyph and the row's unmapped-gate fallback.
+ */
+export const BUILDER_STATE_GLYPH: Record<BuilderState, { icon: string; color: string }> = {
+  blocked: { icon: 'bell', color: 'notificationsWarningIcon.foreground' },
+  idle: { icon: 'comment-discussion', color: 'notificationsInfoIcon.foreground' },
+  active: { icon: 'circle-filled', color: 'testing.iconPassed' },
+};
+
+/**
+ * The worst (most severe) state present in a group's rollup: blocked beats
+ * idle beats active. Drives the header's worst-of icon without a nested
+ * ternary at the call site.
+ */
+export function worstBuilderState(rollup: GroupRollup): BuilderState {
+  if (rollup.blocked > 0) { return 'blocked'; }
+  if (rollup.idle > 0) { return 'idle'; }
+  return 'active';
 }
 
 /**

--- a/packages/vscode/src/views/builder-row.ts
+++ b/packages/vscode/src/views/builder-row.ts
@@ -6,6 +6,7 @@
  */
 
 import type { OverviewBuilder } from '@cluesmith/codev-types';
+import { isIdleWaiting } from '@cluesmith/codev-core/builder-helpers';
 
 /**
  * Blocked-gate → codicon name. Keyed off the CANONICAL gate name
@@ -34,6 +35,41 @@ const GATE_ICONS: Record<string, string> = {
 /** Codicon name for a blocked builder's gate, with a `bell` fallback. */
 export function gateIconFor(blockedGate: string | null): string {
   return (blockedGate && GATE_ICONS[blockedGate]) || 'bell';
+}
+
+/**
+ * Roll up a Builders area-group's members into `{ blocked, idle, active }`
+ * counts (#926). Uses the SAME per-builder classification as the row icon in
+ * `builders.ts` — blocked (`b.blocked` truthy) takes precedence over idle
+ * (`isIdleWaiting`), which takes precedence over active — so the header's
+ * worst-of severity always tracks the rows beneath it.
+ *
+ * The header subclass (`BuilderGroupTreeItem`) turns this into the worst-of icon
+ * (blocked → `bell`, else idle → `comment-discussion`, else `circle-filled`) and
+ * a `"<b> blocked · <i> waiting · <a> active"` tooltip. Note the blocked header
+ * uses a GENERIC `bell`, not `gateIconFor` of any one member: a group can hold
+ * builders at different gates, so a single gate shape on the header would
+ * misrepresent the group — the yellow color carries the group-level signal.
+ *
+ * Pure / vscode-free so it's unit-tested under the vitest `__tests__/` harness.
+ */
+export function rollupGroupState(
+  builders: OverviewBuilder[],
+  now: number,
+): { blocked: number; idle: number; active: number } {
+  let blocked = 0;
+  let idle = 0;
+  let active = 0;
+  for (const b of builders) {
+    if (b.blocked) {
+      blocked++;
+    } else if (isIdleWaiting(b, now)) {
+      idle++;
+    } else {
+      active++;
+    }
+  }
+  return { blocked, idle, active };
 }
 
 /**

--- a/packages/vscode/src/views/builder-tree-item.ts
+++ b/packages/vscode/src/views/builder-tree-item.ts
@@ -28,9 +28,31 @@ export class BuilderTreeItem extends vscode.TreeItem {
  * `AreaGroupTreeItem` so the per-view expand/collapse handler in
  * `extension.ts` can scope to builder groups via `instanceof`
  * (distinct from `BacklogGroupTreeItem`, which uses the same base).
+ *
+ * Carries a worst-of-three roll-up icon (#926) over the group's
+ * `{ blocked, idle, active }` counts (from `rollupGroupState`), reusing the
+ * builder-row vocabulary: any blocked → yellow `bell`; else any idle → blue
+ * `comment-discussion`; else green `circle-filled`. The blocked case uses a
+ * GENERIC `bell` (not the row's gate-specific `gateIconFor` shape) because a
+ * group can hold builders at different gates — the yellow color is the
+ * group-level "needs attention" signal. The triple is spelled out in the
+ * tooltip. Set here in the subclass, not the shared base, because the Backlog
+ * view rolls up differently.
  */
 export class BuilderGroupTreeItem extends AreaGroupTreeItem {
-  constructor(areaName: string, count: number, collapsibleState: vscode.TreeItemCollapsibleState) {
+  constructor(
+    areaName: string,
+    count: number,
+    collapsibleState: vscode.TreeItemCollapsibleState,
+    rollup: { blocked: number; idle: number; active: number },
+  ) {
     super(areaName, 'builder', count, collapsibleState);
+    const { blocked, idle, active } = rollup;
+    this.iconPath = blocked > 0
+      ? new vscode.ThemeIcon('bell', new vscode.ThemeColor('notificationsWarningIcon.foreground'))
+      : idle > 0
+      ? new vscode.ThemeIcon('comment-discussion', new vscode.ThemeColor('notificationsInfoIcon.foreground'))
+      : new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('testing.iconPassed'));
+    this.tooltip = `${blocked} blocked · ${idle} waiting · ${active} active`;
   }
 }

--- a/packages/vscode/src/views/builder-tree-item.ts
+++ b/packages/vscode/src/views/builder-tree-item.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { AreaGroupTreeItem } from './area-group-tree-item.js';
+import { BUILDER_STATE_GLYPH, worstBuilderState, type GroupRollup } from './builder-row.js';
 
 /**
  * TreeItem subclass that carries a builder id as a typed field.
@@ -44,15 +45,11 @@ export class BuilderGroupTreeItem extends AreaGroupTreeItem {
     areaName: string,
     count: number,
     collapsibleState: vscode.TreeItemCollapsibleState,
-    rollup: { blocked: number; idle: number; active: number },
+    rollup: GroupRollup,
   ) {
     super(areaName, 'builder', count, collapsibleState);
-    const { blocked, idle, active } = rollup;
-    this.iconPath = blocked > 0
-      ? new vscode.ThemeIcon('bell', new vscode.ThemeColor('notificationsWarningIcon.foreground'))
-      : idle > 0
-      ? new vscode.ThemeIcon('comment-discussion', new vscode.ThemeColor('notificationsInfoIcon.foreground'))
-      : new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('testing.iconPassed'));
-    this.tooltip = `${blocked} blocked · ${idle} waiting · ${active} active`;
+    const { icon, color } = BUILDER_STATE_GLYPH[worstBuilderState(rollup)];
+    this.iconPath = new vscode.ThemeIcon(icon, new vscode.ThemeColor(color));
+    this.tooltip = `${rollup.blocked} blocked · ${rollup.idle} waiting · ${rollup.active} active`;
   }
 }

--- a/packages/vscode/src/views/builders.ts
+++ b/packages/vscode/src/views/builders.ts
@@ -12,7 +12,25 @@ import { BuilderFolderTreeItem } from './builder-folder-tree-item.js';
 import { buildFilePathTree, type FilePathNode } from './file-path-tree.js';
 import type { BuilderDiffCache } from './builder-diff-cache.js';
 import { AreaGroupExpansionStore } from './area-group-expansion.js';
-import { builderRowLabel, gateIconFor, rollupGroupState } from './builder-row.js';
+import {
+  builderRowLabel,
+  gateIconFor,
+  rollupGroupState,
+  BUILDER_STATE_GLYPH,
+  type BuilderState,
+} from './builder-row.js';
+
+/**
+ * Builder state → `contextValue` family prefix. Drives menu `when`-clause
+ * scoping (Approve Gate inline only on `blocked-builder-*`; the rest apply to
+ * all three families). Keyed by the same `BuilderState` the icon uses so a
+ * row's menu and glyph never disagree.
+ */
+const CONTEXT_FAMILY: Record<BuilderState, 'blocked-builder' | 'awaiting-builder' | 'builder'> = {
+  blocked: 'blocked-builder',
+  idle: 'awaiting-builder',
+  active: 'builder',
+};
 
 /**
  * Order builders for the Builders tree: three buckets, top-down.
@@ -184,26 +202,25 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
     // builder has committed a review file on disk — the
     // `codev.viewReviewFile` menu entry's `when` clause keys off it so
     // PIR rows hide the entry until the review phase produces the file.
-    let family: 'blocked-builder' | 'awaiting-builder' | 'builder';
+    // Classify once (blocked > idle > active); the state drives both the
+    // contextValue family (menu scoping) and the icon.
+    let state: BuilderState;
     if (isBlocked) {
-      family = 'blocked-builder';
+      state = 'blocked';
     } else if (isIdle) {
-      family = 'awaiting-builder';
+      state = 'idle';
     } else {
-      family = 'builder';
+      state = 'active';
     }
     const protocol = b.protocol || 'unknown';
     const reviewSuffix = builderHasReviewFile(b) ? '-review' : '';
-    item.contextValue = `${family}-${protocol}${reviewSuffix}`;
-    // Three icons for three states: gate-specific codicon (blocked, shape
-    // varies by gate via `gateIconFor` — color stays warning-yellow),
-    // comment-discussion (silent, likely waiting on a question), circle-filled
-    // (live/active).
-    item.iconPath = isBlocked
-      ? new vscode.ThemeIcon(gateIconFor(b.blockedGate), new vscode.ThemeColor('notificationsWarningIcon.foreground'))
-      : isIdle
-      ? new vscode.ThemeIcon('comment-discussion', new vscode.ThemeColor('notificationsInfoIcon.foreground'))
-      : new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('testing.iconPassed'));
+    item.contextValue = `${CONTEXT_FAMILY[state]}-${protocol}${reviewSuffix}`;
+    // Icon: the shared per-state glyph (single source of truth in
+    // builder-row.ts). A blocked row overrides the shape with the gate-specific
+    // `gateIconFor` codicon while keeping the shared warning color.
+    const { icon, color } = BUILDER_STATE_GLYPH[state];
+    const iconName = isBlocked ? gateIconFor(b.blockedGate) : icon;
+    item.iconPath = new vscode.ThemeIcon(iconName, new vscode.ThemeColor(color));
     // The row click runs `codev.openBuilderRow` — a wrapper that opens the
     // builder terminal AND expands the row (so single-click matches what
     // most users expect). Pass the item itself so the handler can call

--- a/packages/vscode/src/views/builders.ts
+++ b/packages/vscode/src/views/builders.ts
@@ -12,7 +12,7 @@ import { BuilderFolderTreeItem } from './builder-folder-tree-item.js';
 import { buildFilePathTree, type FilePathNode } from './file-path-tree.js';
 import type { BuilderDiffCache } from './builder-diff-cache.js';
 import { AreaGroupExpansionStore } from './area-group-expansion.js';
-import { builderRowLabel, gateIconFor } from './builder-row.js';
+import { builderRowLabel, gateIconFor, rollupGroupState } from './builder-row.js';
 
 /**
  * Order builders for the Builders tree: three buckets, top-down.
@@ -144,7 +144,7 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
       const state = expanded
         ? vscode.TreeItemCollapsibleState.Expanded
         : vscode.TreeItemCollapsibleState.Collapsed;
-      const groupItem = new BuilderGroupTreeItem(g.area, g.items.length, state);
+      const groupItem = new BuilderGroupTreeItem(g.area, g.items.length, state, rollupGroupState(g.items, now));
       for (const b of g.items) {
         this.groupParentByBuilderId.set(b.id, groupItem);
       }


### PR DESCRIPTION
# PIR Review: VSCode area-header roll-up icons (Backlog & Builders views)

Fixes #926

## Summary

Adds a roll-up status icon to the `area/*` group headers in the VSCode sidebar's
Backlog and Builders trees, so an engineer can triage at a glance without
expanding each group. Both rollups are computed client-side from the overview
cache (no server / payload change). The Backlog header is **binary** — filled
vs. outline grey for "area has a builder" vs. "open to spawn"; the Builders
header is a **worst-of-three** — `bell` (any blocked) → `comment-discussion`
(any idle) → `circle-filled` (all active), reusing the builder-row icon
vocabulary. Counts live in the tooltip.

## Files Changed

Code (anchored at merge-base `b6059d5b`):

- `packages/vscode/src/views/backlog-filter.ts` (+24 / -0) — `activeBuilderCountByArea` (pure)
- `packages/vscode/src/views/backlog-tree-item.ts` (+28 / -... ) — `BacklogGroupTreeItem` icon/tooltip
- `packages/vscode/src/views/backlog.ts` (+5 / -...) — wire into `rootChildren()`
- `packages/vscode/src/views/builder-row.ts` (+70 / -0) — `rollupGroupState`, `BUILDER_STATE_GLYPH`, `worstBuilderState`, `GroupRollup`/`BuilderState`
- `packages/vscode/src/views/builder-tree-item.ts` (+21 / -...) — `BuilderGroupTreeItem` icon/tooltip
- `packages/vscode/src/views/builders.ts` (+49 / -...) — wire rollup into `rootChildren()`; row icon/contextValue now sourced from the shared glyph
- `packages/vscode/src/__tests__/backlog-filter.test.ts` (+38 / -0) — `activeBuilderCountByArea` tests
- `packages/vscode/src/__tests__/builder-row.test.ts` (+53 / -0) — `rollupGroupState` + `worstBuilderState` tests

8 files, +265 / -23.

## Commits

`git log main..HEAD --oneline` (implementation commits; porch chore commits omitted):

- `3d07ae01` [PIR #926] Add area-header roll-up icons to Backlog & Builders views
- `f846f6aa` [PIR #926] Unit-test activeBuilderCountByArea + rollupGroupState
- `b6092ab8` [PIR #926] Backlog header: filled/outline grey instead of green (reserve green for live builders)
- `845c0a45` [PIR #926] Centralize builder-state glyphs + worstBuilderState helper (drop nested ternaries)

## Test Results

- `pnpm check-types`: ✓ pass
- `pnpm lint`: ✓ pass
- `pnpm test:unit`: ✓ pass (211 tests, 14 new across the two helper suites)
- `node esbuild.js`: ✓ pass (extension bundles)
- porch `build` + `tests` checks: ✓ pass (at dev-approval)
- Manual verification: reviewer approved the running worktree at the
  `dev-approval` gate (VSCode Extension Host) — confirmed the Backlog
  filled/outline-grey headers and the Builders worst-of-three headers render and
  their tooltips carry the counts.

## Architecture Updates

No `arch.md` changes needed. This adds two pure helpers and sets `iconPath` on
two existing `AreaGroupTreeItem` subclasses — no new module boundary, service,
or data-flow. It stays within the established VSCode-view pattern (pure,
vscode-free helpers in `backlog-filter.ts` / `builder-row.ts` tested under the
vitest `__tests__/` harness; `ThemeIcon` construction at the tree-item call
site). The one mild structural improvement — `BUILDER_STATE_GLYPH` as the single
source of truth for the three builder-state glyphs shared by the row and the
header — is a local DRY consolidation, not an architectural change.

## Lessons Learned Updates

No `lessons-learned.md` change — the insights here are PR-specific rather than
durable cross-cutting wisdom, and are captured in this review:

- **Issue specs referencing `file:line` icon vocabulary can go stale across a
  rebase.** #926 specced the Builders blocked rollup as a static `bell` "reusing
  the row icons." Between issue authoring and implementation, the row's blocked
  icon became gate-specific (`gateIconFor` → `book`/`checklist`/`code`/…), so
  `bell` is now only an unmapped-gate fallback. The rebase-time accuracy pass
  caught this; the header keeps a *generic* `bell` as a deliberate group-level
  "attention" glyph (a group can hold builders at different gates), documented at
  `builder-tree-item.ts`.
- **Reserve color semantics across sibling views.** Green = "live/active agent"
  on builder rows; using a green dot in the Backlog overloaded it. The Backlog
  rollup ships as filled/outline *grey* so green stays exclusive to live
  builders and the Backlog reads as a calm "where can I spawn" surface.

## 3-Way Consultation (single advisory pass — PIR does not re-review)

- **Claude: APPROVE** (HIGH).
- **Codex: REQUEST_CHANGES** (HIGH) — two findings, both bookkeeping, no code defect:
  1. *Backlog dot is grey, but the plan said green.* **Addressed by updating the
     plan, not the code.** The grey was an explicit reviewer request at the
     `dev-approval` gate (reserve green for the Builders "live agent" signal),
     and the gate was approved with grey in place — reverting would contradict
     the human decision. The plan's Backlog section is updated to match what
     shipped, removing the drift. No code change, so no regression test applies.
  2. *Plan lacks `approved`/`validated` frontmatter.* **Rebutted.** That
     frontmatter is the architect-pre-approval convention (e.g. plan #925);
     PIR builder-created plans approved via the porch `plan-approval` gate don't
     carry it (siblings #920, #930, #932 have none), the approval record lives
     in `status.yaml`, and `validated: [gemini, codex, claude]` would be
     factually false — PIR's plan phase runs no consultation.
- **Gemini: no verdict** — the run looped on a repeated file-search tool call
  and exited without emitting a verdict file (infra issue, not a code finding).

Net: one APPROVE, one REQUEST_CHANGES whose two findings are a plan-doc sync
(done) and a frontmatter-convention rebut. Escalated to the human at the `pr`
gate since PIR will not independently re-review.

## Things to Look At During PR Review

- **Backlog "active builder" semantics.** `activeBuilderCountByArea` counts
  *any* builder in the area (including one blocked at a gate) as "active" — the
  Backlog question is "is anyone working this area?". A consequence worth a
  conscious nod: the same area can show a filled-grey Backlog header (has a
  builder) while its Builders header is `bell`/yellow (that builder is blocked).
  That's intended — the two views answer different questions.
- **Known limitation (accepted).** An area whose only open issue is being built
  has that issue filtered out of the backlog (`spawnableBacklog`), so it renders
  no Backlog header at all and can't show "working" there. Fine for the "where
  do I spawn?" goal; a follow-up (#948) tracks optionally keeping in-progress
  issues in the Backlog with the builder's state icon.
- **Builders worst-of-three is a severity summary, not a full picture.** One
  glyph can't convey a mixed group; the full `{blocked, idle, active}` breakdown
  is in the tooltip. This was discussed at the gate and kept deliberately.
- **Shared-glyph refactor touched existing row code** (`builders.ts`
  `makeBuilderRow`): the row now classifies once into a `BuilderState` driving
  both `contextValue` family (`CONTEXT_FAMILY`) and icon (`BUILDER_STATE_GLYPH`),
  with the blocked row still overriding the *glyph* via `gateIconFor` while
  reusing the shared *color*. Behavior is identical; worth a glance to confirm
  the contextValue strings (`blocked-builder`/`awaiting-builder`/`builder`) are
  unchanged so menu `when`-clauses still match.

## How to Test Locally

For reviewers pulling the branch:

- **View diff**: VSCode sidebar → right-click builder `pir-926` → **View Diff**
- **Run dev server**: VSCode sidebar → **Run Dev Server**, or `afx dev pir-926`
- **What to verify** (mapped to the plan's Test Plan):
  - Backlog: an area with a spawnable issue **and** a live builder → filled grey
    dot; an area with only spawnable issues → outline grey dot. Hover → builder
    count.
  - Builders: a group with a builder blocked at a gate → yellow `bell`;
    worst-idle group → blue `comment-discussion`; all-active → green
    `circle-filled`. Hover → "b blocked · i waiting · a active".
  - Both: collapse/expand still works; a single-`Uncategorized` repo renders flat
    rows with no header (unchanged).
  - Unit: `cd packages/vscode && pnpm test:unit`.
