### PR TITLE
Fix #1079: pass prompts as agy --print values

### DIFF
--- a/codev/projects/bugfix-1079-consult-agy-consumes-sandbox-a/status.yaml
+++ b/codev/projects/bugfix-1079-consult-agy-consumes-sandbox-a/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1079
 title: consult-agy-consumes-sandbox-a
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-19T23:24:59.389Z'
-updated_at: '2026-06-19T23:26:32.991Z'
+updated_at: '2026-06-19T23:31:52.969Z'

--- a/codev/projects/bugfix-1079-consult-agy-consumes-sandbox-a/status.yaml
+++ b/codev/projects/bugfix-1079-consult-agy-consumes-sandbox-a/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-06-19T23:40:12.956Z'
+    approved_at: '2026-06-19T23:50:36.445Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-19T23:24:59.389Z'
-updated_at: '2026-06-19T23:40:12.956Z'
-pr_ready_for_human: true
+updated_at: '2026-06-19T23:50:36.446Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1079-consult-agy-consumes-sandbox-a/status.yaml
+++ b/codev/projects/bugfix-1079-consult-agy-consumes-sandbox-a/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-06-19T23:40:12.956Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-19T23:24:59.389Z'
-updated_at: '2026-06-19T23:31:52.969Z'
+updated_at: '2026-06-19T23:40:12.956Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1079-consult-agy-consumes-sandbox-a/status.yaml
+++ b/codev/projects/bugfix-1079-consult-agy-consumes-sandbox-a/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1079
+title: consult-agy-consumes-sandbox-a
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-06-19T23:24:59.389Z'
+updated_at: '2026-06-19T23:24:59.390Z'

--- a/codev/projects/bugfix-1079-consult-agy-consumes-sandbox-a/status.yaml
+++ b/codev/projects/bugfix-1079-consult-agy-consumes-sandbox-a/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1079
 title: consult-agy-consumes-sandbox-a
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-19T23:24:59.389Z'
-updated_at: '2026-06-19T23:24:59.390Z'
+updated_at: '2026-06-19T23:26:32.991Z'

--- a/codev/projects/bugfix-1079-consult-agy-consumes-sandbox-a/status.yaml
+++ b/codev/projects/bugfix-1079-consult-agy-consumes-sandbox-a/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1079
 title: consult-agy-consumes-sandbox-a
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,5 +13,5 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-19T23:24:59.389Z'
-updated_at: '2026-06-19T23:50:36.446Z'
+updated_at: '2026-06-19T23:50:42.333Z'
 pr_ready_for_human: false

--- a/codev/state/bugfix-1079_thread.md
+++ b/codev/state/bugfix-1079_thread.md
@@ -25,3 +25,7 @@ Verification:
 - Guarded real-agy 1.0.10 inline contract test passed and returned its unique marker.
 - Guarded real-agy file-access test passed and returned the planted file marker.
 - Built front doors returned exact markers for `-m gemini --prompt`, `-m pro --prompt`, and `-m gemini --prompt-file`.
+
+## PR
+
+Opened PR #1081. CMAP results so far: Gemini APPROVE (HIGH) and Codex APPROVE (HIGH), both with no key issues. The initially invoked globally installed Gemini lane reproduced the very bug being fixed, so the review was rerun through the freshly built local CLI and then approved. Claude consultation is blocked by the Claude Code session limit until its stated 8:30pm America/Toronto reset; architect notified. Holding before the PR gate until the required third verdict is available.

--- a/codev/state/bugfix-1079_thread.md
+++ b/codev/state/bugfix-1079_thread.md
@@ -1,0 +1,27 @@
+# Bugfix 1079 thread
+
+## Investigate
+Started BUGFIX investigation in strict mode. Issue reports `agy --print` is followed by another option, causing Antigravity CLI 1.0.10 to consume that option as the prompt.
+
+Reproduced with installed `agy` 1.0.10:
+
+- `agy --print --sandbox --print-timeout 45s 'Reply with exactly: AGY_ORDER_OK'` returned generic readiness text instead of the marker.
+- `agy --sandbox --print-timeout 45s --print 'Reply with exactly: AGY_ORDER_OK'` returned exactly `AGY_ORDER_OK`.
+- The installed `consult -m gemini --prompt 'Reply with exactly: CONSULT_GEMINI_OK'` returned empty-sandbox guidance, confirming the user-facing path is affected.
+
+Root cause confirmed at `packages/codev/src/commands/consult/index.ts`: argv begins `--print --sandbox`, so agy consumes `--sandbox` as the string value of `--print`; the folded role/query is left as a trailing positional. `packages/codev/src/commands/doctor.ts` repeats the same contract violation with `--print --print-timeout ...`. Existing unit assertions check token presence or assume the prompt is simply the final token, so they do not enforce adjacency. A guarded real-agy integration test exists but currently exercises a file-reading task rather than explicitly locking the 1.0.10 print-value contract.
+
+Scope assessment: minimal argv reordering plus focused unit/integration assertions across the two call sites; well under 300 LOC and no architecture change. BUGFIX remains appropriate.
+
+## Fix
+
+Reordered both call sites so all agy options precede the final `--print <prompt>` pair. Regression tests now assert adjacency for direct prompts, the `pro` alias, prompt files, folded role/query text, large-prompt indirection, and the doctor probe (including its `20s` timeout). Added a guarded real-agy contract test.
+
+Verification:
+
+- New unit assertions failed against the old ordering (`--sandbox` / `--print-timeout` observed as the print value), then passed after the fix.
+- `pnpm build` passed.
+- `pnpm test -- --run` passed: 166 files passed, 3 skipped; 3339 tests passed, 48 skipped.
+- Guarded real-agy 1.0.10 inline contract test passed and returned its unique marker.
+- Guarded real-agy file-access test passed and returned the planted file marker.
+- Built front doors returned exact markers for `-m gemini --prompt`, `-m pro --prompt`, and `-m gemini --prompt-file`.

--- a/codev/state/bugfix-1079_thread.md
+++ b/codev/state/bugfix-1079_thread.md
@@ -29,3 +29,5 @@ Verification:
 ## PR
 
 Opened PR #1081. CMAP results so far: Gemini APPROVE (HIGH) and Codex APPROVE (HIGH), both with no key issues. The initially invoked globally installed Gemini lane reproduced the very bug being fixed, so the review was rerun through the freshly built local CLI and then approved. Claude consultation is blocked by the Claude Code session limit until its stated 8:30pm America/Toronto reset; architect notified. Holding before the PR gate until the required third verdict is available.
+
+The architect subsequently gave explicit human authorization to bypass the unavailable Claude lane and proceed with the two recorded approvals, documenting the quota exception. All six required GitHub CI checks passed before the gate request.

--- a/packages/codev/src/__tests__/cli/agy-integration.e2e.test.ts
+++ b/packages/codev/src/__tests__/cli/agy-integration.e2e.test.ts
@@ -22,6 +22,28 @@ function isSkip(out: string): boolean {
 }
 
 describe('agy lane integration (guarded; real agy)', () => {
+  it('delivers the complete inline prompt under the agy 1.0.10 argument contract', async () => {
+    if (!resolveAgyBin()) return;
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agy-print-contract-'));
+    try {
+      const marker = `PRINT_CONTRACT_${Date.now()}`;
+      const outputPath = path.join(dir, 'review.txt');
+      await _runAgyConsultation(
+        `Reply with exactly: ${marker}`,
+        'Follow the response format exactly.',
+        dir,
+        outputPath,
+      );
+
+      const out = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, 'utf-8') : '';
+      if (isSkip(out)) return;
+      expect(out).toContain(marker);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }, 90_000);
+
   it('returns a review that used file contents, or skips non-blockingly', async () => {
     if (!resolveAgyBin()) {
       // agy CLI not installed in this environment — nothing to verify.

--- a/packages/codev/src/__tests__/consult.test.ts
+++ b/packages/codev/src/__tests__/consult.test.ts
@@ -750,7 +750,7 @@ describe('consult command', () => {
       return { consult, spawn: vi.mocked(cp.spawn) };
     }
 
-    it('invokes agy with --print --sandbox --add-dir (agentic, never the IDE/yolo)', async () => {
+    it('passes the folded consultation prompt immediately after --print', async () => {
       const { consult, spawn } = await loadAgy();
       spawn.mockClear();
 
@@ -762,6 +762,9 @@ describe('consult command', () => {
       expect(args).toContain('--print');
       expect(args).toContain('--sandbox');
       expect(args).toContain('--add-dir');
+      const printIndex = args.indexOf('--print');
+      expect(args[printIndex + 1]).toContain('review this');
+      expect(args[printIndex + 1]).toContain('Consultant Role');
       // Safety (replaces the #370 --yolo concern): never auto-approve all tools.
       expect(args).not.toContain('--dangerously-skip-permissions');
     });
@@ -793,7 +796,24 @@ describe('consult command', () => {
 
       const call = spawn.mock.calls.find(c => c[0] === agyBin);
       expect(call).toBeDefined(); // resolved to the agy backend
-      expect(call![1] as string[]).toContain('--print');
+      const args = call![1] as string[];
+      const printIndex = args.indexOf('--print');
+      expect(args[printIndex + 1]).toContain('review this');
+    });
+
+    it('passes --prompt-file contents as the value of --print', async () => {
+      const promptFile = path.join(testBaseDir, 'agy-prompt.md');
+      fs.writeFileSync(promptFile, 'PROMPT_FILE_MARKER');
+      const { consult, spawn } = await loadAgy();
+      spawn.mockClear();
+
+      await consult({ model: 'gemini', promptFile });
+
+      const call = spawn.mock.calls.find(c => c[0] === agyBin);
+      expect(call).toBeDefined();
+      const args = call![1] as string[];
+      const printIndex = args.indexOf('--print');
+      expect(args[printIndex + 1]).toContain('PROMPT_FILE_MARKER');
     });
 
     it('folds the reviewer role into the prompt (no GEMINI_SYSTEM_MD env)', async () => {
@@ -805,7 +825,7 @@ describe('consult command', () => {
       const call = spawn.mock.calls.find(c => c[0] === agyBin);
       expect(call).toBeDefined();
       const args = call![1] as string[];
-      const promptArg = args[args.length - 1];
+      const promptArg = args[args.indexOf('--print') + 1];
       expect(promptArg).toContain('UNIQUE_QUERY_MARKER'); // query inlined
       expect(promptArg).toContain('Consultant Role');     // role folded in
       const opts = call![2] as { env?: Record<string, string> };
@@ -822,7 +842,7 @@ describe('consult command', () => {
       const call = spawn.mock.calls.find(c => c[0] === agyBin);
       expect(call).toBeDefined();
       const args = call![1] as string[];
-      const promptArg = args[args.length - 1];
+      const promptArg = args[args.indexOf('--print') + 1];
       expect(promptArg).not.toContain(huge); // not inlined on argv
       expect(promptArg).toMatch(/Read the full consultation prompt from this file/);
     });

--- a/packages/codev/src/__tests__/doctor.test.ts
+++ b/packages/codev/src/__tests__/doctor.test.ts
@@ -871,6 +871,45 @@ describe('doctor command', () => {
       }
     });
 
+    it('passes the probe text immediately after --print and retains the print timeout', async () => {
+      const agyBin = path.join(testBaseDir, 'agy-fake');
+      fs.writeFileSync(agyBin, '#!/bin/sh\n');
+      process.env.CODEV_AGY_BIN = agyBin;
+
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd.includes('which')) return Buffer.from('/usr/bin/command');
+        if (cmd.includes('gh auth status')) return Buffer.from('Logged in');
+        return Buffer.from('');
+      });
+      vi.mocked(spawnSync).mockImplementation((cmd: string) => ({
+        status: 0,
+        stdout: cmd === 'node' ? 'v20.0.0' : cmd === 'git' ? 'git version 2.40.0' : 'working',
+        stderr: '',
+        signal: null,
+        output: [null, 'working', ''],
+        pid: 0,
+      }));
+      vi.mocked(spawn).mockImplementation(
+        () => makeFakeChild({ stdout: 'OK', code: 0 }) as unknown as ReturnType<typeof spawn>,
+      );
+      vi.resetModules();
+
+      try {
+        const { doctor } = await import('../commands/doctor.js');
+        await doctor();
+
+        const call = vi.mocked(spawn).mock.calls.find(c => c[0] === agyBin);
+        expect(call).toBeDefined();
+        const args = call![1] as string[];
+        const printIndex = args.indexOf('--print');
+        expect(args[printIndex + 1]).toBe('Reply with just OK');
+        expect(args.slice(0, printIndex)).toContain('--print-timeout');
+        expect(args[args.indexOf('--print-timeout') + 1]).toBe('20s');
+      } finally {
+        delete process.env.CODEV_AGY_BIN;
+      }
+    });
+
     it('should show operational when Codex login status succeeds', async () => {
       vi.mocked(execSync).mockImplementation((cmd: string) => {
         if (cmd.includes('which')) {

--- a/packages/codev/src/commands/consult/index.ts
+++ b/packages/codev/src/commands/consult/index.ts
@@ -800,9 +800,11 @@ async function runAgyConsultation(
     ].join('\n\n');
   }
 
-  const args = ['--print', '--sandbox', '--print-timeout', AGY_PRINT_TIMEOUT];
+  const args = ['--sandbox', '--print-timeout', AGY_PRINT_TIMEOUT];
   for (const d of addDirs) args.push('--add-dir', d);
-  args.push(promptArg);
+  // agy 1.0.10 defines --print as a string-valued option, so its prompt must
+  // immediately follow the flag rather than another option such as --sandbox.
+  args.push('--print', promptArg);
 
   const cleanup = () => {
     if (tempFile && fs.existsSync(tempFile)) {

--- a/packages/codev/src/commands/doctor.ts
+++ b/packages/codev/src/commands/doctor.ts
@@ -388,7 +388,7 @@ function verifyAgy(): Promise<CheckResult> {
   if (!bin) return Promise.resolve({ status: 'skip', version: 'not installed', note: AGY_INSTALL_HINT });
 
   return new Promise<CheckResult>((resolve) => {
-    const proc = spawn(bin, ['--print', '--print-timeout', '20s', 'Reply with just OK'], {
+    const proc = spawn(bin, ['--print-timeout', '20s', '--print', 'Reply with just OK'], {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     let settled = false;


### PR DESCRIPTION
## Summary

Correct Antigravity CLI argument ordering so Gemini consultations and the doctor probe deliver their intended prompts instead of option names.

Fixes #1079

## Root Cause

`agy` 1.0.10 treats `--print` as a string-valued option. Codev placed `--sandbox` or `--print-timeout` immediately after it, so those option tokens became the prompt while the real consultation/probe text was left as a trailing positional argument.

## Fix

- Place all agy options first and append the final `--print <prompt>` pair in both consultation and doctor paths.
- Assert prompt adjacency for direct prompts, `pro`, prompt files, folded structured content, large-prompt indirection, and the doctor probe.
- Add a guarded real-agy 1.0.10 contract test.

## Test Plan

- [x] Regression tests fail with the old ordering and pass with the fix
- [x] `pnpm build`
- [x] `pnpm test -- --run` (3339 passed, 48 skipped)
- [x] Guarded real-agy inline prompt and file-access tests
- [x] Built `gemini`, `pro`, and `--prompt-file` front doors return exact markers