### PR TITLE
vscode: point-of-action feedback on every guarded-command click (PIR #989)

### DIFF
--- a/codev/plans/989-vscode-guarded-command-feedbac.md
+++ b/codev/plans/989-vscode-guarded-command-feedbac.md
@@ -1,0 +1,165 @@
+# PIR Plan: Guarded-command feedback — modal-first / ephemeral-after
+
+## Understanding
+
+When the CLI preflight (#791) decides the environment is `missing` or `outdated`, the
+**first** click on any of the 15 `regCli`-guarded commands shows a modal warning toast
+with a `Run Setup` action. Every subsequent click in the same session is **silent**: the
+`setupToastShown` one-shot flag at `packages/vscode/src/preflight/preflight.ts:244-248`
+short-circuits `showSetupRequiredToast`, so the guard rejects the click with no signal.
+
+The flag was meant to stop modal spam, but it overshot to *zero* feedback. After the first
+click the user can't tell a silent no-op apart from a missed click, a hung extension, or a
+command that ran invisibly. The fix is **attenuated** feedback, not absent feedback:
+
+- **First** bad-state click in a session: keep today's modal warning toast (`Run Setup`).
+- **Subsequent** bad-state clicks: show an ephemeral status-bar message
+  (`vscode.window.setStatusBarMessage(text, ms)`) — visible, co-located with the action,
+  no modal interrupt, auto-dismissing after a few seconds.
+
+The flag-reset semantics stay: when `recheckCli` confirms `ok`, the session counter resets,
+so a fresh breakage later restarts the modal-first pattern (`preflight.ts:176-181`).
+
+This issue also lays a **reusable helper** (`showPreflightFeedback`) so #983 (Tower
+running-vs-installed version divergence) can reuse the modal-first / ephemeral-after
+dispatch instead of re-inventing the suppression logic.
+
+## Proposed Change
+
+Follow the existing split in this module: pure, vscode-free logic lives in
+`preflight-core.ts` (unit-tested by `preflight-core.test.ts`); vscode glue lives in
+`preflight.ts`.
+
+### 1. `preflight-core.ts` — pure wording derivation (new, unit-tested)
+
+Add a pure function that maps a bad preflight status to the ephemeral message text:
+
+```ts
+/** Ephemeral status-bar text for a non-ok preflight status. */
+export function preflightFeedbackMessage(status: PreflightStatus): string {
+  const label = status === 'outdated' ? 'outdated' : 'not installed';
+  return `Codev: CLI ${label}. Run "Codev: Recheck CLI" when ready.`;
+}
+```
+
+Keeping this pure means the wording (the part #983 will extend with a Tower dimension) is
+testable without a vscode mock, matching how `decidePreflight` / `parseCliVersion` are tested.
+
+(Note on copy: the issue's example uses an em dash; I use a period + quoted command name
+instead, both to satisfy the project's no-em-dash convention and to name the recovery
+command precisely. Functionally identical.)
+
+### 2. `preflight.ts` — the reusable dispatch helper
+
+Replace `showSetupRequiredToast` with `showPreflightFeedback`, and rename the session flag
+to reflect its new meaning (modal-shown, not toast-shown):
+
+```ts
+let modalShownThisSession = false;
+
+/**
+ * Point-of-action feedback when a guarded command is rejected because the CLI
+ * is missing / outdated. First call this session: modal warning toast with a
+ * `Run Setup` action. Subsequent calls: ephemeral status-bar message. Resets
+ * when `recheckCli` confirms `ok`. Reusable by #983 for the Tower-version
+ * dimension.
+ */
+export function showPreflightFeedback(): void {
+  if (!modalShownThisSession) {
+    modalShownThisSession = true;
+    vscode.window
+      .showWarningMessage('Codev: CLI not installed / outdated — run setup', 'Run Setup')
+      .then((choice) => {
+        if (choice !== 'Run Setup') return;
+        if (cachedStatus === 'outdated') {
+          showOutdatedNotification(cachedVersion, deps?.context.extension.packageJSON.version ?? '');
+        } else {
+          openWalkthrough();
+        }
+      });
+    return;
+  }
+  vscode.window.setStatusBarMessage(preflightFeedbackMessage(cachedStatus as PreflightStatus), 4000);
+}
+```
+
+- The modal branch is byte-for-byte today's `showSetupRequiredToast` body (acceptance:
+  "unchanged from today"), so the `Run Setup` routing to walkthrough / outdated-notification
+  is preserved.
+- The ephemeral branch is the only new behavior. 4000ms matches the issue's "around 3-4
+  seconds".
+- `cachedStatus` is guaranteed non-ok here because the guard only calls this helper when
+  `isCliReady()` is false (i.e. `missing` or `outdated`), so the `PreflightStatus` cast is safe.
+
+### 3. Flag reset
+
+Rename `setupToastShown = false` → `modalShownThisSession = false` at `preflight.ts:177`
+inside the `recheckCli` `status === 'ok'` branch. Semantics unchanged.
+
+### 4. `extension.ts` — call the renamed helper
+
+Update the import (`preflight.ts:49`) and the `guard` body (`extension.ts:528`) from
+`showSetupRequiredToast()` to `showPreflightFeedback()`. No other call sites exist
+(verified by grep: only `extension.ts` imports it).
+
+### Why a no-arg helper rather than `showPreflightFeedback(state)`
+
+The issue's suggested signature takes a `PreflightState`. In this module the CLI state is
+already module-level (`cachedStatus` / `cachedVersion`), and the existing
+`showSetupRequiredToast` reads it directly, so a no-arg helper matches the current style and
+keeps the single source of truth. #983 introduces a *second* dimension (Tower version) that
+is not module-level here; when it lands, the helper gains a small discriminator argument
+(e.g. `showPreflightFeedback(dimension)`) and `preflightFeedbackMessage` gains a Tower branch.
+The pure-wording-in-core + flag-driven-dispatch structure is the reusable foundation #983
+needs; pre-adding the parameter now would be speculative shape with one caller. This is
+called out so the reviewer can object if they want the parameter wired in immediately.
+
+## Files to Change
+
+- `packages/vscode/src/preflight/preflight-core.ts` — add pure `preflightFeedbackMessage(status)`.
+- `packages/vscode/src/preflight/preflight.ts:47` — rename `setupToastShown` → `modalShownThisSession`.
+- `packages/vscode/src/preflight/preflight.ts:177` — rename in the reset.
+- `packages/vscode/src/preflight/preflight.ts:240-261` — replace `showSetupRequiredToast` with
+  `showPreflightFeedback` (modal-first / ephemeral-after); import `preflightFeedbackMessage`.
+- `packages/vscode/src/extension.ts:49` — update import name.
+- `packages/vscode/src/extension.ts:528` — call `showPreflightFeedback()`.
+- `packages/vscode/src/__tests__/preflight-core.test.ts` — add cases for `preflightFeedbackMessage`.
+
+## Risks & Alternatives Considered
+
+- **Risk: status-bar messages are easy to miss.** Mitigation: the modal still fires first
+  (highest-salience moment — first discovery of the bad state); the ephemeral message is the
+  deliberately-attenuated follow-up. The persistent Status row from #791 remains the
+  always-visible surface. This issue is explicitly *not* adding a new persistent indicator.
+- **Risk: the `PreflightStatus` cast on `cachedStatus`.** Mitigation: the guard only invokes
+  the helper when `isCliReady()` is false, which excludes `ok` and `pending`. If that
+  invariant ever changes, `preflightFeedbackMessage` still returns the "not installed" string
+  for any non-`outdated` value, so the worst case is slightly-wrong copy, never a crash.
+- **Alternative: keep `showSetupRequiredToast` as a thin wrapper around the new helper.**
+  Rejected — only one caller (`extension.ts`), so renaming in place is cleaner than carrying a
+  deprecated alias. The issue explicitly allows "merges into the helper".
+- **Alternative: pass `PreflightState` into the helper now (issue's literal signature).**
+  Deferred to #983 (see "Why a no-arg helper" above); flagged for reviewer override.
+- **Alternative: a status-bar message with a `Run Setup` action.** Not possible —
+  `setStatusBarMessage` takes only text + timeout, no actions. That's acceptable: the modal
+  already offered the action, and `Codev: Recheck CLI` is named in the ephemeral text.
+
+## Test Plan
+
+- **Unit (`preflight-core.test.ts`)**: `preflightFeedbackMessage('outdated')` contains
+  "outdated"; `preflightFeedbackMessage('missing')` contains "not installed"; both name
+  `Codev: Recheck CLI`. Run via `pnpm --filter @cluesmith/codev-vscode test` (or the package's
+  vitest script).
+- **Build / lint**: `pnpm --filter @cluesmith/codev-vscode build` and the package lint to
+  confirm the rename has no dangling references.
+- **Manual (at the `dev-approval` gate, in the Extension Development Host)**: with a `missing`
+  or `outdated` CLI state —
+  1. First click on a guarded command (e.g. *Spawn Builder*) → modal toast with `Run Setup`.
+  2. Second + third clicks → brief status-bar message naming the state and `Codev: Recheck CLI`,
+     no modal.
+  3. Run `Codev: Recheck CLI` while still broken → still status-bar on next click (no `ok`,
+     no reset).
+  4. Fix the CLI, run `Codev: Recheck CLI` → `ok` info toast; next breakage restarts at the
+     modal.
+  5. Happy path: with `ok`/`pending`, guarded commands run normally, zero feedback noise.
+- **Cross-platform**: n/a (VSCode-host behavior only).

--- a/codev/projects/989-vscode-guarded-command-feedbac/989-review-iter1-rebuttals.md
+++ b/codev/projects/989-vscode-guarded-command-feedbac/989-review-iter1-rebuttals.md
@@ -1,0 +1,54 @@
+# PIR #989 — Review Iteration 1 Rebuttals
+
+3-way consult verdicts: **Gemini APPROVE**, **Claude APPROVE**, **Codex REQUEST_CHANGES**.
+
+Both Gemini and Claude confirmed the implementation matches the plan with no code issues.
+Codex's REQUEST_CHANGES raised two points — **both about the review file's accuracy, neither
+about the code**. Both were correct and both are now fixed. No code change resulted, so no
+regression test applies.
+
+PIR runs a single advisory consult pass (`max_iterations: 1`); this rebuttal + the corrected
+review file are the record the human reviews at the `pr` gate.
+
+---
+
+## Codex finding 1 — wrong package filter in Test Results (VALID, fixed)
+
+> `codev/reviews/...md:34-37` claims successful runs of `pnpm --filter @cluesmith/codev-vscode
+> ...`, but the actual package name is `codev-vscode`, not `@cluesmith/codev-vscode`
+> (`packages/vscode/package.json:2`). That scoped filter matches nothing, so the recorded
+> test commands/results are not credible as written.
+
+**Agreed.** Verified: `packages/vscode/package.json` `name` is `codev-vscode` (unscoped), and
+`pnpm --filter @cluesmith/codev-vscode exec true` → "No projects matched the filters". The
+*results* I recorded were real — I ran the suite from inside `packages/vscode/` (`pnpm
+test:unit` → 287 pass, `pnpm compile` ✓), not via that filter — but the documented *command
+string* was wrong and not reproducible as written.
+
+**Fix:** Test Results now states the actual command (`pnpm test:unit` / `pnpm compile` run
+from `packages/vscode/`, with the correct unscoped `--filter codev-vscode` equivalent noted).
+Confirmed `pnpm --filter codev-vscode exec true` matches the package.
+
+## Codex finding 2 — incomplete Files Changed section (VALID, fixed)
+
+> The actual PR scope also includes `codev/plans/...md`, `codev/projects/.../status.yaml`,
+> and `codev/state/pir-989_thread.md`, but they are omitted from the review file, making the
+> retrospective inaccurate.
+
+**Agreed.** The Files Changed section listed only the 4 code files and omitted the PIR
+protocol artifacts carried on the branch.
+
+**Fix:** Files Changed now has two subsections — "Code (the substance of the fix)" (the 4
+source files) and "PIR protocol artifacts" (plan, review, thread, status.yaml) — matching the
+full `git diff --stat main...HEAD`.
+
+---
+
+## Disposition
+
+Both findings fixed in commit `[PIR #989] Correct review file: package filter name +
+complete Files Changed (Codex finding)`; the PR body (#995) was refreshed from the corrected
+review file. No source code changed — the fixes are entirely within the retrospective, so no
+behavior, build, or test outcome is affected (287 tests still pass). Escalated to the
+architect leading with the REQUEST_CHANGES per PIR step 7, since the single-pass design means
+this correction is not independently re-reviewed.

--- a/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
+++ b/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-06-05T01:55:51.222Z'
     approved_at: '2026-06-05T09:17:40.291Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-06-05T09:20:47.096Z'
+    approved_at: '2026-06-05T10:12:43.850Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-05T01:53:22.296Z'
-updated_at: '2026-06-05T09:20:47.097Z'
+updated_at: '2026-06-05T10:12:43.851Z'

--- a/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
+++ b/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
@@ -1,7 +1,7 @@
 id: '989'
 title: vscode-guarded-command-feedbac
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-05T01:53:22.296Z'
-updated_at: '2026-06-05T10:12:43.851Z'
+updated_at: '2026-06-05T10:12:58.964Z'

--- a/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
+++ b/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
@@ -1,7 +1,7 @@
 id: '989'
 title: vscode-guarded-command-feedbac
 protocol: pir
-phase: review
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -21,7 +21,7 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-06-05T01:53:22.296Z'
-updated_at: '2026-06-05T10:28:01.084Z'
+updated_at: '2026-06-05T10:28:14.065Z'
 pr_history:
   - phase: review
     pr_number: 995

--- a/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
+++ b/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-06-05T09:20:47.096Z'
     approved_at: '2026-06-05T10:12:43.850Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-06-05T10:18:50.210Z'
+    approved_at: '2026-06-05T10:28:01.083Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-06-05T01:53:22.296Z'
-updated_at: '2026-06-05T10:18:50.212Z'
+updated_at: '2026-06-05T10:28:01.084Z'
 pr_history:
   - phase: review
     pr_number: 995
     branch: builder/pir-989
     created_at: '2026-06-05T10:14:24.045Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
+++ b/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
@@ -21,10 +21,12 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-06-05T01:53:22.296Z'
-updated_at: '2026-06-05T10:28:14.065Z'
+updated_at: '2026-06-05T10:28:24.817Z'
 pr_history:
   - phase: review
     pr_number: 995
     branch: builder/pir-989
     created_at: '2026-06-05T10:14:24.045Z'
+    merged: true
+    merged_at: '2026-06-05T10:28:24.816Z'
 pr_ready_for_human: false

--- a/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
+++ b/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
@@ -1,0 +1,18 @@
+id: '989'
+title: vscode-guarded-command-feedbac
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-06-05T01:53:22.296Z'
+updated_at: '2026-06-05T01:53:22.297Z'

--- a/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
+++ b/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-06-05T01:53:22.296Z'
-updated_at: '2026-06-05T10:14:24.046Z'
+updated_at: '2026-06-05T10:14:31.903Z'
 pr_history:
   - phase: review
     pr_number: 995

--- a/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
+++ b/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
@@ -1,7 +1,7 @@
 id: '989'
 title: vscode-guarded-command-feedbac
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-05T01:53:22.296Z'
-updated_at: '2026-06-05T09:17:40.291Z'
+updated_at: '2026-06-05T09:17:50.797Z'

--- a/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
+++ b/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-05T01:53:22.296Z'
-updated_at: '2026-06-05T10:12:58.964Z'
+updated_at: '2026-06-05T10:14:24.046Z'
+pr_history:
+  - phase: review
+    pr_number: 995
+    branch: builder/pir-989
+    created_at: '2026-06-05T10:14:24.045Z'

--- a/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
+++ b/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-06-05T01:55:51.222Z'
+    approved_at: '2026-06-05T09:17:40.291Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-05T01:53:22.296Z'
-updated_at: '2026-06-05T01:55:51.223Z'
+updated_at: '2026-06-05T09:17:40.291Z'

--- a/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
+++ b/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-06-05T10:12:43.850Z'
   pr:
     status: pending
+    requested_at: '2026-06-05T10:18:50.210Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-06-05T01:53:22.296Z'
-updated_at: '2026-06-05T10:14:31.903Z'
+updated_at: '2026-06-05T10:18:50.212Z'
 pr_history:
   - phase: review
     pr_number: 995
     branch: builder/pir-989
     created_at: '2026-06-05T10:14:24.045Z'
+pr_ready_for_human: true

--- a/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
+++ b/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-06-05T01:55:51.222Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-05T01:53:22.296Z'
-updated_at: '2026-06-05T01:53:22.297Z'
+updated_at: '2026-06-05T01:55:51.223Z'

--- a/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
+++ b/codev/projects/989-vscode-guarded-command-feedbac/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-06-05T09:17:40.291Z'
   dev-approval:
     status: pending
+    requested_at: '2026-06-05T09:20:47.096Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-05T01:53:22.296Z'
-updated_at: '2026-06-05T09:17:50.797Z'
+updated_at: '2026-06-05T09:20:47.097Z'

--- a/codev/reviews/989-vscode-guarded-command-feedbac.md
+++ b/codev/reviews/989-vscode-guarded-command-feedbac.md
@@ -1,0 +1,91 @@
+# PIR Review: Guarded-command feedback — modal-first / ephemeral-after
+
+Fixes #989
+
+## Summary
+
+The CLI preflight (#791) guards 15 VSCode commands; when the CLI is `missing`/`outdated`
+the first guarded click showed a modal "run setup" toast and a one-shot `setupToastShown`
+flag silenced every click afterwards, so the user got no point-of-action feedback for the
+rest of the session. This replaces the one-shot suppressor with a modal-first /
+ephemeral-after pattern: the first bad-state click keeps the modal, subsequent clicks show
+a brief auto-dismissing status-bar message naming the state and the recovery command. The
+dispatch is factored into a reusable `showPreflightFeedback` helper (wording derived by a
+new pure `preflightFeedbackMessage`) so #983 can route its Tower-version dimension through
+the same channel.
+
+## Files Changed
+
+- `packages/vscode/src/preflight/preflight-core.ts` (+13 / -0) — new pure `preflightFeedbackMessage(status)`
+- `packages/vscode/src/preflight/preflight.ts` (+36 / -21) — `showSetupRequiredToast` → `showPreflightFeedback`; flag rename; ephemeral branch
+- `packages/vscode/src/extension.ts` (+8 / -4) — import + guard call renamed; updated the stale "single toast" comment
+- `packages/vscode/src/__tests__/preflight-core.test.ts` (+19 / -0) — 3 cases for the new helper
+
+## Commits
+
+- `379b5eaa` [PIR #989] Add pure preflightFeedbackMessage helper + tests
+- `647e8ff1` [PIR #989] Replace one-shot toast with modal-first / ephemeral-after feedback
+- `796bbdb9` [PIR #989] Update thread for implement phase
+
+## Test Results
+
+- `npm run build`: ✓ pass (porch check, 6.8s)
+- `npm test`: ✓ pass (porch check, 20.7s)
+- `pnpm --filter @cluesmith/codev-vscode test:unit`: ✓ 287 pass (+3 new) — the suite that
+  actually covers this diff (the root `build`/`test` filter `@cluesmith/codev-core` +
+  `@cluesmith/codev`, not the vscode package)
+- `pnpm --filter @cluesmith/codev-vscode compile`: ✓ check-types + lint + esbuild
+- Manual verification (human, at the `dev-approval` gate): first click → modal with
+  `Run Setup`; subsequent clicks → ephemeral status-bar message; recheck→ok resets the
+  modal-first pattern; happy path runs with no feedback noise
+
+## Architecture Updates
+
+No arch changes — this PR swaps the behaviour behind an existing guard rejection path
+(#791's preflight). No module boundaries, data flow, or patterns changed: the new pure
+helper lives in the already-established `preflight-core.ts` (pure logic) / `preflight.ts`
+(vscode glue) split, and the guard wiring in `extension.ts` is unchanged in shape (it still
+calls one helper on rejection). `codev/resources/arch.md` needs no update.
+
+## Lessons Learned Updates
+
+No durable lessons captured — the change is a localized UX fix following the module's
+existing pure-core / vscode-glue convention. One worth-noting-but-not-arch-worthy
+observation is recorded here rather than in `lessons-learned.md` (too narrow to generalize):
+porch's PIR `build`/`test` checks filter `@cluesmith/codev-core` + `@cluesmith/codev` and do
+**not** build/run the `@cluesmith/codev-vscode` package, so a green porch gate does not by
+itself prove a vscode-package diff — the package's own `compile` + `test:unit` (run manually
+here) and the human dev-approval run are the real verification. `codev/resources/lessons-learned.md`
+needs no update.
+
+## Things to Look At During PR Review
+
+- **The `cachedStatus as PreflightStatus` cast** in the ephemeral branch
+  (`preflight.ts`). It's safe because `guard` only calls the helper when `isCliReady()` is
+  false (excludes `ok` and `pending`), and `preflightFeedbackMessage` degrades to the
+  "not installed" string for any non-`outdated` value, so a future invariant change is
+  cosmetic, never a crash. Inline comment documents this.
+- **The modal branch is byte-for-byte the old `showSetupRequiredToast` body** — acceptance
+  required it "unchanged from today", so the `Run Setup` → walkthrough / outdated-notification
+  routing is preserved verbatim; only the surrounding flag semantics and the new ephemeral
+  branch changed.
+- **No-arg helper vs the issue's `showPreflightFeedback(state)` signature** — deliberately
+  deferred the `PreflightState` parameter to #983 (CLI state is module-level here; #983 adds
+  the second Tower dimension that warrants the discriminator). Reviewed and accepted at the
+  plan gate.
+- **Ephemeral copy** uses a period + quoted command name instead of the issue's em-dash
+  example (`Codev: CLI not installed. Run "Codev: Recheck CLI" when ready.`) — project
+  no-em-dash convention; functionally identical.
+
+## How to Test Locally
+
+- **View diff**: VSCode sidebar → right-click builder pir-989 → **View Diff**
+- **Run dev server**: `afx dev pir-989` (or the sidebar **Run Dev Server**) — though for a
+  VSCode extension the realer test is launching the Extension Development Host against this
+  worktree (esbuild `watch`, then reload the dev host); no Tower restart involved
+- **What to verify** (CLI in `missing`/`outdated` state):
+  1. First click on a guarded command (e.g. Spawn Builder) → modal toast with `Run Setup`
+  2. Second + third clicks → brief status-bar message naming the state + `Codev: Recheck CLI`, no modal
+  3. `Codev: Recheck CLI` while still broken → next click still status-bar (no reset)
+  4. Fix CLI, `Codev: Recheck CLI` → `ok` info toast; next breakage restarts at the modal
+  5. Happy path (`ok`/`pending`) → guarded commands run normally, zero feedback noise

--- a/codev/reviews/989-vscode-guarded-command-feedbac.md
+++ b/codev/reviews/989-vscode-guarded-command-feedbac.md
@@ -16,10 +16,19 @@ the same channel.
 
 ## Files Changed
 
+Code (the substance of the fix):
+
 - `packages/vscode/src/preflight/preflight-core.ts` (+13 / -0) — new pure `preflightFeedbackMessage(status)`
 - `packages/vscode/src/preflight/preflight.ts` (+36 / -21) — `showSetupRequiredToast` → `showPreflightFeedback`; flag rename; ephemeral branch
 - `packages/vscode/src/extension.ts` (+8 / -4) — import + guard call renamed; updated the stale "single toast" comment
 - `packages/vscode/src/__tests__/preflight-core.test.ts` (+19 / -0) — 3 cases for the new helper
+
+PIR protocol artifacts (carried on the branch, ship with the merge):
+
+- `codev/plans/989-vscode-guarded-command-feedbac.md` (+165 / -0) — the approved plan
+- `codev/reviews/989-vscode-guarded-command-feedbac.md` — this retrospective (also the PR body)
+- `codev/state/pir-989_thread.md` — builder narrative thread
+- `codev/projects/989-vscode-guarded-command-feedbac/status.yaml` — porch state (auto-managed)
 
 ## Commits
 
@@ -31,10 +40,11 @@ the same channel.
 
 - `npm run build`: ✓ pass (porch check, 6.8s)
 - `npm test`: ✓ pass (porch check, 20.7s)
-- `pnpm --filter @cluesmith/codev-vscode test:unit`: ✓ 287 pass (+3 new) — the suite that
-  actually covers this diff (the root `build`/`test` filter `@cluesmith/codev-core` +
-  `@cluesmith/codev`, not the vscode package)
-- `pnpm --filter @cluesmith/codev-vscode compile`: ✓ check-types + lint + esbuild
+- `pnpm test:unit` run from `packages/vscode/` (equivalently `pnpm --filter codev-vscode
+  test:unit` — the package is named `codev-vscode`, unscoped): ✓ 287 pass (+3 new). This is
+  the suite that actually covers this diff; the root `build`/`test` filter
+  `@cluesmith/codev-core` + `@cluesmith/codev`, **not** the vscode package
+- `pnpm compile` run from `packages/vscode/`: ✓ check-types + lint + esbuild
 - Manual verification (human, at the `dev-approval` gate): first click → modal with
   `Run Setup`; subsequent clicks → ephemeral status-bar message; recheck→ok resets the
   modal-first pattern; happy path runs with no feedback noise
@@ -59,6 +69,21 @@ here) and the human dev-approval run are the real verification. `codev/resources
 needs no update.
 
 ## Things to Look At During PR Review
+
+- **3-way consult dispositions (single advisory pass, `max_iterations: 1`):** Gemini
+  APPROVE, Claude APPROVE, **Codex REQUEST_CHANGES**. Codex's two findings were both about
+  *this review file's accuracy*, not the code — and both were correct:
+  1. The Test Results referenced `pnpm --filter @cluesmith/codev-vscode ...`, but the package
+     is named `codev-vscode` (unscoped), so that filter matches nothing. **Fixed** — the
+     section now names the actual command run (`pnpm test:unit` from `packages/vscode/`,
+     equivalently `--filter codev-vscode`). The 287-pass result was always real; only the
+     documented command string was wrong.
+  2. The Files Changed section omitted the `codev/` PIR artifacts (plan, status.yaml,
+     thread). **Fixed** — they're now listed under a separate "protocol artifacts" subsection.
+  No code change resulted, so no regression test applies (the findings were documentation
+  accuracy, not a code defect). Both fixes are in the review-revision commit on this branch.
+  Per PIR's single-pass design this revision is **not** independently re-reviewed — flagging
+  it here for the human at the `pr` gate.
 
 - **The `cachedStatus as PreflightStatus` cast** in the ephemeral branch
   (`preflight.ts`). It's safe because `guard` only calls the helper when `isCliReady()` is

--- a/codev/state/pir-989_thread.md
+++ b/codev/state/pir-989_thread.md
@@ -34,3 +34,11 @@ needed `@cluesmith/codev-core` + `-types` built first or check-types fails on mi
 declarations (env state, not my change).
 
 Awaiting dev-approval.
+
+## Review phase
+
+dev-approval approved. Wrote `codev/reviews/989-vscode-guarded-command-feedbac.md`
+(Summary / Files / Commits / Test Results / Architecture Updates [none] / Lessons [none] /
+Things to Look At / How to Test Locally). No arch.md or lessons-learned.md changes needed.
+Opening PR with the review as body (Fixes #989), recording with porch, then porch runs the
+single-pass 3-way consult. Will lead architect notification with any REQUEST_CHANGES.

--- a/codev/state/pir-989_thread.md
+++ b/codev/state/pir-989_thread.md
@@ -42,3 +42,10 @@ dev-approval approved. Wrote `codev/reviews/989-vscode-guarded-command-feedbac.m
 Things to Look At / How to Test Locally). No arch.md or lessons-learned.md changes needed.
 Opening PR with the review as body (Fixes #989), recording with porch, then porch runs the
 single-pass 3-way consult. Will lead architect notification with any REQUEST_CHANGES.
+
+3-way consult done: Gemini APPROVE, Claude APPROVE, Codex REQUEST_CHANGES. Codex's two
+findings were both review-file accuracy (not code): (1) wrong package filter
+`@cluesmith/codev-vscode` — package is `codev-vscode`; (2) Files Changed omitted codev/
+artifacts. Both correct, both fixed in the review file. No code change → no regression test.
+Documented in review "Things to Look At" and escalating to architect leading with the
+REQUEST_CHANGES. PR #995. Advancing to pr gate.

--- a/codev/state/pir-989_thread.md
+++ b/codev/state/pir-989_thread.md
@@ -1,0 +1,19 @@
+# PIR #989 — guarded-command feedback (modal-first / ephemeral-after)
+
+## Plan phase
+
+Issue: vscode guarded commands go silent after the first "run setup" toast because
+`setupToastShown` is a one-shot session suppressor. Want point-of-action feedback on
+every click: modal first time, ephemeral status-bar message thereafter.
+
+Key code:
+- `packages/vscode/src/preflight/preflight.ts:244-261` — `showSetupRequiredToast` + `setupToastShown`
+- `packages/vscode/src/preflight/preflight.ts:176-181` — flag reset on recheck→ok
+- `packages/vscode/src/extension.ts:526-529` — `guard` wrapper calls the toast
+- `packages/vscode/src/preflight/preflight-core.ts` — pure logic home (unit-tested)
+
+Design: extract a reusable `showPreflightFeedback` helper; pure wording derivation in
+preflight-core for testability; modal-vs-ephemeral chosen by a session flag that resets
+on recheck→ok (unchanged semantics). Sets up #983 reuse (Tower dimension).
+
+Wrote plan to `codev/plans/989-vscode-guarded-command-feedbac.md`. Awaiting plan-approval.

--- a/codev/state/pir-989_thread.md
+++ b/codev/state/pir-989_thread.md
@@ -17,3 +17,20 @@ preflight-core for testability; modal-vs-ephemeral chosen by a session flag that
 on recheck→ok (unchanged semantics). Sets up #983 reuse (Tower dimension).
 
 Wrote plan to `codev/plans/989-vscode-guarded-command-feedbac.md`. Awaiting plan-approval.
+
+## Implement phase
+
+Plan approved. Implemented as planned (no deviations):
+- `preflight-core.ts`: new pure `preflightFeedbackMessage(status)` (em-dash-free copy:
+  `Codev: CLI <state>. Run "Codev: Recheck CLI" when ready.`).
+- `preflight.ts`: `showSetupRequiredToast` → `showPreflightFeedback`; flag
+  `setupToastShown` → `modalShownThisSession`; modal first, `setStatusBarMessage(..., 4000)`
+  after. Reset-on-recheck→ok unchanged.
+- `extension.ts`: import + guard call renamed; updated the stale "single toast" comment.
+- `preflight-core.test.ts`: +3 cases for the new helper.
+
+Checks: porch build ✓ (6.8s), tests ✓ (20.7s, 287 pass / +3 new). Note: fresh worktree
+needed `@cluesmith/codev-core` + `-types` built first or check-types fails on missing
+declarations (env state, not my change).
+
+Awaiting dev-approval.

--- a/packages/vscode/src/__tests__/preflight-core.test.ts
+++ b/packages/vscode/src/__tests__/preflight-core.test.ts
@@ -9,6 +9,7 @@ import {
   parseSemver,
   compareSemver,
   parseCliVersion,
+  preflightFeedbackMessage,
   resolveCodevPath,
   decidePreflight,
 } from '../preflight/preflight-core.js';
@@ -96,5 +97,23 @@ describe('decidePreflight', () => {
   });
   it('is outdated when the CLI is older than the extension', () => {
     expect(decidePreflight({ cliFound: true, cliVersion: '3.1.4', extVersion })).toBe('outdated');
+  });
+});
+
+describe('preflightFeedbackMessage', () => {
+  it('names the outdated state for an outdated CLI', () => {
+    const msg = preflightFeedbackMessage('outdated');
+    expect(msg).toContain('outdated');
+    expect(msg).not.toContain('not installed');
+  });
+  it('names the not-installed state for a missing CLI', () => {
+    const msg = preflightFeedbackMessage('missing');
+    expect(msg).toContain('not installed');
+    expect(msg).not.toContain('outdated');
+  });
+  it('points at the recheck recovery command in every case', () => {
+    for (const status of ['missing', 'outdated'] as const) {
+      expect(preflightFeedbackMessage(status)).toContain('Codev: Recheck CLI');
+    }
   });
 });

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -46,7 +46,7 @@ import { BuilderFileDecorationProvider } from './views/builder-file-decoration.j
 import { BacklogGroupTreeItem, BacklogTreeItem } from './views/backlog-tree-item.js';
 import { persistAreaGroupExpansion } from './views/area-group-expansion.js';
 import { buildArchitectReferenceInjection } from './architect-reference-injection.js';
-import { runPreflight, recheckCli, isCliReady, showSetupRequiredToast } from './preflight/preflight.js';
+import { runPreflight, recheckCli, isCliReady, showPreflightFeedback } from './preflight/preflight.js';
 import { detectWorkspacePath } from './workspace-detector.js';
 import { loadWorktreeConfig, hasRunnableDevCommand } from './load-worktree-config.js';
 
@@ -513,9 +513,11 @@ export async function activate(context: vscode.ExtensionContext) {
 	// the guard decision, so there's no separate list or per-call flag to keep
 	// in sync:
 	//   - `regCli`  — the command needs the codev CLI / Tower. When the CLI is
-	//                 missing or outdated it no-ops with a single "run setup"
-	//                 toast (via `guard`) instead of failing with a misleading
-	//                 "not connected to Tower" error.
+	//                 missing or outdated it no-ops with point-of-action feedback
+	//                 (via `guard` → `showPreflightFeedback`: a modal "run setup"
+	//                 toast on the first click, an ephemeral status-bar message on
+	//                 later clicks) instead of failing with a misleading "not
+	//                 connected to Tower" error.
 	//   - `reg`     — CLI-independent command (recovery paths like reconnect /
 	//                 recheck, config toggles, read-only viewers); registered
 	//                 with no guard.
@@ -525,7 +527,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	const guard = <A extends unknown[], R>(handler: (...args: A) => R) =>
 		(...args: A): R | undefined => {
 			if (isCliReady()) { return handler(...args); }
-			showSetupRequiredToast();
+			showPreflightFeedback();
 			return undefined;
 		};
 	const reg = <A extends unknown[]>(id: string, handler: (...args: A) => unknown) =>

--- a/packages/vscode/src/preflight/preflight-core.ts
+++ b/packages/vscode/src/preflight/preflight-core.ts
@@ -103,3 +103,16 @@ export function decidePreflight(input: {
   }
   return compareSemver(input.cliVersion, input.extVersion) < 0 ? 'outdated' : 'ok';
 }
+
+/**
+ * Ephemeral status-bar text shown when a guarded command is rejected for a
+ * non-ok preflight status, after the first-click modal has already fired this
+ * session (see `showPreflightFeedback` in `preflight.ts`). Names the current
+ * problem and the recovery command so the click reads as registered, not as a
+ * silent no-op. Kept pure so the wording is unit-tested without a vscode mock;
+ * #983 will extend it with a Tower-version branch.
+ */
+export function preflightFeedbackMessage(status: PreflightStatus): string {
+  const label = status === 'outdated' ? 'outdated' : 'not installed';
+  return `Codev: CLI ${label}. Run "Codev: Recheck CLI" when ready.`;
+}

--- a/packages/vscode/src/preflight/preflight.ts
+++ b/packages/vscode/src/preflight/preflight.ts
@@ -21,6 +21,7 @@ import { existsSync } from 'node:fs';
 import {
   decidePreflight,
   parseCliVersion,
+  preflightFeedbackMessage,
   resolveCodevPath,
   type PreflightStatus,
 } from './preflight-core.js';
@@ -44,7 +45,7 @@ export interface PreflightState {
 
 let cachedStatus: PreflightStatus | 'pending' = 'pending';
 let cachedVersion: string | null = null;
-let setupToastShown = false;
+let modalShownThisSession = false;
 
 /** Dependencies captured on the first `runPreflight`, reused by recheck / button handlers. */
 let deps: {
@@ -174,7 +175,7 @@ export async function recheckCli(): Promise<void> {
   changeEmitter.fire();
   const status = await performPreflight();
   if (status === 'ok') {
-    setupToastShown = false; // a fresh problem later should be allowed to re-toast
+    modalShownThisSession = false; // a fresh problem later restarts the modal-first pattern
     vscode.window.showInformationMessage(
       `Codev: CLI ready — codev ${cachedVersion ?? ''}`.trim(),
     );
@@ -238,24 +239,42 @@ function updateViaNpm(): void {
 }
 
 /**
- * Shown the first time a guarded command is invoked while the CLI is
- * unresolved. Single-per-session so repeated invocations don't spam.
+ * Point-of-action feedback when a guarded command is rejected because the CLI
+ * is missing / outdated. Attenuated, never silent:
+ *
+ * - **First** bad-state click this session: a modal warning toast with a
+ *   `Run Setup` action — the user is being told the state for the first time,
+ *   so a modal interrupt is warranted.
+ * - **Subsequent** clicks: an ephemeral status-bar message naming the same
+ *   state and the recovery command, auto-dismissing after a few seconds. No
+ *   modal, no action button — just enough to confirm the click registered and
+ *   the same problem still applies.
+ *
+ * The session flag resets when `recheckCli` confirms `ok`, so a fresh breakage
+ * later restarts the modal-first pattern. Reusable by #983 for the Tower-version
+ * dimension (it will pass a different status into `preflightFeedbackMessage`).
  */
-export function showSetupRequiredToast(): void {
-  if (setupToastShown) {
+export function showPreflightFeedback(): void {
+  if (!modalShownThisSession) {
+    modalShownThisSession = true;
+    vscode.window
+      .showWarningMessage('Codev: CLI not installed / outdated — run setup', 'Run Setup')
+      .then((choice) => {
+        if (choice !== 'Run Setup') {
+          return;
+        }
+        if (cachedStatus === 'outdated') {
+          showOutdatedNotification(cachedVersion, deps?.context.extension.packageJSON.version ?? '');
+        } else {
+          openWalkthrough();
+        }
+      });
     return;
   }
-  setupToastShown = true;
-  vscode.window
-    .showWarningMessage('Codev: CLI not installed / outdated — run setup', 'Run Setup')
-    .then((choice) => {
-      if (choice !== 'Run Setup') {
-        return;
-      }
-      if (cachedStatus === 'outdated') {
-        showOutdatedNotification(cachedVersion, deps?.context.extension.packageJSON.version ?? '');
-      } else {
-        openWalkthrough();
-      }
-    });
+  // The guard only calls this when `isCliReady()` is false, so `cachedStatus`
+  // is `missing` or `outdated` here — never `ok` / `pending`.
+  vscode.window.setStatusBarMessage(
+    preflightFeedbackMessage(cachedStatus as PreflightStatus),
+    4000,
+  );
 }


### PR DESCRIPTION
# PIR Review: Guarded-command feedback — modal-first / ephemeral-after

Fixes #989

## Summary

The CLI preflight (#791) guards 15 VSCode commands; when the CLI is `missing`/`outdated`
the first guarded click showed a modal "run setup" toast and a one-shot `setupToastShown`
flag silenced every click afterwards, so the user got no point-of-action feedback for the
rest of the session. This replaces the one-shot suppressor with a modal-first /
ephemeral-after pattern: the first bad-state click keeps the modal, subsequent clicks show
a brief auto-dismissing status-bar message naming the state and the recovery command. The
dispatch is factored into a reusable `showPreflightFeedback` helper (wording derived by a
new pure `preflightFeedbackMessage`) so #983 can route its Tower-version dimension through
the same channel.

## Files Changed

Code (the substance of the fix):

- `packages/vscode/src/preflight/preflight-core.ts` (+13 / -0) — new pure `preflightFeedbackMessage(status)`
- `packages/vscode/src/preflight/preflight.ts` (+36 / -21) — `showSetupRequiredToast` → `showPreflightFeedback`; flag rename; ephemeral branch
- `packages/vscode/src/extension.ts` (+8 / -4) — import + guard call renamed; updated the stale "single toast" comment
- `packages/vscode/src/__tests__/preflight-core.test.ts` (+19 / -0) — 3 cases for the new helper

PIR protocol artifacts (carried on the branch, ship with the merge):

- `codev/plans/989-vscode-guarded-command-feedbac.md` (+165 / -0) — the approved plan
- `codev/reviews/989-vscode-guarded-command-feedbac.md` — this retrospective (also the PR body)
- `codev/state/pir-989_thread.md` — builder narrative thread
- `codev/projects/989-vscode-guarded-command-feedbac/status.yaml` — porch state (auto-managed)

## Commits

- `379b5eaa` [PIR #989] Add pure preflightFeedbackMessage helper + tests
- `647e8ff1` [PIR #989] Replace one-shot toast with modal-first / ephemeral-after feedback
- `796bbdb9` [PIR #989] Update thread for implement phase

## Test Results

- `npm run build`: ✓ pass (porch check, 6.8s)
- `npm test`: ✓ pass (porch check, 20.7s)
- `pnpm test:unit` run from `packages/vscode/` (equivalently `pnpm --filter codev-vscode
  test:unit` — the package is named `codev-vscode`, unscoped): ✓ 287 pass (+3 new). This is
  the suite that actually covers this diff; the root `build`/`test` filter
  `@cluesmith/codev-core` + `@cluesmith/codev`, **not** the vscode package
- `pnpm compile` run from `packages/vscode/`: ✓ check-types + lint + esbuild
- Manual verification (human, at the `dev-approval` gate): first click → modal with
  `Run Setup`; subsequent clicks → ephemeral status-bar message; recheck→ok resets the
  modal-first pattern; happy path runs with no feedback noise

## Architecture Updates

No arch changes — this PR swaps the behaviour behind an existing guard rejection path
(#791's preflight). No module boundaries, data flow, or patterns changed: the new pure
helper lives in the already-established `preflight-core.ts` (pure logic) / `preflight.ts`
(vscode glue) split, and the guard wiring in `extension.ts` is unchanged in shape (it still
calls one helper on rejection). `codev/resources/arch.md` needs no update.

## Lessons Learned Updates

No durable lessons captured — the change is a localized UX fix following the module's
existing pure-core / vscode-glue convention. One worth-noting-but-not-arch-worthy
observation is recorded here rather than in `lessons-learned.md` (too narrow to generalize):
porch's PIR `build`/`test` checks filter `@cluesmith/codev-core` + `@cluesmith/codev` and do
**not** build/run the `@cluesmith/codev-vscode` package, so a green porch gate does not by
itself prove a vscode-package diff — the package's own `compile` + `test:unit` (run manually
here) and the human dev-approval run are the real verification. `codev/resources/lessons-learned.md`
needs no update.

## Things to Look At During PR Review

- **3-way consult dispositions (single advisory pass, `max_iterations: 1`):** Gemini
  APPROVE, Claude APPROVE, **Codex REQUEST_CHANGES**. Codex's two findings were both about
  *this review file's accuracy*, not the code — and both were correct:
  1. The Test Results referenced `pnpm --filter @cluesmith/codev-vscode ...`, but the package
     is named `codev-vscode` (unscoped), so that filter matches nothing. **Fixed** — the
     section now names the actual command run (`pnpm test:unit` from `packages/vscode/`,
     equivalently `--filter codev-vscode`). The 287-pass result was always real; only the
     documented command string was wrong.
  2. The Files Changed section omitted the `codev/` PIR artifacts (plan, status.yaml,
     thread). **Fixed** — they're now listed under a separate "protocol artifacts" subsection.
  No code change resulted, so no regression test applies (the findings were documentation
  accuracy, not a code defect). Both fixes are in the review-revision commit on this branch.
  Per PIR's single-pass design this revision is **not** independently re-reviewed — flagging
  it here for the human at the `pr` gate.

- **The `cachedStatus as PreflightStatus` cast** in the ephemeral branch
  (`preflight.ts`). It's safe because `guard` only calls the helper when `isCliReady()` is
  false (excludes `ok` and `pending`), and `preflightFeedbackMessage` degrades to the
  "not installed" string for any non-`outdated` value, so a future invariant change is
  cosmetic, never a crash. Inline comment documents this.
- **The modal branch is byte-for-byte the old `showSetupRequiredToast` body** — acceptance
  required it "unchanged from today", so the `Run Setup` → walkthrough / outdated-notification
  routing is preserved verbatim; only the surrounding flag semantics and the new ephemeral
  branch changed.
- **No-arg helper vs the issue's `showPreflightFeedback(state)` signature** — deliberately
  deferred the `PreflightState` parameter to #983 (CLI state is module-level here; #983 adds
  the second Tower dimension that warrants the discriminator). Reviewed and accepted at the
  plan gate.
- **Ephemeral copy** uses a period + quoted command name instead of the issue's em-dash
  example (`Codev: CLI not installed. Run "Codev: Recheck CLI" when ready.`) — project
  no-em-dash convention; functionally identical.

## How to Test Locally

- **View diff**: VSCode sidebar → right-click builder pir-989 → **View Diff**
- **Run dev server**: `afx dev pir-989` (or the sidebar **Run Dev Server**) — though for a
  VSCode extension the realer test is launching the Extension Development Host against this
  worktree (esbuild `watch`, then reload the dev host); no Tower restart involved
- **What to verify** (CLI in `missing`/`outdated` state):
  1. First click on a guarded command (e.g. Spawn Builder) → modal toast with `Run Setup`
  2. Second + third clicks → brief status-bar message naming the state + `Codev: Recheck CLI`, no modal
  3. `Codev: Recheck CLI` while still broken → next click still status-bar (no reset)
  4. Fix CLI, `Codev: Recheck CLI` → `ok` info toast; next breakage restarts at the modal
  5. Happy path (`ok`/`pending`) → guarded commands run normally, zero feedback noise
