### PR TITLE
ci: run vscode + dashboard vitest unit suites in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,10 @@ jobs:
         working-directory: packages/core
         run: pnpm build
 
+      - name: Build types package
+        working-directory: packages/types
+        run: pnpm build
+
       - name: Run core unit tests
         working-directory: packages/core
         run: pnpm test
@@ -57,6 +61,14 @@ jobs:
               exit $VITEST_EXIT
             fi
           fi
+
+      - name: Run dashboard unit tests
+        working-directory: packages/dashboard
+        run: pnpm test
+
+      - name: Run vscode unit tests
+        working-directory: packages/vscode
+        run: pnpm test:unit
 
   integration:
     name: Tower Integration Tests

--- a/codev/plans/967-ci-run-vscode-dashboard-vitest.md
+++ b/codev/plans/967-ci-run-vscode-dashboard-vitest.md
@@ -1,0 +1,121 @@
+# PIR Plan: Run vscode + dashboard vitest unit suites in CI
+
+## Understanding
+
+Two vitest unit suites have **zero CI coverage** today — they only ever run on a builder's
+machine:
+
+| Package | Suite | Runs in CI? |
+|---|---|---|
+| `packages/dashboard` (`@cluesmith/codev-dashboard`) | `vitest run` — `__tests__/*.test.ts(x)` | ❌ local only |
+| `packages/vscode` (`codev-vscode`) | `test:unit` → `vitest run` — `src/__tests__/**/*.test.ts` | ❌ local only |
+
+`test.yml`'s `unit` job runs `packages/core` (added in #961) and `packages/codev`. The dashboard's
+Playwright e2e runs in `dashboard-e2e.yml`, but its **vitest unit** suite does not. A regression in
+either uncovered suite (e.g. `dashboard/__tests__/Terminal.reconnect.test.tsx`,
+`vscode/src/__tests__/terminal-adapter.test.ts`) passes CI today.
+
+### Findings from running both suites on this clean tree
+
+1. **Dashboard suite passes clean**: `vitest run` → **317 passed, 1 skipped (31 files)**, exit 0, ~1.9s.
+2. **The pre-existing failing dashboard test no longer exists.** The issue flagged
+   `scrollController.test.ts > ... > warns on unexpected scroll-to-top` as failing on a clean tree.
+   That test has since been **replaced** by `accepts scroll-to-top without auto-correcting or warning
+   (Issue #630)` and the whole `scrollController.test.ts` file passes 45/45. **No quarantine or fix is
+   needed** — the prerequisite the issue worried about is already resolved upstream.
+3. **vscode `test:unit` needs `@cluesmith/codev-types` built first.** On a tree where `packages/types`
+   has no `dist/`, two files fail:
+   `src/__tests__/terminal-adapter.test.ts` and `src/__tests__/reconnect-link-provider.test.ts`, with
+   `Error: Failed to resolve entry for package "@cluesmith/codev-types"`. Root cause: types' export map
+   is `{ "types": "./src/index.ts", "default": "./dist/index.js" }`
+   (`packages/types/package.json`). vscode's vitest runs in a plain `node` environment and resolves the
+   `default` condition → `dist/index.js`, which doesn't exist until `pnpm --filter @cluesmith/codev-types build`.
+   After building types, vscode `test:unit` passes **284/284**, exit 0, <1s.
+   (The dashboard suite resolves types from source `./src/index.ts` because Vite's react plugin
+   transforms `.ts` on the fly, so it doesn't strictly need the build — but building types is harmless
+   and makes the job robust.)
+4. **Neither suite needs the forks-pool teardown-crash workaround** that `packages/codev` uses
+   (pipefail + tee + grep). Both exit cleanly with code 0. A plain `vitest run` (via the package
+   scripts) is sufficient — no output-scraping shim.
+
+## Proposed Change
+
+Add the two suites to the existing **`unit` job** in `.github/workflows/test.yml` as additional steps,
+rather than creating separate jobs.
+
+**Why fold into the `unit` job instead of new jobs:** the `unit` job already does `pnpm install` and
+builds `packages/core`. Both new suites are sub-2s. Standing up two new jobs would each repeat
+checkout + `pnpm install` (~30–60s) + a core build to run ~2s of tests — poor wall-clock and
+CI-minute economics. Folding in reuses the install/build that's already paid for; the only marginal
+addition is one `pnpm --filter @cluesmith/codev-types build` step (types isn't built in the job today).
+The job already exercises `core` + `codev`, so "all unit suites in one job" stays cohesive.
+
+Steps to add to the `unit` job, after the existing core build and before/after the codev steps:
+
+1. **Build types package** — `pnpm --filter @cluesmith/codev-types build` (required by vscode's suite).
+2. **Run dashboard unit tests** — `working-directory: packages/dashboard`, `run: pnpm test`
+   (the `test` script is `vitest run`).
+3. **Run vscode unit tests** — `working-directory: packages/vscode`, `run: pnpm test:unit`
+   (the `test:unit` script is `vitest run`).
+
+Use the package scripts (`pnpm test` / `pnpm test:unit`) rather than re-spelling `vitest run`, so the
+CI command tracks whatever the package owner defines.
+
+### Decisions on the issue's open questions
+
+- **Fold vs. separate jobs** → fold into `unit` (rationale above).
+- **Coverage thresholds** → **no**. Neither config defines coverage today, and `core` deliberately
+  ships without a threshold (#961). Match that precedent; run plain `vitest run`. Adding thresholds is
+  a separate, opt-in decision per package owner and out of scope for "make them run in CI".
+- **Forks-pool teardown workaround** → **not needed**. Both suites exit 0 cleanly; plain `vitest run`
+  via the package scripts suffices. No tee/grep shim.
+- **The flagged failing dashboard test** → already resolved upstream (finding #2); nothing to fix or
+  quarantine.
+
+## Files to Change
+
+- `.github/workflows/test.yml` — in the `unit` job, add three steps:
+  - `Build types package` → `pnpm --filter @cluesmith/codev-types build`
+  - `Run dashboard unit tests` → `working-directory: packages/dashboard`, `run: pnpm test`
+  - `Run vscode unit tests` → `working-directory: packages/vscode`, `run: pnpm test:unit`
+
+No source/test files change — both suites pass as-is on `main`.
+
+## Risks & Alternatives Considered
+
+- **Risk: the dashboard's 1 skipped test masks a real gap.** It's an intentional `.skip` in the suite,
+  unrelated to this work; surfacing it is out of scope. Mention it in the review, don't touch it.
+- **Risk: types build ordering.** vscode's suite hard-requires `packages/types/dist`. The new step
+  builds it before the vscode step runs. Verified locally: clean tree → 2 failures; after types build →
+  284/284 pass.
+- **Risk: a future flaky-teardown crash in these suites** (the thing codev's tee/grep shim guards
+  against). Not observed in either suite today. If it ever surfaces, the same documented workaround can
+  be applied then — adding it pre-emptively would be cargo-culting. Documented here so the next person
+  knows the option exists.
+- **Alternative: separate jobs per package.** Rejected for cost (duplicate install/build for ~2s of
+  tests). Revisit only if the `unit` job's wall-clock becomes a bottleneck or a suite needs a
+  materially different toolchain/runner.
+- **Alternative: add the dashboard unit suite to `dashboard-e2e.yml`.** Rejected — that workflow is
+  schedule/dispatch-only (daily cron), so it wouldn't gate PRs. The unit suites must gate PRs, which
+  means `test.yml` (runs on `pull_request` + push to `main`).
+
+## Test Plan
+
+This change is **CI-config only** — the "running worktree" to review at the `dev-approval` gate is the
+CI behavior, verified by reproducing each CI step locally.
+
+- **Reproduce the new CI steps locally** (from the worktree root):
+  ```bash
+  pnpm install
+  pnpm --filter @cluesmith/codev-core build
+  pnpm --filter @cluesmith/codev-types build
+  pnpm --filter @cluesmith/codev-dashboard test     # expect: 317 passed, 1 skipped, exit 0
+  pnpm --filter codev-vscode test:unit              # expect: 284 passed, exit 0
+  ```
+- **Negative check (proves the types build is load-bearing):** remove `packages/types/dist`, run the
+  vscode suite, observe the 2 `Failed to resolve entry for "@cluesmith/codev-types"` failures; rebuild
+  types, observe them pass.
+- **Workflow lint:** confirm `.github/workflows/test.yml` YAML is valid (the added steps mirror the
+  existing core/codev step structure exactly).
+- **End-to-end:** once pushed, the `unit` job on the PR shows the two new steps green. (Final
+  confirmation lands when the PR's CI runs.)

--- a/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
+++ b/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-06-03T21:44:04.587Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T21:40:18.973Z'
-updated_at: '2026-06-03T21:40:18.974Z'
+updated_at: '2026-06-03T21:44:04.587Z'

--- a/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
+++ b/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-06-03T21:44:04.587Z'
     approved_at: '2026-06-05T01:50:44.407Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-06-05T01:52:03.197Z'
+    approved_at: '2026-06-05T09:26:25.529Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T21:40:18.973Z'
-updated_at: '2026-06-05T01:52:03.198Z'
+updated_at: '2026-06-05T09:26:25.530Z'

--- a/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
+++ b/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
@@ -1,7 +1,7 @@
 id: '967'
 title: ci-run-vscode-dashboard-vitest
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T21:40:18.973Z'
-updated_at: '2026-06-05T01:50:44.408Z'
+updated_at: '2026-06-05T01:50:52.365Z'

--- a/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
+++ b/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
@@ -1,7 +1,7 @@
 id: '967'
 title: ci-run-vscode-dashboard-vitest
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T21:40:18.973Z'
-updated_at: '2026-06-05T09:26:25.530Z'
+updated_at: '2026-06-05T09:26:37.081Z'

--- a/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
+++ b/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-06-05T01:50:44.407Z'
   dev-approval:
     status: pending
+    requested_at: '2026-06-05T01:52:03.197Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T21:40:18.973Z'
-updated_at: '2026-06-05T01:50:52.365Z'
+updated_at: '2026-06-05T01:52:03.198Z'

--- a/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
+++ b/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T21:40:18.973Z'
-updated_at: '2026-06-05T09:26:37.081Z'
+updated_at: '2026-06-05T09:28:39.589Z'
+pr_history:
+  - phase: review
+    pr_number: 993
+    branch: builder/pir-967
+    created_at: '2026-06-05T09:28:39.588Z'

--- a/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
+++ b/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-06-05T01:52:03.197Z'
     approved_at: '2026-06-05T09:26:25.529Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-06-05T09:30:45.947Z'
+    approved_at: '2026-06-05T09:32:07.415Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T21:40:18.973Z'
-updated_at: '2026-06-05T09:30:45.947Z'
+updated_at: '2026-06-05T09:32:07.416Z'
 pr_history:
   - phase: review
     pr_number: 993
     branch: builder/pir-967
     created_at: '2026-06-05T09:28:39.588Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
+++ b/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-06-05T09:26:25.529Z'
   pr:
     status: pending
+    requested_at: '2026-06-05T09:30:45.947Z'
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-06-03T21:40:18.973Z'
-updated_at: '2026-06-05T09:28:47.488Z'
+updated_at: '2026-06-05T09:30:45.947Z'
 pr_history:
   - phase: review
     pr_number: 993
     branch: builder/pir-967
     created_at: '2026-06-05T09:28:39.588Z'
+pr_ready_for_human: true

--- a/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
+++ b/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-06-03T21:44:04.587Z'
+    approved_at: '2026-06-05T01:50:44.407Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-03T21:40:18.973Z'
-updated_at: '2026-06-03T21:44:04.587Z'
+updated_at: '2026-06-05T01:50:44.408Z'

--- a/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
+++ b/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-06-03T21:40:18.973Z'
-updated_at: '2026-06-05T09:28:39.589Z'
+updated_at: '2026-06-05T09:28:47.488Z'
 pr_history:
   - phase: review
     pr_number: 993

--- a/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
+++ b/codev/projects/967-ci-run-vscode-dashboard-vitest/status.yaml
@@ -1,0 +1,18 @@
+id: '967'
+title: ci-run-vscode-dashboard-vitest
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-06-03T21:40:18.973Z'
+updated_at: '2026-06-03T21:40:18.974Z'

--- a/codev/reviews/967-ci-run-vscode-dashboard-vitest.md
+++ b/codev/reviews/967-ci-run-vscode-dashboard-vitest.md
@@ -1,0 +1,71 @@
+# PIR Review: Run vscode + dashboard vitest unit suites in CI
+
+Fixes #967
+
+## Summary
+
+The `Tests` workflow (`.github/workflows/test.yml`) only ran the `packages/core` and `packages/codev` vitest suites, so the `packages/dashboard` and `packages/vscode` unit suites (which exist and pass locally) had zero CI coverage: a regression in either would pass CI unnoticed. This PR adds those two suites to the existing `unit` job, plus the one prerequisite they need (building `@cluesmith/codev-types`). It is a CI-configuration-only change: no source or test code was modified, and both suites already pass on the current tree.
+
+## Files Changed
+
+- `.github/workflows/test.yml` (+12 / -0)
+
+Supporting artifacts (not product code):
+- `codev/plans/967-ci-run-vscode-dashboard-vitest.md` (plan)
+- `codev/reviews/967-ci-run-vscode-dashboard-vitest.md` (this file)
+- `codev/state/pir-967_thread.md` (builder thread)
+
+## Commits
+
+- `8dfdac77` [PIR #967] Run vscode + dashboard vitest unit suites in CI
+- `c1574f7f` [PIR #967] Plan draft
+- `166913b1` [PIR #967] Thread: implement phase
+
+(plus porch phase-transition bookkeeping commits)
+
+## Test Results
+
+- `porch done` checks: `build` ✓, `tests` ✓
+- Per-suite, reproducing the new CI steps locally:
+  - dashboard `pnpm test`: 317 passed, 1 skipped (31 files), exit 0
+  - vscode `pnpm test:unit`: 284 passed (22 files), exit 0
+- **Full workflow run via `act`** (real GitHub Actions container, fresh checkout, `catthehacker/ubuntu:act-latest`): the entire `unit` job succeeded (`🏁 Job succeeded`). All 11 steps green, including the three new ones (`Build types package`, `Run dashboard unit tests`, `Run vscode unit tests`). This exercised the change under genuine CI conditions: clean `pnpm install` from scratch, no pre-existing `dist/`, correct step ordering.
+
+## Architecture Updates
+
+No arch changes. This is a CI-config change that adds existing test suites to an existing job; it introduces no new module, boundary, or pattern. `codev/resources/arch.md` is unaffected.
+
+## Lessons Learned Updates
+
+One durable lesson worth recording (captured here for the next MAINTAIN run to fold into `codev/resources/lessons-learned.md`, consistent with how that file is curated from reviews):
+
+- **A node-environment vitest suite that imports `@cluesmith/codev-types` requires that package to be built (`dist/index.js`) before it runs, even though a Vite-based suite in the same monorepo does not.** The types package export map is `{ "types": "./src/index.ts", "default": "./dist/index.js" }`. The vscode suite runs in vitest's plain `node` environment and resolves the `default` condition to `dist/index.js`, so on a clean tree (no `dist/`) it fails with `Failed to resolve entry for package "@cluesmith/codev-types"`. The dashboard suite resolves the same dependency from source (`./src/index.ts`) because Vite's react plugin transforms `.ts` on the fly, so it needs no build. Takeaway for adding any future cross-package suite to CI: build the workspace `dist/` of any dependency the suite resolves at runtime in a node environment, do not assume the Vite-style source resolution applies.
+
+## Things to Look At During PR Review
+
+- **Placement of the `Build types package` step.** It sits after the core build and before the two new suites. This ordering is load-bearing for the vscode suite (verified by a negative test: removing `packages/types/dist` reproduces the two `Failed to resolve entry` failures; rebuilding fixes them). It also runs in the `unit` job specifically, which is where the suites that need it live.
+- **Folded into the `unit` job rather than separate jobs.** Both suites are sub-7s; standing up new jobs would each repeat `pnpm install` (~90s in the act run) and a core build for a few seconds of tests. The plan documents this tradeoff and the rejected alternatives (separate jobs, adding the dashboard unit suite to the schedule-only `dashboard-e2e.yml`).
+- **Deliberate non-additions:** no coverage thresholds (neither config has them; `core` ships without one by design) and no forks-pool tee/grep teardown shim (both suites exit 0 cleanly, unlike `codev`). Adding either would have been cargo-culting.
+- **The flagged "pre-existing failing dashboard test" from the issue no longer exists.** `scrollController.test.ts > ... > warns on unexpected scroll-to-top` was replaced upstream by `accepts scroll-to-top without auto-correcting or warning (Issue #630)`; the file passes 45/45. Nothing was quarantined.
+- The dashboard suite's 1 skipped test is an intentional pre-existing `.skip`, unrelated to this change, and was left untouched.
+
+## How to Test Locally
+
+For reviewers pulling the branch:
+
+- **View diff**: VSCode sidebar → right-click builder pir-967 → **View Diff** (auto-detects default branch)
+- **Reproduce the CI steps** (the change is CI-config, so the "running thing" is the workflow):
+  ```bash
+  pnpm install
+  pnpm --filter @cluesmith/codev-core build
+  pnpm --filter @cluesmith/codev-types build
+  pnpm --filter @cluesmith/codev-dashboard test     # 317 passed / 1 skipped
+  pnpm --filter codev-vscode test:unit              # 284 passed
+  ```
+- **Or run the job as CI would** (requires `act` + Docker):
+  ```bash
+  act pull_request -j unit -W .github/workflows/test.yml \
+    --container-architecture linux/amd64 \
+    -P ubuntu-latest=catthehacker/ubuntu:act-latest
+  ```
+- **Negative check** (proves the types build is required): delete `packages/types/dist`, run the vscode suite, observe the 2 resolution failures, rebuild types, observe them pass.

--- a/codev/state/pir-967_thread.md
+++ b/codev/state/pir-967_thread.md
@@ -32,3 +32,10 @@ Edited `.github/workflows/test.yml` `unit` job only:
 Verified locally (reproducing the CI steps): core+types build, dashboard 317 passed/1 skipped exit 0, vscode 284 passed exit 0. YAML validated. No source/test changes.
 
 Committed + pushed. Awaiting dev-approval gate.
+
+## Review phase (2026-06-05)
+
+dev-approval approved (human ran a full `act` containerized run of the unit job + reviewed). Wrote review file.
+No arch changes (CI-config only). One lesson recorded in review (node-env vitest needs codev-types dist built;
+Vite resolves from src) for next MAINTAIN run to fold into lessons-learned.md.
+Opening PR; porch verify block runs single-pass 3-way consult next.

--- a/codev/state/pir-967_thread.md
+++ b/codev/state/pir-967_thread.md
@@ -1,0 +1,22 @@
+# pir-967 thread — CI: run vscode + dashboard vitest unit suites
+
+## Plan phase (2026-06-04)
+
+Investigated `.github/workflows/test.yml` + the two uncovered suites.
+
+Key findings (all from running locally on a clean tree):
+- **dashboard** (`@cluesmith/codev-dashboard`, `pnpm test` = `vitest run`): 317 passed / 1 skipped, exit 0. Clean.
+- **vscode** (`codev-vscode`, `pnpm test:unit` = `vitest run`): needs `@cluesmith/codev-types` BUILT first.
+  Clean tree (no types/dist) → 2 failures (terminal-adapter, reconnect-link-provider) with
+  "Failed to resolve entry for @cluesmith/codev-types". After `pnpm --filter @cluesmith/codev-types build` → 284/284.
+  Cause: types export map resolves `default` → ./dist/index.js for vscode's node-env vitest.
+  (dashboard resolves types from src via Vite, so doesn't strictly need the build.)
+- **The issue's flagged failing test** (`scrollController ... warns on unexpected scroll-to-top`) NO LONGER EXISTS —
+  replaced by `accepts scroll-to-top without auto-correcting or warning (Issue #630)`. scrollController passes 45/45.
+  No quarantine/fix needed.
+- Neither suite needs codev's forks-pool tee/grep teardown shim — both exit 0.
+
+Plan decisions: fold both into the existing `unit` job (suites are <2s; reuse install+core build;
+add one types-build step). No coverage thresholds (match core's no-threshold precedent). Plain `vitest run`.
+
+Plan written, committed, awaiting plan-approval gate.

--- a/codev/state/pir-967_thread.md
+++ b/codev/state/pir-967_thread.md
@@ -20,3 +20,15 @@ Plan decisions: fold both into the existing `unit` job (suites are <2s; reuse in
 add one types-build step). No coverage thresholds (match core's no-threshold precedent). Plain `vitest run`.
 
 Plan written, committed, awaiting plan-approval gate.
+
+## Implement phase (2026-06-05)
+
+Rebased onto origin/main first (18 commits; none touched the workflows or relevant packages). Plan re-verified accurate.
+
+Edited `.github/workflows/test.yml` `unit` job only:
+- Added "Build types package" step (pnpm build in packages/types) after the core build — required by vscode suite.
+- Added "Run dashboard unit tests" (packages/dashboard, `pnpm test`) and "Run vscode unit tests" (packages/vscode, `pnpm test:unit`) after the codev coverage step.
+
+Verified locally (reproducing the CI steps): core+types build, dashboard 317 passed/1 skipped exit 0, vscode 284 passed exit 0. YAML validated. No source/test changes.
+
+Committed + pushed. Awaiting dev-approval gate.


### PR DESCRIPTION
# PIR Review: Run vscode + dashboard vitest unit suites in CI

Fixes #967

## Summary

The `Tests` workflow (`.github/workflows/test.yml`) only ran the `packages/core` and `packages/codev` vitest suites, so the `packages/dashboard` and `packages/vscode` unit suites (which exist and pass locally) had zero CI coverage: a regression in either would pass CI unnoticed. This PR adds those two suites to the existing `unit` job, plus the one prerequisite they need (building `@cluesmith/codev-types`). It is a CI-configuration-only change: no source or test code was modified, and both suites already pass on the current tree.

## Files Changed

- `.github/workflows/test.yml` (+12 / -0)

Supporting artifacts (not product code):
- `codev/plans/967-ci-run-vscode-dashboard-vitest.md` (plan)
- `codev/reviews/967-ci-run-vscode-dashboard-vitest.md` (this file)
- `codev/state/pir-967_thread.md` (builder thread)

## Commits

- `8dfdac77` [PIR #967] Run vscode + dashboard vitest unit suites in CI
- `c1574f7f` [PIR #967] Plan draft
- `166913b1` [PIR #967] Thread: implement phase

(plus porch phase-transition bookkeeping commits)

## Test Results

- `porch done` checks: `build` ✓, `tests` ✓
- Per-suite, reproducing the new CI steps locally:
  - dashboard `pnpm test`: 317 passed, 1 skipped (31 files), exit 0
  - vscode `pnpm test:unit`: 284 passed (22 files), exit 0
- **Full workflow run via `act`** (real GitHub Actions container, fresh checkout, `catthehacker/ubuntu:act-latest`): the entire `unit` job succeeded (`🏁 Job succeeded`). All 11 steps green, including the three new ones (`Build types package`, `Run dashboard unit tests`, `Run vscode unit tests`). This exercised the change under genuine CI conditions: clean `pnpm install` from scratch, no pre-existing `dist/`, correct step ordering.

## Architecture Updates

No arch changes. This is a CI-config change that adds existing test suites to an existing job; it introduces no new module, boundary, or pattern. `codev/resources/arch.md` is unaffected.

## Lessons Learned Updates

One durable lesson worth recording (captured here for the next MAINTAIN run to fold into `codev/resources/lessons-learned.md`, consistent with how that file is curated from reviews):

- **A node-environment vitest suite that imports `@cluesmith/codev-types` requires that package to be built (`dist/index.js`) before it runs, even though a Vite-based suite in the same monorepo does not.** The types package export map is `{ "types": "./src/index.ts", "default": "./dist/index.js" }`. The vscode suite runs in vitest's plain `node` environment and resolves the `default` condition to `dist/index.js`, so on a clean tree (no `dist/`) it fails with `Failed to resolve entry for package "@cluesmith/codev-types"`. The dashboard suite resolves the same dependency from source (`./src/index.ts`) because Vite's react plugin transforms `.ts` on the fly, so it needs no build. Takeaway for adding any future cross-package suite to CI: build the workspace `dist/` of any dependency the suite resolves at runtime in a node environment, do not assume the Vite-style source resolution applies.

## Things to Look At During PR Review

- **Placement of the `Build types package` step.** It sits after the core build and before the two new suites. This ordering is load-bearing for the vscode suite (verified by a negative test: removing `packages/types/dist` reproduces the two `Failed to resolve entry` failures; rebuilding fixes them). It also runs in the `unit` job specifically, which is where the suites that need it live.
- **Folded into the `unit` job rather than separate jobs.** Both suites are sub-7s; standing up new jobs would each repeat `pnpm install` (~90s in the act run) and a core build for a few seconds of tests. The plan documents this tradeoff and the rejected alternatives (separate jobs, adding the dashboard unit suite to the schedule-only `dashboard-e2e.yml`).
- **Deliberate non-additions:** no coverage thresholds (neither config has them; `core` ships without one by design) and no forks-pool tee/grep teardown shim (both suites exit 0 cleanly, unlike `codev`). Adding either would have been cargo-culting.
- **The flagged "pre-existing failing dashboard test" from the issue no longer exists.** `scrollController.test.ts > ... > warns on unexpected scroll-to-top` was replaced upstream by `accepts scroll-to-top without auto-correcting or warning (Issue #630)`; the file passes 45/45. Nothing was quarantined.
- The dashboard suite's 1 skipped test is an intentional pre-existing `.skip`, unrelated to this change, and was left untouched.

## How to Test Locally

For reviewers pulling the branch:

- **View diff**: VSCode sidebar → right-click builder pir-967 → **View Diff** (auto-detects default branch)
- **Reproduce the CI steps** (the change is CI-config, so the "running thing" is the workflow):
  ```bash
  pnpm install
  pnpm --filter @cluesmith/codev-core build
  pnpm --filter @cluesmith/codev-types build
  pnpm --filter @cluesmith/codev-dashboard test     # 317 passed / 1 skipped
  pnpm --filter codev-vscode test:unit              # 284 passed
  ```
- **Or run the job as CI would** (requires `act` + Docker):
  ```bash
  act pull_request -j unit -W .github/workflows/test.yml \
    --container-architecture linux/amd64 \
    -P ubuntu-latest=catthehacker/ubuntu:act-latest
  ```
- **Negative check** (proves the types build is required): delete `packages/types/dist`, run the vscode suite, observe the 2 resolution failures, rebuild types, observe them pass.
