### PR TITLE
[Bugfix #1022] Exclude .builders/node_modules from VSCode watch/search; drop test-runner recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "connor4312.esbuild-problem-matchers",
-    "ms-vscode.extension-test-runner"
+    "connor4312.esbuild-problem-matchers"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,13 @@
         "packages/vscode/dist": true,
         "packages/codev/dist": true
     },
+    "files.watcherExclude": {
+        "**/.builders/**": true,
+        "**/node_modules/**": true
+    },
     "search.exclude": {
+        "**/.builders/**": true,
+        "**/node_modules/**": true,
         "packages/vscode/out": true,
         "packages/vscode/dist": true,
         "packages/codev/dist": true

--- a/codev/projects/bugfix-1022-vscode-dev-config-exclude-buil/status.yaml
+++ b/codev/projects/bugfix-1022-vscode-dev-config-exclude-buil/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1022
 title: vscode-dev-config-exclude-buil
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-12T23:08:50.454Z'
-updated_at: '2026-06-12T23:08:50.455Z'
+updated_at: '2026-06-12T23:10:07.587Z'

--- a/codev/projects/bugfix-1022-vscode-dev-config-exclude-buil/status.yaml
+++ b/codev/projects/bugfix-1022-vscode-dev-config-exclude-buil/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1022
+title: vscode-dev-config-exclude-buil
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-06-12T23:08:50.454Z'
+updated_at: '2026-06-12T23:08:50.455Z'

--- a/codev/projects/bugfix-1022-vscode-dev-config-exclude-buil/status.yaml
+++ b/codev/projects/bugfix-1022-vscode-dev-config-exclude-buil/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-06-12T23:15:12.240Z'
+    approved_at: '2026-06-12T23:30:41.187Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-12T23:08:50.454Z'
-updated_at: '2026-06-12T23:15:12.241Z'
-pr_ready_for_human: true
+updated_at: '2026-06-12T23:30:41.187Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1022-vscode-dev-config-exclude-buil/status.yaml
+++ b/codev/projects/bugfix-1022-vscode-dev-config-exclude-buil/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1022
 title: vscode-dev-config-exclude-buil
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-12T23:08:50.454Z'
-updated_at: '2026-06-12T23:10:07.587Z'
+updated_at: '2026-06-12T23:13:52.180Z'

--- a/codev/projects/bugfix-1022-vscode-dev-config-exclude-buil/status.yaml
+++ b/codev/projects/bugfix-1022-vscode-dev-config-exclude-buil/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-06-12T23:15:12.240Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-12T23:08:50.454Z'
-updated_at: '2026-06-12T23:13:52.180Z'
+updated_at: '2026-06-12T23:15:12.241Z'
+pr_ready_for_human: true

--- a/codev/state/bugfix-1022_thread.md
+++ b/codev/state/bugfix-1022_thread.md
@@ -1,0 +1,20 @@
+# Builder thread: bugfix-1022
+
+VSCode dev config: exclude `.builders/` + `node_modules` from watch/search; drop Extension Test Runner recommendation (issue #1022).
+
+## Investigate
+
+Confirmed both pieces of the root cause by inspection:
+
+- `.vscode/extensions.json` recommends `ms-vscode.extension-test-runner`. On workspaces with builder worktrees, its test discovery runs `rg --no-ignore --follow` globs that walk every `.builders/*/node_modules` pnpm symlink farm, pegging CPU.
+- `.vscode/settings.json` has no `files.watcherExclude` block at all, and its `search.exclude` only covers `packages/*/out|dist` — nothing for `.builders/` or `node_modules`.
+- `packages/vscode/vsc-extension-quickstart.md` line 14 tells devs to install recommended extensions including the test runner (and `amodio.tsl-problem-matcher`, which was never in `extensions.json`).
+
+This is a config-only fix; no reproduction beyond inspection is possible or needed (the bug manifests as VSCode-host `rg` process storms, environmental).
+
+Plan for fix phase:
+1. Add `files.watcherExclude` and extend `search.exclude` in `.vscode/settings.json` with `**/.builders/**` and `**/node_modules/**`.
+2. Remove `ms-vscode.extension-test-runner` from `extensions.json` recommendations (keep eslint + esbuild-problem-matchers; keep the file).
+3. Fix quickstart line 14 to match actual recommendations. Keep the "Run tests" section's manual install link — installing the test runner deliberately when working on extension tests is still valid; the bug was the blanket recommendation.
+
+No regression test is practical for editor config JSON; the verification is the config content itself.

--- a/packages/codev/src/__tests__/bugfix-1022-vscode-dev-config.test.ts
+++ b/packages/codev/src/__tests__/bugfix-1022-vscode-dev-config.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression test for bugfix #1022: VSCode dev config must not walk the
+ * builder worktree farm.
+ *
+ * Two repo-provided pieces collided: `.vscode/extensions.json` recommended
+ * ms-vscode.extension-test-runner (whose test discovery runs
+ * `rg --no-ignore --follow` over the whole tree), and `.vscode/settings.json`
+ * had no watcher/search excludes for `.builders/` or `node_modules`. On a
+ * workspace with ~15 builder worktrees this pegged CPU for ~30s at a time.
+ *
+ * Guards:
+ * - extensions.json never re-recommends the test-runner extension
+ * - settings.json keeps `.builders` and `node_modules` excluded from both
+ *   the file watcher and search
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// Resolve repo root (packages/codev -> repo root)
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+
+function readJson(relPath: string): Record<string, unknown> | null {
+  const fullPath = path.join(repoRoot, relPath);
+  if (!fs.existsSync(fullPath)) {
+    return null;
+  }
+  return JSON.parse(fs.readFileSync(fullPath, 'utf-8'));
+}
+
+describe('bugfix-1022: VSCode dev config excludes the builder worktree farm', () => {
+  it('.vscode/extensions.json does not recommend ms-vscode.extension-test-runner', () => {
+    const extensions = readJson('.vscode/extensions.json');
+    expect(extensions, '.vscode/extensions.json must exist').not.toBeNull();
+
+    const recommendations = (extensions!.recommendations ?? []) as string[];
+    expect(recommendations).not.toContain('ms-vscode.extension-test-runner');
+  });
+
+  it('.vscode/settings.json excludes .builders and node_modules from watch and search', () => {
+    const settings = readJson('.vscode/settings.json');
+    expect(settings, '.vscode/settings.json must exist').not.toBeNull();
+
+    for (const section of ['files.watcherExclude', 'search.exclude'] as const) {
+      const excludes = settings![section] as Record<string, boolean> | undefined;
+      expect(excludes, `${section} must be present`).toBeDefined();
+      expect(excludes!['**/.builders/**'], `${section} must exclude **/.builders/**`).toBe(true);
+      expect(excludes!['**/node_modules/**'], `${section} must exclude **/node_modules/**`).toBe(true);
+    }
+  });
+});

--- a/packages/vscode/vsc-extension-quickstart.md
+++ b/packages/vscode/vsc-extension-quickstart.md
@@ -11,7 +11,7 @@
 
 ## Setup
 
-* install the recommended extensions (amodio.tsl-problem-matcher, ms-vscode.extension-test-runner, and dbaeumer.vscode-eslint)
+* install the recommended extensions (dbaeumer.vscode-eslint and connor4312.esbuild-problem-matchers)
 
 
 ## Get up and running straight away
@@ -33,7 +33,7 @@
 
 ## Run tests
 
-* Install the [Extension Test Runner](https://marketplace.visualstudio.com/items?itemName=ms-vscode.extension-test-runner)
+* Install the [Extension Test Runner](https://marketplace.visualstudio.com/items?itemName=ms-vscode.extension-test-runner). It is deliberately not in the workspace's recommended extensions: its test discovery walks the whole tree ignoring `.gitignore`, which is very expensive on workspaces containing `.builders/` worktrees. Install it only when working on extension tests.
 * Run the "watch" task via the **Tasks: Run Task** command. Make sure this is running, or tests might not be discovered.
 * Open the Testing view from the activity bar and click the Run Test" button, or use the hotkey `Ctrl/Cmd + ; A`
 * See the output of the test result in the Test Results view.


### PR DESCRIPTION
Fixes #1022

## Problem

Opening the repo in VSCode and accepting the recommended extensions installs `ms-vscode.extension-test-runner`. Its test discovery runs `rg --files --hidden --no-require-git --no-ignore --follow ...`, which skips `.gitignore` and chases symlinks, so on a workspace with builder worktrees it walks every `.builders/*/node_modules` pnpm symlink farm. With ~15 worktrees this spawns a flood of `rg` processes and pegs CPU for ~30s at a time, recurring on file changes.

## Fix

- **`.vscode/settings.json`**: add `files.watcherExclude` and extend `search.exclude` with `**/.builders/**` and `**/node_modules/**`. Defense-in-depth: any tool VSCode drives (search, quick-open, other extensions) stops traversing the worktree farm.
- **`.vscode/extensions.json`**: remove `ms-vscode.extension-test-runner` from recommendations. `dbaeumer.vscode-eslint` and `connor4312.esbuild-problem-matchers` are kept; the file stays.
- **`packages/vscode/vsc-extension-quickstart.md`**: the setup line now lists the actual recommended extensions (it previously also named `amodio.tsl-problem-matcher`, which was never in `extensions.json`), and the "Run tests" section notes the test runner is install-on-demand and why.

## Regression test

`packages/codev/src/__tests__/bugfix-1022-vscode-dev-config.test.ts` guards both invariants: the test-runner extension is never re-recommended, and `.builders`/`node_modules` stay excluded from both watcher and search.

## Verification

- New regression test passes.
- `porch check`: build ✓, full test suite ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)