### PR TITLE
[Bugfix #1110] Fix flaky artifact-canvas D2 watch-failure test (missing waitFor)

### DIFF
--- a/codev/projects/bugfix-1110-bugfix-artifact-canvas-test-su/status.yaml
+++ b/codev/projects/bugfix-1110-bugfix-artifact-canvas-test-su/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1110
 title: bugfix-artifact-canvas-test-su
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-28T05:52:25.996Z'
-updated_at: '2026-06-28T05:52:25.997Z'
+updated_at: '2026-06-28T05:52:58.629Z'

--- a/codev/projects/bugfix-1110-bugfix-artifact-canvas-test-su/status.yaml
+++ b/codev/projects/bugfix-1110-bugfix-artifact-canvas-test-su/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-06-28T06:00:05.286Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-28T05:52:25.996Z'
-updated_at: '2026-06-28T05:55:57.904Z'
+updated_at: '2026-06-28T06:00:05.287Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1110-bugfix-artifact-canvas-test-su/status.yaml
+++ b/codev/projects/bugfix-1110-bugfix-artifact-canvas-test-su/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1110
 title: bugfix-artifact-canvas-test-su
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-28T05:52:25.996Z'
-updated_at: '2026-06-28T05:52:58.629Z'
+updated_at: '2026-06-28T05:55:57.904Z'

--- a/codev/projects/bugfix-1110-bugfix-artifact-canvas-test-su/status.yaml
+++ b/codev/projects/bugfix-1110-bugfix-artifact-canvas-test-su/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1110
+title: bugfix-artifact-canvas-test-su
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-06-28T05:52:25.996Z'
+updated_at: '2026-06-28T05:52:25.997Z'

--- a/codev/state/bugfix-1110_thread.md
+++ b/codev/state/bugfix-1110_thread.md
@@ -1,0 +1,18 @@
+# bugfix-1110 thread
+
+## Investigate
+
+Issue #1110: flaky test `surfaces a synchronous FileAdapter.watch() failure via onError without throwing (D2)`
+in `packages/artifact-canvas/src/components/__tests__/artifact-canvas.test.tsx`.
+
+Verified root cause against source (lines 157-166):
+- Line 163: `await waitFor(() => expect(onError).toHaveBeenCalled());`
+- Line 164: bare synchronous `expect(document.querySelector('p[data-line]')).not.toBeNull();`
+
+The async `read()` render can resolve after `onError` fires; under CI load the DOM query at
+line 164 lands before the paragraph is in the tree. Race → intermittent failure.
+
+Sibling test (line 171) uses the correct pattern: `await waitFor(() => expect(...).not.toBeNull())`.
+
+Fix: wrap line 164's assertion in `waitFor`. One-line semantic-preserving change. Confirmed
+BUGFIX scope (trivial, mechanical, no production code change).

--- a/codev/state/bugfix-1110_thread.md
+++ b/codev/state/bugfix-1110_thread.md
@@ -16,3 +16,25 @@ Sibling test (line 171) uses the correct pattern: `await waitFor(() => expect(..
 
 Fix: wrap line 164's assertion in `waitFor`. One-line semantic-preserving change. Confirmed
 BUGFIX scope (trivial, mechanical, no production code change).
+
+## Fix
+
+Applied the one-line change (line 164 wrapped in `waitFor`). Verified:
+- `pnpm --filter @cluesmith/codev-artifact-canvas test` → 56/56 pass
+- D2 test stress-run 5× in isolation → 5/5 pass
+- porch checks: build ✓ (5.2s), tests ✓ (20.7s)
+Committed `[Bugfix #1110]`, advanced to PR phase.
+
+## PR
+
+PR #1111 opened (https://github.com/cluesmith/codev/pull/1111).
+Running CMAP (gemini/codex/claude) — consult needs `--issue 1110` to disambiguate
+the many projects visible in this worktree's `codev/projects/`.
+
+CMAP verdicts: gemini=APPROVE, codex=APPROVE, claude=APPROVE.
+Claude flagged the identical bare-assertion race in the sibling D2 adapter-error
+test (line 133) — the issue invited this ride-along, so applied the same waitFor
+wrap (commit 846b53dc). 56/56 pass. Posted CMAP results as PR comment.
+
+`pr` gate requested via `porch done`. Notified architect. **Waiting for human
+approval** — will merge only after `porch approve bugfix-1110 pr`.

--- a/packages/artifact-canvas/src/components/__tests__/artifact-canvas.test.tsx
+++ b/packages/artifact-canvas/src/components/__tests__/artifact-canvas.test.tsx
@@ -161,7 +161,7 @@ describe('ArtifactCanvas (Phase 3)', () => {
     const err = vi.spyOn(console, 'error').mockImplementation(() => {});
     expect(() => render(<ArtifactCanvas uri="x" {...host} onAddComment={vi.fn()} onError={onError} />)).not.toThrow();
     await waitFor(() => expect(onError).toHaveBeenCalled());
-    expect(document.querySelector('p[data-line]')).not.toBeNull(); // read succeeded → content still renders
+    await waitFor(() => expect(document.querySelector('p[data-line]')).not.toBeNull()); // read succeeded → content still renders
     err.mockRestore();
   });
 

--- a/packages/artifact-canvas/src/components/__tests__/artifact-canvas.test.tsx
+++ b/packages/artifact-canvas/src/components/__tests__/artifact-canvas.test.tsx
@@ -130,7 +130,7 @@ describe('ArtifactCanvas (Phase 3)', () => {
     const err = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<ArtifactCanvas uri="x" {...host} onAddComment={vi.fn()} onError={onError} />);
     await waitFor(() => expect(onError).toHaveBeenCalled());
-    expect(document.querySelector('p[data-line]')).not.toBeNull(); // still rendered, no throw
+    await waitFor(() => expect(document.querySelector('p[data-line]')).not.toBeNull()); // still rendered, no throw
     err.mockRestore();
   });
 


### PR DESCRIPTION
## Summary

Fixes a CI-load flake in the artifact-canvas test `surfaces a synchronous FileAdapter.watch() failure via onError without throwing (D2)`.

## Root Cause

The test awaited `onError` firing, then asserted the DOM **synchronously** on the next line:

```ts
await waitFor(() => expect(onError).toHaveBeenCalled());
expect(document.querySelector('p[data-line]')).not.toBeNull(); // bare read — race
```

`ArtifactCanvas`'s async `read()` render can resolve *after* `onError` fires. Under CI load the render is delayed enough that the synchronous DOM query runs before the paragraph is in the tree, so the assertion intermittently fails. The sibling test directly below (`Disposable.dispose is safe to call more than once`) already uses the correct `waitFor`-wrapped pattern.

## Fix

Wrap the second assertion in `waitFor` to match the sibling test's pattern:

```ts
await waitFor(() => expect(onError).toHaveBeenCalled());
await waitFor(() => expect(document.querySelector('p[data-line]')).not.toBeNull());
```

Semantics are unchanged (the assertion still must eventually hold); only the timing tolerance widens. One-line change, no production code touched.

## Test Plan

- `pnpm --filter @cluesmith/codev-artifact-canvas test` → 56/56 pass.
- Stress-ran the D2 test in isolation 5× → 5/5 pass.
- Full workspace `pnpm build` + `pnpm test` green (verified via porch checks: build ✓, tests ✓).

## Regression Coverage

This is a test-timing fix to a race, so the corrected D2 test **is** the regression coverage: with the bare synchronous read it flakes under load; with the `waitFor` wrapper it is deterministic. An additional standalone test would only re-assert the same behavior.

Fixes #1110
