### PR TITLE
vscode: gate builder-row Run/Stop Dev Server menu on worktree.devCommand (#975)

### DIFF
--- a/codev/plans/975-vscode-run-stop-dev-server-con.md
+++ b/codev/plans/975-vscode-run-stop-dev-server-con.md
@@ -1,0 +1,89 @@
+# PIR Plan: Gate builder-row Run/Stop Dev Server menu on `worktree.devCommand` presence
+
+## Understanding
+
+**The bug (issue #975).** Right-clicking a builder row in the Codev **Builders** tree always shows **Run Dev Server** / **Stop Dev Server** context-menu entries, even when `worktree.devCommand` is not configured. Picking either runs a command that has nothing to run — `dev-shared.ts:90-94` shows a "Configure worktree.devCommand…" error toast (or a no-op for stop). The right behavior is to **not offer the option** when there's no dev command.
+
+**Why the divergence (root cause).** The two offending menu entries gate on view + viewItem family only:
+
+- `packages/vscode/package.json:386-390` — `codev.runWorktreeDev`, `when: "view == codev.builders && viewItem =~ /^(builder|blocked-builder|awaiting-builder)-/"`
+- `packages/vscode/package.json:391-394` — `codev.stopWorktreeDev`, same `when`
+
+The Workspace view's equivalent rows work correctly because they gate on `viewItem == workspace-dev-start` / `workspace-dev-stop`, and those `viewItem` values are **only emitted when a dev command is configured** (`workspace.ts:185` — the `else if (devCommand !== null)` branch). The menu inherits the config gate transitively through the row's existence. The builder-row `viewItem` (`builder-<protocol>`, `blocked-builder-…`, `awaiting-builder-…`) is unrelated to dev-command presence, so there's nothing to inherit — hence the always-on menu.
+
+**The fix shape.** Add a `codev.hasDevCommand` setContext key, kept live via the same `worktree-config-updated` SSE event the Workspace view already consumes, and add `&& codev.hasDevCommand` to the two builder-row `when` clauses. Six design calls (issue's "Design questions") inform the *exact* shape; decisions below.
+
+## Design decisions (the plan-approval calls)
+
+These mirror the issue's six questions. **Recommendations are marked ✅; reviewer can redirect any of them by editing this file before approving.**
+
+1. **Where is the context key set?** ✅ **Subscribe to the live config-change signal, not activation-only.** Reuse the exact pair `WorkspaceProvider` uses (`workspace.ts:22-53`): `connectionManager.onStateChange` (seed/refresh on connect) + `connectionManager.onSSEEvent` filtered to `envelope.type === 'worktree-config-updated'` (Tower's server-side `worktree-config-watcher.ts` fires this whenever `.codev/config(.local).json` changes). This preserves v3.1.1's live-refresh behavior — acceptance criterion #5. Activation-only would go stale on config edits.
+
+2. **Shared vs layered config.** ✅ **Layered.** Resolve via the existing `loadWorktreeConfig(connectionManager)` (`load-worktree-config.ts`), which returns Tower's canonical 5-layer deep-merge (defaults / cache / global / project / project-local) — exactly what the Workspace view and `dev-shared.ts` already use. No new resolver, no client-side `.codev/config.json` parsing. Per-engineer `.codev/config.local.json` dev commands are honored for free.
+
+3. **Per-worktree overrides → single global key vs per-row metadata.** ✅ **Single global `codev.hasDevCommand` key.** Rationale: `.codev/config.json` is *always symlinked* into each builder worktree (the worktree-block invariant in CLAUDE.md — root `.codev/config.json` is symlinked regardless of the `symlinks` list), so the resolved `devCommand` is identical across every builder row and the active workspace. `afx dev <id>` itself resolves the same shared config. A single key reflecting the active workspace's resolved config is therefore the truth for all rows. If genuine *per-worktree* dev commands are ever supported, this would need per-row `viewItem` metadata (`builder-with-dev-…` vs `builder-no-dev-…`) — noted as **future work, not built now**. Keeping it global also keeps it consistent with the Workspace view, which is itself single-target scoped.
+
+4. **Keybindings (`ctrl+alt+r` / `cmd+alt+r`, `ctrl+alt+s` / `cmd+alt+s` → `runWorkspaceDev` / `stopWorkspaceDev`, `package.json:558-567`).** ✅ **Gate them with `codev.hasDevCommand`** for consistency with the principle "don't offer what won't work." The keystroke becomes silent (no-op) when no dev command is configured. `dev-shared.ts`'s error toast remains as defense-in-depth for the brief window where the context key may be momentarily stale. *Alternative (rejected, but reviewer may prefer):* leave keybindings ungated so the keystroke still surfaces the helpful "Configure worktree.devCommand…" toast — trades consistency for explicit feedback.
+
+5. **Command palette (the `Codev: Run/Stop …Dev…` entries).** ✅ **Gate the two workspace-level dev commands** (`runWorkspaceDev`, `stopWorkspaceDev`) in `contributes.menus.commandPalette` with `when: "codev.hasDevCommand"` — palette shouldn't surface commands that can't run. The two **builder-row** commands (`runWorktreeDev`, `stopWorktreeDev`) require a tree-row argument and do the wrong thing when invoked argless from the palette (same situation as `viewSpecFile`/`viewPlanFile`/`viewReviewFile`, which are pinned `when: "false"`). ✅ **Pin those two `when: "false"`** — a one-line correctness win that also moots the config question for them. (`openDevUrl` palette visibility is a sibling concern — see Out of Scope.)
+
+6. **What "presence" means — empty string.** ✅ **Treat `""`/whitespace-only as absent.** The truth we want is "is there a *runnable* dev command," which matches `dev-shared.ts:91`'s actual gate (`if (!devCommand)` — empty string is falsy → error). Define `hasRunnableDevCommand(config) = typeof config?.devCommand === 'string' && config.devCommand.trim().length > 0`. **Latent inconsistency found:** `workspace.ts:185` currently uses `devCommand !== null`, which would show the Start row for `"devCommand": ""` even though clicking it errors. ✅ **Extract the shared `hasRunnableDevCommand` helper and use it in both the new context key and `workspace.ts:185`**, fixing the empty-string footgun in one place and keeping the two surfaces provably consistent. (`ResolvedWorktreeConfig.devCommand` is typed `string | null` — `packages/types/src/api.ts:305` — so `""` is reachable.)
+
+## Proposed Change
+
+1. **New shared helper** in `load-worktree-config.ts`: `hasRunnableDevCommand(config: ResolvedWorktreeConfig | null): boolean`. Co-located with the config loader (the workspace-wide config concern already lives there).
+
+2. **Context-key wiring** in `extension.ts`: a single named async function `syncHasDevCommandContext()` that fetches the merged config and calls `setContext('codev.hasDevCommand', hasRunnableDevCommand(config))`. Seed it once after the connection block, and re-invoke from one consolidated subscription handling `onStateChange` + the `worktree-config-updated` SSE envelope (one subscription, named function — not duplicated inline closures). Mirrors the existing `syncTerminalFocusContext` pattern (`extension.ts:164-171`).
+
+3. **`workspace.ts:185`**: replace `else if (devCommand !== null)` with `else if (hasRunnableDevCommand(worktreeConfig))` (consistency + empty-string fix). No other workspace-view change.
+
+4. **`package.json` manifest**:
+   - Append `&& codev.hasDevCommand` to the two builder-row `when` clauses (`runWorktreeDev` line 388, `stopWorktreeDev` line 393).
+   - Add `commandPalette` entries: `runWorkspaceDev`/`stopWorkspaceDev` with `when: "codev.hasDevCommand"`; `runWorktreeDev`/`stopWorktreeDev` with `when: "false"`.
+   - Add `&& codev.hasDevCommand` (or `when: "codev.hasDevCommand"`) to the four keybindings at `package.json:558-567` — wait: only `runWorkspaceDev`/`stopWorkspaceDev` have keybindings (two entries). Gate both.
+
+5. **Tests** — extend `packages/vscode/src/__tests__/menu-when-clauses.test.ts` (or a sibling spec):
+   - Assert the two builder-row dev `when` clauses contain `codev.hasDevCommand`.
+   - Assert `runWorkspaceDev`/`stopWorkspaceDev` keybindings carry the `codev.hasDevCommand` guard.
+   - Assert palette gating (workspace dev → `codev.hasDevCommand`; worktree dev → `false`).
+   - Unit-test `hasRunnableDevCommand`: `null` → false, `{devCommand: null}` → false, `{devCommand: ""}` → false, `{devCommand: "  "}` → false, `{devCommand: "pnpm dev"}` → true.
+
+## Files to Change
+
+- `packages/vscode/src/load-worktree-config.ts` — add `hasRunnableDevCommand()` helper (+ export).
+- `packages/vscode/src/extension.ts` — add `syncHasDevCommandContext()`, seed + wire to `onStateChange` and the `worktree-config-updated` SSE envelope.
+- `packages/vscode/src/views/workspace.ts:185` — use `hasRunnableDevCommand(worktreeConfig)` instead of `devCommand !== null`.
+- `packages/vscode/package.json`
+  - `:388`, `:393` — append `&& codev.hasDevCommand` to the two builder-row `when` clauses.
+  - `contributes.menus.commandPalette` (~`:267-326`) — add 4 entries (2 × `codev.hasDevCommand`, 2 × `false`).
+  - `:558-567` — gate the two dev keybindings with `codev.hasDevCommand`.
+- `packages/vscode/src/__tests__/menu-when-clauses.test.ts` — extend (or add `dev-command-gating.test.ts`).
+
+## Risks & Alternatives Considered
+
+- **Risk: context key stale right after connect** (key not yet set before first tree render). Mitigation: seed `syncHasDevCommandContext()` immediately in the connection-established path and on every `onStateChange` to `connected`; `dev-shared.ts`'s toast covers any residual race. Worst case before seed: a builder row briefly omits the entries — fail-safe direction (hide, not falsely show).
+- **Risk: SSE envelope shape drift.** The `worktree-config-updated` filter copies `WorkspaceProvider`'s exact guard (`JSON.parse(data).type === 'worktree-config-updated'`); if Tower's envelope changes, both break together — acceptable, single source of truth.
+- **Alternative (rejected): per-row `viewItem` metadata** (`builder-with-dev-…`). Rejected — `.codev/config.json` symlink invariant makes per-row dev commands non-divergent today; adds regex/contextValue complexity for no current payoff. Documented as future work.
+- **Alternative (rejected): activation-only context key.** Rejected — breaks the v3.1.1 live-refresh contract (acceptance #5).
+- **Alternative (rejected): client-side `.codev/config.json` parse.** Rejected — misses `.codev/config.local.json` layering; `loadWorktreeConfig` already does the correct merge.
+
+## Test Plan
+
+**Unit (vitest, `pnpm --filter @cluesmith/codev-vscode test` or the vscode package's runner):**
+- `hasRunnableDevCommand` truth table (null / null-cmd / "" / whitespace / real).
+- `menu-when-clauses.test.ts`: the two builder-row dev entries' `when` contains `codev.hasDevCommand`; workspace-dev entries unchanged; keybinding + palette gating as decided.
+
+**Manual at `dev-approval` (run the worktree, this is PIR's killer move):**
+1. With `worktree.devCommand` **unset** in `.codev/config.json` → right-click a builder row → **no** Run/Stop Dev Server entries. ✔ acceptance #1.
+2. Add `"devCommand": "pnpm dev"` and **save** (no window reload) → entries appear on the builder row within a beat (live SSE refresh). ✔ acceptance #2, #5.
+3. Remove it again, save → entries disappear live. ✔ acceptance #5.
+4. Set `"devCommand": ""` → entries stay hidden (empty = absent). ✔ Q6.
+5. Workspace view Start/Stop rows behave exactly as before across the same edits. ✔ acceptance #3.
+6. Keybinding `cmd+alt+r` with no dev command → silent no-op (or toast, per Q4 decision); with a dev command → starts dev. ✔ acceptance #4.
+7. Build: `pnpm build` clean; existing vscode tests green.
+
+## Out of Scope (per issue + sibling-audit note)
+
+- Reshaping `worktree.devCommand` or its contents.
+- Dashboard's equivalent dev-command surfacing.
+- **`worktree.devUrls` "Open Dev URL" rows** — `codev.openDevUrl` is referenced only by the Workspace view (`workspace.ts:217`); it has **no builder-row context-menu entry**, so the issue's symptom doesn't apply there. Its palette entry (`package.json:202`) is visible regardless of config — same gating *principle*, different (and lower-priority) surface. Flagged for a sibling issue, not fixed here, to keep this change bounded.

--- a/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
+++ b/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-06-03T00:56:25.606Z'
     approved_at: '2026-06-03T01:01:00.520Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-06-03T01:26:46.800Z'
+    approved_at: '2026-06-03T01:29:45.267Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T00:52:06.771Z'
-updated_at: '2026-06-03T01:26:46.801Z'
+updated_at: '2026-06-03T01:29:45.268Z'

--- a/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
+++ b/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-06-03T00:56:25.606Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T00:52:06.771Z'
-updated_at: '2026-06-03T00:52:06.772Z'
+updated_at: '2026-06-03T00:56:25.607Z'

--- a/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
+++ b/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-06-03T00:56:25.606Z'
+    approved_at: '2026-06-03T01:01:00.520Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T00:52:06.771Z'
-updated_at: '2026-06-03T00:56:25.607Z'
+updated_at: '2026-06-03T01:01:00.520Z'

--- a/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
+++ b/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
@@ -1,7 +1,7 @@
 id: '975'
 title: vscode-run-stop-dev-server-con
 protocol: pir
-phase: review
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -21,7 +21,7 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-06-03T00:52:06.771Z'
-updated_at: '2026-06-03T02:06:35.320Z'
+updated_at: '2026-06-03T02:06:40.879Z'
 pr_history:
   - phase: review
     pr_number: 978

--- a/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
+++ b/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-06-03T01:29:45.267Z'
   pr:
     status: pending
+    requested_at: '2026-06-03T01:47:38.951Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-06-03T00:52:06.771Z'
-updated_at: '2026-06-03T01:31:06.087Z'
+updated_at: '2026-06-03T01:47:38.952Z'
 pr_history:
   - phase: review
     pr_number: 978
     branch: builder/pir-975
     created_at: '2026-06-03T01:30:58.525Z'
+pr_ready_for_human: true

--- a/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
+++ b/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T00:52:06.771Z'
-updated_at: '2026-06-03T01:29:49.828Z'
+updated_at: '2026-06-03T01:30:58.526Z'
+pr_history:
+  - phase: review
+    pr_number: 978
+    branch: builder/pir-975
+    created_at: '2026-06-03T01:30:58.525Z'

--- a/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
+++ b/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
@@ -1,7 +1,7 @@
 id: '975'
 title: vscode-run-stop-dev-server-con
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T00:52:06.771Z'
-updated_at: '2026-06-03T01:01:00.520Z'
+updated_at: '2026-06-03T01:05:02.148Z'

--- a/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
+++ b/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-06-03T00:52:06.771Z'
-updated_at: '2026-06-03T01:30:58.526Z'
+updated_at: '2026-06-03T01:31:06.087Z'
 pr_history:
   - phase: review
     pr_number: 978

--- a/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
+++ b/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
@@ -1,7 +1,7 @@
 id: '975'
 title: vscode-run-stop-dev-server-con
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T00:52:06.771Z'
-updated_at: '2026-06-03T01:29:45.268Z'
+updated_at: '2026-06-03T01:29:49.828Z'

--- a/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
+++ b/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-06-03T01:26:46.800Z'
     approved_at: '2026-06-03T01:29:45.267Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-06-03T01:47:38.951Z'
+    approved_at: '2026-06-03T02:06:35.317Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-06-03T00:52:06.771Z'
-updated_at: '2026-06-03T01:47:38.952Z'
+updated_at: '2026-06-03T02:06:35.320Z'
 pr_history:
   - phase: review
     pr_number: 978
     branch: builder/pir-975
     created_at: '2026-06-03T01:30:58.525Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
+++ b/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
@@ -1,0 +1,18 @@
+id: '975'
+title: vscode-run-stop-dev-server-con
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-06-03T00:52:06.771Z'
+updated_at: '2026-06-03T00:52:06.772Z'

--- a/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
+++ b/codev/projects/975-vscode-run-stop-dev-server-con/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-06-03T01:01:00.520Z'
   dev-approval:
     status: pending
+    requested_at: '2026-06-03T01:26:46.800Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T00:52:06.771Z'
-updated_at: '2026-06-03T01:05:02.148Z'
+updated_at: '2026-06-03T01:26:46.801Z'

--- a/codev/reviews/975-vscode-run-stop-dev-server-con.md
+++ b/codev/reviews/975-vscode-run-stop-dev-server-con.md
@@ -1,0 +1,56 @@
+# PIR Review: Gate builder-row Run/Stop Dev Server menu on `worktree.devCommand`
+
+Fixes #975
+
+## Summary
+
+The builder-row **Run/Stop Dev Server** context-menu entries used to show on every builder row regardless of whether `worktree.devCommand` was configured, so picking one ran against a missing command (error toast or no-op). This PR gates those entries — plus the dev keybindings and the workspace-dev command-palette entries — on a new `codev.hasDevCommand` context key. The key is refreshed from `BuildersProvider`'s render path (no dedicated config-file listener), and a shared `hasRunnableDevCommand()` helper now backs both the key and the Workspace view's Start-row gate, also fixing a latent empty-string bug.
+
+## Files Changed
+
+- `packages/vscode/package.json` (+22 / -4) — `&& codev.hasDevCommand` on the two builder-row dev `when` clauses; `when` gating on the two dev keybindings; commandPalette entries (workspace-dev → `codev.hasDevCommand`, builder-row dev → `false`)
+- `packages/vscode/src/load-worktree-config.ts` (+18 / -0) — `hasRunnableDevCommand()` helper (single source of truth)
+- `packages/vscode/src/views/builders.ts` (+24 / -0) — `refreshDevCommandContext()` called fire-and-forget from `getChildren`'s root branch; `connectionManager` injected
+- `packages/vscode/src/views/workspace.ts` (+~12 / -~11) — Start-row gate switched from `devCommand !== null` to `hasRunnableDevCommand(worktreeConfig)`
+- `packages/vscode/src/extension.ts` (+1 / -1) — pass `connectionManager` to `BuildersProvider`
+- `packages/vscode/src/__tests__/has-runnable-dev-command.test.ts` (+47 / -0, new) — helper truth table
+- `packages/vscode/src/__tests__/menu-when-clauses.test.ts` (+67 / -0) — `when`-shape assertions for the gating across menu / palette / keybinding surfaces
+
+## Commits
+
+- `4c856a92` [PIR #975] Gate builder-row Run/Stop Dev Server menu on worktree.devCommand
+- `50a66686` [PIR #975] Group BuildersProvider parameter-properties together
+
+## Test Results
+
+- `pnpm build`: ✓ pass (porch check, 6.3s)
+- `pnpm test`: ✓ pass (porch check, 20.8s)
+- `pnpm check-types`: ✓ clean
+- `pnpm test:unit`: ✓ 276 tests pass (21 files), incl. 2 new test files
+- `eslint` (changed files): ✓ clean
+- Manual verification: performed by the human at the `dev-approval` gate against the running worktree — builder-row entries hidden with no `devCommand`, present with one, live on next tree refresh after a config edit; Workspace view unaffected.
+
+## Architecture Updates
+
+No `arch.md` changes needed. This PR fixes a UI-gating bug within the existing VSCode TreeView + `when`-clause / setContext pattern; it introduces no new module boundary or architectural pattern. The render-path context-key refresh is a local choice within `BuildersProvider`, consistent with the existing context-key usage in the builders tree (`codev.buildersAutoCollapse`, `codev.buildersGroupBy`).
+
+## Lessons Learned Updates
+
+No addition to `codev/resources/lessons-learned.md`. The one transferable observation — *gate a menu entry on the same condition that governs the resource it acts on, and pick a refresh cadence matched to the surface's lifecycle (ephemeral context menu ⇒ render-path snapshot, not a constant listener)* — is implementation guidance already captured in the code comments and this review, not broad enough to warrant a standing lessons entry.
+
+## Things to Look At During PR Review
+
+- **Render-path liveness trade-off (intentional).** `codev.hasDevCommand` is refreshed when `BuildersProvider.getChildren` renders the root, not via the `worktree-config-updated` SSE. So a `worktree.devCommand` edit is reflected on the *next* Builders-tree refresh (overview poll / tree event), not instantly. This was a deliberate design call (the context menu is on-demand and short-lived, unlike the always-on Workspace view, which keeps its SSE subscription). Acceptance #5 ("without a window reload") still holds.
+- **Empty-string semantics.** `hasRunnableDevCommand` treats `"devCommand": ""` / whitespace as absent, matching `dev-shared.ts`'s `if (!devCommand)` runnability gate. This also changes the Workspace view's Start-row gate (previously `devCommand !== null`, which would have shown a Start row for `""` that errors on click) — a latent bug fix. Confirm no Workspace-view regression.
+- **Builder-row dev palette entries pinned `when: false`.** They need a tree-row argument; argless palette invocation falls through (same rationale as `viewSpecFile`/`viewPlanFile`/`viewReviewFile`). This is a behavior change — before this PR they had no palette entry and so defaulted to visible.
+
+## How to Test Locally
+
+- **View diff**: VSCode sidebar → right-click builder `pir-975` → **View Diff**
+- **Run dev server**: VSCode sidebar → **Run Dev Server**, or `afx dev pir-975`
+- **What to verify**:
+  - With no `worktree.devCommand` in `.codev/config.json`: right-click a builder row → **no** Run/Stop Dev Server entries.
+  - Add `"devCommand": "pnpm dev"`, then interact with the Builders tree (refresh): entries appear.
+  - Remove it again / set it to `""`: entries hidden.
+  - Workspace view Start/Stop rows behave as before across the same edits.
+  - Keybinding `cmd+alt+r` is silent with no dev command; starts dev with one.

--- a/codev/reviews/975-vscode-run-stop-dev-server-con.md
+++ b/codev/reviews/975-vscode-run-stop-dev-server-con.md
@@ -10,9 +10,10 @@ The builder-row **Run/Stop Dev Server** context-menu entries used to show on eve
 
 - `packages/vscode/package.json` (+22 / -4) — `&& codev.hasDevCommand` on the two builder-row dev `when` clauses; `when` gating on the two dev keybindings; commandPalette entries (workspace-dev → `codev.hasDevCommand`, builder-row dev → `false`)
 - `packages/vscode/src/load-worktree-config.ts` (+18 / -0) — `hasRunnableDevCommand()` helper (single source of truth)
-- `packages/vscode/src/views/builders.ts` (+24 / -0) — `refreshDevCommandContext()` called fire-and-forget from `getChildren`'s root branch; `connectionManager` injected
+- `packages/vscode/src/extension.ts` (+32 / -0) — `syncHasDevCommandContext()` refreshing the context key on `onStateChange` + the `worktree-config-updated` SSE envelope, plus an initial seed
+- `packages/vscode/src/load-worktree-config.ts` (+18 / -0) — `hasRunnableDevCommand()` helper (single source of truth)
 - `packages/vscode/src/views/workspace.ts` (+~12 / -~11) — Start-row gate switched from `devCommand !== null` to `hasRunnableDevCommand(worktreeConfig)`
-- `packages/vscode/src/extension.ts` (+1 / -1) — pass `connectionManager` to `BuildersProvider`
+- `packages/vscode/package.json` (+22 / -4) — `&& codev.hasDevCommand` on the two builder-row dev `when` clauses; `when` gating on the two dev keybindings; commandPalette entries (workspace-dev → `codev.hasDevCommand`, builder-row dev → `false`)
 - `packages/vscode/src/__tests__/has-runnable-dev-command.test.ts` (+47 / -0, new) — helper truth table
 - `packages/vscode/src/__tests__/menu-when-clauses.test.ts` (+67 / -0) — `when`-shape assertions for the gating across menu / palette / keybinding surfaces
 
@@ -20,6 +21,7 @@ The builder-row **Run/Stop Dev Server** context-menu entries used to show on eve
 
 - `4c856a92` [PIR #975] Gate builder-row Run/Stop Dev Server menu on worktree.devCommand
 - `50a66686` [PIR #975] Group BuildersProvider parameter-properties together
+- (final) [PIR #975] Use global onStateChange + SSE refresh for hasDevCommand (consult REQUEST_CHANGES)
 
 ## Test Results
 
@@ -28,19 +30,20 @@ The builder-row **Run/Stop Dev Server** context-menu entries used to show on eve
 - `pnpm check-types`: ✓ clean
 - `pnpm test:unit`: ✓ 276 tests pass (21 files), incl. 2 new test files
 - `eslint` (changed files): ✓ clean
-- Manual verification: performed by the human at the `dev-approval` gate against the running worktree — builder-row entries hidden with no `devCommand`, present with one, live on next tree refresh after a config edit; Workspace view unaffected.
+- Manual verification: performed by the human at the `dev-approval` gate against the running worktree — builder-row entries hidden with no `devCommand`, present with one, live after a config edit; Workspace view unaffected. **Note:** dev-approval was on an earlier render-path implementation; the refresh mechanism was changed post-gate (see "Things to Look At") — the user-facing menu behavior is unchanged and now extends correctly to the keybindings/palette.
 
 ## Architecture Updates
 
-No `arch.md` changes needed. This PR fixes a UI-gating bug within the existing VSCode TreeView + `when`-clause / setContext pattern; it introduces no new module boundary or architectural pattern. The render-path context-key refresh is a local choice within `BuildersProvider`, consistent with the existing context-key usage in the builders tree (`codev.buildersAutoCollapse`, `codev.buildersGroupBy`).
+No `arch.md` changes needed. This PR fixes a UI-gating bug within the existing VSCode TreeView + `when`-clause / setContext pattern; it introduces no new module boundary or architectural pattern. The `codev.hasDevCommand` refresh mirrors the established global context-key pattern in this extension — `WorkspaceProvider`'s own dev-row gate (`onStateChange` + `worktree-config-updated` SSE) and the builders-tree setting keys (`codev.buildersAutoCollapse`, `codev.buildersGroupBy`), which are driven by global `vscode.workspace.onDidChangeConfiguration` listeners. The key is refreshed by global signals — not the tree render path — because the keybindings and palette entries it also gates are invokable independent of the Builders tree's visibility.
 
 ## Lessons Learned Updates
 
-No addition to `codev/resources/lessons-learned.md`. The one transferable observation — *gate a menu entry on the same condition that governs the resource it acts on, and pick a refresh cadence matched to the surface's lifecycle (ephemeral context menu ⇒ render-path snapshot, not a constant listener)* — is implementation guidance already captured in the code comments and this review, not broad enough to warrant a standing lessons entry.
+No addition to `codev/resources/lessons-learned.md`. The transferable observation — *a context key shared by surfaces with different lifecycles (an ephemeral tree context menu vs. global keybindings/palette) must be refreshed on the cadence of the most demanding surface; a render-path refresh that fits the menu silently breaks the global surfaces* — is the heart of this PR's review back-and-forth and is captured in the code comments + the "Things to Look At" note below, not broad enough to warrant a standing lessons entry.
 
 ## Things to Look At During PR Review
 
-- **Render-path liveness trade-off (intentional).** `codev.hasDevCommand` is refreshed when `BuildersProvider.getChildren` renders the root, not via the `worktree-config-updated` SSE. So a `worktree.devCommand` edit is reflected on the *next* Builders-tree refresh (overview poll / tree event), not instantly. This was a deliberate design call (the context menu is on-demand and short-lived, unlike the always-on Workspace view, which keeps its SSE subscription). Acceptance #5 ("without a window reload") still holds.
+- **Consult finding + disposition (REQUEST_CHANGES → fixed).** The PR-stage 3-way consult split 2 REQUEST_CHANGES (Gemini, Codex; HIGH) vs 1 APPROVE (Claude). Both dissents were correct and the same: an earlier implementation refreshed `codev.hasDevCommand` from the Builders-tree render path, which left the **global** keybindings (`cmd+alt+r`/`s`) and workspace-dev palette entries stale when the Builders tree wasn't rendered (e.g. collapsed) — `cmd+alt+r` could silently no-op with a `devCommand` configured. **Disposition: fixed**, not rebutted — the refresh was moved to global signals (`onStateChange` + `worktree-config-updated` SSE) in `extension.ts`, mirroring `WorkspaceProvider`. All three surfaces are now live and consistent. Gemini also correctly flagged a factual error in an earlier draft of this review (it claimed the render-path was "consistent with" `buildersAutoCollapse`/`buildersGroupBy`, which are actually `onDidChangeConfiguration`-driven) — corrected above. PIR is single-pass, so this fix was **not** independently re-reviewed by the models; please verify it at the `pr` gate.
+- **Coverage note (Codex's ask).** The testable unit — the value computation `hasRunnableDevCommand` — is fully covered (truth table incl. empty/whitespace). The menu/keybinding/palette `when`-clause contract is pinned in `menu-when-clauses.test.ts`. The event-wiring itself (which signals trigger the refresh) is activation-time VSCode glue: it mirrors `WorkspaceProvider`'s already-trusted, identical `onStateChange` + `worktree-config-updated` filter, and like all such glue in this extension is exercised by the vscode-test integration harness / manual run rather than vitest. No brittle vscode-mock unit test was added for it.
 - **Empty-string semantics.** `hasRunnableDevCommand` treats `"devCommand": ""` / whitespace as absent, matching `dev-shared.ts`'s `if (!devCommand)` runnability gate. This also changes the Workspace view's Start-row gate (previously `devCommand !== null`, which would have shown a Start row for `""` that errors on click) — a latent bug fix. Confirm no Workspace-view regression.
 - **Builder-row dev palette entries pinned `when: false`.** They need a tree-row argument; argless palette invocation falls through (same rationale as `viewSpecFile`/`viewPlanFile`/`viewReviewFile`). This is a behavior change — before this PR they had no palette entry and so defaulted to visible.
 
@@ -50,7 +53,7 @@ No addition to `codev/resources/lessons-learned.md`. The one transferable observ
 - **Run dev server**: VSCode sidebar → **Run Dev Server**, or `afx dev pir-975`
 - **What to verify**:
   - With no `worktree.devCommand` in `.codev/config.json`: right-click a builder row → **no** Run/Stop Dev Server entries.
-  - Add `"devCommand": "pnpm dev"`, then interact with the Builders tree (refresh): entries appear.
-  - Remove it again / set it to `""`: entries hidden.
+  - Add `"devCommand": "pnpm dev"` and save: entries appear live (no window reload), via the `worktree-config-updated` SSE.
+  - Remove it again / set it to `""`: entries hidden live.
   - Workspace view Start/Stop rows behave as before across the same edits.
-  - Keybinding `cmd+alt+r` is silent with no dev command; starts dev with one.
+  - Keybinding `cmd+alt+r` is silent with no dev command (even with the Builders tree collapsed); starts dev with one — verify both tree-collapsed and tree-expanded states.

--- a/codev/reviews/975-vscode-run-stop-dev-server-con.md
+++ b/codev/reviews/975-vscode-run-stop-dev-server-con.md
@@ -4,12 +4,10 @@ Fixes #975
 
 ## Summary
 
-The builder-row **Run/Stop Dev Server** context-menu entries used to show on every builder row regardless of whether `worktree.devCommand` was configured, so picking one ran against a missing command (error toast or no-op). This PR gates those entries — plus the dev keybindings and the workspace-dev command-palette entries — on a new `codev.hasDevCommand` context key. The key is refreshed from `BuildersProvider`'s render path (no dedicated config-file listener), and a shared `hasRunnableDevCommand()` helper now backs both the key and the Workspace view's Start-row gate, also fixing a latent empty-string bug.
+The builder-row **Run/Stop Dev Server** context-menu entries used to show on every builder row regardless of whether `worktree.devCommand` was configured, so picking one ran against a missing command (error toast or no-op). This PR gates those entries — plus the dev keybindings and the workspace-dev command-palette entries — on a new `codev.hasDevCommand` context key. The key is refreshed by global signals in `extension.ts` (`onStateChange` + the `worktree-config-updated` SSE), mirroring the Workspace view's own dev-row gate, so all three gated surfaces stay live — including the keybindings/palette, which are invokable independent of the Builders tree's visibility. A shared `hasRunnableDevCommand()` helper backs both the key and the Workspace view's Start-row gate, also fixing a latent empty-string bug.
 
 ## Files Changed
 
-- `packages/vscode/package.json` (+22 / -4) — `&& codev.hasDevCommand` on the two builder-row dev `when` clauses; `when` gating on the two dev keybindings; commandPalette entries (workspace-dev → `codev.hasDevCommand`, builder-row dev → `false`)
-- `packages/vscode/src/load-worktree-config.ts` (+18 / -0) — `hasRunnableDevCommand()` helper (single source of truth)
 - `packages/vscode/src/extension.ts` (+32 / -0) — `syncHasDevCommandContext()` refreshing the context key on `onStateChange` + the `worktree-config-updated` SSE envelope, plus an initial seed
 - `packages/vscode/src/load-worktree-config.ts` (+18 / -0) — `hasRunnableDevCommand()` helper (single source of truth)
 - `packages/vscode/src/views/workspace.ts` (+~12 / -~11) — Start-row gate switched from `devCommand !== null` to `hasRunnableDevCommand(worktreeConfig)`

--- a/codev/state/pir-975_thread.md
+++ b/codev/state/pir-975_thread.md
@@ -57,3 +57,13 @@ Build + type-check clean; 276 unit tests pass (incl. 2 new test files:
 has-runnable-dev-command + menu-when-clauses additions). Lint clean.
 
 Pushing and signaling dev-approval — reviewer verifies the running worktree.
+
+## Review phase (iteration 1)
+
+dev-approval approved (incl. a constructor-param-grouping tweak at the gate:
+moved connectionManager ahead of the transient workspaceState param).
+
+Wrote `codev/reviews/975-vscode-run-stop-dev-server-con.md`. No arch.md /
+lessons-learned.md changes (UI-gating bug within existing TreeView+when-clause
+pattern; the one transferable note lives in code comments + the review). Opening
+PR, recording with porch, then porch's single-pass 3-way consult runs.

--- a/codev/state/pir-975_thread.md
+++ b/codev/state/pir-975_thread.md
@@ -1,0 +1,29 @@
+# PIR #975 — gate builder-row Run/Stop Dev Server on `worktree.devCommand`
+
+## Plan phase (iteration 1)
+
+Investigated the surface. Root cause confirmed: builder-row dev menu entries
+(`package.json:386-394`) gate on view+viewItem family only, no config gate. The
+Workspace view rows work because their `viewItem` (`workspace-dev-start/stop`) is
+only emitted when `devCommand` is set (`workspace.ts:185`).
+
+Key findings driving the plan:
+- Config resolves via `loadWorktreeConfig()` → Tower's 5-layer merge (already
+  shared+local layered). Reuse it; no new resolver.
+- Live-refresh precedent: `WorkspaceProvider` re-renders on the
+  `worktree-config-updated` SSE envelope (`workspace.ts:43-53`). Mirror that for
+  the context key → satisfies acceptance #5 (no reload).
+- `.codev/config.json` is always symlinked into worktrees ⇒ devCommand identical
+  across builder rows ⇒ a single global `codev.hasDevCommand` key is the truth.
+  Per-row metadata = future work only.
+- Latent bug: `workspace.ts:185` uses `devCommand !== null`, so `"devCommand": ""`
+  would show a Start row that errors on click. dev-shared.ts uses `!devCommand`.
+  Resolving with a shared `hasRunnableDevCommand` (trim non-empty) helper used by
+  both surfaces.
+
+Decisions (issue's 6 design Qs): live SSE-driven key; layered config; single
+global key; gate keybindings + palette too; empty-string = absent. All laid out
+in the plan for the reviewer to redirect at the gate.
+
+Plan written to `codev/plans/975-vscode-run-stop-dev-server-con.md`. Awaiting
+plan-approval.

--- a/codev/state/pir-975_thread.md
+++ b/codev/state/pir-975_thread.md
@@ -27,3 +27,33 @@ in the plan for the reviewer to redirect at the gate.
 
 Plan written to `codev/plans/975-vscode-run-stop-dev-server-con.md`. Awaiting
 plan-approval.
+
+## Implement phase (iteration 1)
+
+Plan approved. Implemented the `codev.hasDevCommand` context-key gate.
+
+Design evolved during pre-commit review with the architect:
+- Started with an SSE-driven key (mirrors WorkspaceProvider: onStateChange +
+  `worktree-config-updated` envelope). Architect pushed back: the context menu
+  is on-demand/ephemeral, unlike the always-on Workspace view — it doesn't
+  warrant a constant config-file listener.
+- Considered a visibility-snapshot (refresh on Builders view `onDidChangeVisibility`).
+  Rejected: split wiring + staleness if config edited while view already visible.
+- **Landed on render-path**: `BuildersProvider.refreshDevCommandContext()` called
+  fire-and-forget from `getChildren`'s root branch. The key tracks the same
+  cadence as the rows the menu gates; no dedicated listener; fully co-located in
+  the provider (extension.ts only passes connectionManager). Liveness: picks up
+  config edits on the next tree refresh (overview poll / tree event).
+
+Also fixed a latent empty-string bug: `workspace.ts` used `devCommand !== null`
+(would show a Start row for `"devCommand": ""` that errors on click). Both
+surfaces now share `hasRunnableDevCommand()` (trim non-empty).
+
+Surfaces gated: builder-row context menu (the bug), dev keybindings, and
+workspace-dev palette entries; builder-row dev palette entries pinned `when:false`
+(need a row arg — same as view{Spec,Plan,Review}File).
+
+Build + type-check clean; 276 unit tests pass (incl. 2 new test files:
+has-runnable-dev-command + menu-when-clauses additions). Lint clean.
+
+Pushing and signaling dev-approval — reviewer verifies the running worktree.

--- a/codev/state/pir-975_thread.md
+++ b/codev/state/pir-975_thread.md
@@ -65,5 +65,22 @@ moved connectionManager ahead of the transient workspaceState param).
 
 Wrote `codev/reviews/975-vscode-run-stop-dev-server-con.md`. No arch.md /
 lessons-learned.md changes (UI-gating bug within existing TreeView+when-clause
-pattern; the one transferable note lives in code comments + the review). Opening
-PR, recording with porch, then porch's single-pass 3-way consult runs.
+pattern; the one transferable note lives in code comments + the review). Opened
+PR #978, recorded with porch.
+
+### Consult: 2 REQUEST_CHANGES (Gemini, Codex; HIGH) vs 1 APPROVE (Claude)
+
+Both dissents were correct and identical: the render-path refresh left the
+*global* keybindings/palette stale when the Builders tree wasn't rendered
+(cmd+alt+r could silently no-op with a devCommand configured). Real defect, not
+a rebuttal. Gemini also caught a factual error in the review draft (render-path
+isn't "consistent with" buildersAutoCollapse/buildersGroupBy — those are
+onDidChangeConfiguration-driven).
+
+Surfaced to architect; they chose **Option B (global listener)**. Reverted
+builders.ts to original; restored the global `syncHasDevCommandContext` in
+extension.ts (onStateChange + worktree-config-updated SSE + seed) — the
+original pre-render-path approach. All three surfaces now live + consistent.
+Fixed review file (mechanism + factual error + Codex coverage note). Build +
+typecheck + 276 tests + lint all green. PIR is single-pass: escalating the
+REQUEST_CHANGES + fix disposition to the human at the pr gate.

--- a/codev/state/pir-975_thread.md
+++ b/codev/state/pir-975_thread.md
@@ -30,6 +30,11 @@ plan-approval.
 
 ## Implement phase (iteration 1)
 
+> **Superseded** — the render-path mechanism described in this section was
+> reverted in the Review phase (consult REQUEST_CHANGES). Final implementation
+> uses the global `onStateChange` + `worktree-config-updated` SSE listener in
+> extension.ts. See the Review-phase section below for the final state.
+
 Plan approved. Implemented the `codev.hasDevCommand` context-key gate.
 
 Design evolved during pre-commit review with the architect:

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -320,6 +320,22 @@
         {
           "command": "codev.deleteReviewComment",
           "when": "false"
+        },
+        {
+          "command": "codev.runWorkspaceDev",
+          "when": "codev.hasDevCommand"
+        },
+        {
+          "command": "codev.stopWorkspaceDev",
+          "when": "codev.hasDevCommand"
+        },
+        {
+          "command": "codev.runWorktreeDev",
+          "when": "false"
+        },
+        {
+          "command": "codev.stopWorktreeDev",
+          "when": "false"
         }
       ],
       "view/item/context": [
@@ -385,12 +401,12 @@
         },
         {
           "command": "codev.runWorktreeDev",
-          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder|awaiting-builder)-/",
+          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder|awaiting-builder)-/ && codev.hasDevCommand",
           "group": "3_dev@2"
         },
         {
           "command": "codev.stopWorktreeDev",
-          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder|awaiting-builder)-/",
+          "when": "view == codev.builders && viewItem =~ /^(builder|blocked-builder|awaiting-builder)-/ && codev.hasDevCommand",
           "group": "3_dev@3"
         },
         {
@@ -558,12 +574,14 @@
       {
         "command": "codev.runWorkspaceDev",
         "key": "ctrl+alt+r",
-        "mac": "cmd+alt+r"
+        "mac": "cmd+alt+r",
+        "when": "codev.hasDevCommand"
       },
       {
         "command": "codev.stopWorkspaceDev",
         "key": "ctrl+alt+s",
-        "mac": "cmd+alt+s"
+        "mac": "cmd+alt+s",
+        "when": "codev.hasDevCommand"
       },
       {
         "command": "codev.pasteImage",

--- a/packages/vscode/src/__tests__/has-runnable-dev-command.test.ts
+++ b/packages/vscode/src/__tests__/has-runnable-dev-command.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Unit coverage for `hasRunnableDevCommand` (#975).
+ *
+ * This helper is the single source of truth for "is there a runnable
+ * worktree.devCommand" across two surfaces: the `codev.hasDevCommand`
+ * context key (gates the builder-row Run/Stop Dev Server menu) and the
+ * Workspace view's Start-row visibility. The critical case is the empty
+ * string: `ResolvedWorktreeConfig.devCommand` is typed `string | null`, so
+ * `""` is reachable, and it must be treated as absent (matching
+ * dev-shared.ts's `if (!devCommand)` runnability gate) — not as a present
+ * command that errors on click.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ResolvedWorktreeConfig } from '@cluesmith/codev-types';
+import { hasRunnableDevCommand } from '../load-worktree-config.js';
+
+/** Minimal config stub — only `devCommand` matters to the helper. */
+function cfg(devCommand: string | null): ResolvedWorktreeConfig {
+  return { devCommand } as ResolvedWorktreeConfig;
+}
+
+describe('hasRunnableDevCommand', () => {
+  it('returns false for a null config (Tower unreachable / not activated)', () => {
+    expect(hasRunnableDevCommand(null)).toBe(false);
+  });
+
+  it('returns false when devCommand is null', () => {
+    expect(hasRunnableDevCommand(cfg(null))).toBe(false);
+  });
+
+  it('returns false for an empty-string devCommand', () => {
+    expect(hasRunnableDevCommand(cfg(''))).toBe(false);
+  });
+
+  it('returns false for a whitespace-only devCommand', () => {
+    expect(hasRunnableDevCommand(cfg('   '))).toBe(false);
+  });
+
+  it('returns true for a real devCommand', () => {
+    expect(hasRunnableDevCommand(cfg('pnpm dev'))).toBe(true);
+  });
+
+  it('returns true even when the command has surrounding whitespace', () => {
+    expect(hasRunnableDevCommand(cfg('  pnpm dev  '))).toBe(true);
+  });
+});

--- a/packages/vscode/src/__tests__/menu-when-clauses.test.ts
+++ b/packages/vscode/src/__tests__/menu-when-clauses.test.ts
@@ -123,3 +123,70 @@ describe('commandPalette hiding for view{Spec,Plan,Review}File', () => {
     });
   }
 });
+
+/**
+ * `codev.hasDevCommand` gating for the dev-server commands (#975).
+ *
+ * The builder-row Run/Stop Dev Server context-menu entries must only
+ * surface when a runnable `worktree.devCommand` is configured. Previously
+ * they gated on view + viewItem family only, so they showed even with no
+ * dev command — picking one ran against a missing command. The fix appends
+ * `&& codev.hasDevCommand` (a setContext key the BuildersProvider refreshes
+ * from its render path off the Tower-merged config) to the `when` clause.
+ *
+ * The same gate extends to the keybindings and the workspace-dev palette
+ * entries for consistency; the builder-row dev commands are `when: false`
+ * in the palette because they need a tree-row argument (same rationale as
+ * the view{Spec,Plan,Review}File commands above).
+ *
+ * Pinning the wiring here: a drift in any of these `when` shapes would
+ * silently re-expose a command that can't run — no compile/runtime error
+ * would catch it.
+ */
+describe('codev.hasDevCommand gating for dev-server commands', () => {
+  const paletteEntries: Array<{ command: string; when?: string }> =
+    PKG.contributes.menus.commandPalette;
+  const keybindings: Array<{ command: string; when?: string }> =
+    PKG.contributes.keybindings;
+
+  for (const cmd of ['codev.runWorktreeDev', 'codev.stopWorktreeDev']) {
+    it(`${cmd} builder-row menu entry is gated by codev.hasDevCommand`, () => {
+      const entry = viewItemMenuEntries.find(
+        e => e.command === cmd && e.when.includes('view == codev.builders'));
+      expect(entry, `builders view/item/context entry for ${cmd}`).toBeDefined();
+      expect(entry!.when, `${cmd} when-clause`).toContain('&& codev.hasDevCommand');
+    });
+
+    it(`${cmd} is hidden from the command palette (needs a row argument)`, () => {
+      const entry = paletteEntries.find(e => e.command === cmd);
+      expect(entry, `commandPalette entry for ${cmd}`).toBeDefined();
+      expect(entry!.when, `${cmd} palette when-clause`).toBe('false');
+    });
+  }
+
+  for (const cmd of ['codev.runWorkspaceDev', 'codev.stopWorkspaceDev']) {
+    it(`${cmd} command palette entry is gated by codev.hasDevCommand`, () => {
+      const entry = paletteEntries.find(e => e.command === cmd);
+      expect(entry, `commandPalette entry for ${cmd}`).toBeDefined();
+      expect(entry!.when, `${cmd} palette when-clause`).toBe('codev.hasDevCommand');
+    });
+
+    it(`${cmd} keybinding is gated by codev.hasDevCommand`, () => {
+      const entry = keybindings.find(k => k.command === cmd);
+      expect(entry, `keybinding for ${cmd}`).toBeDefined();
+      expect(entry!.when, `${cmd} keybinding when-clause`).toBe('codev.hasDevCommand');
+    });
+  }
+
+  it('does not gate the Workspace view dev rows on codev.hasDevCommand (they gate via viewItem)', () => {
+    // The Workspace view rows are config-gated by row existence (the
+    // viewItem is only emitted when a dev command is configured), so their
+    // menu `when` must stay viewItem-only — no redundant context key.
+    for (const cmd of ['codev.runWorkspaceDev', 'codev.stopWorkspaceDev']) {
+      const entry = viewItemMenuEntries.find(
+        e => e.command === cmd && e.when.includes('view == codev.workspace'));
+      expect(entry, `workspace view/item/context entry for ${cmd}`).toBeDefined();
+      expect(entry!.when, `${cmd} workspace when-clause`).not.toContain('codev.hasDevCommand');
+    }
+  });
+});

--- a/packages/vscode/src/__tests__/menu-when-clauses.test.ts
+++ b/packages/vscode/src/__tests__/menu-when-clauses.test.ts
@@ -131,8 +131,9 @@ describe('commandPalette hiding for view{Spec,Plan,Review}File', () => {
  * surface when a runnable `worktree.devCommand` is configured. Previously
  * they gated on view + viewItem family only, so they showed even with no
  * dev command — picking one ran against a missing command. The fix appends
- * `&& codev.hasDevCommand` (a setContext key the BuildersProvider refreshes
- * from its render path off the Tower-merged config) to the `when` clause.
+ * `&& codev.hasDevCommand` (a setContext key extension.ts refreshes from the
+ * Tower-merged config on connect + the `worktree-config-updated` SSE) to the
+ * `when` clause.
  *
  * The same gate extends to the keybindings and the workspace-dev palette
  * entries for consistency; the builder-row dev commands are `when: false`

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -48,6 +48,7 @@ import { persistAreaGroupExpansion } from './views/area-group-expansion.js';
 import { buildArchitectReferenceInjection } from './architect-reference-injection.js';
 import { runPreflight, recheckCli, isCliReady, showSetupRequiredToast } from './preflight/preflight.js';
 import { detectWorkspacePath } from './workspace-detector.js';
+import { loadWorktreeConfig, hasRunnableDevCommand } from './load-worktree-config.js';
 
 let connectionManager: ConnectionManager | null = null;
 let terminalManager: TerminalManager | null = null;
@@ -170,6 +171,37 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.window.onDidChangeActiveTerminal(syncTerminalFocusContext));
 	syncTerminalFocusContext(); // seed initial state
 
+	// Drive the `codev.hasDevCommand` context key so the builder-row Run/Stop
+	// Dev Server menu entries, the dev keybindings, and the workspace-dev palette
+	// entries only surface when a runnable `worktree.devCommand` is configured
+	// (#975). These surfaces are global (the keybindings/palette are invokable
+	// regardless of whether the Builders tree has rendered), so the key is
+	// refreshed by global signals — mirroring the Workspace view's own gate:
+	// `onStateChange` for the initial value once Tower is reachable, plus the
+	// `worktree-config-updated` SSE envelope (fired by Tower's config-file
+	// watcher) so the key stays live on `.codev/config(.local).json` edits
+	// without a window reload. The config is the Tower-merged 5-layer view
+	// (shared + project-local). Fail-safe: a disconnected/error state resolves
+	// to `false` — hide, never falsely offer.
+	const syncHasDevCommandContext = async () => {
+		const config = await loadWorktreeConfig(connectionManager!);
+		await vscode.commands.executeCommand(
+			'setContext', 'codev.hasDevCommand', hasRunnableDevCommand(config));
+	};
+	context.subscriptions.push(
+		connectionManager.onStateChange(() => { syncHasDevCommandContext(); }));
+	context.subscriptions.push(
+		connectionManager.onSSEEvent(({ data }) => {
+			try {
+				if ((JSON.parse(data) as { type?: unknown }).type === 'worktree-config-updated') {
+					syncHasDevCommandContext();
+				}
+			} catch {
+				// benign — malformed envelope
+			}
+		}));
+	syncHasDevCommandContext(); // seed initial state
+
 	// Update status bar with builder + needs-attention counts.
 	// Two "needs me" signals: blocked (formal gate) and idle-waiting
 	// (PTY silent past threshold, likely paused at a non-gate question
@@ -290,7 +322,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// List views use createTreeView so their title can carry a live item
 	// count; the rest stay on registerTreeDataProvider.
-	const buildersProvider = new BuildersProvider(overviewCache, builderDiffCache, connectionManager, context.workspaceState);
+	const buildersProvider = new BuildersProvider(overviewCache, builderDiffCache, context.workspaceState);
 	buildersView = vscode.window.createTreeView('codev.builders', { treeDataProvider: buildersProvider });
 	context.subscriptions.push(...persistAreaGroupExpansion(
 		buildersView, BuilderGroupTreeItem, buildersProvider.expansion,

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -290,7 +290,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// List views use createTreeView so their title can carry a live item
 	// count; the rest stay on registerTreeDataProvider.
-	const buildersProvider = new BuildersProvider(overviewCache, builderDiffCache, context.workspaceState);
+	const buildersProvider = new BuildersProvider(overviewCache, builderDiffCache, context.workspaceState, connectionManager);
 	buildersView = vscode.window.createTreeView('codev.builders', { treeDataProvider: buildersProvider });
 	context.subscriptions.push(...persistAreaGroupExpansion(
 		buildersView, BuilderGroupTreeItem, buildersProvider.expansion,

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -290,7 +290,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// List views use createTreeView so their title can carry a live item
 	// count; the rest stay on registerTreeDataProvider.
-	const buildersProvider = new BuildersProvider(overviewCache, builderDiffCache, context.workspaceState, connectionManager);
+	const buildersProvider = new BuildersProvider(overviewCache, builderDiffCache, connectionManager, context.workspaceState);
 	buildersView = vscode.window.createTreeView('codev.builders', { treeDataProvider: buildersProvider });
 	context.subscriptions.push(...persistAreaGroupExpansion(
 		buildersView, BuilderGroupTreeItem, buildersProvider.expansion,

--- a/packages/vscode/src/load-worktree-config.ts
+++ b/packages/vscode/src/load-worktree-config.ts
@@ -31,3 +31,21 @@ export async function loadWorktreeConfig(
   if (!client || !workspacePath || connectionManager.getState() !== 'connected') { return null; }
   return client.getWorktreeConfig(workspacePath);
 }
+
+/**
+ * Whether the resolved config carries a *runnable* `worktree.devCommand`.
+ *
+ * "Runnable" means a non-empty, non-whitespace string — matching the
+ * actual gate in `commands/dev-shared.ts` (`if (!devCommand)`), where an
+ * empty string falls through to the "configure devCommand" error. The
+ * type is `string | null` (`ResolvedWorktreeConfig.devCommand`), so `""`
+ * is reachable and must be treated as absent, not present-but-disabled.
+ *
+ * Single source of truth for two surfaces: the `codev.hasDevCommand`
+ * context key (gates the builder-row Run/Stop Dev Server menu) and the
+ * Workspace view's Start-row visibility. Keeping both on this helper
+ * guarantees they agree on every config state.
+ */
+export function hasRunnableDevCommand(config: ResolvedWorktreeConfig | null): boolean {
+  return typeof config?.devCommand === 'string' && config.devCommand.trim().length > 0;
+}

--- a/packages/vscode/src/views/builders.ts
+++ b/packages/vscode/src/views/builders.ts
@@ -10,6 +10,8 @@ import { BuilderFileTreeItem } from './builder-file-tree-item.js';
 import { BuilderFolderTreeItem } from './builder-folder-tree-item.js';
 import { buildFilePathTree, type FilePathNode } from './file-path-tree.js';
 import type { BuilderDiffCache } from './builder-diff-cache.js';
+import type { ConnectionManager } from '../connection-manager.js';
+import { loadWorktreeConfig, hasRunnableDevCommand } from '../load-worktree-config.js';
 import { AreaGroupExpansionStore, type GroupExpansionStore } from './area-group-expansion.js';
 import {
   type BuilderGrouping,
@@ -107,12 +109,31 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
     private cache: OverviewCache,
     private readonly diffCache: BuilderDiffCache,
     workspaceState: vscode.Memento,
+    private readonly connectionManager: ConnectionManager,
   ) {
     this.groupings = {
       stage: stageGrouping(new AreaGroupExpansionStore(workspaceState, 'codev.buildersStageGroupExpansion')),
       area: areaGrouping(new AreaGroupExpansionStore(workspaceState, 'codev.buildersGroupExpansion')),
     };
     cache.onDidChange(() => this.changeEmitter.fire());
+  }
+
+  /**
+   * Refresh the `codev.hasDevCommand` context key so the builder-row Run/Stop
+   * Dev Server menu entries (and the dev keybindings + palette entries) only
+   * surface when a runnable `worktree.devCommand` is configured (#975).
+   *
+   * Driven from the render path (`getChildren`'s root branch) rather than a
+   * dedicated config-file listener: the context menu is on-demand and short-
+   * lived, so the key only needs to track the same cadence as the rows it
+   * gates — not a constant stream (contrast the always-on Workspace view).
+   * Fire-and-forget: the Tower config fetch must never block tree rendering.
+   * A disconnected/unreachable state resolves to `false` — fail-safe to hidden.
+   */
+  private refreshDevCommandContext(): void {
+    loadWorktreeConfig(this.connectionManager).then(config =>
+      vscode.commands.executeCommand(
+        'setContext', 'codev.hasDevCommand', hasRunnableDevCommand(config)));
   }
 
   /**
@@ -175,6 +196,9 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
       return this.rowsForGroup(element.groupName);
     }
     // Root: group headers, or the single-Uncategorized flatten case (area mode).
+    // Refresh the dev-command menu gate on the same cadence as the rows it
+    // applies to (fire-and-forget — does not block the render). See #975.
+    this.refreshDevCommandContext();
     return this.rootChildren();
   }
 

--- a/packages/vscode/src/views/builders.ts
+++ b/packages/vscode/src/views/builders.ts
@@ -10,8 +10,6 @@ import { BuilderFileTreeItem } from './builder-file-tree-item.js';
 import { BuilderFolderTreeItem } from './builder-folder-tree-item.js';
 import { buildFilePathTree, type FilePathNode } from './file-path-tree.js';
 import type { BuilderDiffCache } from './builder-diff-cache.js';
-import type { ConnectionManager } from '../connection-manager.js';
-import { loadWorktreeConfig, hasRunnableDevCommand } from '../load-worktree-config.js';
 import { AreaGroupExpansionStore, type GroupExpansionStore } from './area-group-expansion.js';
 import {
   type BuilderGrouping,
@@ -108,7 +106,6 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
   constructor(
     private cache: OverviewCache,
     private readonly diffCache: BuilderDiffCache,
-    private readonly connectionManager: ConnectionManager,
     workspaceState: vscode.Memento,
   ) {
     this.groupings = {
@@ -116,24 +113,6 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
       area: areaGrouping(new AreaGroupExpansionStore(workspaceState, 'codev.buildersGroupExpansion')),
     };
     cache.onDidChange(() => this.changeEmitter.fire());
-  }
-
-  /**
-   * Refresh the `codev.hasDevCommand` context key so the builder-row Run/Stop
-   * Dev Server menu entries (and the dev keybindings + palette entries) only
-   * surface when a runnable `worktree.devCommand` is configured (#975).
-   *
-   * Driven from the render path (`getChildren`'s root branch) rather than a
-   * dedicated config-file listener: the context menu is on-demand and short-
-   * lived, so the key only needs to track the same cadence as the rows it
-   * gates — not a constant stream (contrast the always-on Workspace view).
-   * Fire-and-forget: the Tower config fetch must never block tree rendering.
-   * A disconnected/unreachable state resolves to `false` — fail-safe to hidden.
-   */
-  private refreshDevCommandContext(): void {
-    loadWorktreeConfig(this.connectionManager).then(config =>
-      vscode.commands.executeCommand(
-        'setContext', 'codev.hasDevCommand', hasRunnableDevCommand(config)));
   }
 
   /**
@@ -196,9 +175,6 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
       return this.rowsForGroup(element.groupName);
     }
     // Root: group headers, or the single-Uncategorized flatten case (area mode).
-    // Refresh the dev-command menu gate on the same cadence as the rows it
-    // applies to (fire-and-forget — does not block the render). See #975.
-    this.refreshDevCommandContext();
     return this.rootChildren();
   }
 

--- a/packages/vscode/src/views/builders.ts
+++ b/packages/vscode/src/views/builders.ts
@@ -108,8 +108,8 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
   constructor(
     private cache: OverviewCache,
     private readonly diffCache: BuilderDiffCache,
-    workspaceState: vscode.Memento,
     private readonly connectionManager: ConnectionManager,
+    workspaceState: vscode.Memento,
   ) {
     this.groupings = {
       stage: stageGrouping(new AreaGroupExpansionStore(workspaceState, 'codev.buildersStageGroupExpansion')),

--- a/packages/vscode/src/views/workspace.ts
+++ b/packages/vscode/src/views/workspace.ts
@@ -4,7 +4,7 @@ import type { ConnectionManager } from '../connection-manager.js';
 import type { TerminalManager } from '../terminal-manager.js';
 import { getTowerAddress } from '../workspace-detector.js';
 import { resolveWorkspaceDevTarget } from '../commands/dev-shared.js';
-import { loadWorktreeConfig } from '../load-worktree-config.js';
+import { loadWorktreeConfig, hasRunnableDevCommand } from '../load-worktree-config.js';
 
 /**
  * Workspace-level entry points: architect terminal, Tower web dashboard,
@@ -145,13 +145,16 @@ export class WorkspaceProvider implements vscode.TreeDataProvider<vscode.TreeIte
     // too. The visible control is itself the state indicator (play/stop
     // model) — never both, no row-count jitter.
     //
-    // Visibility also depends on whether devCommand is configured:
+    // Visibility also depends on whether a *runnable* devCommand is
+    // configured (non-empty, non-whitespace — see hasRunnableDevCommand):
     //   - dev running → always show Stop (lets the user kill a dev they
-    //     started before nulling out devCommand)
-    //   - no dev running + devCommand set → show Start
-    //   - no dev running + devCommand null → show nothing
-    // The third case is the new one — it removes the "click Start, get a
-    // toast saying devCommand isn't configured" footgun.
+    //     started before clearing devCommand)
+    //   - no dev running + runnable devCommand → show Start
+    //   - no dev running + no runnable devCommand → show nothing
+    // The third case removes the "click Start, get a toast saying
+    // devCommand isn't configured" footgun. Gating on hasRunnableDevCommand
+    // (not `devCommand !== null`) also treats `"devCommand": ""` as absent,
+    // matching dev-shared.ts's runnability check.
     const allDevs = this.terminalManager.listDevTerminals();
     const targetDev = devTarget ? allDevs.find(d => d.builderId === devTarget.id) : undefined;
     const otherDev = !targetDev ? allDevs[0] : undefined; // single-slot ⇒ at most one
@@ -182,8 +185,8 @@ export class WorkspaceProvider implements vscode.TreeDataProvider<vscode.TreeIte
         title: 'Stop Dev Server',
       };
       items.push(stopDev);
-    } else if (devCommand !== null) {
-      // No dev anywhere AND a devCommand is configured — Start row.
+    } else if (hasRunnableDevCommand(worktreeConfig)) {
+      // No dev anywhere AND a runnable devCommand is configured — Start row.
       const startDev = new vscode.TreeItem('Start Dev Server');
       startDev.iconPath = new vscode.ThemeIcon('play');
       startDev.tooltip = devTarget
@@ -196,7 +199,7 @@ export class WorkspaceProvider implements vscode.TreeDataProvider<vscode.TreeIte
       };
       items.push(startDev);
     }
-    // else: no dev running and no devCommand → no dev-server row at all.
+    // else: no dev running and no runnable devCommand → no dev-server row at all.
 
     // Open Dev URL rows: one per entry in `worktree.devUrls`. Visible
     // independent of dev-PTY


### PR DESCRIPTION
# PIR Review: Gate builder-row Run/Stop Dev Server menu on `worktree.devCommand`

Fixes #975

## Summary

The builder-row **Run/Stop Dev Server** context-menu entries used to show on every builder row regardless of whether `worktree.devCommand` was configured, so picking one ran against a missing command (error toast or no-op). This PR gates those entries — plus the dev keybindings and the workspace-dev command-palette entries — on a new `codev.hasDevCommand` context key. The key is refreshed by global signals in `extension.ts` (`onStateChange` + the `worktree-config-updated` SSE), mirroring the Workspace view's own dev-row gate, so all three gated surfaces stay live — including the keybindings/palette, which are invokable independent of the Builders tree's visibility. A shared `hasRunnableDevCommand()` helper backs both the key and the Workspace view's Start-row gate, also fixing a latent empty-string bug.

## Files Changed

- `packages/vscode/src/extension.ts` (+32 / -0) — `syncHasDevCommandContext()` refreshing the context key on `onStateChange` + the `worktree-config-updated` SSE envelope, plus an initial seed
- `packages/vscode/src/load-worktree-config.ts` (+18 / -0) — `hasRunnableDevCommand()` helper (single source of truth)
- `packages/vscode/src/views/workspace.ts` (+~12 / -~11) — Start-row gate switched from `devCommand !== null` to `hasRunnableDevCommand(worktreeConfig)`
- `packages/vscode/package.json` (+22 / -4) — `&& codev.hasDevCommand` on the two builder-row dev `when` clauses; `when` gating on the two dev keybindings; commandPalette entries (workspace-dev → `codev.hasDevCommand`, builder-row dev → `false`)
- `packages/vscode/src/__tests__/has-runnable-dev-command.test.ts` (+47 / -0, new) — helper truth table
- `packages/vscode/src/__tests__/menu-when-clauses.test.ts` (+67 / -0) — `when`-shape assertions for the gating across menu / palette / keybinding surfaces

## Commits

- `4c856a92` [PIR #975] Gate builder-row Run/Stop Dev Server menu on worktree.devCommand
- `50a66686` [PIR #975] Group BuildersProvider parameter-properties together
- (final) [PIR #975] Use global onStateChange + SSE refresh for hasDevCommand (consult REQUEST_CHANGES)

## Test Results

- `pnpm build`: ✓ pass (porch check, 6.3s)
- `pnpm test`: ✓ pass (porch check, 20.8s)
- `pnpm check-types`: ✓ clean
- `pnpm test:unit`: ✓ 276 tests pass (21 files), incl. 2 new test files
- `eslint` (changed files): ✓ clean
- Manual verification: performed by the human at the `dev-approval` gate against the running worktree — builder-row entries hidden with no `devCommand`, present with one, live after a config edit; Workspace view unaffected. **Note:** dev-approval was on an earlier render-path implementation; the refresh mechanism was changed post-gate (see "Things to Look At") — the user-facing menu behavior is unchanged and now extends correctly to the keybindings/palette.

## Architecture Updates

No `arch.md` changes needed. This PR fixes a UI-gating bug within the existing VSCode TreeView + `when`-clause / setContext pattern; it introduces no new module boundary or architectural pattern. The `codev.hasDevCommand` refresh mirrors the established global context-key pattern in this extension — `WorkspaceProvider`'s own dev-row gate (`onStateChange` + `worktree-config-updated` SSE) and the builders-tree setting keys (`codev.buildersAutoCollapse`, `codev.buildersGroupBy`), which are driven by global `vscode.workspace.onDidChangeConfiguration` listeners. The key is refreshed by global signals — not the tree render path — because the keybindings and palette entries it also gates are invokable independent of the Builders tree's visibility.

## Lessons Learned Updates

No addition to `codev/resources/lessons-learned.md`. The transferable observation — *a context key shared by surfaces with different lifecycles (an ephemeral tree context menu vs. global keybindings/palette) must be refreshed on the cadence of the most demanding surface; a render-path refresh that fits the menu silently breaks the global surfaces* — is the heart of this PR's review back-and-forth and is captured in the code comments + the "Things to Look At" note below, not broad enough to warrant a standing lessons entry.

## Things to Look At During PR Review

- **Consult finding + disposition (REQUEST_CHANGES → fixed).** The PR-stage 3-way consult split 2 REQUEST_CHANGES (Gemini, Codex; HIGH) vs 1 APPROVE (Claude). Both dissents were correct and the same: an earlier implementation refreshed `codev.hasDevCommand` from the Builders-tree render path, which left the **global** keybindings (`cmd+alt+r`/`s`) and workspace-dev palette entries stale when the Builders tree wasn't rendered (e.g. collapsed) — `cmd+alt+r` could silently no-op with a `devCommand` configured. **Disposition: fixed**, not rebutted — the refresh was moved to global signals (`onStateChange` + `worktree-config-updated` SSE) in `extension.ts`, mirroring `WorkspaceProvider`. All three surfaces are now live and consistent. Gemini also correctly flagged a factual error in an earlier draft of this review (it claimed the render-path was "consistent with" `buildersAutoCollapse`/`buildersGroupBy`, which are actually `onDidChangeConfiguration`-driven) — corrected above. PIR is single-pass, so this fix was **not** independently re-reviewed by the models; please verify it at the `pr` gate.
- **Coverage note (Codex's ask).** The testable unit — the value computation `hasRunnableDevCommand` — is fully covered (truth table incl. empty/whitespace). The menu/keybinding/palette `when`-clause contract is pinned in `menu-when-clauses.test.ts`. The event-wiring itself (which signals trigger the refresh) is activation-time VSCode glue: it mirrors `WorkspaceProvider`'s already-trusted, identical `onStateChange` + `worktree-config-updated` filter, and like all such glue in this extension is exercised by the vscode-test integration harness / manual run rather than vitest. No brittle vscode-mock unit test was added for it.
- **Empty-string semantics.** `hasRunnableDevCommand` treats `"devCommand": ""` / whitespace as absent, matching `dev-shared.ts`'s `if (!devCommand)` runnability gate. This also changes the Workspace view's Start-row gate (previously `devCommand !== null`, which would have shown a Start row for `""` that errors on click) — a latent bug fix. Confirm no Workspace-view regression.
- **Builder-row dev palette entries pinned `when: false`.** They need a tree-row argument; argless palette invocation falls through (same rationale as `viewSpecFile`/`viewPlanFile`/`viewReviewFile`). This is a behavior change — before this PR they had no palette entry and so defaulted to visible.

## How to Test Locally

- **View diff**: VSCode sidebar → right-click builder `pir-975` → **View Diff**
- **Run dev server**: VSCode sidebar → **Run Dev Server**, or `afx dev pir-975`
- **What to verify**:
  - With no `worktree.devCommand` in `.codev/config.json`: right-click a builder row → **no** Run/Stop Dev Server entries.
  - Add `"devCommand": "pnpm dev"` and save: entries appear live (no window reload), via the `worktree-config-updated` SSE.
  - Remove it again / set it to `""`: entries hidden live.
  - Workspace view Start/Stop rows behave as before across the same edits.
  - Keybinding `cmd+alt+r` is silent with no dev command (even with the Builders tree collapsed); starts dev with one — verify both tree-collapsed and tree-expanded states.
