### PR TITLE
[AIR #1072] vscode: centralise duplicated builder-lookup and file-view config reads

### DIFF
--- a/codev/projects/1072-vscode-centralise-duplicated-b/status.yaml
+++ b/codev/projects/1072-vscode-centralise-duplicated-b/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-06-20T01:12:04.059Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-20T01:01:19.275Z'
-updated_at: '2026-06-20T01:09:50.520Z'
+updated_at: '2026-06-20T01:12:04.059Z'
+pr_ready_for_human: true

--- a/codev/projects/1072-vscode-centralise-duplicated-b/status.yaml
+++ b/codev/projects/1072-vscode-centralise-duplicated-b/status.yaml
@@ -1,7 +1,7 @@
 id: '1072'
 title: vscode-centralise-duplicated-b
 protocol: air
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,5 +13,5 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-20T01:01:19.275Z'
-updated_at: '2026-06-20T01:16:52.849Z'
+updated_at: '2026-06-20T01:16:58.713Z'
 pr_ready_for_human: false

--- a/codev/projects/1072-vscode-centralise-duplicated-b/status.yaml
+++ b/codev/projects/1072-vscode-centralise-duplicated-b/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-06-20T01:12:04.059Z'
+    approved_at: '2026-06-20T01:16:52.848Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-20T01:01:19.275Z'
-updated_at: '2026-06-20T01:12:04.059Z'
-pr_ready_for_human: true
+updated_at: '2026-06-20T01:16:52.849Z'
+pr_ready_for_human: false

--- a/codev/projects/1072-vscode-centralise-duplicated-b/status.yaml
+++ b/codev/projects/1072-vscode-centralise-duplicated-b/status.yaml
@@ -1,7 +1,7 @@
 id: '1072'
 title: vscode-centralise-duplicated-b
 protocol: air
-phase: implement
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-20T01:01:19.275Z'
-updated_at: '2026-06-20T01:01:19.276Z'
+updated_at: '2026-06-20T01:09:50.520Z'

--- a/codev/projects/1072-vscode-centralise-duplicated-b/status.yaml
+++ b/codev/projects/1072-vscode-centralise-duplicated-b/status.yaml
@@ -1,0 +1,14 @@
+id: '1072'
+title: vscode-centralise-duplicated-b
+protocol: air
+phase: implement
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-06-20T01:01:19.275Z'
+updated_at: '2026-06-20T01:01:19.276Z'

--- a/codev/state/air-1072_thread.md
+++ b/codev/state/air-1072_thread.md
@@ -1,0 +1,27 @@
+# air-1072 — vscode: centralise duplicated builder-lookup and file-view config reads
+
+## Context
+AIR refactor (issue #1072). Pure refactor surfaced during PIR #1066. No behavior change.
+
+## What I did
+Two new shared modules in `packages/vscode/src/`:
+
+1. **`builder-lookup.ts`** (pure, no vscode import — testable like `builder-pick-rows.ts`)
+   - `builderById(data, id)` — replaces `builders.find(b => b.id === id)`
+   - `builderWithWorktree(data, id)` — narrows `worktreePath` to non-null string (mirrors the #1066 helper)
+   - Both accept the nullable `OverviewData` straight from `getData()` / `getOverview()`.
+   - Exported `OverviewBuilderWithWorktree` type.
+
+2. **`builders-config.ts`** — `readBuildersFileViewAsTree()`, one home for the `codev.buildersFileViewAsTree` key + `true` default. Scoped to just that key (the broader settings-module question is out of scope per the issue).
+
+### Call sites updated
+- Builder lookup: `open-worktree-window`, `run-worktree-dev`, `open-worktree-folder`, `view-artifact`, `view-diff` (command sites pass `overview`, keep their own `pickBuilder` fallback + not-found messages), `diff-nav` (uses `builderWithWorktree`), `views/builders.ts` (private wrapper now delegates).
+- Config read: `views/builders.ts` (`viewAsTree()`), `extension.ts` (dropped the local `readFileViewAsTree` const), `diff-nav.ts` (dropped local `viewAsTree()`).
+
+## Tests
+- New `__tests__/builder-lookup.test.ts` (7 cases: match / no-match / null data / worktree narrowing).
+- `pnpm test:unit` → 486 passed (was 479). `check-types` + `lint` clean.
+- Had to build workspace deps first (`codev-core`, `codev-types`, `artifact-canvas`) — pre-existing, not my changes.
+
+## Status
+Implementation + tests complete. Diff ~24 ins / 26 del across 8 files + 3 new files. Running porch to PR gate.

--- a/packages/vscode/src/__tests__/builder-lookup.test.ts
+++ b/packages/vscode/src/__tests__/builder-lookup.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for the shared builder-by-id lookup helpers (Issue #1072).
+ *
+ * `builderById` / `builderWithWorktree` replace the `builders.find(b => b.id
+ * === id)` pattern that was duplicated across six command files and
+ * `views/builders.ts`. These cover the absent-data, no-match, and
+ * worktree-narrowing paths the call sites rely on.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { OverviewBuilder, OverviewData } from '@cluesmith/codev-types';
+import { builderById, builderWithWorktree } from '../builder-lookup.js';
+
+// Only the `id` and `worktreePath` fields matter to these helpers; the rest of
+// the (large) OverviewBuilder shape is filled by the cast.
+const builder = (o: Partial<OverviewBuilder> & { id: string }): OverviewBuilder =>
+  ({ worktreePath: `.builders/${o.id}`, ...o } as OverviewBuilder);
+
+const data = (builders: OverviewBuilder[]): OverviewData =>
+  ({ builders } as OverviewData);
+
+describe('builderById', () => {
+  it('returns the builder whose id matches', () => {
+    const target = builder({ id: 'air-1072' });
+    const found = builderById(data([builder({ id: 'pir-1066' }), target]), 'air-1072');
+    expect(found).toBe(target);
+  });
+
+  it('returns undefined when no builder matches', () => {
+    expect(builderById(data([builder({ id: 'pir-1066' })]), 'air-1072')).toBeUndefined();
+  });
+
+  it('returns undefined when data is null or undefined', () => {
+    expect(builderById(null, 'air-1072')).toBeUndefined();
+    expect(builderById(undefined, 'air-1072')).toBeUndefined();
+  });
+});
+
+describe('builderWithWorktree', () => {
+  it('returns the builder when it has a worktree on record', () => {
+    const target = builder({ id: 'air-1072', worktreePath: '.builders/air-1072' });
+    const found = builderWithWorktree(data([target]), 'air-1072');
+    expect(found).toBe(target);
+    // Narrowed type: worktreePath is a plain string the caller can use directly.
+    expect(found?.worktreePath).toBe('.builders/air-1072');
+  });
+
+  it('returns undefined when the builder has no worktree', () => {
+    const target = builder({ id: 'air-1072', worktreePath: '' });
+    expect(builderWithWorktree(data([target]), 'air-1072')).toBeUndefined();
+  });
+
+  it('returns undefined when no builder matches', () => {
+    expect(builderWithWorktree(data([builder({ id: 'pir-1066' })]), 'air-1072')).toBeUndefined();
+  });
+
+  it('returns undefined when data is null', () => {
+    expect(builderWithWorktree(null, 'air-1072')).toBeUndefined();
+  });
+});

--- a/packages/vscode/src/builder-lookup.ts
+++ b/packages/vscode/src/builder-lookup.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared builder-by-id lookup over `/api/overview` data (#1072).
+ *
+ * `builders.find(b => b.id === <id>)` was repeated across six command files and
+ * `views/builders.ts`. Two variants live here so the lookup — and the
+ * worktree-narrowing cast #1066 introduced in `views/builders.ts` — exist in
+ * one place. Callers keep their own not-found handling (each surfaces a
+ * different message), so these only do the find, never the UI.
+ *
+ * Pure and dependency-light (no `vscode` import) so it can be unit-tested
+ * without a live Tower, following the `builder-pick-rows.ts` precedent.
+ */
+
+import type { OverviewBuilder, OverviewData } from '@cluesmith/codev-types';
+
+/** An `OverviewBuilder` whose `worktreePath` is known to be a non-empty string. */
+export type OverviewBuilderWithWorktree = OverviewBuilder & { worktreePath: string };
+
+/**
+ * The builder with this id, or `undefined` if `data` is absent or no builder
+ * matches. Accepts the nullable `OverviewData` straight from
+ * `OverviewCache.getData()` / `client.getOverview()` so callers needn't guard
+ * the cache read separately.
+ */
+export function builderById(
+  data: OverviewData | null | undefined,
+  id: string,
+): OverviewBuilder | undefined {
+  return data?.builders.find(b => b.id === id);
+}
+
+/**
+ * The builder with this id, but only when it has a worktree on record. The
+ * return type narrows `worktreePath` to a non-null `string`, so callers can
+ * pass it to `diffCache.getDiff` / `vscode.Uri.file` without re-guarding —
+ * mirroring the precondition the changed-file methods share in
+ * `views/builders.ts`.
+ */
+export function builderWithWorktree(
+  data: OverviewData | null | undefined,
+  id: string,
+): OverviewBuilderWithWorktree | undefined {
+  const builder = builderById(data, id);
+  if (!builder?.worktreePath) { return undefined; }
+  return builder as OverviewBuilderWithWorktree;
+}

--- a/packages/vscode/src/builders-config.ts
+++ b/packages/vscode/src/builders-config.ts
@@ -1,0 +1,24 @@
+/**
+ * Typed reader for the `codev.buildersFileViewAsTree` setting (#1072).
+ *
+ * The same key + default (`true`) was read inline in three places —
+ * `views/builders.ts`, `extension.ts`, and `commands/diff-nav.ts`. Centralising
+ * it keeps the key string and default value in one spot so they can't drift.
+ *
+ * Scope note: this package has no central config-helpers module by design —
+ * roughly ten files read `getConfiguration('codev')` inline. This reader is
+ * deliberately scoped to the one duplicated key; whether the rest should follow
+ * is a separate call (see #1072's "Out of scope").
+ */
+
+import * as vscode from 'vscode';
+
+/**
+ * Whether the Builders sidebar renders each builder's changed files as a folder
+ * tree (`true`, the default) or a flat list (`false`).
+ */
+export function readBuildersFileViewAsTree(): boolean {
+  return vscode.workspace
+    .getConfiguration('codev')
+    .get<boolean>('buildersFileViewAsTree', true);
+}

--- a/packages/vscode/src/commands/diff-nav.ts
+++ b/packages/vscode/src/commands/diff-nav.ts
@@ -29,6 +29,8 @@ import type { BuilderDiffCache, BuilderFileChange } from '../views/builder-diff-
 import { getDiffInjectEntry } from '../diff-inject-codelens.js';
 import { buildFilePathTree, flattenTreeOrder } from '../views/file-path-tree.js';
 import { openBuilderFileDiff } from './view-diff.js';
+import { builderWithWorktree } from '../builder-lookup.js';
+import { readBuildersFileViewAsTree } from '../builders-config.js';
 
 // ── Pure helpers (no vscode/git dependency — unit-tested directly) ──────────
 
@@ -48,11 +50,6 @@ export function orderedRelPaths(files: BuilderFileChange[]): string[] {
  */
 export function navigationOrder(files: BuilderFileChange[], viewAsTree: boolean): BuilderFileChange[] {
   return viewAsTree ? flattenTreeOrder(buildFilePathTree(files)) : files;
-}
-
-/** Read the Builders file-view-as-tree setting (mirrors `BuildersProvider`). */
-function viewAsTree(): boolean {
-  return vscode.workspace.getConfiguration('codev').get<boolean>('buildersFileViewAsTree', true);
 }
 
 /**
@@ -118,13 +115,12 @@ export async function navigateDiff(direction: 1 | -1, deps: NavDeps): Promise<vo
   }
 
   // 2. Resolve the worktree path for that builder (synchronous overview read).
-  const worktreePath = deps.overviewCache
-    .getData()
-    ?.builders.find(b => b.id === current.builderId)?.worktreePath;
-  if (!worktreePath) {
+  const builder = builderWithWorktree(deps.overviewCache.getData(), current.builderId);
+  if (!builder) {
     flash(`no worktree on record for ${current.builderId}`);
     return;
   }
+  const worktreePath = builder.worktreePath;
 
   // 3. Load the builder's ordered changed-file list (cached), then reorder it to
   //    match what the user sees in the Builders tree (#1066): depth-first tree
@@ -134,7 +130,7 @@ export async function navigateDiff(direction: 1 | -1, deps: NavDeps): Promise<vo
     flash('no changed files to navigate');
     return;
   }
-  const ordered = navigationOrder(result.files, viewAsTree());
+  const ordered = navigationOrder(result.files, readBuildersFileViewAsTree());
 
   // 4. Find where we are; bail if the current file isn't in this list.
   const idx = indexOfRelPath(ordered, current.relPath);

--- a/packages/vscode/src/commands/open-worktree-folder.ts
+++ b/packages/vscode/src/commands/open-worktree-folder.ts
@@ -10,6 +10,7 @@
 
 import * as vscode from 'vscode';
 import type { ConnectionManager } from '../connection-manager.js';
+import { builderById } from '../builder-lookup.js';
 
 export async function openWorktreeFolder(
   connectionManager: ConnectionManager,
@@ -30,7 +31,7 @@ export async function openWorktreeFolder(
   }
 
   const builder = builderIdArg
-    ? builders.find(b => b.id === builderIdArg)
+    ? builderById(overview, builderIdArg)
     : await pickBuilder(builders);
   if (!builder) {
     if (builderIdArg) {

--- a/packages/vscode/src/commands/open-worktree-window.ts
+++ b/packages/vscode/src/commands/open-worktree-window.ts
@@ -17,6 +17,7 @@
 
 import * as vscode from 'vscode';
 import type { ConnectionManager } from '../connection-manager.js';
+import { builderById } from '../builder-lookup.js';
 
 export async function openWorktreeWindow(
   connectionManager: ConnectionManager,
@@ -37,7 +38,7 @@ export async function openWorktreeWindow(
   }
 
   const builder = builderIdArg
-    ? builders.find(b => b.id === builderIdArg)
+    ? builderById(overview, builderIdArg)
     : await pickBuilder(builders);
   if (!builder) {
     if (builderIdArg) {

--- a/packages/vscode/src/commands/run-worktree-dev.ts
+++ b/packages/vscode/src/commands/run-worktree-dev.ts
@@ -13,6 +13,7 @@ import { resolveAgentName } from '@cluesmith/codev-core/agent-names';
 import type { ConnectionManager } from '../connection-manager.js';
 import type { TerminalManager } from '../terminal-manager.js';
 import { startDevForTarget } from './dev-shared.js';
+import { builderById } from '../builder-lookup.js';
 
 export async function runWorktreeDev(
   connectionManager: ConnectionManager,
@@ -34,7 +35,7 @@ export async function runWorktreeDev(
     return;
   }
   const builder = builderIdArg
-    ? builders.find(b => b.id === builderIdArg)
+    ? builderById(overview, builderIdArg)
     : await pickBuilder(builders);
   if (!builder) {
     if (builderIdArg) {

--- a/packages/vscode/src/commands/view-artifact.ts
+++ b/packages/vscode/src/commands/view-artifact.ts
@@ -25,6 +25,7 @@ import { resolve } from 'node:path';
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import type { ConnectionManager } from '../connection-manager.js';
 import { MarkdownPreviewProvider } from '../markdown-preview/preview-provider.js';
+import { builderById } from '../builder-lookup.js';
 
 type ArtifactKind = 'plan' | 'spec' | 'review';
 
@@ -66,7 +67,7 @@ async function viewArtifact(
   }
 
   const builder = builderIdArg
-    ? builders.find(b => b.id === builderIdArg)
+    ? builderById(overview, builderIdArg)
     : await pickBuilder(builders, kind);
   if (!builder) {
     if (builderIdArg) {

--- a/packages/vscode/src/commands/view-diff.ts
+++ b/packages/vscode/src/commands/view-diff.ts
@@ -31,6 +31,7 @@ import type { ConnectionManager } from '../connection-manager.js';
 import { parseHunkRanges, parseUnifiedDiff } from '../diff-inject-ref.js';
 import { setDiffInjectSession, upsertDiffInjectEntry, type DiffInjectSessionEntry } from '../diff-inject-codelens.js';
 import { ensureDiffEditorCodeLens } from '../ensure-diff-codelens.js';
+import { builderById } from '../builder-lookup.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -320,7 +321,7 @@ export async function viewDiff(
   }
 
   const builder = builderIdArg
-    ? builders.find(b => b.id === builderIdArg)
+    ? builderById(overview, builderIdArg)
     : await pickBuilder(builders);
   if (!builder) {
     if (builderIdArg) {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -35,6 +35,7 @@ import { BuilderSpawnHandler } from './builder-spawn-handler.js';
 import { BuilderTerminalLinkProvider, ReconnectTerminalLinkProvider } from './terminal-link-provider.js';
 import { computeBuildersToClose, roleIdsFromBuilders } from './prune-builder-terminals.js';
 import { buildBuilderPickRows } from './builder-pick-rows.js';
+import { readBuildersFileViewAsTree } from './builders-config.js';
 import { isIdleWaiting } from '@cluesmith/codev-core/builder-helpers';
 import { BuildersProvider, AccordionGate } from './views/builders.js';
 import { PullRequestsProvider, PullRequestTreeItem } from './views/pull-requests.js';
@@ -546,13 +547,11 @@ export async function activate(context: vscode.ExtensionContext) {
 	// header button / `codev.buildersFileViewAsTree`. Same mechanics as
 	// accordion above — read setting, mirror to context key, refresh
 	// provider on change so the tree redraws in the new mode.
-	const readFileViewAsTree = () =>
-		vscode.workspace.getConfiguration('codev').get<boolean>('buildersFileViewAsTree', true);
-	vscode.commands.executeCommand('setContext', 'codev.buildersFileViewAsTree', readFileViewAsTree());
+	vscode.commands.executeCommand('setContext', 'codev.buildersFileViewAsTree', readBuildersFileViewAsTree());
 	context.subscriptions.push(
 		vscode.workspace.onDidChangeConfiguration((e) => {
 			if (!e.affectsConfiguration('codev.buildersFileViewAsTree')) { return; }
-			vscode.commands.executeCommand('setContext', 'codev.buildersFileViewAsTree', readFileViewAsTree());
+			vscode.commands.executeCommand('setContext', 'codev.buildersFileViewAsTree', readBuildersFileViewAsTree());
 			buildersProvider.refresh();
 		}),
 	);

--- a/packages/vscode/src/views/builders.ts
+++ b/packages/vscode/src/views/builders.ts
@@ -5,6 +5,8 @@ import type { OverviewBuilder } from '@cluesmith/codev-types';
 import { isIdleWaiting } from '@cluesmith/codev-core/builder-helpers';
 import { UNCATEGORIZED_AREA } from '@cluesmith/codev-core/constants';
 import type { OverviewCache } from './overview-data.js';
+import { builderWithWorktree, type OverviewBuilderWithWorktree } from '../builder-lookup.js';
+import { readBuildersFileViewAsTree } from '../builders-config.js';
 import { BuilderGroupTreeItem, BuilderTreeItem } from './builder-tree-item.js';
 import { BuilderFileTreeItem } from './builder-file-tree-item.js';
 import { BuilderFolderTreeItem } from './builder-folder-tree-item.js';
@@ -189,10 +191,8 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
    * `worktreePath` to a non-null `string`, so callers can pass it to
    * `diffCache.getDiff` without re-guarding.
    */
-  private builderWithWorktree(builderId: string): (OverviewBuilder & { worktreePath: string }) | undefined {
-    const builder = this.cache.getData()?.builders.find(b => b.id === builderId);
-    if (!builder?.worktreePath) { return undefined; }
-    return builder as OverviewBuilder & { worktreePath: string };
+  private builderWithWorktree(builderId: string): OverviewBuilderWithWorktree | undefined {
+    return builderWithWorktree(this.cache.getData(), builderId);
   }
 
   private async parentForFileNode(
@@ -406,9 +406,7 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
 
   /** Read the file-view-as-tree setting; falls back to the spec default. */
   private viewAsTree(): boolean {
-    return vscode.workspace
-      .getConfiguration('codev')
-      .get<boolean>('buildersFileViewAsTree', true);
+    return readBuildersFileViewAsTree();
   }
 }
 


### PR DESCRIPTION
## Summary

Pure refactor (closes #1072). Centralises two patterns that were copy-pasted across `packages/vscode` and were deliberately left untouched in PIR #1066 to keep that PR scoped. **No behavior change** — same lookups, same config values, fewer copies.

## What changed

Two new shared modules in `packages/vscode/src/`:

1. **`builder-lookup.ts`** (pure, no `vscode` import — unit-testable like `builder-pick-rows.ts`)
   - `builderById(data, id)` — replaces the repeated `builders.find(b => b.id === id)`.
   - `builderWithWorktree(data, id)` — same lookup but narrows `worktreePath` to a non-null `string` (mirrors the helper #1066 introduced in `views/builders.ts`), so callers can use the path without re-guarding.
   - Both accept the nullable `OverviewData` straight from `OverviewCache.getData()` / `client.getOverview()`. Exports the `OverviewBuilderWithWorktree` type.

2. **`builders-config.ts`** — `readBuildersFileViewAsTree()`, a single typed reader so the `codev.buildersFileViewAsTree` key + `true` default live in one place. Deliberately scoped to just that key; whether the other ~10 inline `getConfiguration('codev')` reads should follow is left as a separate decision (per the issue's "Out of scope").

### Call sites updated

- **Builder lookup:** `commands/open-worktree-window.ts`, `commands/run-worktree-dev.ts`, `commands/open-worktree-folder.ts`, `commands/view-artifact.ts`, `commands/view-diff.ts` (command sites pass `overview` and keep their own `pickBuilder` fallback + not-found messages), `commands/diff-nav.ts` (uses `builderWithWorktree`), and `views/builders.ts` (the private `builderWithWorktree` wrapper now delegates, keeping its 4 internal callers unchanged).
- **Config read:** `views/builders.ts` (`viewAsTree()`), `extension.ts` (dropped the local `readFileViewAsTree` const), `commands/diff-nav.ts` (dropped its local `viewAsTree()`).

## Key decisions

- **Helper signature follows the issue's `builderById(overviewData, id)`** — accepts the nullable `OverviewData` rather than a pre-extracted `builders` array, so `diff-nav` / `views/builders.ts` can pass `getData()` directly. Command sites still extract `const builders = overview?.builders ?? []` for the empty-check and `pickBuilder` fallback, then call `builderById(overview, …)`.
- **`builder-lookup.ts` stays free of `vscode`** so the pure lookup logic is unit-testable without a live Tower, following the `builder-pick-rows.ts` / `prune-builder-terminals.ts` precedent.
- **Callers keep their own not-found handling** (each surfaces a different message), so the helpers only do the find.

## Test plan

- New `src/__tests__/builder-lookup.test.ts` — 7 cases covering match / no-match / null+undefined data / worktree narrowing.
- `pnpm test:unit` → **486 passed** (was 479).
- `pnpm check-types` and `pnpm lint` → clean.

## Out of scope

- Behavior changes.
- Moving the other ~10 inline `getConfiguration('codev')` reads behind a settings module (decide separately, per the issue).
