### PR TITLE
vscode: overwrite terminal reconnect notices in place, wipe on successful reconnect

### DIFF
--- a/codev/plans/1001-vscode-terminal-adapter-reconn.md
+++ b/codev/plans/1001-vscode-terminal-adapter-reconn.md
@@ -1,0 +1,115 @@
+# PIR Plan: Overwrite-in-place reconnect notices, wiped on successful reconnect
+
+Issue: #1001 — `vscode: terminal-adapter reconnect notices accumulate as orphaned scrollback lines; not cleared on successful reconnect`
+
+## Understanding
+
+When a Codev terminal's WebSocket drops, `CodevPseudoterminal.scheduleReconnect()` writes a yellow status notice to the terminal pane on each backoff attempt. Today each notice is terminated with `\r\n` (`packages/vscode/src/terminal-adapter.ts:204-207`), so successive attempts stack as separate scrollback lines:
+
+```
+[Codev: Connection lost — retrying in 1s (attempt 1/6)]
+[Codev: Connection lost — retrying in 2s (attempt 2/6)]
+...
+```
+
+Two defects, both rooted in the `#936` implementation taking the "one line per attempt" path without the in-place-overwrite mechanic the `#936` PR body described:
+
+1. **Notices stack instead of overwriting.** The `\r\n` terminator advances to a new line each attempt rather than rewriting the same line.
+2. **No success-side wipe.** There is no symmetric handler at the reconnect-success point (`ws.on('open')`, terminal-adapter.ts:132-151) that clears the notice when the connection comes back. After `#991` made in-budget reconnects the common case, the orphaned `[Codev: Connection lost…]` line is left dangling in scrollback above the resumed output until the user closes and reopens the pane.
+
+The give-up state (`#939`'s red `[… Click here to reconnect]` notice, terminal-adapter.ts:230-232) is the terminal *failure* state and must remain visible — only in-progress retry notices should be wiped.
+
+A key enabling fact: on every reconnect, Tower pauses, replays its full scrollback buffer, then resumes (the `pause`/`resume` control messages handled at terminal-adapter.ts:311-321; replayed bytes flow through `handleData` → `writeEmitter`). So any real terminal content transiently erased by an ANSI clear-line is re-rendered by the replay — the notice only ever needs to occupy one transient line.
+
+## Proposed Change
+
+Adopt the overwrite-in-place pattern from the original `#936` intent. Three coordinated edits in `packages/vscode/src/terminal-adapter.ts`, plus tests.
+
+### 1. Add a `hadReconnectNotice` flag
+
+Alongside the existing reconnect-loop state (terminal-adapter.ts:55-57):
+
+```ts
+private hadReconnectNotice = false;
+```
+
+Tracks whether a wipeable in-progress retry notice currently occupies the terminal's current line. Guards against emitting cursor-control sequences on the happy-path first connect (where no notice was ever written).
+
+### 2. Retry notices overwrite in place (no trailing newline)
+
+In `scheduleReconnect()` (terminal-adapter.ts:204-207), replace the trailing `\r\n` with a leading `\r\x1b[2K` (carriage return + erase-entire-line) and set the flag:
+
+```ts
+this.hadReconnectNotice = true;
+this.writeEmitter.fire(
+  `\r\x1b[2K\x1b[33m[Codev: Connection lost. retrying in ${delay / 1000}s ` +
+  `(attempt ${this.backoff.attempt}/${MAX_RECONNECT_ATTEMPTS})]\x1b[0m`,
+);
+```
+
+Each attempt rewrites the same line; the attempt counter ticks `1/6 → 6/6` in place. (The em dash is dropped from the message text per project convention, as the issue requests.)
+
+### 3. Wipe the notice on successful reconnect
+
+Add a small guarded helper and call it from the `ws.on('open')` handler (terminal-adapter.ts:132-151), right after the existing `this.gaveUp = false;`:
+
+```ts
+private clearReconnectNotice(): void {
+  if (this.hadReconnectNotice) {
+    this.writeEmitter.fire('\r\x1b[2K');
+    this.hadReconnectNotice = false;
+  }
+}
+```
+
+Emits exactly one `\r\x1b[2K` to clear the single notice line before Tower's replayed buffer / normal output resumes. No-ops (and emits nothing) when no notice was written — so the happy-path first `open` stays silent.
+
+### 4. Give-up overwrites the retry notice, then stays put
+
+`giveUp()` (terminal-adapter.ts:222-233) transitions from the retry state into the terminal failure state. When reached via the exhausted-budget path, a yellow retry notice is sitting on the current line; the red give-up notice should *replace* it rather than append below it. When reached via the immediate-4xx path (no prior notice), it should not disturb the current line. So prefix the clear conditionally on the flag, and clear the flag (the line now holds the give-up notice, which must NOT be wiped by a later success):
+
+```ts
+const prefix = this.hadReconnectNotice ? '\r\x1b[2K' : '';
+this.hadReconnectNotice = false;
+this.writeEmitter.fire(
+  `${prefix}\x1b[31m[Codev: Connection lost. ${reason}. ${RECONNECT_LINK_TEXT}]\x1b[0m\r\n`,
+);
+```
+
+The give-up notice keeps its trailing `\r\n` (it is the final state — a newline keeps any later output off its line) and is never wiped, satisfying acceptance criterion 3. The em dash in this message is also dropped for consistency, since the line is being edited anyway (minor; see Risks).
+
+## Files to Change
+
+- `packages/vscode/src/terminal-adapter.ts`
+  - `:55-57` — add `private hadReconnectNotice = false;`
+  - `:132-151` — call `this.clearReconnectNotice()` in the `ws.on('open')` handler after `this.gaveUp = false;`
+  - `:204-207` — retry notice: leading `\r\x1b[2K`, drop trailing `\r\n`, set `hadReconnectNotice`, drop em dash
+  - `:222-233` — `giveUp()`: conditional `\r\x1b[2K` prefix, clear the flag, drop em dash
+  - add the `clearReconnectNotice()` private helper
+- `packages/vscode/src/__tests__/terminal-adapter.test.ts`
+  - new assertions for overwrite-in-place + success wipe + give-up-stays (see Test Plan)
+
+## Risks & Alternatives Considered
+
+- **Risk: the leading `\r\x1b[2K` on the first retry notice erases a partial last line of real output** (e.g. a drop mid-stream of `yes | head -200`). Mitigation: Tower replays its full buffer on reconnect, so the erased content is re-rendered; the notice is wiped before replay output resumes. The notice never occupies more than one line, so a single clear suffices. Covered by acceptance criterion 4 in the manual test.
+- **Risk: editing the give-up message text is slightly beyond the issue's literal request** (the issue only calls out dropping the em dash in the retry notice). Mitigation: `giveUp()` is already being edited for the conditional clear prefix; aligning its em dash is a one-character consistency change with no behavior impact. If the reviewer prefers strict surgical scope, the give-up em dash can be left as-is — flag at the gate.
+- **Alternative: a "walk back up N lines and clear" success handler** (as the issue's "why the bug landed" section imagines). Rejected: unnecessary once notices overwrite in place — there is only ever one notice line, so one `\r\x1b[2K` clears it. Simpler and avoids assuming how many lines scrolled.
+- **Alternative: keep `\r\n` and clear on success only.** Rejected: leaves the stacking behavior during an active multi-attempt cycle (criterion 1 unmet).
+
+## Test Plan
+
+Unit (`packages/vscode/src/__tests__/terminal-adapter.test.ts`, extending the existing `#936` suite which already drives real `ws` lifecycle events through the adapter):
+
+- **Overwrite-in-place**: drive a multi-attempt reconnect; assert each retry notice contains the erase-line prefix (`\r\x1b[2K`) and no trailing `\r\n`, and that the cumulative buffer contains the latest `(attempt N/6)` as the only live notice line.
+- **Wipe on success**: drive one retry notice, then `emit('open')`; assert the post-success writes contain a `\r\x1b[2K` wipe and that no `Connection lost` notice survives un-wiped.
+- **Happy-path silence**: a first `open` with no prior close emits no cursor-control wipe (`hadReconnectNotice` false).
+- **Give-up stays**: burn the 6-attempt budget; assert the red give-up notice is present, contains `RECONNECT_LINK_TEXT`, overwrote the last retry notice (`\r\x1b[2K` prefix present), and is NOT wiped by any subsequent write.
+- **Immediate 4xx give-up**: no retry notice was written, so the give-up notice has no `\r\x1b[2K` prefix (does not disturb the current line) — preserves the existing test's intent.
+- Confirm the existing suite (one-notice-per-close, backoff reset, identity guard, EscapeBuffer reset) still passes with the new format.
+
+Build + unit run: `pnpm --filter @cluesmith/codev-vscode test` (and `pnpm --filter @cluesmith/codev-vscode build`) — exact filter confirmed against the package during implement.
+
+Manual (at the `dev-approval` gate, on the running dev host):
+- Force a quick Tower bounce within the first 2-3 backoff intervals; confirm the terminal shows a single notice line ticking the attempt counter in place, and **no orphaned `[Codev: Connection lost…]` line** remains after reconnect.
+- Run `yes | head -200` and bounce Tower mid-stream; confirm the `\r\x1b[2K` does not leave the pane garbled after reconnect (replay restores the output).
+- Exhaust the budget (keep Tower down past 6 attempts); confirm the red `Click here to reconnect` give-up notice remains visible and is not wiped.

--- a/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
+++ b/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-06-06T05:52:25.922Z'
     approved_at: '2026-06-06T05:53:23.150Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-06-06T05:56:44.704Z'
+    approved_at: '2026-06-06T06:00:14.049Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-06T05:49:17.984Z'
-updated_at: '2026-06-06T05:56:44.705Z'
+updated_at: '2026-06-06T06:00:14.050Z'

--- a/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
+++ b/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-06-06T05:52:25.922Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-06T05:49:17.984Z'
-updated_at: '2026-06-06T05:49:17.985Z'
+updated_at: '2026-06-06T05:52:25.922Z'

--- a/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
+++ b/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
@@ -1,0 +1,18 @@
+id: '1001'
+title: vscode-terminal-adapter-reconn
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-06-06T05:49:17.984Z'
+updated_at: '2026-06-06T05:49:17.985Z'

--- a/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
+++ b/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-06-06T05:52:25.922Z'
+    approved_at: '2026-06-06T05:53:23.150Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-06T05:49:17.984Z'
-updated_at: '2026-06-06T05:52:25.922Z'
+updated_at: '2026-06-06T05:53:23.150Z'

--- a/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
+++ b/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-06T05:49:17.984Z'
-updated_at: '2026-06-06T06:00:20.640Z'
+updated_at: '2026-06-06T06:01:17.749Z'
+pr_history:
+  - phase: review
+    pr_number: 1002
+    branch: builder/pir-1001
+    created_at: '2026-06-06T06:01:17.748Z'

--- a/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
+++ b/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-06-06T05:53:23.150Z'
   dev-approval:
     status: pending
+    requested_at: '2026-06-06T05:56:44.704Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-06T05:49:17.984Z'
-updated_at: '2026-06-06T05:53:29.579Z'
+updated_at: '2026-06-06T05:56:44.705Z'

--- a/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
+++ b/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-06-06T06:00:14.049Z'
   pr:
     status: pending
+    requested_at: '2026-06-06T06:05:31.341Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-06-06T05:49:17.984Z'
-updated_at: '2026-06-06T06:01:26.231Z'
+updated_at: '2026-06-06T06:05:31.343Z'
 pr_history:
   - phase: review
     pr_number: 1002
     branch: builder/pir-1001
     created_at: '2026-06-06T06:01:17.748Z'
+pr_ready_for_human: true

--- a/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
+++ b/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
@@ -1,7 +1,7 @@
 id: '1001'
 title: vscode-terminal-adapter-reconn
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-06T05:49:17.984Z'
-updated_at: '2026-06-06T06:00:14.050Z'
+updated_at: '2026-06-06T06:00:20.640Z'

--- a/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
+++ b/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
@@ -1,7 +1,7 @@
 id: '1001'
 title: vscode-terminal-adapter-reconn
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-06T05:49:17.984Z'
-updated_at: '2026-06-06T05:53:23.150Z'
+updated_at: '2026-06-06T05:53:29.579Z'

--- a/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
+++ b/codev/projects/1001-vscode-terminal-adapter-reconn/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-06-06T05:49:17.984Z'
-updated_at: '2026-06-06T06:01:17.749Z'
+updated_at: '2026-06-06T06:01:26.231Z'
 pr_history:
   - phase: review
     pr_number: 1002

--- a/codev/reviews/1001-vscode-terminal-adapter-reconn.md
+++ b/codev/reviews/1001-vscode-terminal-adapter-reconn.md
@@ -1,0 +1,49 @@
+# PIR Review: Overwrite reconnect notices in place, wipe on successful reconnect
+
+Fixes #1001
+
+## Summary
+
+The VSCode terminal adapter wrote a fresh `\r\n`-terminated "Connection lost — retrying…" line on every reconnect attempt, so notices stacked in scrollback and were never cleared when the connection came back — leaving orphaned status lines above the resumed output. This change adopts the overwrite-in-place pattern the original `#936` PR intended: each retry notice now leads with `\r\x1b[2K` (carriage return + erase-line) and drops its trailing newline, so only one notice line is ever visible and the attempt counter ticks `1/6 → 6/6` in place. A `hadReconnectNotice` flag drives a `clearReconnectNotice()` helper called from the `ws.on('open')` success path, which wipes that single line before Tower's replayed buffer resumes. The give-up (`#939`) state overwrites the last retry notice but is itself never wiped, so it remains visible as the terminal failure state.
+
+## Files Changed
+
+- `packages/vscode/src/terminal-adapter.ts` (+40 / -3)
+- `packages/vscode/src/__tests__/terminal-adapter.test.ts` (+78 / -0)
+
+## Commits
+
+- `c0d2f6cf` [PIR #1001] Plan draft
+- `fc6c9bc7` [PIR #1001] Overwrite reconnect notices in place and wipe on successful reconnect
+- `e8c1c846` [PIR #1001] Thread: implement phase complete
+
+## Test Results
+
+- `pnpm check-types`: ✓ pass
+- `pnpm lint`: ✓ pass
+- `node esbuild.js` (bundle): ✓ pass
+- `pnpm test:unit` (`vitest run`): ✓ pass (336 tests, 6 new for PIR #1001)
+- Manual verification: human approved at the `dev-approval` gate — confirmed working as expected (single notice line ticking in place, cleared on reconnect, give-up state preserved).
+
+## Architecture Updates
+
+No arch changes — this is a localized rendering fix within `CodevPseudoterminal`'s existing reconnect loop. It introduces no new module boundaries, dependencies, or patterns; it completes the in-place-overwrite mechanic the `#936` reconnect overhaul (already documented) had only partially implemented.
+
+## Lessons Learned Updates
+
+No new durable lesson worth promoting to `codev/resources/lessons-learned.md`. The one notable point is local-and-already-recorded in arch convention: transient terminal status notices should overwrite in place (`\r\x1b[2K`) and pair every "lost"-side write with a symmetric "recovered"-side wipe, rather than appending `\r\n`-terminated lines that orphan in scrollback. This is captured in the code comments at the change site and in the issue thread; it does not generalize beyond terminal-notice rendering.
+
+## Things to Look At During PR Review
+
+- **First-notice erase vs. partial output (acceptance criterion 4):** the leading `\r\x1b[2K` on the *first* retry notice erases whatever is on the terminal's current line, which can be a partial last line of real output if the drop happened mid-stream. This is intentional and safe because Tower replays its full scrollback buffer on every reconnect (the `pause`/`resume` path in `handleControlMessage`), so the content is re-rendered after the success-wipe. Verified manually at the dev-approval gate.
+- **`giveUp()` conditional prefix:** the erase prefix is applied only when `hadReconnectNotice` is true (exhausted-budget path, where a retry notice is on the line). The immediate-4xx path writes no prefix so it doesn't disturb an unrelated current line — covered by the `immediate 4xx give-up has no erase prefix` test.
+- **Em dashes dropped from both notice messages** ("Connection lost. retrying…" and the give-up text) per project convention. The issue only requested it for the retry notice; the give-up line was edited anyway for the conditional prefix, so its dash was aligned for consistency. Flagged at the plan gate; approved.
+
+## How to Test Locally
+
+- **View diff**: VSCode sidebar → right-click builder pir-1001 → **View Diff**
+- **Run dev server**: VSCode sidebar → **Run Dev Server**, or `afx dev pir-1001`
+- **What to verify**:
+  - Open a Codev terminal, bounce Tower (`afx tower stop && afx tower start`) within the first 2-3 backoff intervals → a single notice line ticks the attempt counter in place; no orphaned `[Codev: Connection lost…]` line remains after reconnect.
+  - Run `yes | head -200`, bounce Tower mid-stream → no garbled output after reconnect (replay restores it).
+  - Keep Tower down past 6 attempts → the red `Click here to reconnect` give-up notice remains visible and is not wiped.

--- a/codev/reviews/1001-vscode-terminal-adapter-reconn.md
+++ b/codev/reviews/1001-vscode-terminal-adapter-reconn.md
@@ -22,7 +22,7 @@ The VSCode terminal adapter wrote a fresh `\r\n`-terminated "Connection lost —
 - `pnpm check-types`: ✓ pass
 - `pnpm lint`: ✓ pass
 - `node esbuild.js` (bundle): ✓ pass
-- `pnpm test:unit` (`vitest run`): ✓ pass (336 tests, 6 new for PIR #1001)
+- `pnpm test:unit` (`vitest run`): ✓ pass (336 tests, 5 new for PIR #1001)
 - Manual verification: human approved at the `dev-approval` gate — confirmed working as expected (single notice line ticking in place, cleared on reconnect, give-up state preserved).
 
 ## Architecture Updates

--- a/codev/state/pir-1001_thread.md
+++ b/codev/state/pir-1001_thread.md
@@ -9,3 +9,12 @@ vscode: reconnect notices accumulate as orphaned scrollback; not cleared on succ
 - Approach: overwrite-in-place (leading `\r\x1b[2K`, no trailing `\r\n`) for retry notices + a `hadReconnectNotice` flag wiped in the `ws.on('open')` success path. Give-up notice (#939) stays visible.
 - Tower replays its full buffer on reconnect, so any real output transiently cleared by the ANSI controls is re-rendered — the notice only ever occupies one transient line.
 - Writing plan to `codev/plans/1001-vscode-terminal-adapter-reconn.md`.
+
+## Plan approved → Implement phase (commit fc6c9bc7)
+
+- Implemented all 4 edits in `terminal-adapter.ts`: `hadReconnectNotice` flag, leading `\r\x1b[2K` overwrite-in-place retry notice (no trailing `\r\n`), `clearReconnectNotice()` helper called from `ws.on('open')`, conditional erase prefix in `giveUp()`. Dropped em dashes from both messages.
+- Added 6 tests under a `PIR #1001` describe block: overwrite-in-place, wipe-on-success, happy-path-silence, give-up-overwrites-but-never-wiped, immediate-4xx-no-prefix.
+- Gotcha: fresh worktree — `@cluesmith/codev-types` / `-core` dists weren't built, so vitest failed to resolve the package entry. Built both (`pnpm --filter ... build`) then everything passed.
+- check-types ✓, lint ✓, esbuild ✓, `vitest run` ✓ (336 tests, 6 new).
+- Pushing branch, signaling `porch done` → `dev-approval` gate.
+

--- a/codev/state/pir-1001_thread.md
+++ b/codev/state/pir-1001_thread.md
@@ -1,0 +1,11 @@
+# PIR #1001 — terminal-adapter reconnect notices
+
+vscode: reconnect notices accumulate as orphaned scrollback; not cleared on successful reconnect.
+
+## Plan phase (in progress)
+
+- Read PIR protocol, issue #1001, `packages/vscode/src/terminal-adapter.ts`, and the existing test suite.
+- Root cause confirmed: `scheduleReconnect()` (terminal-adapter.ts:204-207) terminates each notice with `\r\n`, so notices stack; there is no success-side handler to wipe the notice.
+- Approach: overwrite-in-place (leading `\r\x1b[2K`, no trailing `\r\n`) for retry notices + a `hadReconnectNotice` flag wiped in the `ws.on('open')` success path. Give-up notice (#939) stays visible.
+- Tower replays its full buffer on reconnect, so any real output transiently cleared by the ANSI controls is re-rendered — the notice only ever occupies one transient line.
+- Writing plan to `codev/plans/1001-vscode-terminal-adapter-reconn.md`.

--- a/codev/state/pir-1001_thread.md
+++ b/codev/state/pir-1001_thread.md
@@ -18,3 +18,14 @@ vscode: reconnect notices accumulate as orphaned scrollback; not cleared on succ
 - check-types ✓, lint ✓, esbuild ✓, `vitest run` ✓ (336 tests, 6 new).
 - Pushing branch, signaling `porch done` → `dev-approval` gate.
 
+## dev-approval approved → Review phase
+
+- Human verified at `dev-approval` gate ("working as expected").
+- Wrote `codev/reviews/1001-vscode-terminal-adapter-reconn.md` (commit 2e60732e). No arch/lessons-doc changes — localized rendering fix; rationale in review sections.
+- Opened PR #1002, body = review file (contains `Fixes #1001`). Recorded with `porch done --pr 1002`.
+- Signaled `porch done` → ran single-pass 3-way consult (Gemini/Codex/Claude, type=impl).
+- Verdicts: Gemini APPROVE, Claude APPROVE, Codex COMMENT. No REQUEST_CHANGES.
+  - Codex's only point: review file said "6 new" tests but the PIR #1001 block has 5. Doc-accuracy fix (not a code defect) — corrected review file to "5 new". No code/test change.
+- Notifying architect (all-clear), waiting at `pr` gate.
+
+

--- a/packages/vscode/src/__tests__/terminal-adapter.test.ts
+++ b/packages/vscode/src/__tests__/terminal-adapter.test.ts
@@ -216,3 +216,81 @@ describe('PIR #936 — adapter-owned reconnect loop', () => {
     expect(writes[0]).toContain('(attempt 1/6)');
   });
 });
+
+describe('PIR #1001 — reconnect notices overwrite in place and clear on success', () => {
+  const ERASE_LINE = '\r\x1b[2K'; // carriage return + erase-entire-line
+  const NOTICE_RE = /Connection lost\. retrying/;
+
+  it('overwrites the previous notice in place: each retry erases the line, none stacks', () => {
+    const { writes } = makeAdapter();
+
+    for (let attempt = 1; attempt <= 4; attempt++) {
+      currentSocket().emit('close');
+      const notice = writes[writes.length - 1];
+      // Each notice leads with the erase-line sequence and does NOT terminate
+      // with a newline — so the next attempt rewrites the same line.
+      expect(notice.startsWith(ERASE_LINE)).toBe(true);
+      expect(notice.endsWith('\r\n')).toBe(false);
+      expect(notice).toContain(`(attempt ${attempt}/6)`);
+      vi.advanceTimersByTime(30000);
+    }
+
+    // Across the whole cycle every retry notice carried the erase prefix, so no
+    // bare (un-erased) notice was ever appended as a fresh scrollback line.
+    const retryNotices = writes.filter((w) => NOTICE_RE.test(w));
+    expect(retryNotices.length).toBe(4);
+    expect(retryNotices.every((w) => w.startsWith(ERASE_LINE))).toBe(true);
+  });
+
+  it('wipes the notice line on a successful reconnect (no orphaned scrollback)', () => {
+    const { writes } = makeAdapter();
+    currentSocket().emit('close');   // one retry notice on the line
+    expect(writes.some((w) => NOTICE_RE.test(w))).toBe(true);
+    vi.advanceTimersByTime(1000);    // opens a new socket
+    writes.length = 0;
+
+    currentSocket().emit('open');    // success → wipe
+    // Exactly one erase-line wipe fired, and no retry notice survives after it.
+    expect(writes).toContain(ERASE_LINE);
+    expect(writes.some((w) => NOTICE_RE.test(w))).toBe(false);
+  });
+
+  it('emits no cursor-control wipe on the happy-path first connect', () => {
+    const { writes } = makeAdapter();
+    writes.length = 0;
+    currentSocket().emit('open');    // first connect, no prior notice
+    // No notice was ever written, so nothing is wiped.
+    expect(writes).not.toContain(ERASE_LINE);
+  });
+
+  it('give-up overwrites the last retry notice but is itself never wiped', () => {
+    const { writes } = makeAdapter();
+    for (let i = 0; i < 6; i++) { currentSocket().emit('close'); vi.advanceTimersByTime(30000); }
+    writes.length = 0;
+
+    currentSocket().emit('close');   // 7th close → give up
+    expect(writes).toHaveLength(1);
+    const giveUp = writes[0];
+    expect(giveUp.startsWith(ERASE_LINE)).toBe(true); // overwrote the last retry notice
+    expect(giveUp).toContain(RECONNECT_LINK_TEXT);
+    expect(giveUp).toContain('\x1b[31m');             // red terminal-failure state
+
+    // A later reconnect must NOT wipe the give-up line: gaveUp blocks the loop,
+    // and the give-up cleared hadReconnectNotice. Manually re-open to be sure.
+    writes.length = 0;
+    currentSocket().emit('open');
+    expect(writes).not.toContain(ERASE_LINE);
+  });
+
+  it('immediate 4xx give-up has no erase prefix (no retry notice to overwrite)', () => {
+    const { writes } = makeAdapter();
+    writes.length = 0;
+    currentSocket().emit('error', new Error('Unexpected server response: 404'));
+    currentSocket().emit('close');
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].startsWith(ERASE_LINE)).toBe(false); // nothing on the line to clear
+    expect(writes[0]).toContain('no longer exists');
+    expect(writes[0]).toContain(RECONNECT_LINK_TEXT);
+  });
+});

--- a/packages/vscode/src/terminal-adapter.ts
+++ b/packages/vscode/src/terminal-adapter.ts
@@ -55,6 +55,12 @@ export class CodevPseudoterminal implements vscode.Pseudoterminal {
   private readonly backoff = new BackoffController({ maxAttempts: MAX_RECONNECT_ATTEMPTS });
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private gaveUp = false;
+  // Tracks whether a wipeable in-progress retry notice currently occupies the
+  // terminal's current line (#1001). Set when scheduleReconnect writes a notice;
+  // cleared when a successful reconnect wipes it or the give-up state replaces
+  // it. Guards against emitting cursor-control sequences on the happy-path first
+  // connect, where no notice was ever written.
+  private hadReconnectNotice = false;
 
   constructor(
     private wsUrl: string,
@@ -136,6 +142,9 @@ export class CodevPseudoterminal implements vscode.Pseudoterminal {
       // where the previous failure run left off.
       this.backoff.recordSuccess();
       this.gaveUp = false;
+      // Wipe any in-progress retry notice before replayed buffer / normal
+      // output resumes, so it doesn't orphan in scrollback (#1001).
+      this.clearReconnectNotice();
       // Send auth via control message (not query param)
       if (this.authKey) {
         this.sendControl({ type: 'ping', payload: { auth: this.authKey } });
@@ -201,9 +210,14 @@ export class CodevPseudoterminal implements vscode.Pseudoterminal {
     }
 
     const delay = this.backoff.nextDelayMs();
+    // Overwrite the previous notice in place: leading `\r\x1b[2K` (carriage
+    // return + erase-entire-line) rewrites the same line each attempt rather
+    // than stacking a new scrollback line, so only one notice is ever visible
+    // and the attempt counter ticks 1/6 → 6/6 in place (#1001).
+    this.hadReconnectNotice = true;
     this.writeEmitter.fire(
-      `\x1b[33m[Codev: Connection lost — retrying in ${delay / 1000}s ` +
-      `(attempt ${this.backoff.attempt}/${MAX_RECONNECT_ATTEMPTS})]\x1b[0m\r\n`,
+      `\r\x1b[2K\x1b[33m[Codev: Connection lost. retrying in ${delay / 1000}s ` +
+      `(attempt ${this.backoff.attempt}/${MAX_RECONNECT_ATTEMPTS})]\x1b[0m`,
     );
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
@@ -227,9 +241,29 @@ export class CodevPseudoterminal implements vscode.Pseudoterminal {
       this.reconnectTimer = null;
     }
     this.log('WARN', `Giving up reconnect: ${reason}`);
+    // When reached via the exhausted-budget path, a yellow retry notice is
+    // sitting on the current line; overwrite it in place. When reached via the
+    // immediate-4xx path, no notice exists, so don't disturb the current line.
+    // Either way the give-up notice keeps its trailing `\r\n` and is never
+    // wiped — it is the terminal failure state and must stay visible (#1001).
+    const prefix = this.hadReconnectNotice ? '\r\x1b[2K' : '';
+    this.hadReconnectNotice = false;
     this.writeEmitter.fire(
-      `\x1b[31m[Codev: Connection lost — ${reason}. ${RECONNECT_LINK_TEXT}]\x1b[0m\r\n`,
+      `${prefix}\x1b[31m[Codev: Connection lost. ${reason}. ${RECONNECT_LINK_TEXT}]\x1b[0m\r\n`,
     );
+  }
+
+  /**
+   * Wipe the single in-progress retry notice line on a successful reconnect
+   * (#1001). One `\r\x1b[2K` clears it because notices overwrite in place — only
+   * one ever occupies the current line. No-ops (emits nothing) when no notice
+   * was written, keeping the happy-path first connect silent.
+   */
+  private clearReconnectNotice(): void {
+    if (this.hadReconnectNotice) {
+      this.writeEmitter.fire('\r\x1b[2K');
+      this.hadReconnectNotice = false;
+    }
   }
 
   /** Fresh decoder + escape buffer. Shared by every (re)connect path so none


### PR DESCRIPTION
# PIR Review: Overwrite reconnect notices in place, wipe on successful reconnect

Fixes #1001

## Summary

The VSCode terminal adapter wrote a fresh `\r\n`-terminated "Connection lost — retrying…" line on every reconnect attempt, so notices stacked in scrollback and were never cleared when the connection came back — leaving orphaned status lines above the resumed output. This change adopts the overwrite-in-place pattern the original `#936` PR intended: each retry notice now leads with `\r\x1b[2K` (carriage return + erase-line) and drops its trailing newline, so only one notice line is ever visible and the attempt counter ticks `1/6 → 6/6` in place. A `hadReconnectNotice` flag drives a `clearReconnectNotice()` helper called from the `ws.on('open')` success path, which wipes that single line before Tower's replayed buffer resumes. The give-up (`#939`) state overwrites the last retry notice but is itself never wiped, so it remains visible as the terminal failure state.

## Files Changed

- `packages/vscode/src/terminal-adapter.ts` (+40 / -3)
- `packages/vscode/src/__tests__/terminal-adapter.test.ts` (+78 / -0)

## Commits

- `c0d2f6cf` [PIR #1001] Plan draft
- `fc6c9bc7` [PIR #1001] Overwrite reconnect notices in place and wipe on successful reconnect
- `e8c1c846` [PIR #1001] Thread: implement phase complete

## Test Results

- `pnpm check-types`: ✓ pass
- `pnpm lint`: ✓ pass
- `node esbuild.js` (bundle): ✓ pass
- `pnpm test:unit` (`vitest run`): ✓ pass (336 tests, 5 new for PIR #1001)
- Manual verification: human approved at the `dev-approval` gate — confirmed working as expected (single notice line ticking in place, cleared on reconnect, give-up state preserved).

## Architecture Updates

No arch changes — this is a localized rendering fix within `CodevPseudoterminal`'s existing reconnect loop. It introduces no new module boundaries, dependencies, or patterns; it completes the in-place-overwrite mechanic the `#936` reconnect overhaul (already documented) had only partially implemented.

## Lessons Learned Updates

No new durable lesson worth promoting to `codev/resources/lessons-learned.md`. The one notable point is local-and-already-recorded in arch convention: transient terminal status notices should overwrite in place (`\r\x1b[2K`) and pair every "lost"-side write with a symmetric "recovered"-side wipe, rather than appending `\r\n`-terminated lines that orphan in scrollback. This is captured in the code comments at the change site and in the issue thread; it does not generalize beyond terminal-notice rendering.

## Things to Look At During PR Review

- **First-notice erase vs. partial output (acceptance criterion 4):** the leading `\r\x1b[2K` on the *first* retry notice erases whatever is on the terminal's current line, which can be a partial last line of real output if the drop happened mid-stream. This is intentional and safe because Tower replays its full scrollback buffer on every reconnect (the `pause`/`resume` path in `handleControlMessage`), so the content is re-rendered after the success-wipe. Verified manually at the dev-approval gate.
- **`giveUp()` conditional prefix:** the erase prefix is applied only when `hadReconnectNotice` is true (exhausted-budget path, where a retry notice is on the line). The immediate-4xx path writes no prefix so it doesn't disturb an unrelated current line — covered by the `immediate 4xx give-up has no erase prefix` test.
- **Em dashes dropped from both notice messages** ("Connection lost. retrying…" and the give-up text) per project convention. The issue only requested it for the retry notice; the give-up line was edited anyway for the conditional prefix, so its dash was aligned for consistency. Flagged at the plan gate; approved.

## How to Test Locally

- **View diff**: VSCode sidebar → right-click builder pir-1001 → **View Diff**
- **Run dev server**: VSCode sidebar → **Run Dev Server**, or `afx dev pir-1001`
- **What to verify**:
  - Open a Codev terminal, bounce Tower (`afx tower stop && afx tower start`) within the first 2-3 backoff intervals → a single notice line ticks the attempt counter in place; no orphaned `[Codev: Connection lost…]` line remains after reconnect.
  - Run `yes | head -200`, bounce Tower mid-stream → no garbled output after reconnect (replay restores it).
  - Keep Tower down past 6 attempts → the red `Click here to reconnect` give-up notice remains visible and is not wiped.
