### PR TITLE
[Bugfix #974] Fix stale scrollController scroll-to-top test

### DIFF
--- a/codev/projects/bugfix-974-dashboard-scrollcontroller-tes/status.yaml
+++ b/codev/projects/bugfix-974-dashboard-scrollcontroller-tes/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-974
 title: dashboard-scrollcontroller-tes
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T00:52:36.293Z'
-updated_at: '2026-06-03T00:52:36.294Z'
+updated_at: '2026-06-03T00:55:21.274Z'

--- a/codev/projects/bugfix-974-dashboard-scrollcontroller-tes/status.yaml
+++ b/codev/projects/bugfix-974-dashboard-scrollcontroller-tes/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-974
 title: dashboard-scrollcontroller-tes
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,5 +13,5 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T00:52:36.293Z'
-updated_at: '2026-06-03T01:02:17.715Z'
+updated_at: '2026-06-03T01:02:24.372Z'
 pr_ready_for_human: false

--- a/codev/projects/bugfix-974-dashboard-scrollcontroller-tes/status.yaml
+++ b/codev/projects/bugfix-974-dashboard-scrollcontroller-tes/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-06-03T01:00:34.416Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T00:52:36.293Z'
-updated_at: '2026-06-03T00:56:43.242Z'
+updated_at: '2026-06-03T01:00:34.416Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-974-dashboard-scrollcontroller-tes/status.yaml
+++ b/codev/projects/bugfix-974-dashboard-scrollcontroller-tes/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-974
+title: dashboard-scrollcontroller-tes
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-06-03T00:52:36.293Z'
+updated_at: '2026-06-03T00:52:36.294Z'

--- a/codev/projects/bugfix-974-dashboard-scrollcontroller-tes/status.yaml
+++ b/codev/projects/bugfix-974-dashboard-scrollcontroller-tes/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-974
 title: dashboard-scrollcontroller-tes
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T00:52:36.293Z'
-updated_at: '2026-06-03T00:55:21.274Z'
+updated_at: '2026-06-03T00:56:43.242Z'

--- a/codev/projects/bugfix-974-dashboard-scrollcontroller-tes/status.yaml
+++ b/codev/projects/bugfix-974-dashboard-scrollcontroller-tes/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-06-03T01:00:34.416Z'
+    approved_at: '2026-06-03T01:02:17.714Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T00:52:36.293Z'
-updated_at: '2026-06-03T01:00:34.416Z'
-pr_ready_for_human: true
+updated_at: '2026-06-03T01:02:17.715Z'
+pr_ready_for_human: false

--- a/codev/state/bugfix-974_thread.md
+++ b/codev/state/bugfix-974_thread.md
@@ -1,0 +1,30 @@
+# bugfix-974 — scrollController stale test
+
+## Issue
+`packages/dashboard/__tests__/scrollController.test.ts` →
+`onScroll handler > warns on unexpected scroll-to-top but does not auto-correct (Issue #630)`
+fails deterministically on clean main: `expected "warn" to be called ... Number of calls: 0`.
+
+## Investigation
+- Reproduced clean baseline (after `pnpm --filter @cluesmith/codev-core build`):
+  `1 failed | 316 passed | 1 skipped (318)` — sole failure is this test.
+- `git log -S "unexpected scroll-to-top"` traced the warn path:
+  - `42980bfa` added scroll-to-top correction + `console.warn`.
+  - `28ef9307` / `a4eaea54` iterated on it (diagnostic vs jump-threshold correction).
+  - **`a4c131ef` (v3.0.0-rc.6) deleted the entire diagnostic/correction block** from
+    `scrollController.ts handleScroll` — root cause fixed upstream by blocking ESC[3J
+    (`eraseInDisplay` case-3 interception in Terminal.tsx) + WebGL context-loss handler
+    + EscapeBuffer. That commit touched ONLY the source, not the test.
+- Result: test still asserts `console.warn('...unexpected scroll-to-top...')` that no
+  longer exists by design.
+
+## Root cause
+Stale test, not a code regression. The warn diagnostic was intentionally removed; the
+user-facing mitigation lives in `Terminal.tsx` (still intact: lines ~252 WebGL,
+~343-355 ESC[3J block, ~418 EscapeBuffer).
+
+## Fix shape
+Update the test to pin current correct behavior: scroll-to-top is accepted (state
+updated to viewportY=0), NOT auto-corrected (no scrollToLine/scrollToBottom), and NOT
+warned. Asserting `warn` is NOT called turns the test into a guard against the
+correction-hack being re-added. No source change — mitigation preserved.

--- a/codev/state/bugfix-974_thread.md
+++ b/codev/state/bugfix-974_thread.md
@@ -23,6 +23,11 @@ Stale test, not a code regression. The warn diagnostic was intentionally removed
 user-facing mitigation lives in `Terminal.tsx` (still intact: lines ~252 WebGL,
 ~343-355 ESC[3J block, ~418 EscapeBuffer).
 
+## Status (PR phase)
+- PR #977 opened; `Fixes #974`. Net diff: test-only (+24/-11 in scrollController.test.ts).
+- 3-way CMAP review: Gemini / Codex / Claude all **APPROVE / HIGH**, zero issues.
+- porch `pr` gate REQUESTED — waiting for human `porch approve bugfix-974 pr`.
+
 ## Fix shape
 Update the test to pin current correct behavior: scroll-to-top is accepted (state
 updated to viewportY=0), NOT auto-corrected (no scrollToLine/scrollToBottom), and NOT

--- a/packages/dashboard/__tests__/scrollController.test.ts
+++ b/packages/dashboard/__tests__/scrollController.test.ts
@@ -336,7 +336,7 @@ describe('ScrollController', () => {
       expect(ctrl.state.wasAtBottom).toBe(true);
     });
 
-    it('warns on unexpected scroll-to-top but does not auto-correct (Issue #630)', () => {
+    it('accepts scroll-to-top without auto-correcting or warning (Issue #630)', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const { ctrl, term } = createController();
       ctrl.enterInteractive();
@@ -346,21 +346,23 @@ describe('ScrollController', () => {
       term.buffer.active.viewportY = 200;
       term._triggerScroll();
 
-      // Unexpected scroll to top (viewportY=0 with scrollback)
+      // Scroll to top (viewportY=0 with scrollback)
       term.buffer.active.viewportY = 0;
       term._triggerScroll();
 
-      // Should warn but NOT auto-correct — viewportY=0 is also the normal
-      // state when a user intentionally scrolls to the top of history.
-      // Root causes are prevented upstream by EscapeBuffer and WebGL handler.
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('unexpected scroll-to-top'),
-        expect.any(String),
-      );
-      // State IS updated (no correction, user may be at top intentionally)
-      expect(ctrl.state.viewportY).toBe(0);
+      // viewportY=0 is also the normal state when a user intentionally scrolls
+      // to the top of history, so handleScroll neither auto-corrects nor warns.
+      // The scroll-to-top *root causes* (ESC[3J clear-scrollback, WebGL context
+      // loss, split escape sequences) are prevented upstream in Terminal.tsx
+      // (eraseInDisplay case-3 interception, the context-loss handler, and
+      // EscapeBuffer) — see v3.0.0-rc.6. The diagnostic/correction block that
+      // once lived in handleScroll was removed once those causes were fixed at
+      // the source, so no warning is emitted here anymore.
       expect(term.scrollToLine).not.toHaveBeenCalled();
       expect(term.scrollToBottom).not.toHaveBeenCalled();
+      // State IS updated (no correction, user may be at top intentionally)
+      expect(ctrl.state.viewportY).toBe(0);
+      expect(warnSpy).not.toHaveBeenCalled();
       warnSpy.mockRestore();
     });
   });


### PR DESCRIPTION
## Summary
Fixes #974

The dashboard vitest suite had one deterministic failure on a clean `main` checkout:

```
FAIL  packages/dashboard/__tests__/scrollController.test.ts
  ScrollController > onScroll handler
    × warns on unexpected scroll-to-top but does not auto-correct (Issue #630)
      AssertionError: expected "warn" to be called at least once — Number of calls: 0
```

## Root Cause
**Stale test, not a code regression.** `git log -S "unexpected scroll-to-top"` traces the warn path:

- `42980bfa` added a scroll-to-top correction block with a `console.warn` diagnostic to `ScrollController.handleScroll`.
- `a4c131ef` (**v3.0.0-rc.6**) **deliberately deleted that entire block** once the scroll-to-top *root cause* was fixed upstream — Claude CLI's `ESC[3J` (clear-scrollback) is now intercepted in `Terminal.tsx` (`eraseInDisplay` case-3 no-op), alongside the existing WebGL context-loss handler and `EscapeBuffer` split-escape buffering.

That commit changed only the source file and left the test asserting a `console.warn` that no longer fires — so the test failed deterministically on every clean `main`.

## Fix
Updated the test to pin the **current correct behavior** (no source change — runtime mitigation untouched):

- Scroll-to-top is **accepted**: state updates to `viewportY=0` (this is also the normal state when a user intentionally scrolls to the top of history).
- **No auto-correction**: `scrollToLine` / `scrollToBottom` are not called.
- **No warning**: asserting `warn` is *not* called turns the test into a guard against the removed correction-hack being silently re-added.

Renamed the test to `accepts scroll-to-top without auto-correcting or warning (Issue #630)` and updated its comment to point at the upstream mitigation in `Terminal.tsx`.

This unblocks #967 (adding the dashboard vitest suite to CI).

## Test Plan
- [x] Verified fix locally — `pnpm --filter @cluesmith/codev-dashboard test` exits 0
- [x] Full suite green: `31 passed (31)` files, `317 passed | 1 skipped (318)` tests
- [x] The 1 pre-existing skip is unchanged (no new skips added)
- [x] Failure was deterministic; fix preserves determinism (no flakiness)
- [x] Runtime scroll-to-top mitigation (#630) preserved — `Terminal.tsx` unchanged

## CMAP Review

3-way parallel review — all **APPROVE / HIGH confidence**, zero issues:

| Model | Verdict | Confidence |
|-------|---------|------------|
| Gemini | APPROVE | HIGH |
| Codex  | APPROVE | HIGH |
| Claude | APPROVE | HIGH |

- **Gemini**: "Stale test properly updated to reflect current expected behavior; PR well-documented and properly scoped."
- **Codex**: "Focused bugfix PR that correctly updates a stale dashboard regression test to match current ScrollController behavior."
- **Claude**: Verified `handleScroll` contains zero `console.warn` calls / no correction logic — test assertions now match reality. Noted the `expect(warnSpy).not.toHaveBeenCalled()` inversion is a smart guard against the removed correction-hack being re-added. Scope, hygiene, determinism all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
