### PR TITLE
VSCode Builders tree: neutral inline gate-action icon (#933)

### DIFF
--- a/codev/plans/933-afx-tower-ui-gate-action-butto.md
+++ b/codev/plans/933-afx-tower-ui-gate-action-butto.md
@@ -1,0 +1,44 @@
+# PIR Plan: Neutral inline gate-action icon (icon-only)
+
+> Issue [#933](https://github.com/cluesmith/codev/issues/933). Scope: **VSCode extension**, **icon-only**. An earlier iteration of this work (per-gate action dispatch) was reverted at the architect's direction as scope creep; the branch was reset to the pristine init commit. This plan covers only the icon swap.
+
+## Understanding
+
+In the VSCode **Builders** tree, each *blocked* builder row shows an inline action button bound to `codev.approveGate`. That command declares a static checkmark icon in `packages/vscode/package.json`:
+
+```json
+{ "command": "codev.approveGate", "title": "Codev: Approve Gate", "icon": "$(check)" }
+```
+
+The inline button's icon comes from this static command declaration (VSCode renders a menu action's icon from the command, not from the tree item — there is no per-row override). So every blocked builder shows the same ✓, which reads as the specific promise "approve" rather than a neutral "this row wants your attention."
+
+The row's **leading** icon is already gate-specific (`gateIconFor`/`GATE_ICONS` in `builder-row.ts`), so per-gate triage already exists and is **not** touched here.
+
+## Proposed Change
+
+Change the `codev.approveGate` command's `icon` from `$(check)` to `$(arrow-right)` (→) — a neutral "act on this row" glyph (architect-confirmed). The button's **command and behavior are unchanged**: clicking it still opens the existing approve confirmation flow.
+
+This is a one-line, declarative change. Because `codev.approveGate`'s icon only renders in the inline menu (context-menu entries render the command *title*, and the gate-pending toast uses its own button labels — neither uses the command icon), the swap affects only the inline button. No code, no `contextValue`, no `when`-clauses, no new commands.
+
+## Files to Change
+
+- `packages/vscode/package.json` — in `contributes.commands`, change the `codev.approveGate` entry's `"icon": "$(check)"` to `"icon": "$(arrow-right)"`. (One line.)
+
+## Risks & Alternatives Considered
+
+- **Risk — the icon also renders somewhere unexpected.** *Mitigation:* `codev.approveGate` is used in (a) the inline `blocked-builder` menu (icon shown), (b) the `1_primary@2` context-menu entry (title shown, not icon), and (c) the gate-pending toast's `Approve` button (its own label, not the command icon). Only (a) renders the icon, so this is the sole visible effect. Verified by grepping the menu/command/toast wiring.
+- **Risk — a neutral arrow under an "approve" action is itself slightly ambiguous.** Accepted: the issue's goal is specifically to stop the ✓ from over-promising "approve"; the leading per-gate row icon carries the state meaning. (The architect chose icon-only over varying the action.)
+- **Alternative — per-gate inline icons / per-gate actions.** Rejected (explicitly de-scoped): both require encoding the gate in `contextValue` plus multiple commands or a dispatcher — behavior/machinery beyond an icon change.
+- **No new automated test.** This is a single declarative icon string; the existing `contributes-commands` test already loads and validates `package.json`. Adding a test that pins one icon literal would be low-value churn against the "minimal" intent. (Open to adding a one-line assertion if the reviewer prefers.)
+
+## Test Plan
+
+**Build:** `pnpm --filter codev-vscode check-types` and `lint` pass (no code changed; package.json must remain valid JSON). Porch's `build`/`tests` checks pass.
+
+**Manual (at the `dev-approval` gate — load the extension via the Extension Development Host):**
+- A blocked builder's inline action button shows **→**, not **✓**.
+- Clicking it still opens the approve confirmation (behavior unchanged).
+- The right-click "Approve Gate" entry and **Cmd+K G** still work.
+- The gate-pending toast's buttons are unchanged.
+
+**Cross-platform:** codicons render identically across OSes; no platform-specific concerns.

--- a/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
+++ b/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
@@ -1,7 +1,7 @@
 id: '933'
 title: afx-tower-ui-gate-action-butto
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-02T00:03:40.820Z'
-updated_at: '2026-06-02T01:45:42.207Z'
+updated_at: '2026-06-02T01:45:51.932Z'

--- a/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
+++ b/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-06-02T01:45:23.271Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-02T00:03:40.820Z'
-updated_at: '2026-06-02T00:03:40.821Z'
+updated_at: '2026-06-02T01:45:23.271Z'

--- a/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
+++ b/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-06-02T01:52:20.562Z'
   pr:
     status: pending
+    requested_at: '2026-06-02T01:55:51.864Z'
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-06-02T00:03:40.820Z'
-updated_at: '2026-06-02T01:53:42.095Z'
+updated_at: '2026-06-02T01:55:51.864Z'
 pr_history:
   - phase: review
     pr_number: 963
     branch: builder/pir-933
     created_at: '2026-06-02T01:53:31.390Z'
+pr_ready_for_human: true

--- a/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
+++ b/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-06-02T01:45:23.271Z'
     approved_at: '2026-06-02T01:45:42.206Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-06-02T01:47:23.037Z'
+    approved_at: '2026-06-02T01:52:20.562Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-02T00:03:40.820Z'
-updated_at: '2026-06-02T01:47:23.038Z'
+updated_at: '2026-06-02T01:52:20.563Z'

--- a/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
+++ b/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
@@ -1,0 +1,18 @@
+id: '933'
+title: afx-tower-ui-gate-action-butto
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-06-02T00:03:40.820Z'
+updated_at: '2026-06-02T00:03:40.821Z'

--- a/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
+++ b/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-06-02T01:45:23.271Z'
+    approved_at: '2026-06-02T01:45:42.206Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-02T00:03:40.820Z'
-updated_at: '2026-06-02T01:45:23.271Z'
+updated_at: '2026-06-02T01:45:42.207Z'

--- a/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
+++ b/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-06-02T00:03:40.820Z'
-updated_at: '2026-06-02T01:53:31.391Z'
+updated_at: '2026-06-02T01:53:42.095Z'
 pr_history:
   - phase: review
     pr_number: 963

--- a/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
+++ b/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-02T00:03:40.820Z'
-updated_at: '2026-06-02T01:52:29.810Z'
+updated_at: '2026-06-02T01:53:31.391Z'
+pr_history:
+  - phase: review
+    pr_number: 963
+    branch: builder/pir-933
+    created_at: '2026-06-02T01:53:31.390Z'

--- a/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
+++ b/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
@@ -1,7 +1,7 @@
 id: '933'
 title: afx-tower-ui-gate-action-butto
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-02T00:03:40.820Z'
-updated_at: '2026-06-02T01:52:20.563Z'
+updated_at: '2026-06-02T01:52:29.810Z'

--- a/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
+++ b/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-06-02T01:47:23.037Z'
     approved_at: '2026-06-02T01:52:20.562Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-06-02T01:55:51.864Z'
+    approved_at: '2026-06-02T01:59:39.939Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-02T00:03:40.820Z'
-updated_at: '2026-06-02T01:55:51.864Z'
+updated_at: '2026-06-02T01:59:39.939Z'
 pr_history:
   - phase: review
     pr_number: 963
     branch: builder/pir-933
     created_at: '2026-06-02T01:53:31.390Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
+++ b/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-06-02T01:45:42.206Z'
   dev-approval:
     status: pending
+    requested_at: '2026-06-02T01:47:23.037Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-02T00:03:40.820Z'
-updated_at: '2026-06-02T01:45:51.932Z'
+updated_at: '2026-06-02T01:47:23.038Z'

--- a/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
+++ b/codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml
@@ -1,7 +1,7 @@
 id: '933'
 title: afx-tower-ui-gate-action-butto
 protocol: pir
-phase: review
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -21,7 +21,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-02T00:03:40.820Z'
-updated_at: '2026-06-02T01:59:39.939Z'
+updated_at: '2026-06-02T01:59:48.486Z'
 pr_history:
   - phase: review
     pr_number: 963

--- a/codev/reviews/933-afx-tower-ui-gate-action-butto.md
+++ b/codev/reviews/933-afx-tower-ui-gate-action-butto.md
@@ -1,0 +1,55 @@
+# PIR Review: Neutral inline gate-action icon on the VSCode Builders tree
+
+Fixes #933
+
+## Summary
+
+The VSCode Builders tree showed a checkmark (`$(check)`) on the inline action button of every blocked builder, implying "approve" regardless of which gate the builder was at. This change swaps that glyph for a neutral arrow (`$(arrow-right)`) so the button no longer over-promises "approve." It is a one-line, behavior-preserving change to the `codev.approveGate` command's declared icon in `package.json` — clicking the button still opens the same approve flow; the context menu and `Cmd+K G` are untouched. Per-gate triage at a glance is already provided by the row's *leading* icon (`gateIconFor`), which was not modified.
+
+## Files Changed
+
+- `packages/vscode/package.json` (+1 / -1) — `codev.approveGate` icon `$(check)` → `$(arrow-right)`
+- `codev/plans/933-afx-tower-ui-gate-action-butto.md` (+44 / -0) — the approved plan
+- `codev/state/pir-933_thread.md` (+30 / -0) — builder thread log
+- `codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml` (+22 / -0) — porch state (managed automatically)
+
+## Commits
+
+- `e093d8c8` [PIR #933] Builders tree: neutral inline gate-action icon (arrow, not checkmark)
+- `89338131` [PIR #933] Thread: implement notes (icon-only)
+- `31d09e87` [PIR #933] Plan draft (icon-only)
+
+(plus porch-managed `chore(porch)` state-transition commits)
+
+## Test Results
+
+- `pnpm --filter codev-vscode check-types`: ✓ pass
+- `pnpm --filter codev-vscode lint`: ✓ pass
+- `pnpm --filter codev-vscode test:unit`: ✓ pass (197 tests)
+- porch `build` / `tests` checks: ✓ pass
+- Manual verification: approved by the human at the `dev-approval` gate (inline button renders the arrow instead of the checkmark; approve flow, context menu, and Cmd+K G unchanged).
+
+## Architecture Updates
+
+No arch changes — this is a single declarative icon-string swap in `package.json`. It introduces no new module, command, pattern, or boundary, so `codev/resources/arch.md` needs no update.
+
+## Lessons Learned Updates
+
+No new lesson added to `codev/resources/lessons-learned.md`. The one takeaway from this work was process, not architecture, and is already captured by existing guidance: **scope an issue to what it literally asks for.** This issue read "change the icon," but its acceptance criteria also implied a per-gate *action* change; an earlier iteration built that (a runtime dispatcher) and it was reverted as scope creep before re-doing it as the one-line icon swap. The existing `feedback_match_protocol_to_scope` / surgical-scope guidance already covers this; no durable doc change warranted.
+
+## Things to Look At During PR Review
+
+- Confirm the glyph only renders where intended: `codev.approveGate`'s icon appears solely on the inline `blocked-builder` menu action. Its context-menu entry (`1_primary@2`) renders the command *title*, and the gate-pending toast (`gate-toast.ts`) uses its own button labels — neither uses the command icon. So the only visible effect is the inline button.
+- This is deliberately icon-only: the button's command and behavior are unchanged. If a reviewer expected the inline action to *do* something different per gate (open the plan / run dev), that was explicitly de-scoped — see the issue's "Out of scope" section.
+
+## How to Test Locally
+
+For reviewers pulling the branch:
+
+- **View diff**: VSCode sidebar → right-click builder `pir-933` → **View Diff** (or the one-line `package.json` diff on the PR).
+- **Run the extension**: open the `pir-933` worktree as a workspace → Run & Debug → "Run Codev Extension" (F5) → inspect a blocked builder row in the Builders tree.
+- **What to verify**:
+  - The inline action button on a blocked builder shows **→**, not **✓**.
+  - Clicking it still opens the approve confirmation (behavior unchanged).
+  - Right-click "Approve Gate" and **Cmd+K G** still approve.
+  - The gate-pending toast's buttons are unchanged.

--- a/codev/state/pir-933_thread.md
+++ b/codev/state/pir-933_thread.md
@@ -35,3 +35,11 @@ Review file written, PR #963 opened (body = review). 3-way consult (single
 advisory pass): gemini/codex/claude all APPROVE, HIGH, no issues. (Gemini's
 first run hit a transient exit-1; rerun succeeded.) `pr` gate pending —
 notified architect (all-clear), awaiting human merge + gate approval.
+
+## Merge blocked on branch protection (2026-06-02)
+
+porch pr-gate approved + protocol complete (phase: verified), but `gh pr merge 963 --merge`
+rejected: base branch policy. mergeStateStatus=BLOCKED, mergeable=MERGEABLE,
+reviewDecision=REVIEW_REQUIRED. Blockers: (1) required GitHub PR review approval
+(I'm author, can't self-approve); (2) 6 CI checks pending. Asked architect how to
+proceed (approve+merge / --auto / --admin). Holding.

--- a/codev/state/pir-933_thread.md
+++ b/codev/state/pir-933_thread.md
@@ -28,3 +28,10 @@ Plan approved. One-line change: `codev.approveGate` icon `$(check)` →
 `$(arrow-right)` in `packages/vscode/package.json`. No code, no behavior change.
 Checks (worktree): check-types ✓, lint ✓, test:unit 197/197 ✓.
 Committed, pushed. `porch done` → awaiting `dev-approval`.
+
+## Review (2026-06-02)
+
+Review file written, PR #963 opened (body = review). 3-way consult (single
+advisory pass): gemini/codex/claude all APPROVE, HIGH, no issues. (Gemini's
+first run hit a transient exit-1; rerun succeeded.) `pr` gate pending —
+notified architect (all-clear), awaiting human merge + gate approval.

--- a/codev/state/pir-933_thread.md
+++ b/codev/state/pir-933_thread.md
@@ -1,0 +1,23 @@
+# PIR #933 — VSCode Builders tree: inline gate-action icon
+
+## Restart (2026-06-02) — icon-only
+
+**History reset.** An earlier iteration implemented a per-gate *action* dispatcher
+(inline button opened the plan / ran dev / approved depending on gate). The
+architect judged the action-change to be scope creep — the issue only calls for
+an icon change — and directed a clean restart.
+
+Done:
+- `git reset --hard fcea5028` (pristine porch-init commit) → porch back in the
+  **plan** phase; all prior plan/implement commits removed.
+- `git push --force-with-lease` → remote branch cleaned to fcea5028.
+- GitHub issue #933 realigned to **icon-only** scope (per-gate action behavior
+  moved to explicit Out-of-scope; acceptance simplified).
+
+**Scope now:** one-line change — swap `codev.approveGate`'s declared icon from
+`$(check)` to `$(arrow-right)` in `packages/vscode/package.json`. Action/behavior
+unchanged; only the inline button glyph. The row's leading icon is already
+gate-specific (gateIconFor) and untouched.
+
+Plan rewritten → `codev/plans/933-afx-tower-ui-gate-action-butto.md`. Awaiting
+`plan-approval`.

--- a/codev/state/pir-933_thread.md
+++ b/codev/state/pir-933_thread.md
@@ -21,3 +21,10 @@ gate-specific (gateIconFor) and untouched.
 
 Plan rewritten → `codev/plans/933-afx-tower-ui-gate-action-butto.md`. Awaiting
 `plan-approval`.
+
+## Implement (2026-06-02) — icon-only
+
+Plan approved. One-line change: `codev.approveGate` icon `$(check)` →
+`$(arrow-right)` in `packages/vscode/package.json`. No code, no behavior change.
+Checks (worktree): check-types ✓, lint ✓, test:unit 197/197 ✓.
+Committed, pushed. `porch done` → awaiting `dev-approval`.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -78,7 +78,7 @@
       {
         "command": "codev.approveGate",
         "title": "Codev: Approve Gate",
-        "icon": "$(check)"
+        "icon": "$(arrow-right)"
       },
       {
         "command": "codev.cleanupBuilder",


### PR DESCRIPTION
# PIR Review: Neutral inline gate-action icon on the VSCode Builders tree

Fixes #933

## Summary

The VSCode Builders tree showed a checkmark (`$(check)`) on the inline action button of every blocked builder, implying "approve" regardless of which gate the builder was at. This change swaps that glyph for a neutral arrow (`$(arrow-right)`) so the button no longer over-promises "approve." It is a one-line, behavior-preserving change to the `codev.approveGate` command's declared icon in `package.json` — clicking the button still opens the same approve flow; the context menu and `Cmd+K G` are untouched. Per-gate triage at a glance is already provided by the row's *leading* icon (`gateIconFor`), which was not modified.

## Files Changed

- `packages/vscode/package.json` (+1 / -1) — `codev.approveGate` icon `$(check)` → `$(arrow-right)`
- `codev/plans/933-afx-tower-ui-gate-action-butto.md` (+44 / -0) — the approved plan
- `codev/state/pir-933_thread.md` (+30 / -0) — builder thread log
- `codev/projects/933-afx-tower-ui-gate-action-butto/status.yaml` (+22 / -0) — porch state (managed automatically)

## Commits

- `e093d8c8` [PIR #933] Builders tree: neutral inline gate-action icon (arrow, not checkmark)
- `89338131` [PIR #933] Thread: implement notes (icon-only)
- `31d09e87` [PIR #933] Plan draft (icon-only)

(plus porch-managed `chore(porch)` state-transition commits)

## Test Results

- `pnpm --filter codev-vscode check-types`: ✓ pass
- `pnpm --filter codev-vscode lint`: ✓ pass
- `pnpm --filter codev-vscode test:unit`: ✓ pass (197 tests)
- porch `build` / `tests` checks: ✓ pass
- Manual verification: approved by the human at the `dev-approval` gate (inline button renders the arrow instead of the checkmark; approve flow, context menu, and Cmd+K G unchanged).

## Architecture Updates

No arch changes — this is a single declarative icon-string swap in `package.json`. It introduces no new module, command, pattern, or boundary, so `codev/resources/arch.md` needs no update.

## Lessons Learned Updates

No new lesson added to `codev/resources/lessons-learned.md`. The one takeaway from this work was process, not architecture, and is already captured by existing guidance: **scope an issue to what it literally asks for.** This issue read "change the icon," but its acceptance criteria also implied a per-gate *action* change; an earlier iteration built that (a runtime dispatcher) and it was reverted as scope creep before re-doing it as the one-line icon swap. The existing `feedback_match_protocol_to_scope` / surgical-scope guidance already covers this; no durable doc change warranted.

## Things to Look At During PR Review

- Confirm the glyph only renders where intended: `codev.approveGate`'s icon appears solely on the inline `blocked-builder` menu action. Its context-menu entry (`1_primary@2`) renders the command *title*, and the gate-pending toast (`gate-toast.ts`) uses its own button labels — neither uses the command icon. So the only visible effect is the inline button.
- This is deliberately icon-only: the button's command and behavior are unchanged. If a reviewer expected the inline action to *do* something different per gate (open the plan / run dev), that was explicitly de-scoped — see the issue's "Out of scope" section.

## How to Test Locally

For reviewers pulling the branch:

- **View diff**: VSCode sidebar → right-click builder `pir-933` → **View Diff** (or the one-line `package.json` diff on the PR).
- **Run the extension**: open the `pir-933` worktree as a workspace → Run & Debug → "Run Codev Extension" (F5) → inspect a blocked builder row in the Builders tree.
- **What to verify**:
  - The inline action button on a blocked builder shows **→**, not **✓**.
  - Clicking it still opens the approve confirmation (behavior unchanged).
  - Right-click "Approve Gate" and **Cmd+K G** still approve.
  - The gate-pending toast's buttons are unchanged.
