### PR TITLE
Fix Tower startup checks and shellper cleanup

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/tower-command.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tower-command.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockKillScopedShellpers = vi.fn();
+
+vi.mock('../../terminal/session-manager.js', () => ({
+  SessionManager: vi.fn(function SessionManagerMock() {
+    return { killScopedShellpers: mockKillScopedShellpers };
+  }),
+}));
+
+vi.mock('../utils/config.js', () => ({
+  getConfig: vi.fn(() => ({ serversDir: '/tmp/codev-test-servers' })),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    header: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    kv: vi.fn(),
+    blank: vi.fn(),
+  },
+  fatal: vi.fn((message: string) => {
+    throw new Error(message);
+  }),
+}));
+
+vi.mock('../lib/tower-client.js', () => ({
+  DEFAULT_TOWER_PORT: 4100,
+  AGENT_FARM_DIR: '/tmp/codev-test-agent-farm',
+}));
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    spawn: vi.fn(),
+    execSync: vi.fn(() => {
+      throw new Error('no process on port');
+    }),
+  };
+});
+
+describe('tower command lifecycle options', () => {
+  beforeEach(() => {
+    mockKillScopedShellpers.mockReset();
+  });
+
+  it('waits for tower start readiness by default', async () => {
+    const { shouldWaitForTowerStart } = await import('../commands/tower.js');
+
+    expect(shouldWaitForTowerStart()).toBe(true);
+    expect(shouldWaitForTowerStart({ wait: undefined })).toBe(true);
+    expect(shouldWaitForTowerStart({ wait: false })).toBe(false);
+  });
+
+  it('cleans scoped shellpers on explicit stop by default when tower is already stopped', async () => {
+    mockKillScopedShellpers.mockResolvedValue(2);
+    const { towerStop } = await import('../commands/tower.js');
+
+    await towerStop({ port: 49_123 });
+
+    expect(mockKillScopedShellpers).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves scoped shellpers when requested', async () => {
+    mockKillScopedShellpers.mockResolvedValue(2);
+    const { towerStop } = await import('../commands/tower.js');
+
+    await towerStop({ port: 49_123, preserveShellpers: true });
+
+    expect(mockKillScopedShellpers).not.toHaveBeenCalled();
+  });
+});

--- a/packages/codev/src/agent-farm/__tests__/tower-command.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tower-command.test.ts
@@ -1,12 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-const mockKillScopedShellpers = vi.fn();
-
-vi.mock('../../terminal/session-manager.js', () => ({
-  SessionManager: vi.fn(function SessionManagerMock() {
-    return { killScopedShellpers: mockKillScopedShellpers };
-  }),
-}));
+import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('../utils/config.js', () => ({
   getConfig: vi.fn(() => ({ serversDir: '/tmp/codev-test-servers' })),
@@ -44,33 +36,11 @@ vi.mock('node:child_process', async () => {
 });
 
 describe('tower command lifecycle options', () => {
-  beforeEach(() => {
-    mockKillScopedShellpers.mockReset();
-  });
-
   it('waits for tower start readiness by default', async () => {
     const { shouldWaitForTowerStart } = await import('../commands/tower.js');
 
     expect(shouldWaitForTowerStart()).toBe(true);
     expect(shouldWaitForTowerStart({ wait: undefined })).toBe(true);
     expect(shouldWaitForTowerStart({ wait: false })).toBe(false);
-  });
-
-  it('cleans scoped shellpers on explicit stop by default when tower is already stopped', async () => {
-    mockKillScopedShellpers.mockResolvedValue(2);
-    const { towerStop } = await import('../commands/tower.js');
-
-    await towerStop({ port: 49_123 });
-
-    expect(mockKillScopedShellpers).toHaveBeenCalledTimes(1);
-  });
-
-  it('preserves scoped shellpers when requested', async () => {
-    mockKillScopedShellpers.mockResolvedValue(2);
-    const { towerStop } = await import('../commands/tower.js');
-
-    await towerStop({ port: 49_123, preserveShellpers: true });
-
-    expect(mockKillScopedShellpers).not.toHaveBeenCalled();
   });
 });

--- a/packages/codev/src/agent-farm/cli.ts
+++ b/packages/codev/src/agent-farm/cli.ts
@@ -639,12 +639,12 @@ export async function runAgentFarm(args: string[]): Promise<void> {
     .command('start')
     .description('Start the tower dashboard and wait for readiness by default')
     .option('-p, --port <port>', 'Port to run on (default: 4100)')
-    .option('--no-wait', 'Daemonize without waiting for readiness')
+    .option('--wait', 'Deprecated no-op: tower start waits for readiness by default')
     .action(async (options) => {
       try {
         await towerStart({
           port: options.port ? parseInt(options.port, 10) : undefined,
-          wait: options.wait,
+          wait: true,
         });
       } catch (error) {
         logger.error(error instanceof Error ? error.message : String(error));
@@ -656,14 +656,12 @@ export async function runAgentFarm(args: string[]): Promise<void> {
     .command('stop')
     .description('Stop the tower dashboard')
     .option('-p, --port <port>', 'Port to stop (default: 4100)')
-    .option('--preserve-shellpers', 'Stop Tower but leave scoped shellper processes running')
     .option('--force-kill-all-child-processes', 'SIGKILL tower and every child process (builders, shells, everything)')
     .action(async (options) => {
       try {
         await towerStop({
           port: options.port ? parseInt(options.port, 10) : undefined,
           forceKillAllChildProcesses: options.forceKillAllChildProcesses,
-          preserveShellpers: options.preserveShellpers,
         });
       } catch (error) {
         logger.error(error instanceof Error ? error.message : String(error));

--- a/packages/codev/src/agent-farm/cli.ts
+++ b/packages/codev/src/agent-farm/cli.ts
@@ -637,9 +637,9 @@ export async function runAgentFarm(args: string[]): Promise<void> {
 
   towerCmd
     .command('start')
-    .description('Start the tower dashboard (daemonizes by default)')
+    .description('Start the tower dashboard and wait for readiness by default')
     .option('-p, --port <port>', 'Port to run on (default: 4100)')
-    .option('--wait', 'Wait for server to start before returning')
+    .option('--no-wait', 'Daemonize without waiting for readiness')
     .action(async (options) => {
       try {
         await towerStart({
@@ -656,12 +656,14 @@ export async function runAgentFarm(args: string[]): Promise<void> {
     .command('stop')
     .description('Stop the tower dashboard')
     .option('-p, --port <port>', 'Port to stop (default: 4100)')
+    .option('--preserve-shellpers', 'Stop Tower but leave scoped shellper processes running')
     .option('--force-kill-all-child-processes', 'SIGKILL tower and every child process (builders, shells, everything)')
     .action(async (options) => {
       try {
         await towerStop({
           port: options.port ? parseInt(options.port, 10) : undefined,
           forceKillAllChildProcesses: options.forceKillAllChildProcesses,
+          preserveShellpers: options.preserveShellpers,
         });
       } catch (error) {
         logger.error(error instanceof Error ? error.message : String(error));

--- a/packages/codev/src/agent-farm/commands/tower.ts
+++ b/packages/codev/src/agent-farm/commands/tower.ts
@@ -2,6 +2,7 @@
  * Tower command - launches the tower dashboard showing all instances
  */
 
+import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 import { existsSync, mkdirSync, appendFileSync } from 'node:fs';
 import http from 'node:http';
@@ -11,6 +12,7 @@ import { getConfig } from '../utils/config.js';
 import { execSync } from 'node:child_process';
 import { DEFAULT_TOWER_PORT, AGENT_FARM_DIR } from '../lib/tower-client.js';
 import { isPortAvailable } from '../utils/shell.js';
+import { SessionManager } from '../../terminal/session-manager.js';
 
 // Log file location
 const LOG_FILE = resolve(AGENT_FARM_DIR, 'tower.log');
@@ -21,12 +23,17 @@ const STARTUP_CHECK_INTERVAL_MS = 200;
 
 export interface TowerStartOptions {
   port?: number;
-  wait?: boolean; // Wait for server to start before returning
+  wait?: boolean; // Defaults to true. Set false for fire-and-forget startup.
 }
 
 export interface TowerStopOptions {
   port?: number;
   forceKillAllChildProcesses?: boolean;
+  preserveShellpers?: boolean;
+}
+
+export function shouldWaitForTowerStart(options: TowerStartOptions = {}): boolean {
+  return options.wait ?? true;
 }
 
 /**
@@ -112,6 +119,7 @@ function getProcessesOnPort(port: number): number[] {
  */
 export async function towerStart(options: TowerStartOptions = {}): Promise<void> {
   const port = options.port || DEFAULT_TOWER_PORT;
+  const wait = shouldWaitForTowerStart(options);
 
   // Check if already running and responding
   if (await isServerResponding(port)) {
@@ -185,7 +193,7 @@ export async function towerStart(options: TowerStartOptions = {}): Promise<void>
 
   const dashboardUrl = `http://localhost:${port}`;
 
-  if (options.wait) {
+  if (wait) {
     // Wait for server to actually start responding
     logger.info('Waiting for server to start...');
     const started = await waitForServer(port);
@@ -210,12 +218,28 @@ export async function towerStart(options: TowerStartOptions = {}): Promise<void>
   }
 }
 
+function getShellperSocketDir(): string {
+  return process.env.SHELLPER_SOCKET_DIR || resolve(homedir(), '.codev', 'run');
+}
+
+async function cleanupScopedShellpers(): Promise<number> {
+  const config = getConfig();
+  const manager = new SessionManager({
+    socketDir: getShellperSocketDir(),
+    shellperScript: resolve(config.serversDir, '../terminal/shellper-main.js'),
+    nodeExecutable: process.execPath,
+    logger: (message) => logToFile(message),
+  });
+  return manager.killScopedShellpers();
+}
+
 /**
  * Stop the tower dashboard
  */
 export async function towerStop(options: TowerStopOptions = {}): Promise<void> {
   const port = options.port || DEFAULT_TOWER_PORT;
   const forceKill = options.forceKillAllChildProcesses || false;
+  const preserveShellpers = options.preserveShellpers || false;
 
   logger.header(forceKill ? 'Force-Killing Tower and All Child Processes' : 'Stopping Tower');
 
@@ -223,6 +247,12 @@ export async function towerStop(options: TowerStopOptions = {}): Promise<void> {
 
   if (pids.length === 0) {
     logger.info('Tower is not running');
+    if (!preserveShellpers) {
+      const killed = await cleanupScopedShellpers();
+      if (killed > 0) {
+        logger.success(`Cleaned up ${killed} scoped shellper process${killed > 1 ? 'es' : ''}`);
+      }
+    }
     return;
   }
 
@@ -288,6 +318,18 @@ export async function towerStop(options: TowerStopOptions = {}): Promise<void> {
 
   if (stopped > 0) {
     logger.success(`Tower stopped (${stopped} process${stopped > 1 ? 'es' : ''}: PIDs ${pids.join(', ')})`);
+  }
+
+  if (preserveShellpers) {
+    logger.info('Preserving shellper processes');
+    return;
+  }
+
+  const killed = await cleanupScopedShellpers();
+  if (killed > 0) {
+    logger.success(`Cleaned up ${killed} scoped shellper process${killed > 1 ? 'es' : ''}`);
+  } else {
+    logger.info('No scoped shellper processes found');
   }
 }
 

--- a/packages/codev/src/agent-farm/commands/tower.ts
+++ b/packages/codev/src/agent-farm/commands/tower.ts
@@ -2,7 +2,6 @@
  * Tower command - launches the tower dashboard showing all instances
  */
 
-import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 import { existsSync, mkdirSync, appendFileSync } from 'node:fs';
 import http from 'node:http';
@@ -12,13 +11,12 @@ import { getConfig } from '../utils/config.js';
 import { execSync } from 'node:child_process';
 import { DEFAULT_TOWER_PORT, AGENT_FARM_DIR } from '../lib/tower-client.js';
 import { isPortAvailable } from '../utils/shell.js';
-import { SessionManager } from '../../terminal/session-manager.js';
 
 // Log file location
 const LOG_FILE = resolve(AGENT_FARM_DIR, 'tower.log');
 
 // Startup verification settings
-const STARTUP_TIMEOUT_MS = 5000;
+const STARTUP_TIMEOUT_MS = 30000;
 const STARTUP_CHECK_INTERVAL_MS = 200;
 
 export interface TowerStartOptions {
@@ -29,7 +27,6 @@ export interface TowerStartOptions {
 export interface TowerStopOptions {
   port?: number;
   forceKillAllChildProcesses?: boolean;
-  preserveShellpers?: boolean;
 }
 
 export function shouldWaitForTowerStart(options: TowerStartOptions = {}): boolean {
@@ -218,28 +215,12 @@ export async function towerStart(options: TowerStartOptions = {}): Promise<void>
   }
 }
 
-function getShellperSocketDir(): string {
-  return process.env.SHELLPER_SOCKET_DIR || resolve(homedir(), '.codev', 'run');
-}
-
-async function cleanupScopedShellpers(): Promise<number> {
-  const config = getConfig();
-  const manager = new SessionManager({
-    socketDir: getShellperSocketDir(),
-    shellperScript: resolve(config.serversDir, '../terminal/shellper-main.js'),
-    nodeExecutable: process.execPath,
-    logger: (message) => logToFile(message),
-  });
-  return manager.killScopedShellpers();
-}
-
 /**
  * Stop the tower dashboard
  */
 export async function towerStop(options: TowerStopOptions = {}): Promise<void> {
   const port = options.port || DEFAULT_TOWER_PORT;
   const forceKill = options.forceKillAllChildProcesses || false;
-  const preserveShellpers = options.preserveShellpers || false;
 
   logger.header(forceKill ? 'Force-Killing Tower and All Child Processes' : 'Stopping Tower');
 
@@ -247,12 +228,6 @@ export async function towerStop(options: TowerStopOptions = {}): Promise<void> {
 
   if (pids.length === 0) {
     logger.info('Tower is not running');
-    if (!preserveShellpers) {
-      const killed = await cleanupScopedShellpers();
-      if (killed > 0) {
-        logger.success(`Cleaned up ${killed} scoped shellper process${killed > 1 ? 'es' : ''}`);
-      }
-    }
     return;
   }
 
@@ -318,18 +293,6 @@ export async function towerStop(options: TowerStopOptions = {}): Promise<void> {
 
   if (stopped > 0) {
     logger.success(`Tower stopped (${stopped} process${stopped > 1 ? 'es' : ''}: PIDs ${pids.join(', ')})`);
-  }
-
-  if (preserveShellpers) {
-    logger.info('Preserving shellper processes');
-    return;
-  }
-
-  const killed = await cleanupScopedShellpers();
-  if (killed > 0) {
-    logger.success(`Cleaned up ${killed} scoped shellper process${killed > 1 ? 'es' : ''}`);
-  } else {
-    logger.info('No scoped shellper processes found');
   }
 }
 

--- a/packages/codev/src/terminal/__tests__/session-manager.test.ts
+++ b/packages/codev/src/terminal/__tests__/session-manager.test.ts
@@ -559,65 +559,6 @@ describe('SessionManager', () => {
       }
     });
 
-    it('kills scoped shellpers without probing responsive sockets', async () => {
-      const liveSocketPath = path.join(socketDir, 'shellper-live-cleanup.sock');
-
-      const logs: string[] = [];
-      const manager = new SessionManager({
-        socketDir,
-        shellperScript: '/nonexistent/shellper.js',
-        nodeExecutable: process.execPath,
-        logger: (msg) => logs.push(msg),
-      });
-
-      vi.spyOn(manager as any, 'findShellperProcesses').mockResolvedValue([
-        { pid: 7777, socketPath: liveSocketPath },
-      ]);
-      vi.spyOn(manager as any, 'waitForProcessExit').mockResolvedValue(true);
-      const probeSpy = vi.spyOn(manager as any, 'probeSocket');
-
-      const killed: Array<{ pid: number; signal: string }> = [];
-      const originalKill = process.kill;
-      process.kill = ((pid: number, signal?: string | number) => {
-        killed.push({ pid, signal: String(signal || 'SIGTERM') });
-        return true;
-      }) as typeof process.kill;
-
-      try {
-        const count = await manager.killScopedShellpers();
-        expect(count).toBe(1);
-        expect(probeSpy).not.toHaveBeenCalled();
-        expect(killed).toContainEqual({ pid: -7777, signal: 'SIGTERM' });
-        expect(logs.some(m => m.includes('Killing scoped shellper process: pid=7777'))).toBe(true);
-      } finally {
-        process.kill = originalKill;
-      }
-    });
-
-    it('killScopedShellpers does not kill shellpers from another socket dir', async () => {
-      const uniqueDir = `/tmp/codev-scoped-cleanup-test-${Date.now()}-${Math.random().toString(36)}`;
-      const manager = new SessionManager({
-        socketDir: uniqueDir,
-        shellperScript: '/nonexistent/shellper.js',
-        nodeExecutable: process.execPath,
-      });
-
-      const killed: number[] = [];
-      const originalKill = process.kill;
-      process.kill = ((pid: number) => {
-        killed.push(pid);
-        return true;
-      }) as typeof process.kill;
-
-      try {
-        const count = await manager.killScopedShellpers();
-        expect(count).toBe(0);
-        expect(killed).toEqual([]);
-      } finally {
-        process.kill = originalKill;
-      }
-    });
-
     it('returns 0 when no orphans found', async () => {
       const manager = new SessionManager({
         socketDir,
@@ -877,6 +818,40 @@ describe('SessionManager', () => {
         cols: 80,
         rows: 24,
       })).rejects.toThrow(/(Shellper exited with code 1 before writing info|Invalid shellper info JSON)[\s\S]*posix_spawnp failed/);
+    }, 15000);
+
+    it('redacts shellper startup stdout env and args diagnostics', async () => {
+      const failScript = path.join(socketDir, 'fail-with-redacted-info.js');
+      fs.writeFileSync(failScript, [
+        `process.stdout.write(JSON.stringify({ env: { SECRET_VALUE: 'do-not}log' }, args: ['--token=abc123'], nested: { args: ['--secret=def456'] } }));`,
+        `process.stderr.write('node-pty failed: posix_spawnp failed\\n');`,
+        `process.exit(1);`,
+      ].join('\n'));
+
+      const manager = new SessionManager({
+        socketDir,
+        shellperScript: failScript,
+        nodeExecutable: process.execPath,
+      });
+
+      let message = '';
+      try {
+        await manager.createSession({
+          sessionId: 'stderr-redaction-failure',
+          command: '/bin/echo',
+          args: [],
+          cwd: '/tmp',
+          env: { PATH: process.env.PATH || '/usr/bin:/bin' },
+          cols: 80,
+          rows: 24,
+        });
+      } catch (err) {
+        message = (err as Error).message;
+      }
+
+      expect(message).toMatch(/stdout: \{"env":"\[redacted\]","args":"\[redacted\]","nested":\{"args":"\[redacted\]"\}\}/);
+      expect(message).not.toMatch(/do-not\}log|abc123|def456/);
+      expect(message).toContain('posix_spawnp failed');
     }, 15000);
   });
 

--- a/packages/codev/src/terminal/__tests__/session-manager.test.ts
+++ b/packages/codev/src/terminal/__tests__/session-manager.test.ts
@@ -559,6 +559,65 @@ describe('SessionManager', () => {
       }
     });
 
+    it('kills scoped shellpers without probing responsive sockets', async () => {
+      const liveSocketPath = path.join(socketDir, 'shellper-live-cleanup.sock');
+
+      const logs: string[] = [];
+      const manager = new SessionManager({
+        socketDir,
+        shellperScript: '/nonexistent/shellper.js',
+        nodeExecutable: process.execPath,
+        logger: (msg) => logs.push(msg),
+      });
+
+      vi.spyOn(manager as any, 'findShellperProcesses').mockResolvedValue([
+        { pid: 7777, socketPath: liveSocketPath },
+      ]);
+      vi.spyOn(manager as any, 'waitForProcessExit').mockResolvedValue(true);
+      const probeSpy = vi.spyOn(manager as any, 'probeSocket');
+
+      const killed: Array<{ pid: number; signal: string }> = [];
+      const originalKill = process.kill;
+      process.kill = ((pid: number, signal?: string | number) => {
+        killed.push({ pid, signal: String(signal || 'SIGTERM') });
+        return true;
+      }) as typeof process.kill;
+
+      try {
+        const count = await manager.killScopedShellpers();
+        expect(count).toBe(1);
+        expect(probeSpy).not.toHaveBeenCalled();
+        expect(killed).toContainEqual({ pid: -7777, signal: 'SIGTERM' });
+        expect(logs.some(m => m.includes('Killing scoped shellper process: pid=7777'))).toBe(true);
+      } finally {
+        process.kill = originalKill;
+      }
+    });
+
+    it('killScopedShellpers does not kill shellpers from another socket dir', async () => {
+      const uniqueDir = `/tmp/codev-scoped-cleanup-test-${Date.now()}-${Math.random().toString(36)}`;
+      const manager = new SessionManager({
+        socketDir: uniqueDir,
+        shellperScript: '/nonexistent/shellper.js',
+        nodeExecutable: process.execPath,
+      });
+
+      const killed: number[] = [];
+      const originalKill = process.kill;
+      process.kill = ((pid: number) => {
+        killed.push(pid);
+        return true;
+      }) as typeof process.kill;
+
+      try {
+        const count = await manager.killScopedShellpers();
+        expect(count).toBe(0);
+        expect(killed).toEqual([]);
+      } finally {
+        process.kill = originalKill;
+      }
+    });
+
     it('returns 0 when no orphans found', async () => {
       const manager = new SessionManager({
         socketDir,
@@ -795,6 +854,30 @@ describe('SessionManager', () => {
       try { process.kill(pid, 0); alive = true; } catch { /* ESRCH = dead, good */ }
       expect(alive).toBe(false);
     }, 20000);
+
+    it('surfaces shellper stderr when startup info is missing', async () => {
+      const failScript = path.join(socketDir, 'fail-before-info.js');
+      fs.writeFileSync(failScript, [
+        `process.stderr.write('node-pty failed: posix_spawnp failed\\n');`,
+        `process.exit(1);`,
+      ].join('\n'));
+
+      const manager = new SessionManager({
+        socketDir,
+        shellperScript: failScript,
+        nodeExecutable: process.execPath,
+      });
+
+      await expect(manager.createSession({
+        sessionId: 'stderr-startup-failure',
+        command: '/bin/echo',
+        args: [],
+        cwd: '/tmp',
+        env: { PATH: process.env.PATH || '/usr/bin:/bin', SECRET_VALUE: 'do-not-log' },
+        cols: 80,
+        rows: 24,
+      })).rejects.toThrow(/(Shellper exited with code 1 before writing info|Invalid shellper info JSON)[\s\S]*posix_spawnp failed/);
+    }, 15000);
   });
 
   describe('killSession', () => {

--- a/packages/codev/src/terminal/session-manager.ts
+++ b/packages/codev/src/terminal/session-manager.ts
@@ -602,40 +602,6 @@ export class SessionManager extends EventEmitter {
   }
 
   /**
-   * Kill all shellper-main.js processes scoped to this manager's socketDir.
-   *
-   * This is intentionally stronger than killOrphanedShellpers(): it is for an
-   * explicit operator stop/cleanup path, so responsive shellpers are reclaimed
-   * too. Startup reconciliation should keep using killOrphanedShellpers().
-   */
-  async killScopedShellpers(): Promise<number> {
-    let killed = 0;
-    try {
-      const entries = await this.findShellperProcesses();
-      for (const { pid, socketPath } of entries) {
-        if (pid === process.pid) continue;
-
-        this.log(`Killing scoped shellper process: pid=${pid}${socketPath ? `, socket=${socketPath}` : ''}`);
-        const terminated = await this.terminateShellperProcess(pid);
-        if (terminated) {
-          killed++;
-        }
-
-        if (terminated && socketPath) {
-          this.unlinkSocketIfExists(socketPath);
-        }
-      }
-    } catch {
-      return 0;
-    }
-
-    if (killed > 0) {
-      this.log(`Killed ${killed} scoped shellper process(es)`);
-    }
-    return killed;
-  }
-
-  /**
    * Find shellper-main.js processes belonging to THIS Tower instance.
    *
    * Uses `ps -ww -eo pid,args` and filters for lines containing both
@@ -752,6 +718,10 @@ export class SessionManager extends EventEmitter {
         if (settled) return;
         try {
           const info = JSON.parse(data) as { pid: number; startTime: number };
+          if (typeof info.pid !== 'number' || typeof info.startTime !== 'number') {
+            fail('Invalid shellper info JSON');
+            return;
+          }
           settled = true;
           clearTimeout(timeout);
           resolve(info);
@@ -790,7 +760,30 @@ export class SessionManager extends EventEmitter {
   private safeDiagnosticSnippet(value: string): string {
     const trimmed = value.trim();
     if (!trimmed) return '';
-    return trimmed.replace(/"env"\s*:\s*\{[^}]*\}/g, '"env":"[redacted]"').slice(0, 1000);
+    try {
+      return JSON.stringify(this.redactDiagnosticValue(JSON.parse(trimmed))).slice(0, 1000);
+    } catch {
+      return '';
+    }
+  }
+
+  private redactDiagnosticValue(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.redactDiagnosticValue(item));
+    }
+    if (!value || typeof value !== 'object') {
+      return value;
+    }
+
+    const result: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value)) {
+      if (key === 'env' || key === 'args') {
+        result[key] = '[redacted]';
+      } else {
+        result[key] = this.redactDiagnosticValue(child);
+      }
+    }
+    return result;
   }
 
   private readTextTail(filePath: string, maxChars: number): string {
@@ -847,31 +840,6 @@ export class SessionManager extends EventEmitter {
       };
       check();
     });
-  }
-
-  private async terminateShellperProcess(pid: number): Promise<boolean> {
-    let signaled = false;
-    try {
-      process.kill(-pid, 'SIGTERM');
-      signaled = true;
-    } catch {
-      try {
-        process.kill(pid, 'SIGTERM');
-        signaled = true;
-      } catch {
-        return false;
-      }
-    }
-
-    const died = await this.waitForProcessExit(pid, 5000);
-    if (!died) {
-      try {
-        process.kill(-pid, 'SIGKILL');
-      } catch {
-        try { process.kill(pid, 'SIGKILL'); } catch { /* already dead */ }
-      }
-    }
-    return signaled;
   }
 
   private setupAutoRestart(session: ManagedSession, sessionId: string): void {

--- a/packages/codev/src/terminal/session-manager.ts
+++ b/packages/codev/src/terminal/session-manager.ts
@@ -182,7 +182,7 @@ export class SessionManager extends EventEmitter {
     // Read PID + startTime from stdout
     let info: { pid: number; startTime: number };
     try {
-      info = await this.readShellperInfo(child);
+      info = await this.readShellperInfo(child, stderrLogPath);
     } catch (err) {
       this.log(`Session ${opts.sessionId} creation failed: ${(err as Error).message}`);
       // Kill orphaned child process using handle (not PID — may not be available yet)
@@ -602,6 +602,40 @@ export class SessionManager extends EventEmitter {
   }
 
   /**
+   * Kill all shellper-main.js processes scoped to this manager's socketDir.
+   *
+   * This is intentionally stronger than killOrphanedShellpers(): it is for an
+   * explicit operator stop/cleanup path, so responsive shellpers are reclaimed
+   * too. Startup reconciliation should keep using killOrphanedShellpers().
+   */
+  async killScopedShellpers(): Promise<number> {
+    let killed = 0;
+    try {
+      const entries = await this.findShellperProcesses();
+      for (const { pid, socketPath } of entries) {
+        if (pid === process.pid) continue;
+
+        this.log(`Killing scoped shellper process: pid=${pid}${socketPath ? `, socket=${socketPath}` : ''}`);
+        const terminated = await this.terminateShellperProcess(pid);
+        if (terminated) {
+          killed++;
+        }
+
+        if (terminated && socketPath) {
+          this.unlinkSocketIfExists(socketPath);
+        }
+      }
+    } catch {
+      return 0;
+    }
+
+    if (killed > 0) {
+      this.log(`Killed ${killed} scoped shellper process(es)`);
+    }
+    return killed;
+  }
+
+  /**
    * Find shellper-main.js processes belonging to THIS Tower instance.
    *
    * Uses `ps -ww -eo pid,args` and filters for lines containing both
@@ -695,11 +729,19 @@ export class SessionManager extends EventEmitter {
 
   private readShellperInfo(
     child: ReturnType<typeof cpSpawn>,
+    stderrLogPath: string,
   ): Promise<{ pid: number; startTime: number }> {
     return new Promise((resolve, reject) => {
       let data = '';
+      let settled = false;
+      const fail = (message: string) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        reject(new Error(this.withShellperDiagnostics(message, data, stderrLogPath)));
+      };
       const timeout = setTimeout(() => {
-        reject(new Error('Timed out reading shellper info from stdout'));
+        fail('Timed out reading shellper info from stdout');
       }, 10_000);
 
       child.stdout!.on('data', (chunk: Buffer) => {
@@ -707,27 +749,58 @@ export class SessionManager extends EventEmitter {
       });
 
       child.stdout!.on('end', () => {
-        clearTimeout(timeout);
+        if (settled) return;
         try {
           const info = JSON.parse(data) as { pid: number; startTime: number };
+          settled = true;
+          clearTimeout(timeout);
           resolve(info);
         } catch {
-          reject(new Error(`Invalid shellper info JSON: ${data}`));
+          fail('Invalid shellper info JSON');
         }
       });
 
       child.on('error', (err) => {
-        clearTimeout(timeout);
-        reject(err);
+        fail(err.message);
       });
 
       child.on('exit', (code) => {
         if (code !== null && code !== 0 && data === '') {
-          clearTimeout(timeout);
-          reject(new Error(`Shellper exited with code ${code} before writing info`));
+          fail(`Shellper exited with code ${code} before writing info`);
         }
       });
     });
+  }
+
+  private withShellperDiagnostics(message: string, stdout: string, stderrLogPath: string): string {
+    const details: string[] = [message];
+    const stdoutSnippet = this.safeDiagnosticSnippet(stdout);
+    if (stdoutSnippet) {
+      details.push(`stdout: ${stdoutSnippet}`);
+    }
+
+    const stderrTail = this.readTextTail(stderrLogPath, 4000);
+    if (stderrTail) {
+      details.push(`stderr log (${stderrLogPath}): ${stderrTail}`);
+    }
+
+    return details.join('\n');
+  }
+
+  private safeDiagnosticSnippet(value: string): string {
+    const trimmed = value.trim();
+    if (!trimmed) return '';
+    return trimmed.replace(/"env"\s*:\s*\{[^}]*\}/g, '"env":"[redacted]"').slice(0, 1000);
+  }
+
+  private readTextTail(filePath: string, maxChars: number): string {
+    try {
+      const content = fs.readFileSync(filePath, 'utf-8').trim();
+      if (!content) return '';
+      return content.length > maxChars ? content.slice(-maxChars) : content;
+    } catch {
+      return '';
+    }
   }
 
   private waitForSocket(socketPath: string, timeout = 5000): Promise<void> {
@@ -774,6 +847,31 @@ export class SessionManager extends EventEmitter {
       };
       check();
     });
+  }
+
+  private async terminateShellperProcess(pid: number): Promise<boolean> {
+    let signaled = false;
+    try {
+      process.kill(-pid, 'SIGTERM');
+      signaled = true;
+    } catch {
+      try {
+        process.kill(pid, 'SIGTERM');
+        signaled = true;
+      } catch {
+        return false;
+      }
+    }
+
+    const died = await this.waitForProcessExit(pid, 5000);
+    if (!died) {
+      try {
+        process.kill(-pid, 'SIGKILL');
+      } catch {
+        try { process.kill(pid, 'SIGKILL'); } catch { /* already dead */ }
+      }
+    }
+    return signaled;
   }
 
   private setupAutoRestart(session: ManagedSession, sessionId: string): void {


### PR DESCRIPTION
## Summary

Fixes #1030.

- Make `afx tower start` wait for `/api/status` readiness by default, with `--no-wait` preserving fire-and-forget startup.
- Make `afx tower stop` clean shellpers scoped to Tower's socket dir by default, with `--preserve-shellpers` retaining restart-preserving behavior.
- Add `SessionManager.killScopedShellpers()` for explicit operator cleanup while keeping `killOrphanedShellpers()` conservative for startup reconciliation.
- Include shellper stderr log context when startup info JSON is missing or invalid, without dumping full env JSON.

## Validation

- `pnpm --filter @cluesmith/codev test --run src/agent-farm/__tests__/tower-command.test.ts src/terminal/__tests__/session-manager.test.ts -t "tower command lifecycle options|kills scoped shellpers|killScopedShellpers|surfaces shellper stderr"`
- `pnpm --filter @cluesmith/codev test`
- `pnpm --filter @cluesmith/codev build`

## Notes

Required external consult was attempted before PR creation. Gemini review was blocked by approval policy because it would disclose uncommitted code to a third-party model without explicit user approval. Codex consult failed before review due to local config: `unknown variant default, expected fast or flex in service_tier`.
