### PR TITLE
Lower SPIR/ASPIR review iteration ceiling (max_iterations) from 8 to 3

### DIFF
--- a/codev-skeleton/protocols/aspir/protocol.json
+++ b/codev-skeleton/protocols/aspir/protocol.json
@@ -23,7 +23,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 8,
+      "max_iterations": 3,
       "on_complete": {
         "commit": true,
         "push": true
@@ -44,7 +44,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 8,
+      "max_iterations": 3,
       "on_complete": {
         "commit": true,
         "push": true
@@ -70,7 +70,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 8,
+      "max_iterations": 3,
       "on_complete": {
         "commit": true,
         "push": true
@@ -107,7 +107,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 8,
+      "max_iterations": 3,
       "on_complete": {
         "commit": true,
         "push": true
@@ -160,7 +160,7 @@
   },
   "defaults": {
     "mode": "strict",
-    "max_iterations": 8,
+    "max_iterations": 3,
     "verify": {
       "models": ["gemini", "codex", "claude"],
       "parallel": true

--- a/codev-skeleton/protocols/spir/protocol.json
+++ b/codev-skeleton/protocols/spir/protocol.json
@@ -24,7 +24,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 8,
+      "max_iterations": 3,
       "on_complete": {
         "commit": true,
         "push": true
@@ -46,7 +46,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 8,
+      "max_iterations": 3,
       "on_complete": {
         "commit": true,
         "push": true
@@ -73,7 +73,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 8,
+      "max_iterations": 3,
       "on_complete": {
         "commit": true,
         "push": true
@@ -110,7 +110,7 @@
         "models": ["gemini", "codex", "claude"],
         "parallel": true
       },
-      "max_iterations": 8,
+      "max_iterations": 3,
       "on_complete": {
         "commit": true,
         "push": true
@@ -163,7 +163,7 @@
   },
   "defaults": {
     "mode": "strict",
-    "max_iterations": 8,
+    "max_iterations": 3,
     "verify": {
       "models": ["gemini", "codex", "claude"],
       "parallel": true


### PR DESCRIPTION
Lowers the build-verify `max_iterations` safety ceiling on every SPIR and ASPIR phase (and their `defaults` block) from **8 to 3**.

This is the runaway-loop backstop, not a target: a phase advances the moment its 3-way consult APPROVEs (normally 1–2 rounds), and `max_iterations` only fires when REQUEST_CHANGES *persists* — at which point porch force-advances and escalates to the human. Lowering 8→3 means a deadlocked phase escalates after 3 stuck rounds instead of 8.

Scope: `codev-skeleton/protocols/{spir,aspir}/protocol.json` only (5 occurrences each). No code changes.