### PR TITLE
Keep agy on-task and stop no-verdict review loops (#1032, #1033)

### DIFF
--- a/packages/codev/src/commands/consult/index.ts
+++ b/packages/codev/src/commands/consult/index.ts
@@ -783,7 +783,19 @@ async function runAgyConsultation(
   }
 
   // agy has no system-prompt flag — fold the role into the prompt (hermes precedent).
-  const prompt = `${role}\n\n---\n\n${queryText}`;
+  // Prepend strict constraint directive to force agy to remain on-task, prevent exploratory actions
+  // that lead to wandering off-task, and avoid unrelated local skills/directories (Issue #1032).
+  const prependConstraints = [
+    '=== CRITICAL: READ-ONLY HEADLESS MODE ===',
+    'You are running in a non-interactive headless test harness.',
+    '1. Do NOT list directories, check git status, check permissions, or run exploratory shell commands.',
+    '2. Do NOT explore, read, or activate local skills or plugins (including google-antigravity-sdk) unless explicitly asked.',
+    '3. Focus strictly on the review/consultation query. Read ONLY the target files specified in the prompt.',
+    '4. You MUST output your response directly. If a review verdict is requested, end your response with a parseable verdict: VERDICT: APPROVE, VERDICT: REQUEST_CHANGES, or VERDICT: COMMENT.',
+    '========================================='
+  ].join('\n');
+
+  const prompt = `${prependConstraints}\n\n${role}\n\n---\n\n${queryText}`;
   // Grant the sandboxed agent read access to the workspace AND the dedicated consult
   // sandbox dir (where buildPRQuery writes the diff and, below, a large-prompt file
   // lands) — NOT the entire OS temp dir, which would over-expose unrelated /tmp files.
@@ -795,6 +807,7 @@ async function runAgyConsultation(
     tempFile = path.join(consultSandboxDir(), `codev-consult-prompt-${Date.now()}.md`);
     fs.writeFileSync(tempFile, prompt);
     promptArg = [
+      prependConstraints,
       `Read the full consultation prompt from this file: ${tempFile}`,
       'You have file access. Read files directly from disk to review code.',
     ].join('\n\n');

--- a/packages/codev/src/commands/porch/__tests__/parse-verdict.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/parse-verdict.test.ts
@@ -114,4 +114,10 @@ After addressing feedback:
 VERDICT: APPROVE`;
     expect(parseVerdict(output)).toBe('APPROVE');
   });
+
+  it('returns COMMENT when no verdict is found in a long output (ran but no verdict)', () => {
+    const output = `Review text that is long enough to pass the minimum length threshold for parsing.
+But it does not contain any VERDICT: line because the reviewer went off-task or didn't write one.`;
+    expect(parseVerdict(output)).toBe('COMMENT');
+  });
 });

--- a/packages/codev/src/commands/porch/verdict.ts
+++ b/packages/codev/src/commands/porch/verdict.ts
@@ -43,8 +43,8 @@ export function parseVerdict(output: string): Verdict {
     }
   }
 
-  // No valid VERDICT: line found — default to REQUEST_CHANGES for safety
-  return 'REQUEST_CHANGES';
+  // No valid VERDICT: line found but the consult ran — treat as COMMENT (non-blocking skip)
+  return 'COMMENT';
 }
 
 /**


### PR DESCRIPTION
## Summary

Two complementary fixes for the agy/Gemini consult lane, **recovered from in-progress local work** and rebased on top of the just-merged #1081 (agy `--print` argv ordering). #1081 ensured the prompt actually *reaches* agy; this PR addresses what agy then *does* with it.

## Changes

**1. consult: on-task headless preamble (#1032)** — `packages/codev/src/commands/consult/index.ts`
Prepends a "READ-ONLY HEADLESS MODE" constraint block to the agy prompt: don't list dirs / check git / run exploratory commands, don't activate local skills (names `google-antigravity-sdk` explicitly), read only the target files, and **end with a parseable `VERDICT:` line**. Applied on both the inline path and the large-prompt temp-file path. This targets the "latches onto the antigravity skill, emits no verdict" half of #1032 that the argv fix alone doesn't cover.

**2. porch: no-verdict → COMMENT, not REQUEST_CHANGES (#1033)** — `packages/codev/src/commands/porch/verdict.ts`
A consult that *ran* but produced no parseable `VERDICT:` line now defaults to `COMMENT` (non-blocking) instead of `REQUEST_CHANGES`. Previously a missing verdict was scored as a change-request and churned the porch review loop. Unit test added for the new COMMENT path.

## Provenance

These changes were sitting uncommitted in the `main` workspace across sessions (author unconfirmed). The working copy *also* contained an independent argv-ordering fix identical to #1081 — that redundant part was dropped during rescue, so this PR is cleanly additive on top of #1081 (verified: final `consult/index.ts` carries #1081's argv form plus this preamble).

## Verification status

- Rebased cleanly onto `main` (post-#1081); no argv overlap.
- ⚠️ **The #1032 on-task behavior is not unit-testable** — it depends on real `agy` 1.0.10 obeying the preamble. Needs a live check: run one structured `consult -m gemini --type integration pr <N>` and confirm a parseable VERDICT comes back. Recommend verifying before relying on the gemini lane in CMAPs again.
- #1033 verdict change is covered by a unit test.

## Related
- #1081 (merged) — agy `--print` argv ordering
- #1032 — agy off-task / no-verdict structured reviews
- #1033 — no-verdict results churning the porch review loop