### PR TITLE
[AIR #1074] vscode: align backlog issue-preview placement with count-then-pick (remove focus side-effect)

### DIFF
--- a/codev/projects/1074-vscode-align-backlog-issue-pre/status.yaml
+++ b/codev/projects/1074-vscode-align-backlog-issue-pre/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-06-18T22:50:17.116Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-18T22:37:33.400Z'
-updated_at: '2026-06-18T22:47:33.404Z'
+updated_at: '2026-06-18T22:50:17.117Z'
+pr_ready_for_human: true

--- a/codev/projects/1074-vscode-align-backlog-issue-pre/status.yaml
+++ b/codev/projects/1074-vscode-align-backlog-issue-pre/status.yaml
@@ -1,7 +1,7 @@
 id: '1074'
 title: vscode-align-backlog-issue-pre
 protocol: air
-phase: implement
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-18T22:37:33.400Z'
-updated_at: '2026-06-18T22:37:33.400Z'
+updated_at: '2026-06-18T22:47:33.404Z'

--- a/codev/projects/1074-vscode-align-backlog-issue-pre/status.yaml
+++ b/codev/projects/1074-vscode-align-backlog-issue-pre/status.yaml
@@ -1,0 +1,14 @@
+id: '1074'
+title: vscode-align-backlog-issue-pre
+protocol: air
+phase: implement
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-06-18T22:37:33.400Z'
+updated_at: '2026-06-18T22:37:33.400Z'

--- a/codev/state/air-1074_thread.md
+++ b/codev/state/air-1074_thread.md
@@ -1,0 +1,79 @@
+# air-1074 — vscode: align backlog issue-preview placement (remove focus side-effect)
+
+## Implement phase — BLOCKED on a baked-decision / API-fact conflict (2026-06-19)
+
+Read the issue, the current `view-issue.ts:160-175`, the target pattern
+`terminal-manager.ts:478-484`, and the existing `codev.openMarkdownPreview`
+(`extension.ts:795-805`, which uses `vscode.openWith` + an explicit ViewColumn,
+NOT the built-in markdown command).
+
+Before coding against the issue's proposed call
+`executeCommand('markdown.showPreview', uri, viewColumn, /* preserveFocus */ true)`,
+I verified the built-in command's real signature against the bundled VS Code
+1.124.2 markdown extension
+(`/Applications/Visual Studio Code.app/.../markdown-language-features/dist/extension.js`).
+
+**Finding (airtight):** `markdown.showPreview` does NOT accept an explicit
+`viewColumn` and has NO `preserveFocus` param.
+
+- `ShowPreviewCommand.execute(e, r, n)` → `e`=mainUri, `r`=allUris (iterated only
+  if it's an array; a number falls back to `[e]`), `n`=settings where ONLY
+  `n.locked` is read and `sideBySide` is hardcoded `false`.
+- The internal `showPreview` computes
+  `previewColumn = n.sideBySide ? Beside : (activeTextEditor?.viewColumn || ViewColumn.One)`.
+- So the preview ALWAYS opens in the **active editor group**; the passed
+  `viewColumn` (2) is silently dropped, and `true` (preserveFocus) only yields
+  `true.locked === undefined` → no effect.
+
+**Consequence:** 3 acceptance criteria + plan-gate decision #2 are unsatisfiable
+as written. The built-in dynamic markdown preview anchors to the active editor
+group by construction, so "explicit group-2 placement" + "preserve focus on the
+sidebar click origin" can't both hold without a custom editor
+(`vscode.openWith` / a WebviewPanel with `{viewColumn, preserveFocus}`) — which
+the issue explicitly ruled out of scope (#1068).
+
+**Action:** escalated to architect via `afx send` with evidence + options. Waiting
+for direction before implementing. NOT relitigating inside spec/plan/review (none
+exist in AIR) — surfacing per the Baked-Decisions rule.
+
+### Options presented to architect
+1. Custom editor via `vscode.openWith` (the existing Codev MarkdownPreviewProvider
+   pattern from `codev.openMarkdownPreview`) — DOES take an explicit ViewColumn +
+   `{preserveFocus}`. Satisfies all criteria but overlaps #1068's "off built-in
+   preview" scope. Need a ruling on whether that's acceptable here.
+2. Keep `markdown.showPreviewToSide` but make placement deterministic by focusing
+   the *computed* target group (group 2 if it exists, else group 1) instead of
+   always group 1. Removes the Beside-chaining + "group 1 closed" fragility but
+   RETAINS a focus side-effect (fails the "preserve focus" criterion).
+3. Redefine the acceptance criteria given the API reality.
+
+## Implement phase — RESOLVED + DONE (2026-06-19)
+
+Architect chose a corrected option 1: open the BUILT-IN preview's custom-editor
+viewType `vscode.markdown.preview.editor` (NOT Codev's `codev.markdownPreview`,
+so no #1068 overlap) via `vscode.openWith`, which DOES accept an explicit
+ViewColumn + `{ preserveFocus }`.
+
+Verified the viewType against bundled VS Code 1.124.2 markdown-language-features
+manifest: `vscode.markdown.preview.editor`, priority "option", selector `*.md`
+(our `codev-issue:<id>.md` URI path ends in `.md` → matches). Precedent for
+`vscode.openWith` in our code: `extension.ts:804`, `view-artifact.ts:127`.
+
+Implementation (`commands/view-issue.ts`):
+- Removed the `workbench.action.focusFirstEditorGroup` call.
+- Added pure helper `pickIssuePreviewColumn(groupCount)` → ViewColumn.Two when
+  `>= 2`, else ViewColumn.One (if/else, no ternary, mirrors terminal-manager).
+- Call site: `vscode.openWith` + `vscode.markdown.preview.editor` +
+  `{ viewColumn, preserveFocus: true }`, column from
+  `vscode.window.tabGroups.all.length`.
+- Unit test `src/__tests__/view-issue-column.test.ts` (4 cases: 2→Two, 3/5→Two,
+  1→One, 0→One) following the diff-nav minimal-vscode-mock pattern.
+- Cache/refresh/close-cleanup (`IssueContentProvider`, `OverviewCache.onDidChange`,
+  `onDidCloseTextDocument`) untouched.
+
+Verification: `pnpm check-types` clean, `eslint` clean, full `vitest run` =
+35 files / 446 tests pass (incl. the 4 new). (First suite run showed 8 files
+failing to resolve `@cluesmith/codev-core` — pre-existing unbuilt-dep issue in
+a fresh worktree; building core+types fixed it, unrelated to this change.)
+
+Next: PR with review in the PR body, then `afx send architect`.

--- a/packages/vscode/src/__tests__/view-issue-column.test.ts
+++ b/packages/vscode/src/__tests__/view-issue-column.test.ts
@@ -1,0 +1,53 @@
+/**
+ * #1074 — issue-preview editor-group placement.
+ *
+ * `pickIssuePreviewColumn` is the count-then-pick decision that aligns the
+ * issue preview with the builder-terminal pattern (#804): group 2 when a second
+ * editor group exists, group 1 otherwise. These tests pin that logic with the
+ * `tabGroups.all.length` input mocked to 1 or 2 (per the acceptance criterion).
+ *
+ * The end-to-end placement (built-in preview opened via `vscode.openWith` with
+ * `{ viewColumn, preserveFocus: true }`) is exercised manually — the helper is
+ * the only branch worth a unit test.
+ *
+ * `view-issue.ts` imports `vscode` and constructs an `IssueContentProvider`
+ * (which `new`s an `EventEmitter`) at module load; the minimal mock below just
+ * lets that import chain resolve and supplies the `ViewColumn` enum values the
+ * helper returns.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('vscode', () => ({
+  EventEmitter: class {
+    event = (): { dispose(): void } => ({ dispose() {} });
+    fire(): void {}
+    dispose(): void {}
+  },
+  // Mirror VS Code's enum: ViewColumn.One === 1, ViewColumn.Two === 2.
+  ViewColumn: { One: 1, Two: 2 },
+  Uri: { parse: (s: string): { toString(): string } => ({ toString: () => s }) },
+}));
+
+const { pickIssuePreviewColumn } = await import('../commands/view-issue.js');
+
+describe('pickIssuePreviewColumn', () => {
+  it('targets group 2 when a second editor group already exists', () => {
+    expect(pickIssuePreviewColumn(2)).toBe(2); // ViewColumn.Two
+  });
+
+  it('targets group 2 for any layout with two or more groups', () => {
+    expect(pickIssuePreviewColumn(3)).toBe(2);
+    expect(pickIssuePreviewColumn(5)).toBe(2);
+  });
+
+  it('falls back to group 1 when only one editor group exists', () => {
+    expect(pickIssuePreviewColumn(1)).toBe(1); // ViewColumn.One
+  });
+
+  it('falls back to group 1 for the zero-group edge (no editors open)', () => {
+    // tabGroups.all is never empty in practice, but the helper must not pick
+    // ViewColumn.Two and force a new group when there is nothing to sit beside.
+    expect(pickIssuePreviewColumn(0)).toBe(1);
+  });
+});

--- a/packages/vscode/src/commands/view-issue.ts
+++ b/packages/vscode/src/commands/view-issue.ts
@@ -76,6 +76,20 @@ function issueIdFromUri(uri: vscode.Uri): string | undefined {
   return uri.path.replace(/\.md$/, '');
 }
 
+/**
+ * Pick the editor group for the issue preview with the same count-then-pick
+ * model the builder/shell terminals use (#804, terminal-manager.ts): target
+ * group 2 when a second group already exists, else group 1. Reading layout
+ * state directly is what makes the placement deterministic — no focus
+ * side-effect, no dependence on `Beside`'s active-group-relative semantics.
+ */
+export function pickIssuePreviewColumn(groupCount: number): vscode.ViewColumn {
+  if (groupCount >= 2) {
+    return vscode.ViewColumn.Two;
+  }
+  return vscode.ViewColumn.One;
+}
+
 function renderIssue(issueId: string, issue: IssueView): string {
   const lines: string[] = [
     `# #${issueId} ${issue.title}`,
@@ -160,16 +174,29 @@ export async function viewBacklogIssue(
 
   provider.set(issueId, renderIssue(issueId, issue));
   const uri = vscode.Uri.parse(`${SCHEME}:${issueId}.md`);
-  // Render as a read-only markdown preview in editor group 2 — the same
-  // placement model as builder terminals (which target ViewColumn.Two).
+  // Render as a read-only markdown preview in editor group 2 when one exists,
+  // else group 1 — the same count-then-pick model as builder terminals (#804).
   //
-  // `markdown.showPreviewToSide` opens in ViewColumn.Beside, which is
-  // RELATIVE to the active editor group, not an absolute column. Without
-  // anchoring, the first click (sidebar focused → group 1 active) lands
-  // in group 2, but a second click while that preview is focused makes
-  // "Beside" resolve to group 3, then 4, … — a brand-new group per click.
-  // Focusing group 1 first pins "Beside" to group 2 every time, so issue
-  // previews consistently reuse a single group like the builder terminals.
-  await vscode.commands.executeCommand('workbench.action.focusFirstEditorGroup');
-  await vscode.commands.executeCommand('markdown.showPreviewToSide', uri);
+  // We open the built-in preview's custom-editor viewType via `vscode.openWith`
+  // (which accepts an explicit ViewColumn + TextDocumentShowOptions) rather than
+  // the `markdown.showPreview` / `showPreviewToSide` commands. Those commands
+  // anchor the preview to the *active* editor group and ignore any column
+  // argument, so the old code had to `focusFirstEditorGroup` first to make
+  // `Beside` resolve to group 2 — a focus side-effect that yanked the user away
+  // from wherever they were sitting and, if any caller skipped the focus step,
+  // chained previews into groups 3/4/5. Reading `tabGroups` and passing the
+  // column explicitly removes both fragilities; `preserveFocus` keeps focus on
+  // the backlog row the user clicked.
+  //
+  // The viewType `vscode.markdown.preview.editor` is VS Code's BUILT-IN markdown
+  // preview (markdown-language-features manifest), distinct from Codev's own
+  // `codev.markdownPreview` artifact canvas — so this stays on the built-in
+  // renderer and does not pre-empt #1068.
+  const viewColumn = pickIssuePreviewColumn(vscode.window.tabGroups.all.length);
+  await vscode.commands.executeCommand(
+    'vscode.openWith',
+    uri,
+    'vscode.markdown.preview.editor',
+    { viewColumn, preserveFocus: true },
+  );
 }


### PR DESCRIPTION
## Summary

Aligns the backlog **issue-preview** placement with the count-then-pick pattern the builder/shell terminals already use (`Bugfix #804`), removing the focus side-effect that `view-issue.ts` previously relied on.

The old code (`view-issue.ts:173-174`) did a two-step dance:
```ts
await vscode.commands.executeCommand('workbench.action.focusFirstEditorGroup');
await vscode.commands.executeCommand('markdown.showPreviewToSide', uri);
```
It worked only because focusing group 1 first pinned `Beside` to group 2. That stole focus from wherever the user was sitting and, if any caller skipped the focus step, chained previews into groups 3/4/5.

## Key decision: corrected API path

The issue proposed `markdown.showPreview(uri, viewColumn, preserveFocus)`. I verified against the **bundled VS Code 1.124.2** markdown extension that this command does **not** accept an explicit `viewColumn` and has **no** `preserveFocus` parameter — `ShowPreviewCommand.execute(mainUri, allUris, {locked})` hardcodes `sideBySide: false` and always opens in the *active* editor group. I surfaced this to the architect rather than coding against the wrong signature.

The architect directed the corrected approach: open the built-in preview's **custom-editor viewType** via `vscode.openWith`, which *does* accept an explicit `ViewColumn` + `TextDocumentShowOptions`:
```ts
const viewColumn = pickIssuePreviewColumn(vscode.window.tabGroups.all.length);
await vscode.commands.executeCommand(
  'vscode.openWith', uri, 'vscode.markdown.preview.editor', { viewColumn, preserveFocus: true },
);
```

- `vscode.markdown.preview.editor` is VS Code's **built-in** markdown preview (verified in the `markdown-language-features` manifest: priority `option`, selector `*.md` — our `codev-issue:<id>.md` URI matches). It is **distinct** from Codev's own `codev.markdownPreview` artifact canvas, so this stays on the built-in renderer and does **not** overlap with #1068.
- `vscode.openWith` precedent already exists in the codebase: `extension.ts:804`, `commands/view-artifact.ts:127`.

## Changes

- `commands/view-issue.ts`: drop `focusFirstEditorGroup`; add the pure helper `pickIssuePreviewColumn(groupCount)` (group 2 when `>= 2`, else group 1 — if/else, mirroring `terminal-manager.ts`); call `vscode.openWith` with an explicit column + `preserveFocus: true`.
- `src/__tests__/view-issue-column.test.ts`: unit test for the column decision logic (mocked `tabGroups.all.length` → 1/2/3/5/0), following the `diff-nav.test.ts` minimal-vscode-mock pattern.
- Cache / refresh / close-cleanup (`IssueContentProvider`, `OverviewCache.onDidChange`, `onDidCloseTextDocument`) untouched.

## Acceptance criteria

- [x] No more `workbench.action.focusFirstEditorGroup`.
- [x] Explicit `viewColumn` derived from `vscode.window.tabGroups.all.length`.
- [x] Group 2 when a second group exists; group 1 otherwise.
- [x] Focus preserved on the click origin (`preserveFocus: true`).
- [x] No group-chaining / `Beside` fragility (explicit column, not `Beside`).
- [x] Unit test for the `viewColumn` decision logic.
- [x] No regression to cache / refresh / close-cleanup.

> Note: the criterion as literally worded named `markdown.showPreview`, but that command cannot take an explicit column (verified, see above). The architect approved `vscode.openWith` + the built-in preview viewType as the correct way to satisfy the *intent* of every criterion.

## Test plan

- `pnpm check-types` — clean
- `eslint src/commands/view-issue.ts src/__tests__/view-issue-column.test.ts` — clean
- `pnpm test:unit` (full `vitest run`) — **35 files / 446 tests pass** (incl. 4 new)
- Manual (recommended at review): click a backlog row with a 2nd editor group open → preview lands in group 2, focus stays on the sidebar; repeat-click → reuses the same group (no 3/4/5 chaining); with a single group → preview lands in group 1.

Closes #1074.
