### PR TITLE
[AIR #1057] afx status: surface architect↔builder ownership

### DIFF
--- a/codev/projects/1057-afx-surface-architect-builder-/status.yaml
+++ b/codev/projects/1057-afx-surface-architect-builder-/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-06-16T19:45:55.268Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-16T19:28:36.390Z'
-updated_at: '2026-06-16T19:43:30.849Z'
+updated_at: '2026-06-16T19:45:55.269Z'
+pr_ready_for_human: true

--- a/codev/projects/1057-afx-surface-architect-builder-/status.yaml
+++ b/codev/projects/1057-afx-surface-architect-builder-/status.yaml
@@ -1,7 +1,7 @@
 id: '1057'
 title: afx-surface-architect-builder-
 protocol: air
-phase: implement
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-16T19:28:36.390Z'
-updated_at: '2026-06-16T19:28:36.391Z'
+updated_at: '2026-06-16T19:43:30.849Z'

--- a/codev/projects/1057-afx-surface-architect-builder-/status.yaml
+++ b/codev/projects/1057-afx-surface-architect-builder-/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-06-16T19:45:55.268Z'
+    approved_at: '2026-06-16T20:59:43.690Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-16T19:28:36.390Z'
-updated_at: '2026-06-16T19:45:55.269Z'
-pr_ready_for_human: true
+updated_at: '2026-06-16T20:59:43.691Z'
+pr_ready_for_human: false

--- a/codev/projects/1057-afx-surface-architect-builder-/status.yaml
+++ b/codev/projects/1057-afx-surface-architect-builder-/status.yaml
@@ -1,0 +1,14 @@
+id: '1057'
+title: afx-surface-architect-builder-
+protocol: air
+phase: implement
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-06-16T19:28:36.390Z'
+updated_at: '2026-06-16T19:28:36.391Z'

--- a/codev/state/air-1057_thread.md
+++ b/codev/state/air-1057_thread.md
@@ -30,7 +30,12 @@ Surface `spawned_by_architect` (Spec 755 data already in `state.db.builders`) th
 - [x] Worktree needed `pnpm install` (no node_modules on spawn); installed.
 - [x] Build (`pnpm build`) clean; full agent-farm suite 1973 pass / 13 pre-existing skips.
 - [x] E2E smoke: seeded a temp state.db, ran the BUILT `afx status --json/--architect/--mine` — owner sort, running flags, and both filters confirmed working end-to-end.
-- [ ] PR
+- [x] PR #1058 created (review embedded in body). porch PR-phase checks pass (pr_exists ✓, e2e_tests ✓).
+- [x] Reached `pr` gate → STOPPED for human approval. Architect notified.
+
+## Final state
+PR: https://github.com/cluesmith/codev/pull/1058 — implements #1057.
+Awaiting human approval at the `pr` gate (`porch approve 1057 pr`). Will not self-approve.
 
 ## E2E note
 `afx status` (human) only reaches the builder table when Tower is down OR the workspace is Tower-registered. Tower-running + unregistered-workspace early-returns at "not active in tower" (pre-existing). The real multi-architect case (Shannon) is registered, so the table renders there. `--json` is independent of registration — validated end-to-end.

--- a/codev/state/air-1057_thread.md
+++ b/codev/state/air-1057_thread.md
@@ -1,0 +1,42 @@
+# air-1057 — afx status: surface architect↔builder ownership
+
+**Protocol**: AIR (strict). Issue #1057. Builder worktree `.builders/air-1057`.
+
+## Goal
+Surface `spawned_by_architect` (Spec 755 data already in `state.db.builders`) through `afx status`:
+1. `owner` column on builder rows + sort by owner.
+2. `afx status --json` — machine-readable, includes `spawnedByArchitect`.
+3. `afx status --architect <name>` and `--mine` filters (`--mine` resolves current architect from `CODEV_ARCHITECT_NAME`).
+
+## Investigation findings
+- `afx status` lives in `packages/codev/src/agent-farm/commands/status.ts`; registered in `cli.ts` (~line 213).
+- Builder ownership is in `state.db.builders.spawned_by_architect`, mapped to `Builder.spawnedByArchitect` via `dbBuilderToBuilder` and loaded by `loadState(workspacePath).builders`.
+- Current status display has TWO paths: Tower-running (uses Tower API terminals, builders shown only as generic `Terminals:` rows) and Tower-down (renders a builders table from `loadState`). Neither shows owner.
+- Current architect identity = `process.env.CODEV_ARCHITECT_NAME` (injected by Tower into architect terminals; spawn.ts already reads it; default `main`).
+- Existing tests: `status-naming.test.ts` (legacy builder table order [spir-109, bugfix-42] + Spec 786 architect enumeration). Must not break.
+
+## Design decisions
+- Source builders for owner display from `state.db` (`loadState`) in BOTH paths — it's the canonical owner source. Hoist `loadState` to top, guard `state?.builders ?? []` (tower-running tests leave loadState mock undefined).
+- Sort builders by owner with a STABLE comparator (unknown owner last); within an owner, preserve `started_at` order — keeps the legacy test's [spir-109, bugfix-42] order (both unknown → comparator 0 → stable).
+- Add Owner as the 2nd column (ID stays first) so `status-naming.test.ts` assertions (col[0]=ID, width[0]=20) still hold.
+- Tower-running path: render owner-aware Builders section from state.db; exclude builders from the generic `Terminals:` list (they get their own section).
+- `--mine` resolves via new pure helper `currentArchitectName(env?)` in `utils/architect-name.ts`.
+- JSON mode returns BEFORE any human chrome (single `console.log` of the payload).
+- Scope: extend `afx status` only (issue offers `afx builders --mine` as an alternative, not a requirement). Keeps LOC tight.
+
+## Status
+- [x] Implement helper (`currentArchitectName`) + status.ts (owner column, sort, filters, JSON) + cli.ts options
+- [x] Tests — `spec-1057-status-owner.test.ts` (17 pass incl. existing status-naming)
+- [x] Worktree needed `pnpm install` (no node_modules on spawn); installed.
+- [x] Build (`pnpm build`) clean; full agent-farm suite 1973 pass / 13 pre-existing skips.
+- [x] E2E smoke: seeded a temp state.db, ran the BUILT `afx status --json/--architect/--mine` — owner sort, running flags, and both filters confirmed working end-to-end.
+- [ ] PR
+
+## E2E note
+`afx status` (human) only reaches the builder table when Tower is down OR the workspace is Tower-registered. Tower-running + unregistered-workspace early-returns at "not active in tower" (pre-existing). The real multi-architect case (Shannon) is registered, so the table renders there. `--json` is independent of registration — validated end-to-end.
+
+## Implementation notes
+- New file: `__tests__/spec-1057-status-owner.test.ts`.
+- Touched: `commands/status.ts`, `cli.ts`, `utils/architect-name.ts`.
+- Net diff well under 300 LOC. No new deps, no schema changes (data already in state.db).
+- `currentArchitectName` is pure + injectable env for testability.

--- a/codev/state/air-1057_thread.md
+++ b/codev/state/air-1057_thread.md
@@ -37,6 +37,14 @@ Surface `spawned_by_architect` (Spec 755 data already in `state.db.builders`) th
 PR: https://github.com/cluesmith/codev/pull/1058 — implements #1057.
 Awaiting human approval at the `pr` gate (`porch approve 1057 pr`). Will not self-approve.
 
+## Architect review follow-up (2026-06-16) — Codex 'merge it' + 2 nits folded in
+1. JSON contract: `emitStatusJson()` now normalizes `workspace.name` to explicit `null`
+   (was dropped as `undefined` for unregistered workspaces). Verified E2E: key present, value null.
+2. Test gap: added Tower-RUNNING human-path tests (owner-aware Builders section renders from
+   state.db; builders excluded from generic Terminals list; --architect honored) + a JSON
+   null-name contract test. Suite now 21 pass (was 17).
+Build clean; pushed to PR; re-running porch check.
+
 ## E2E note
 `afx status` (human) only reaches the builder table when Tower is down OR the workspace is Tower-registered. Tower-running + unregistered-workspace early-returns at "not active in tower" (pre-existing). The real multi-architect case (Shannon) is registered, so the table renders there. `--json` is independent of registration — validated end-to-end.
 

--- a/packages/codev/src/agent-farm/__tests__/spec-1057-status-owner.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/spec-1057-status-owner.test.ts
@@ -240,4 +240,86 @@ describe('afx status --json (Spec 1057)', () => {
     await status({ json: true });
     expect((logger.header as any)).not.toHaveBeenCalled();
   });
+
+  it('emits an explicit workspace.name: null when no workspace is registered', async () => {
+    // Tower down (beforeEach) → no workspace lookup → name must serialize as
+    // an explicit null, not be dropped from the document. (Stable contract.)
+    await status({ json: true });
+
+    const payload = parsePayload();
+    expect(Object.prototype.hasOwnProperty.call(payload.workspace, 'name')).toBe(true);
+    expect(payload.workspace.name).toBeNull();
+  });
+});
+
+// ============================================================================
+// Human table — Tower-RUNNING path (Spec 1057)
+// ============================================================================
+//
+// The Tower-up path is where display semantics changed most: builders move out
+// of the generic `Terminals:` list into a dedicated owner-aware `Builders:`
+// section, sourced from state.db (the Tower terminal list carries no owner).
+
+describe('afx status — Tower-running human path (Spec 1057)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRunning.mockResolvedValue(true);
+    mockGetHealth.mockResolvedValue({ uptime: 100, activeWorkspaces: 1, memoryUsage: 1024 * 1024 });
+    mockGetWorkspaceStatus.mockResolvedValue({
+      path: '/fake/workspace',
+      name: 'project',
+      active: true,
+      terminals: [
+        { type: 'architect', id: 'architect', label: 'main', url: '', active: true,
+          architectName: 'main', pid: 1, terminalId: 's1' },
+        { type: 'builder', id: 'b1', label: 'builder-feedback-1', url: '', active: true },
+        { type: 'shell', id: 'sh1', label: 'shell-1', url: '', active: true },
+      ],
+    });
+    mockLoadState.mockReturnValue({
+      architect: null,
+      architects: [],
+      builders: [
+        builder('builder-feedback-1', 'feedback'),
+        builder('builder-main-1', 'main'),
+      ],
+      utils: [],
+      annotations: [],
+    });
+  });
+
+  it('renders the owner-aware Builders section sourced from state.db', async () => {
+    await status();
+
+    const info = mockLoggerInfo.mock.calls.map((c) => stripAnsi(String(c[0])));
+    expect(info).toContain('Builders:');
+
+    const header = mockLoggerRow.mock.calls
+      .map((c: any[]) => c[0] as string[])
+      .find((cols) => Array.isArray(cols) && cols[0] === 'ID');
+    expect(header).toBeDefined();
+    expect(header![1]).toBe('Owner');
+
+    const rows = builderDataRows();
+    expect(rows.map((r) => r[0])).toEqual(['builder-feedback-1', 'builder-main-1']);
+    expect(rows[0][1]).toBe('feedback');
+    expect(rows[1][1]).toBe('main');
+  });
+
+  it('excludes builders from the generic Terminals list (shells stay)', async () => {
+    await status();
+
+    const info = mockLoggerInfo.mock.calls.map((c) => stripAnsi(String(c[0])));
+    // No `builder - <label>` Terminals row — builders live in the Builders section now.
+    expect(info.some((l) => l.includes('builder - '))).toBe(false);
+    // The shell terminal still appears under Terminals.
+    expect(info.some((l) => l.includes('shell - shell-1'))).toBe(true);
+  });
+
+  it('honors --architect in the Tower-running path', async () => {
+    await status({ architect: 'feedback' });
+
+    const rows = builderDataRows();
+    expect(rows.map((r) => r[0])).toEqual(['builder-feedback-1']);
+  });
 });

--- a/packages/codev/src/agent-farm/__tests__/spec-1057-status-owner.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/spec-1057-status-owner.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for `afx status` architect↔builder ownership surfacing (Spec 1057 / #1057).
+ *
+ * Covers:
+ *   - the `Owner` column + owner sort in the human builder table,
+ *   - the `--architect <name>` and `--mine` ownership filters,
+ *   - the `--json` machine-readable payload (carries `spawnedByArchitect`),
+ *   - the `currentArchitectName` env resolver used by `--mine`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { currentArchitectName } from '../utils/architect-name.js';
+
+// ============================================================================
+// Mocks (mirror status-naming.test.ts so both suites coexist)
+// ============================================================================
+
+const mockLoadState = vi.fn();
+const mockIsRunning = vi.fn();
+const mockGetHealth = vi.fn();
+const mockGetWorkspaceStatus = vi.fn();
+const mockLoggerRow = vi.fn();
+const mockLoggerInfo = vi.fn();
+
+vi.mock('../utils/config.js', () => ({
+  getConfig: vi.fn(() => ({ workspaceRoot: '/fake/workspace' })),
+}));
+
+vi.mock('../state.js', () => ({
+  loadState: (...args: any[]) => mockLoadState(...args),
+}));
+
+vi.mock('../lib/tower-client.js', () => ({
+  getTowerClient: () => ({
+    isRunning: (...a: any[]) => mockIsRunning(...a),
+    getHealth: (...a: any[]) => mockGetHealth(...a),
+    getWorkspaceStatus: (...a: any[]) => mockGetWorkspaceStatus(...a),
+  }),
+}));
+
+vi.mock('../../lib/config.js', () => ({
+  loadConfig: vi.fn(() => ({})),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    header: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    info: (...args: any[]) => mockLoggerInfo(...args),
+    kv: vi.fn(),
+    blank: vi.fn(),
+    row: (...args: any[]) => mockLoggerRow(...args),
+  },
+  fatal: vi.fn((msg: string) => { throw new Error(msg); }),
+}));
+
+import { status } from '../commands/status.js';
+
+// Strip ANSI color codes so assertions are robust regardless of chalk level.
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (s: string) => s.replace(/\[[0-9;]*m/g, '');
+
+function builder(id: string, owner: string | undefined, extra: Record<string, any> = {}) {
+  return {
+    id,
+    name: id.replace(/^builder-/, ''),
+    type: 'spec',
+    status: 'implementing',
+    phase: 'impl',
+    worktree: `/project/.builders/${id}`,
+    branch: `builder/${id}`,
+    terminalId: `term-${id}`,
+    spawnedByArchitect: owner,
+    ...extra,
+  };
+}
+
+/** Return the data rows (cols arrays) of the builder table, ANSI-stripped. */
+function builderDataRows() {
+  return mockLoggerRow.mock.calls
+    .map((call: any[]) => call[0] as string[])
+    .filter((cols) => Array.isArray(cols) && cols[0] !== 'ID' && cols[0] !== '──')
+    .map((cols) => cols.map((c) => stripAnsi(String(c))));
+}
+
+// ============================================================================
+// currentArchitectName (unit)
+// ============================================================================
+
+describe('currentArchitectName (Spec 1057)', () => {
+  it('returns CODEV_ARCHITECT_NAME when set', () => {
+    expect(currentArchitectName({ CODEV_ARCHITECT_NAME: 'feedback' } as any)).toBe('feedback');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(currentArchitectName({ CODEV_ARCHITECT_NAME: '  reflection  ' } as any)).toBe('reflection');
+  });
+
+  it("defaults to 'main' when unset or blank", () => {
+    expect(currentArchitectName({} as any)).toBe('main');
+    expect(currentArchitectName({ CODEV_ARCHITECT_NAME: '   ' } as any)).toBe('main');
+  });
+});
+
+// ============================================================================
+// Human table: Owner column + sort + filters (Tower-down path)
+// ============================================================================
+
+describe('afx status — owner column & filters (Spec 1057)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRunning.mockResolvedValue(false); // legacy/local display
+    mockLoadState.mockReturnValue({
+      architect: null,
+      architects: [],
+      builders: [
+        builder('builder-b', 'zeta'),
+        builder('builder-a', 'alpha'),
+        builder('builder-c', undefined), // legacy / unknown owner
+      ],
+      utils: [],
+      annotations: [],
+    });
+  });
+
+  it('adds an Owner column (ID stays first) to the builder table', async () => {
+    await status();
+
+    const header = mockLoggerRow.mock.calls
+      .map((c: any[]) => c[0] as string[])
+      .find((cols) => Array.isArray(cols) && cols[0] === 'ID');
+    expect(header).toBeDefined();
+    expect(header![0]).toBe('ID');
+    expect(header![1]).toBe('Owner');
+  });
+
+  it('sorts builders by owner, unknown owner last', async () => {
+    await status();
+
+    const rows = builderDataRows();
+    expect(rows.map((r) => r[0])).toEqual(['builder-a', 'builder-b', 'builder-c']);
+    // Owner cell carries the spawning architect; unknown shows the placeholder.
+    expect(rows[0][1]).toBe('alpha');
+    expect(rows[1][1]).toBe('zeta');
+    expect(rows[2][1]).toBe('—');
+  });
+
+  it('--architect <name> shows only that architect\'s builders', async () => {
+    await status({ architect: 'alpha' });
+
+    const rows = builderDataRows();
+    expect(rows.map((r) => r[0])).toEqual(['builder-a']);
+  });
+
+  it('--mine resolves the current architect from CODEV_ARCHITECT_NAME', async () => {
+    const prev = process.env.CODEV_ARCHITECT_NAME;
+    process.env.CODEV_ARCHITECT_NAME = 'zeta';
+    try {
+      await status({ mine: true });
+    } finally {
+      if (prev === undefined) delete process.env.CODEV_ARCHITECT_NAME;
+      else process.env.CODEV_ARCHITECT_NAME = prev;
+    }
+
+    const rows = builderDataRows();
+    expect(rows.map((r) => r[0])).toEqual(['builder-b']);
+  });
+
+  it('reports an empty filtered result without a table', async () => {
+    await status({ architect: 'nobody' });
+
+    expect(builderDataRows()).toHaveLength(0);
+    const infoLines = mockLoggerInfo.mock.calls.map((c) => stripAnsi(String(c[0])));
+    expect(infoLines.some((l) => l.includes('none owned by') && l.includes('nobody'))).toBe(true);
+  });
+});
+
+// ============================================================================
+// JSON output (Spec 1057)
+// ============================================================================
+
+describe('afx status --json (Spec 1057)', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRunning.mockResolvedValue(false);
+    mockLoadState.mockReturnValue({
+      architect: null,
+      architects: [{ name: 'main', cmd: 'claude', startedAt: '2026-06-16T10:00:00Z' }],
+      builders: [
+        builder('builder-b', 'zeta'),
+        builder('builder-a', 'alpha', { terminalId: undefined }), // not running
+      ],
+      utils: [],
+      annotations: [],
+    });
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  function parsePayload() {
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    return JSON.parse(String(logSpy.mock.calls[0][0]));
+  }
+
+  it('emits a single JSON document carrying spawnedByArchitect and running', async () => {
+    await status({ json: true });
+
+    const payload = parsePayload();
+    expect(payload.tower.running).toBe(false);
+    expect(payload.ownerFilter).toBeNull();
+    expect(payload.builders).toHaveLength(2);
+
+    const byId = Object.fromEntries(payload.builders.map((b: any) => [b.id, b]));
+    expect(byId['builder-a'].spawnedByArchitect).toBe('alpha');
+    expect(byId['builder-a'].running).toBe(false);
+    expect(byId['builder-b'].spawnedByArchitect).toBe('zeta');
+    expect(byId['builder-b'].running).toBe(true);
+    // Sorted by owner: alpha before zeta.
+    expect(payload.builders.map((b: any) => b.id)).toEqual(['builder-a', 'builder-b']);
+  });
+
+  it('honors the --architect filter in JSON', async () => {
+    await status({ json: true, architect: 'zeta' });
+
+    const payload = parsePayload();
+    expect(payload.ownerFilter).toBe('zeta');
+    expect(payload.builders.map((b: any) => b.id)).toEqual(['builder-b']);
+  });
+
+  it('does not emit human chrome (header) in JSON mode', async () => {
+    const { logger } = await import('../utils/logger.js');
+    await status({ json: true });
+    expect((logger.header as any)).not.toHaveBeenCalled();
+  });
+});

--- a/packages/codev/src/agent-farm/cli.ts
+++ b/packages/codev/src/agent-farm/cli.ts
@@ -213,10 +213,17 @@ export async function runAgentFarm(args: string[]): Promise<void> {
   program
     .command('status')
     .description('Show status of all agents')
-    .action(async () => {
+    .option('--json', 'Output machine-readable JSON (builders carry spawnedByArchitect)')
+    .option('--architect <name>', 'Only show builders spawned by this architect')
+    .option('--mine', 'Only show builders spawned by the current architect (CODEV_ARCHITECT_NAME)')
+    .action(async (options) => {
       const { status } = await import('./commands/status.js');
       try {
-        await status();
+        await status({
+          json: options.json,
+          architect: options.architect,
+          mine: options.mine,
+        });
       } catch (error) {
         logger.error(error instanceof Error ? error.message : String(error));
         process.exit(1);

--- a/packages/codev/src/agent-farm/commands/status.ts
+++ b/packages/codev/src/agent-farm/commands/status.ts
@@ -116,7 +116,10 @@ function renderBuilders(builders: Builder[], ownerFilter: string | undefined): v
  */
 function emitStatusJson(params: {
   towerRunning: boolean;
-  workspace: { path: string; name?: string; active: boolean };
+  // `name` is explicitly nullable (not optional): an unregistered workspace
+  // must still emit `"name": null` so the machine-readable contract is stable
+  // for tooling — `JSON.stringify` would otherwise drop an `undefined` key.
+  workspace: { path: string; name: string | null; active: boolean };
   architects: Array<{ name: string }>;
   builders: Builder[];
   ownerFilter: string | undefined;
@@ -180,7 +183,7 @@ export async function status(options: StatusOptions = {}): Promise<void> {
     }
     emitStatusJson({
       towerRunning,
-      workspace: { path: workspacePath, name: workspaceName, active: workspaceActive },
+      workspace: { path: workspacePath, name: workspaceName ?? null, active: workspaceActive },
       architects,
       builders,
       ownerFilter,

--- a/packages/codev/src/agent-farm/commands/status.ts
+++ b/packages/codev/src/agent-farm/commands/status.ts
@@ -9,23 +9,186 @@ import { logger } from '../utils/logger.js';
 import { getConfig } from '../utils/config.js';
 import { getTowerClient } from '../lib/tower-client.js';
 import { getTypeColor } from '../utils/display.js';
+import { currentArchitectName } from '../utils/architect-name.js';
+import type { Builder } from '../types.js';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { loadConfig } from '../../lib/config.js';
 import chalk from 'chalk';
 
 /**
+ * Options for `afx status` (Spec 1057).
+ *
+ * - `json`:      emit a machine-readable payload instead of the human table.
+ * - `architect`: only show builders spawned by this architect.
+ * - `mine`:      only show builders spawned by the *current* architect, resolved
+ *                from `CODEV_ARCHITECT_NAME` (see `currentArchitectName`).
+ */
+export interface StatusOptions {
+  json?: boolean;
+  architect?: string;
+  mine?: boolean;
+}
+
+/** Placeholder shown for builders whose spawning architect is unknown (legacy rows). */
+const UNKNOWN_OWNER = '—';
+
+/**
+ * Resolve the owner (spawning-architect) filter from CLI options (Spec 1057).
+ * An explicit `--architect` wins over `--mine`; absent both, no filter.
+ */
+function resolveOwnerFilter(options: StatusOptions): string | undefined {
+  if (options.architect) return options.architect;
+  if (options.mine) return currentArchitectName();
+  return undefined;
+}
+
+/** Keep only builders spawned by `owner` (no-op when `owner` is undefined). */
+function filterByOwner(builders: Builder[], owner: string | undefined): Builder[] {
+  if (!owner) return builders;
+  return builders.filter((b) => b.spawnedByArchitect === owner);
+}
+
+/**
+ * Stable sort builders by owner so same-owner rows cluster together. Unknown
+ * owners (legacy rows with no `spawnedByArchitect`) sort last. Array.sort is
+ * stable, so within an owner the input order (started_at) is preserved.
+ */
+function sortByOwner(builders: Builder[]): Builder[] {
+  return [...builders].sort((a, b) => {
+    const oa = a.spawnedByArchitect;
+    const ob = b.spawnedByArchitect;
+    if (oa === ob) return 0;
+    if (!oa) return 1; // unknown owner sorts last
+    if (!ob) return -1;
+    return oa < ob ? -1 : 1;
+  });
+}
+
+/** A builder is considered "running" when it has a live terminal session. */
+function isBuilderRunning(builder: Builder): boolean {
+  return !!builder.terminalId;
+}
+
+/**
+ * Render the owner-aware Builders table (Spec 1057). Sourced from `state.db`
+ * (the canonical home of `spawnedByArchitect`), so it works identically whether
+ * or not Tower is running. The Owner column is second; ID stays first.
+ */
+function renderBuilders(builders: Builder[], ownerFilter: string | undefined): void {
+  const visible = sortByOwner(filterByOwner(builders, ownerFilter));
+
+  if (visible.length === 0) {
+    if (ownerFilter) {
+      logger.info(`Builders: none owned by ${chalk.cyan(ownerFilter)}`);
+    } else {
+      logger.info('Builders: none');
+    }
+    return;
+  }
+
+  logger.info('Builders:');
+  const widths = [20, 14, 8, 12, 10];
+  logger.row(['ID', 'Owner', 'Type', 'Status', 'Phase'], widths);
+  logger.row(['──', '─────', '────', '──────', '─────'], widths);
+
+  for (const builder of visible) {
+    const running = isBuilderRunning(builder);
+    const statusColor = getStatusColor(builder.status, running);
+    const typeColor = getTypeColor(builder.type || 'spec');
+    const owner = builder.spawnedByArchitect;
+    const ownerCell = owner ? chalk.cyan(owner) : chalk.gray(UNKNOWN_OWNER);
+
+    logger.row([
+      builder.id,
+      ownerCell,
+      typeColor(builder.type || 'spec'),
+      statusColor(builder.status),
+      builder.phase.substring(0, 8),
+    ], widths);
+  }
+}
+
+/**
+ * Emit the machine-readable status payload (Spec 1057). Returns early in
+ * `status()` before any human chrome, so this is the only thing written to
+ * stdout in `--json` mode — safe for tooling to `JSON.parse`.
+ */
+function emitStatusJson(params: {
+  towerRunning: boolean;
+  workspace: { path: string; name?: string; active: boolean };
+  architects: Array<{ name: string }>;
+  builders: Builder[];
+  ownerFilter: string | undefined;
+}): void {
+  const { towerRunning, workspace, architects, builders, ownerFilter } = params;
+  const visible = sortByOwner(filterByOwner(builders, ownerFilter));
+
+  const payload = {
+    tower: { running: towerRunning },
+    workspace,
+    ownerFilter: ownerFilter ?? null,
+    architects: architects.map((a) => ({ name: a.name ?? 'main' })),
+    builders: visible.map((b) => ({
+      id: b.id,
+      name: b.name,
+      type: b.type ?? null,
+      status: b.status,
+      phase: b.phase,
+      spawnedByArchitect: b.spawnedByArchitect ?? null,
+      running: isBuilderRunning(b),
+      worktree: b.worktree,
+      branch: b.branch,
+      issueNumber: b.issueNumber ?? null,
+      protocolName: b.protocolName ?? null,
+    })),
+  };
+
+  console.log(JSON.stringify(payload, null, 2));
+}
+
+/**
  * Display status of all agent farm processes
  */
-export async function status(): Promise<void> {
+export async function status(options: StatusOptions = {}): Promise<void> {
   const config = getConfig();
   const workspacePath = config.workspaceRoot;
-
-  logger.header('Agent Farm Status');
+  const ownerFilter = resolveOwnerFilter(options);
 
   // Try tower API first (Phase 3 - Spec 0090)
   const client = getTowerClient();
   const towerRunning = await client.isRunning();
+
+  // Builder ownership (`spawnedByArchitect`) lives in state.db, so load it up
+  // front — it's the canonical owner source whether or not Tower is running.
+  // Guarded with `?.` because some unit tests leave the loadState mock unset.
+  const state = loadState(workspacePath);
+  const builders = state?.builders ?? [];
+  const architects = state?.architects ?? [];
+
+  // Machine-readable mode (Spec 1057): gather workspace metadata when Tower is
+  // up, then emit JSON and return before any human-facing output.
+  if (options.json) {
+    let workspaceName: string | undefined;
+    let workspaceActive = false;
+    if (towerRunning) {
+      const ws = await client.getWorkspaceStatus(workspacePath);
+      if (ws) {
+        workspaceName = ws.name;
+        workspaceActive = ws.active;
+      }
+    }
+    emitStatusJson({
+      towerRunning,
+      workspace: { path: workspacePath, name: workspaceName, active: workspaceActive },
+      architects,
+      builders,
+      ownerFilter,
+    });
+    return;
+  }
+
+  logger.header('Agent Farm Status');
 
   if (towerRunning) {
     // Get health info
@@ -55,9 +218,12 @@ export async function status(): Promise<void> {
         // ALL registered architects (not just one collapsed "Architect" row).
         // Each architect entry's `architectName`, `pid`, and optional `port`
         // come from the Tower API (per Spec 786 Phase 5's TowerWorkspaceStatus
-        // extension). Builders/shells/dev remain in the general Terminals list.
+        // extension). Spec 1057: builders move to their own owner-aware section
+        // below; shells/dev remain in the general Terminals list.
         const architectTerminals = workspaceStatus.terminals.filter(t => t.type === 'architect');
-        const otherTerminals = workspaceStatus.terminals.filter(t => t.type !== 'architect');
+        const otherTerminals = workspaceStatus.terminals.filter(
+          t => t.type !== 'architect' && t.type !== 'builder',
+        );
 
         if (architectTerminals.length > 0) {
           logger.blank();
@@ -80,13 +246,16 @@ export async function status(): Promise<void> {
           logger.blank();
           logger.info('Terminals:');
           for (const term of otherTerminals) {
-            const typeColor = term.type === 'builder' ? chalk.blue
-              : term.type === 'dev' ? chalk.green
-              : chalk.gray;
+            const typeColor = term.type === 'dev' ? chalk.green : chalk.gray;
             logger.info(`  ${typeColor(term.type)} - ${term.label} (${term.active ? 'active' : 'stopped'})`);
           }
         }
       }
+
+      // Spec 1057: owner-aware Builders section, sourced from state.db so each
+      // row carries its spawning architect (the Tower terminal list does not).
+      logger.blank();
+      renderBuilders(builders, ownerFilter);
 
       return;
     }
@@ -109,13 +278,13 @@ export async function status(): Promise<void> {
   // Spec 786 Phase 5: enumerate ALL architects from state.db. PID and port
   // are not available without Tower (the architect table persists pid=0,
   // port=0 — see state.ts:79, :103), so the fallback shows name + cmd only.
-  // Bugfix #826: scoped by workspace_path.
-  const state = loadState(workspacePath);
+  // Bugfix #826: scoped by workspace_path. (state/architects/builders are
+  // loaded once up front — see top of status().)
 
-  if (state.architects && state.architects.length > 0) {
-    logger.kv('Architects', chalk.green(`${state.architects.length} registered`));
+  if (architects.length > 0) {
+    logger.kv('Architects', chalk.green(`${architects.length} registered`));
     logger.info(`  (Tower not running — PID/port not available)`);
-    for (const a of state.architects) {
+    for (const a of architects) {
       logger.info(`  ${chalk.cyan(a.name ?? 'main')}: cmd=${a.cmd} started=${a.startedAt}`);
     }
   } else {
@@ -124,30 +293,8 @@ export async function status(): Promise<void> {
 
   logger.blank();
 
-  // Builders
-  if (state.builders.length > 0) {
-    logger.info('Builders:');
-    const widths = [20, 20, 10, 12, 10];
-
-    logger.row(['ID', 'Name', 'Type', 'Status', 'Phase'], widths);
-    logger.row(['──', '────', '────', '──────', '─────'], widths);
-
-    for (const builder of state.builders) {
-      const running = !!builder.terminalId;
-      const statusColor = getStatusColor(builder.status, running);
-      const typeColor = getTypeColor(builder.type || 'spec');
-
-      logger.row([
-        builder.id,
-        builder.name.substring(0, 18),
-        typeColor(builder.type || 'spec'),
-        statusColor(builder.status),
-        builder.phase.substring(0, 8),
-      ], widths);
-    }
-  } else {
-    logger.info('Builders: none');
-  }
+  // Spec 1057: owner-aware Builders table (same renderer as the Tower-up path).
+  renderBuilders(builders, ownerFilter);
 
   logger.blank();
 

--- a/packages/codev/src/agent-farm/utils/architect-name.ts
+++ b/packages/codev/src/agent-farm/utils/architect-name.ts
@@ -71,3 +71,20 @@ export function autoNumberArchitectName(existingNames: Iterable<string>): string
   while (usedNumbers.has(n)) n++;
   return `architect-${n}`;
 }
+
+/**
+ * Resolve the *current* terminal session's architect name (Spec 1057).
+ *
+ * Tower injects `CODEV_ARCHITECT_NAME` into every architect terminal it starts
+ * (see `commands/spawn.ts` and `servers/tower-instances.ts`). When present, it
+ * names the architect whose terminal this command is running in — exactly what
+ * `afx status --mine` needs to scope builders to "my own". When absent (a plain
+ * shell, or a pre-#786 single-architect workspace) we fall back to the reserved
+ * default `main`.
+ *
+ * Pure apart from the default `env` binding; pass an explicit `env` in tests.
+ */
+export function currentArchitectName(env: NodeJS.ProcessEnv = process.env): string {
+  const value = env.CODEV_ARCHITECT_NAME?.trim();
+  return value || DEFAULT_ARCHITECT_NAME;
+}


### PR DESCRIPTION
Closes #1057.

## Summary

`afx status` listed every builder but never showed **which architect spawned each one** — so in multi-architect workspaces (the Shannon workspace runs 8 architects / ~17 builders) ownership-scoped sweeps (cleanup, PR-close, messaging) had to hand-query the internal `state.db.builders.spawned_by_architect` column. The data already existed (Spec 755); it just wasn't exposed.

This surfaces the architect↔builder mapping through the CLI, with no schema or state-shape changes:

1. **Owner column** on `afx status` builder rows, **sorted by owner** (unknown/legacy owners last). The builder table is now rendered from `state.db` in both Tower-up and Tower-down paths, so every row carries its spawning architect.
2. **`afx status --json`** — machine-readable payload. Builders carry `spawnedByArchitect` and a `running` flag, so tooling/agents can scope ownership without scraping the human table or hand-querying SQLite.
3. **Ownership filters** — `afx status --architect <name>` and `--mine`. `--mine` resolves the *current* architect from `CODEV_ARCHITECT_NAME` (the env var Tower injects into every architect terminal), so it needs no argument.

## Key decisions

- **Single source of truth for ownership**: builders are read from `state.db` (`loadState().builders`) — the canonical home of `spawnedByArchitect` — rather than from the Tower terminal list (which doesn't carry the owner). This makes the owner display work identically whether or not Tower is running.
- **Stable owner sort**: `Array.sort` is stable, so builders cluster by owner while preserving `started_at` order within each owner group (keeps the existing `status-naming` ordering intact).
- **Owner is the 2nd column** (ID stays first), so existing column-layout assertions still hold.
- **Tower-up mode**: builders move out of the generic `Terminals:` list into their own owner-aware `Builders:` section (shells/dev stay in `Terminals:`).
- **`currentArchitectName()`** is a new pure, env-injectable helper in `utils/architect-name.ts` (reuses `DEFAULT_ARCHITECT_NAME = 'main'`), mirroring how `spawn.ts` already reads `CODEV_ARCHITECT_NAME`.
- **Scope**: extended `afx status` only. The issue offered `afx builders --mine` as an *alternative* ("or"); a whole new command wasn't needed to satisfy the ask, and this keeps the surface tight.

## Files

- `commands/status.ts` — owner column + sort + filters + `--json`; builder table sourced from state.db in both paths.
- `cli.ts` — `--json`, `--architect <name>`, `--mine` options.
- `utils/architect-name.ts` — `currentArchitectName(env?)`.
- `__tests__/spec-1057-status-owner.test.ts` — new tests.

Net production diff ≈ 171 LOC (well under the AIR 300-LOC bar).

## Test plan

- **Unit** (`spec-1057-status-owner.test.ts`, 17 cases incl. shared logic): Owner column present (ID first), owner sort with unknown-last, `--architect` filter, `--mine` env resolution, empty-filter message, `--json` payload shape (carries `spawnedByArchitect` + `running`, honors filter, sorted), no human chrome in JSON mode, and `currentArchitectName` env/whitespace/default cases.
- **Regression**: full `agent-farm` suite — **1973 passed / 13 pre-existing skips**; existing `status-naming` suite unchanged.
- **Build**: `pnpm build` clean; `porch check` build ✓ / tests ✓.
- **End-to-end (built CLI against a seeded state.db)**: confirmed
  - `afx status --json` → all builders, sorted by owner, correct `running` flags;
  - `afx status --json --architect feedback` → only feedback's 2 builders;
  - `afx status --json --mine` with `CODEV_ARCHITECT_NAME=main` → only `main`'s builder.

### Note on the human table & Tower registration
The human builder table renders when Tower is **down** OR the workspace is **Tower-registered**. The pre-existing `Tower-running + workspace-not-registered` branch still early-returns at "not active in tower" (unchanged). Real multi-architect workspaces are registered, so the table renders there; `--json` is independent of registration and was validated end-to-end.