### PR TITLE
[Bugfix #804] vscode: don't force-create a second editor group for builder terminals

### DIFF
--- a/codev/projects/bugfix-804-vscode-don-t-force-create-a-se/status.yaml
+++ b/codev/projects/bugfix-804-vscode-don-t-force-create-a-se/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-06-13T10:56:14.113Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-13T10:52:01.508Z'
-updated_at: '2026-06-13T10:55:27.806Z'
+updated_at: '2026-06-13T10:56:14.114Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-804-vscode-don-t-force-create-a-se/status.yaml
+++ b/codev/projects/bugfix-804-vscode-don-t-force-create-a-se/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-06-13T10:56:14.113Z'
+    approved_at: '2026-06-13T10:59:28.779Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-13T10:52:01.508Z'
-updated_at: '2026-06-13T10:56:14.114Z'
-pr_ready_for_human: true
+updated_at: '2026-06-13T10:59:28.780Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-804-vscode-don-t-force-create-a-se/status.yaml
+++ b/codev/projects/bugfix-804-vscode-don-t-force-create-a-se/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-804
 title: vscode-don-t-force-create-a-se
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-13T10:52:01.508Z'
-updated_at: '2026-06-13T10:54:09.955Z'
+updated_at: '2026-06-13T10:55:27.806Z'

--- a/codev/projects/bugfix-804-vscode-don-t-force-create-a-se/status.yaml
+++ b/codev/projects/bugfix-804-vscode-don-t-force-create-a-se/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-804
 title: vscode-don-t-force-create-a-se
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-13T10:52:01.508Z'
-updated_at: '2026-06-13T10:52:01.509Z'
+updated_at: '2026-06-13T10:54:09.955Z'

--- a/codev/projects/bugfix-804-vscode-don-t-force-create-a-se/status.yaml
+++ b/codev/projects/bugfix-804-vscode-don-t-force-create-a-se/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-804
+title: vscode-don-t-force-create-a-se
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-06-13T10:52:01.508Z'
+updated_at: '2026-06-13T10:52:01.509Z'

--- a/codev/state/bugfix-804_thread.md
+++ b/codev/state/bugfix-804_thread.md
@@ -1,0 +1,23 @@
+# bugfix-804 — vscode: don't force-create a second editor group for builder terminals
+
+## Investigate
+
+Root cause: `packages/vscode/src/terminal-manager.ts` `openTerminal()` else-branch
+unconditionally sets `location = { viewColumn: vscode.ViewColumn.Two }` for builder/shell
+terminals. `ViewColumn.Two` is fixed by ordinal, so VS Code creates a second editor group
+on demand when only one group exists — reshaping the user's layout.
+
+Fix: when the else-branch resolves, pick Two only if ≥2 tab groups already exist, else One.
+Architect (`ViewColumn.One`) and dev/panel terminals untouched.
+
+Test pattern: `terminal-manager.test.ts` uses source-level regex assertions (full
+TerminalManager needs heavy vscode mocking). Regression test follows same pattern.
+
+## Implement (done)
+
+- `terminal-manager.ts`: else-branch now computes `hasSecondGroup =
+  vscode.window.tabGroups.all.length >= 2`; Two when true, One otherwise. Used
+  if/else (not the issue's proposed ternary). Architect/dev/panel untouched.
+- Added 3 source-level regression tests (#804 block).
+- `pnpm test:unit terminal-manager` → 15 passed. `pnpm check-types` → clean.
+- vscode-extension-only change; no codev-skeleton mirror needed.

--- a/packages/vscode/src/__tests__/terminal-manager.test.ts
+++ b/packages/vscode/src/__tests__/terminal-manager.test.ts
@@ -104,6 +104,34 @@ describe('PIR #982 — actionable recovery for a missing terminal', () => {
   });
 });
 
+describe('#804 — builder/shell terminals do not force-create a second editor group', () => {
+  // The else-branch of openTerminal's location resolution (builder + shell
+  // types) must attach to ViewColumn.Two ONLY when a second tab group already
+  // exists, else fall back to ViewColumn.One — otherwise VS Code spawns a new
+  // group on demand, reshaping a single-column user's layout. Source-level per
+  // this file's harness rationale (constructing TerminalManager needs heavy
+  // vscode mocking).
+  const elseBranch =
+    TM_SRC.split("type === 'architect'")[1]?.split('createTerminal')[0] ?? '';
+
+  it('gates the second-group target on existing tab groups', () => {
+    expect(elseBranch).toMatch(/vscode\.window\.tabGroups\.all\.length >= 2/);
+  });
+
+  it('uses ViewColumn.Two when a second group exists, ViewColumn.One otherwise', () => {
+    expect(elseBranch).toMatch(/location = \{ viewColumn: vscode\.ViewColumn\.Two \}/);
+    expect(elseBranch).toMatch(/location = \{ viewColumn: vscode\.ViewColumn\.One \}/);
+  });
+
+  it('no longer unconditionally targets ViewColumn.Two for builder/shell terminals', () => {
+    // Regression guard: the pre-#804 code set `location = { viewColumn:
+    // vscode.ViewColumn.Two }` with no surrounding group-count check. The fix
+    // must keep that assignment behind the `hasSecondGroup` conditional.
+    expect(elseBranch).toMatch(/const hasSecondGroup = vscode\.window\.tabGroups\.all\.length >= 2/);
+    expect(elseBranch).toMatch(/if \(hasSecondGroup\)/);
+  });
+});
+
 describe('#921 — dev surface refresh on manual terminal close', () => {
   // Regression guard: a dev terminal closed via the generic onDidCloseTerminal
   // path (tab ✕ / process exit) must clear devStartedAt AND re-fire

--- a/packages/vscode/src/terminal-manager.ts
+++ b/packages/vscode/src/terminal-manager.ts
@@ -469,7 +469,18 @@ export class TerminalManager {
     } else if (type === 'architect') {
       location = { viewColumn: vscode.ViewColumn.One };
     } else {
-      location = { viewColumn: vscode.ViewColumn.Two };
+      // Builder/shell terminals prefer the second editor group so they live
+      // beside the architect's pane. But `ViewColumn.Two` is fixed by ordinal:
+      // targeting it when only one group is open forces VS Code to spawn a new
+      // group, reshaping the user's layout (#804). Attach to the second group
+      // only when it already exists; otherwise fall back to the first/default
+      // group so single-column users stay undisturbed.
+      const hasSecondGroup = vscode.window.tabGroups.all.length >= 2;
+      if (hasSecondGroup) {
+        location = { viewColumn: vscode.ViewColumn.Two };
+      } else {
+        location = { viewColumn: vscode.ViewColumn.One };
+      }
     }
 
     const terminal = vscode.window.createTerminal({ name, pty, location, iconPath: this.iconPath });


### PR DESCRIPTION
## Summary

Spawning a builder (or shell) terminal unconditionally targeted `vscode.ViewColumn.Two`. Because that column is fixed by ordinal, VS Code force-created a second editor group whenever the user had only one open — reshaping their layout on every spawn.

`openTerminal`'s `else`-branch now checks `vscode.window.tabGroups.all.length`:

- **Second group exists** → target `ViewColumn.Two` (unchanged behavior).
- **Only one group** → target `ViewColumn.One` (first/default group) instead of forcing a new group into existence.

Architect terminals (`ViewColumn.One`) and dev / panel terminals are untouched.

## Acceptance criteria

- [x] ≥2 editor groups → builder terminal attaches to the second group (unchanged).
- [x] 1 editor group → builder terminal attaches to the first/default group, no new group created.
- [x] Same rule applies to shell-type terminals (they share the `else` branch).
- [x] Architect (`ViewColumn.One`) and dev / panel terminals untouched.
- [x] No new configuration setting — behavior is unconditional.
- [x] Existing focus / `show(!focus)` semantics preserved (only the target column changed).

## Tests

3 source-level regression tests added to `terminal-manager.test.ts`, matching that file's established pattern (constructing a full `TerminalManager` requires heavy vscode mocking, so the suite asserts on source structure). They guard the `tabGroups.all.length >= 2` gate and the Two/One fallback, and fail if the unconditional `ViewColumn.Two` assignment returns.

`pnpm test:unit terminal-manager` → 15 passed. `pnpm check-types` → clean. Porch checks (build + tests) → pass.

## Note on related work

Per #803 (builder terminal unopenable after move-between-groups + close — same area of code), these PRs should stay sequenced. This change only touches the spawn-time column selection in the `else`-branch; it does not alter the move/close handling #803 addresses.

## Implementation note

The issue proposed a ternary for the column selection; this PR uses an `if/else` instead, consistent with the codebase style guidance to avoid ternaries.

Fixes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)
