### PR TITLE
[Bugfix #1113] Anchor consult --type integration diff on an integration-branch base

### DIFF
--- a/codev-skeleton/resources/commands/consult.md
+++ b/codev-skeleton/resources/commands/consult.md
@@ -66,12 +66,26 @@ consult -m codex --protocol spir --type phase
 
 # Integration review
 consult -m gemini --type integration
+
+# Integration review anchored on a long-lived integration branch (#1113)
+consult -m codex --type integration --issue 42 --base ci
 ```
 
 **Options:**
 - `--protocol <name>` — Protocol: spir, aspir, air, bugfix, maintain
 - `-t, --type <type>` — Review type: spec, plan, impl, pr, phase, integration
 - `--issue <number>` — Issue number (required from architect context)
+- `--base <ref>` — **`--type integration` only.** Anchor the diff on this base branch (e.g. `ci`), computed locally as `git diff origin/<base>...origin/<head>` (three-dot, merge-base anchored). Use in repos with a long-lived integration branch ahead of the default branch so the review sees only the PR's actual change, not the whole integration-over-trunk delta. Unresolvable refs fail loudly with a `git fetch` hint (no silent fallback to the local checkout). Defaults to config `consult.integrationBranch`; with neither set, the integration review uses the PR's host-recorded base (`gh pr diff`), unchanged.
+
+**Config (`.codev/config.json`):**
+```jsonc
+{
+  "consult": {
+    // Repo-wide default base for `--type integration` (overridden by --base).
+    "integrationBranch": "ci"
+  }
+}
+```
 
 **Context resolution:**
 - **Builder context** (cwd inside `.builders/`): auto-detects project ID, spec, plan, and PR from porch state

--- a/codev/projects/bugfix-1113-consult-type-integration-no-wa/status.yaml
+++ b/codev/projects/bugfix-1113-consult-type-integration-no-wa/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-06-29T00:44:37.929Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-29T00:07:25.656Z'
-updated_at: '2026-06-29T00:27:45.096Z'
+updated_at: '2026-06-29T00:44:37.929Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1113-consult-type-integration-no-wa/status.yaml
+++ b/codev/projects/bugfix-1113-consult-type-integration-no-wa/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1113
 title: consult-type-integration-no-wa
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-29T00:07:25.656Z'
-updated_at: '2026-06-29T00:07:25.657Z'
+updated_at: '2026-06-29T00:26:39.591Z'

--- a/codev/projects/bugfix-1113-consult-type-integration-no-wa/status.yaml
+++ b/codev/projects/bugfix-1113-consult-type-integration-no-wa/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1113
+title: consult-type-integration-no-wa
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-06-29T00:07:25.656Z'
+updated_at: '2026-06-29T00:07:25.657Z'

--- a/codev/projects/bugfix-1113-consult-type-integration-no-wa/status.yaml
+++ b/codev/projects/bugfix-1113-consult-type-integration-no-wa/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1113
 title: consult-type-integration-no-wa
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-06-29T00:07:25.656Z'
-updated_at: '2026-06-29T00:26:39.591Z'
+updated_at: '2026-06-29T00:27:45.096Z'

--- a/codev/resources/commands/consult.md
+++ b/codev/resources/commands/consult.md
@@ -66,12 +66,26 @@ consult -m codex --protocol spir --type phase
 
 # Integration review
 consult -m gemini --type integration
+
+# Integration review anchored on a long-lived integration branch (#1113)
+consult -m codex --type integration --issue 42 --base ci
 ```
 
 **Options:**
 - `--protocol <name>` — Protocol: spir, aspir, air, bugfix, maintain
 - `-t, --type <type>` — Review type: spec, plan, impl, pr, phase, integration
 - `--issue <number>` — Issue number (required from architect context)
+- `--base <ref>` — **`--type integration` only.** Anchor the diff on this base branch (e.g. `ci`), computed locally as `git diff origin/<base>...origin/<head>` (three-dot, merge-base anchored). Use in repos with a long-lived integration branch ahead of the default branch so the review sees only the PR's actual change, not the whole integration-over-trunk delta. Unresolvable refs fail loudly with a `git fetch` hint (no silent fallback to the local checkout). Defaults to config `consult.integrationBranch`; with neither set, the integration review uses the PR's host-recorded base (`gh pr diff`), unchanged.
+
+**Config (`.codev/config.json`):**
+```jsonc
+{
+  "consult": {
+    // Repo-wide default base for `--type integration` (overridden by --base).
+    "integrationBranch": "ci"
+  }
+}
+```
 
 **Context resolution:**
 - **Builder context** (cwd inside `.builders/`): auto-detects project ID, spec, plan, and PR from porch state

--- a/codev/state/bugfix-1113_thread.md
+++ b/codev/state/bugfix-1113_thread.md
@@ -82,6 +82,20 @@ Net diff ~150 LOC + 144 LOC test. Well within BUGFIX scope.
 - PR #1114, CMAP summary comment posted.
 - Final full suite: 170 files passed / 3395 tests / 0 failed. pnpm build green.
 
+## Architect feedback (round 1 on PR) — addressed
+Architect approved the core fix; asked for 2 things before the human pr gate:
+1. A test driving the actual `--type integration` command path (not just helpers).
+   → Added bugfix-1113-integration-dispatch.test.ts: drives resolveArchitectQuery →
+   resolveIntegrationBase → computeLocalPRDiff → buildPRQuery with --base ci (forge
+   stubbed, git real); asserts the query consumed the local three-dot diff (feature.txt
+   only; temp file holds real change, not the stubbed gh pr diff). Exported
+   resolveArchitectQuery. Stable across 3 runs, has teeth. Commit 00f6ecde.
+2. Document proven-vs-deferred in the PR. → PR body now has a "Proven locally vs.
+   deferred" section: diff math + wiring + fail-loud proven; the true end-to-end
+   "overflowing PR now fits + verdicts" requires an adopter repo with real
+   ci-ahead-of-main topology and was NOT run locally (close vs real repro PR after merge).
+- Full suite after change: 171 files / 3396 tests / 0 failed.
+
 ## Status
-- Phase: PR complete. Requesting `pr` gate via porch done. WAITING for human gate approval.
+- Phase: PR. Re-requesting `pr` gate. WAITING for human gate approval.
 - Do NOT self-merge: merge is gated by porch `pr` state, approved only by a human.

--- a/codev/state/bugfix-1113_thread.md
+++ b/codev/state/bugfix-1113_thread.md
@@ -1,0 +1,64 @@
+# bugfix-1113 thread
+
+## Issue
+`consult --type integration pr <N>` produces 10k+ line diffs in repos with a long-lived
+integration branch (`ci`) ahead of `main`. No way to anchor the diff on the integration branch.
+
+## Investigation (complete)
+Root cause confirmed by reading `packages/codev/src/commands/consult/index.ts`:
+- `--type integration` (builder ctx line ~1569, architect ctx line ~1740) → `buildPRQuery(prId)`
+  → `fetchPRDiff` → `pr-diff` forge concept → `gh pr diff <N>`.
+- `gh pr diff` is anchored on the PR's **host-recorded base** (merge-base of base↔head).
+  When head was branched off `ci` but PR targets `main`, the diff swallows the whole
+  `ci`-over-`main` delta.
+- The `impl` path was already hardened (#777/#784): it computes the diff locally as
+  `git diff origin/<base>...origin/<head>` (three-dot), verifying both refs up front and
+  failing loudly. The `integration` path never got this.
+
+## Fix plan (BUGFIX scope, design prescribed in issue)
+1. `--base <ref>` flag + `consult.integrationBranch` config (`.codev/config.json`).
+2. New `computeLocalPRDiff(workspaceRoot, base, head)` — mirrors impl path: fetch both,
+   verify both `origin/<ref>` resolve (fail loudly w/ `git fetch` hint), then
+   `git diff origin/<base>...origin/<head>` (three-dot) + name-only for changed files.
+   execFileSync argv arrays (ref injection-safe, same as impl path).
+3. `buildPRQuery(prId, localDiff?)` — when override present, use local diff + changed files
+   instead of `gh pr diff`; still fetch PR info+comments. Keep on-disk diff handoff.
+4. Wire both integration cases (builder: head = current branch; architect: head = pr.headRefName).
+5. Default (no flag/config) → unchanged `gh pr diff`.
+6. Guard: `--base` only valid with `--type integration` (fail-fast).
+
+## Implementation (done)
+Files changed:
+- `packages/codev/src/lib/config.ts` — added `consult.integrationBranch` to CodevConfig.
+- `packages/codev/src/commands/consult/index.ts` — `base?` option; `resolveIntegrationBase()`,
+  `computeLocalPRDiff()`; `buildPRQuery(prId, localDiff?)`; wired both integration cases
+  (builder head=current branch, architect head=pr.headRefName); fail-fast guard `--base`
+  only valid with `--type integration`; exported helpers for tests.
+- `packages/codev/src/cli.ts` — `--base <ref>` flag, passed through.
+- `codev/resources/commands/consult.md` — documented `--base` + config.
+- `packages/codev/src/__tests__/bugfix-1113-integration-base.test.ts` — regression tests
+  (8 tests: three-dot override excludes ci-over-main delta; bug demo; fail-loud on bad
+  base/head; resolveIntegrationBase precedence; --base guard).
+
+Net diff ~150 LOC + 144 LOC test. Well within BUGFIX scope.
+
+## Test status
+- New test: 8/8 pass, stable across 3 runs (no flakiness).
+- consult.test.ts + pr-query.test.ts: 58/58 pass.
+- Worktree env was incomplete on spawn (no node_modules, no skeleton/, core subpaths
+  unlinked). Ran `pnpm install` + `pnpm copy-skeleton` + `tsc`. Full-suite failures are
+  all environmental (terminal/shellper need built dist + PTY; core package subpath exports
+  unresolved) — none touch consult/config/cli. Verifying with full log.
+
+## Verification (final)
+- New regression test: 8/8 pass, stable across 3 consecutive runs.
+- Full unit suite (after `pnpm install` + building `@cluesmith/codev-core` + `tsc` dist +
+  `copy-skeleton`): **170 files passed, 3393 tests passed, 0 failed** (48 skipped).
+- Full `pnpm build`: green (types→core→artifact-canvas→codev + dashboard + skeleton).
+- The 39 transient failures seen mid-investigation were ALL environmental (worktree was
+  spawned without node_modules / built core / dist / skeleton). Building core+dist cleared
+  them; verified a sample (github, agent-names, pr-ready-872, tower-messages = 138 tests) green.
+  None touched consult/config/cli.
+
+## Status
+- Phase: investigate → fix (complete) → PR next

--- a/codev/state/bugfix-1113_thread.md
+++ b/codev/state/bugfix-1113_thread.md
@@ -60,5 +60,28 @@ Net diff ~150 LOC + 144 LOC test. Well within BUGFIX scope.
   them; verified a sample (github, agent-names, pr-ready-872, tower-messages = 138 tests) green.
   None touched consult/config/cli.
 
+## PR
+- PR #1114 opened against cluesmith/codev main (Fixes #1113).
+
+## CMAP (round 1)
+- claude: APPROVE (HIGH) — clean focused fix mirroring impl-path machinery; strong tests.
+- gemini: APPROVE (HIGH) — correct base override; solid regression suite.
+- codex: REQUEST_CHANGES (HIGH) — blanket try/catch in resolveIntegrationBase swallowed
+  loadConfig errors (malformed config / legacy af-config.json) → broken consult.integrationBranch
+  would silently revert to gh pr diff (the overflow this fix prevents). VALID finding.
+
+## CMAP resolution (2 codex findings, both valid, both addressed)
+1. Config errors swallowed: removed the try/catch in resolveIntegrationBase so loadConfig
+   errors propagate (fail-fast; matches every other caller). --base short-circuits before
+   the read → still works with a broken config. +2 tests. Commit 43507a4b.
+2. Skeleton doc not mirrored: mirrored the consult.md --base/integrationBranch section into
+   codev-skeleton/resources/commands/consult.md (two-tree rule). packages/codev/skeleton/ is a
+   gitignored build artifact. Commit 542b9048.
+
+## Final CMAP: claude=APPROVE, gemini=APPROVE, codex=APPROVE (all HIGH, codex round 3 clean)
+- PR #1114, CMAP summary comment posted.
+- Final full suite: 170 files passed / 3395 tests / 0 failed. pnpm build green.
+
 ## Status
-- Phase: investigate → fix (complete) → PR next
+- Phase: PR complete. Requesting `pr` gate via porch done. WAITING for human gate approval.
+- Do NOT self-merge: merge is gated by porch `pr` state, approved only by a human.

--- a/packages/codev/src/__tests__/bugfix-1113-integration-base.test.ts
+++ b/packages/codev/src/__tests__/bugfix-1113-integration-base.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Regression tests for #1113: `consult --type integration` had no way to anchor
+ * the diff on a long-lived integration branch ahead of the default branch, so
+ * it inherited the PR's host-recorded base (`gh pr diff`) and produced 10k+ line
+ * diffs that overflowed the reviewer.
+ *
+ * The fix adds a base override (`--base <ref>` flag / `consult.integrationBranch`
+ * config) that computes the diff locally as `git diff origin/<base>...origin/<head>`
+ * (three-dot), mirroring the hardened `--type impl` path. Default behavior (no
+ * override) is unchanged.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import {
+  _computeLocalPRDiff as computeLocalPRDiff,
+  _resolveIntegrationBase as resolveIntegrationBase,
+} from '../commands/consult/index.js';
+import { consult } from '../commands/consult/index.js';
+
+function shell(cmd: string, cwd: string): void {
+  execSync(cmd, { cwd, stdio: 'pipe' });
+}
+
+describe('#1113 computeLocalPRDiff anchors on the integration branch (three-dot)', () => {
+  let workDir: string;
+  let originDir: string;
+
+  beforeEach(() => {
+    originDir = fs.mkdtempSync(path.join(os.tmpdir(), 'b1113-origin-'));
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'b1113-work-'));
+
+    // Bare origin + a working clone (so origin/* tracking refs exist locally).
+    execSync(`git init --bare -b main "${originDir}"`, { stdio: 'pipe' });
+    execSync(`git clone "${originDir}" "${workDir}"`, { stdio: 'pipe' });
+    shell('git config user.email "test@test.com"', workDir);
+    shell('git config user.name "Test"', workDir);
+
+    // main: shared baseline.
+    fs.writeFileSync(path.join(workDir, 'shared.txt'), 'shared baseline\n');
+    shell('git add shared.txt', workDir);
+    shell('git commit -m "initial on main"', workDir);
+    shell('git push origin main', workDir);
+
+    // ci: long-lived integration branch, well ahead of main (big delta).
+    shell('git checkout -b ci', workDir);
+    fs.writeFileSync(
+      path.join(workDir, 'ci-big.txt'),
+      Array.from({ length: 500 }, (_, i) => `ci line ${i}`).join('\n') + '\n',
+    );
+    shell('git add ci-big.txt', workDir);
+    shell('git commit -m "advance ci far ahead of main"', workDir);
+    shell('git push origin ci', workDir);
+
+    // feature: branched off ci, small change. On the host the PR targets main.
+    shell('git checkout -b feature', workDir);
+    fs.writeFileSync(path.join(workDir, 'feature.txt'), 'the actual PR change\n');
+    shell('git add feature.txt', workDir);
+    shell('git commit -m "feature work"', workDir);
+    shell('git push origin feature', workDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+    fs.rmSync(originDir, { recursive: true, force: true });
+  });
+
+  it('three-dot against the integration branch yields ONLY the PR change', () => {
+    const { diff, changedFiles } = computeLocalPRDiff(workDir, 'ci', 'feature');
+    expect(changedFiles).toEqual(['feature.txt']);
+    expect(diff).toContain('the actual PR change');
+    // The ci-over-main delta — the overflow source — must be excluded.
+    expect(diff).not.toContain('ci line 0');
+    expect(diff).not.toContain('shared baseline');
+  });
+
+  it('demonstrates the bug: anchoring on main sweeps in the whole ci delta', () => {
+    // What `gh pr diff` (PR base = main) surfaces: the feature change PLUS the
+    // entire ci-over-main delta — the 10k-line overflow the issue reports.
+    const { changedFiles } = computeLocalPRDiff(workDir, 'main', 'feature');
+    expect(changedFiles).toContain('feature.txt');
+    expect(changedFiles).toContain('ci-big.txt');
+  });
+
+  it('fails loudly with a `git fetch` hint when the base ref is unresolvable', () => {
+    expect(() => computeLocalPRDiff(workDir, 'does-not-exist', 'feature')).toThrow(/git fetch/);
+  });
+
+  it('fails loudly when the head ref is unresolvable (no silent local-tree fallback)', () => {
+    expect(() => computeLocalPRDiff(workDir, 'ci', 'no-such-head')).toThrow(/git fetch/);
+  });
+});
+
+describe('#1113 resolveIntegrationBase precedence', () => {
+  let workDir: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'b1113-cfg-'));
+    // Redirect HOME so the global ~/.codev/config.json layer can't make the
+    // "no override → undefined" assertion machine-dependent (matches the
+    // isolation pattern in config.test.ts).
+    origHome = process.env.HOME;
+    process.env.HOME = path.join(workDir, 'fake-home');
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  function writeProjectConfig(config: Record<string, unknown>): void {
+    const dir = path.join(workDir, '.codev');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'config.json'), JSON.stringify(config));
+  }
+
+  it('returns undefined with no flag and no config (default → gh pr diff, unchanged)', () => {
+    writeProjectConfig({});
+    expect(resolveIntegrationBase(workDir, undefined)).toBeUndefined();
+  });
+
+  it('reads consult.integrationBranch from config when no flag is given', () => {
+    writeProjectConfig({ consult: { integrationBranch: 'ci' } });
+    expect(resolveIntegrationBase(workDir, undefined)).toBe('ci');
+  });
+
+  it('the --base flag overrides config (flag precedence)', () => {
+    writeProjectConfig({ consult: { integrationBranch: 'ci' } });
+    expect(resolveIntegrationBase(workDir, 'release-2.0')).toBe('release-2.0');
+  });
+});
+
+describe('#1113 --base is rejected outside --type integration (fail-fast)', () => {
+  it('throws when --base is used with a non-integration type', async () => {
+    await expect(
+      consult({ model: 'codex', type: 'impl', base: 'ci' }),
+    ).rejects.toThrow(/--base only applies to --type integration/);
+  });
+});

--- a/packages/codev/src/__tests__/bugfix-1113-integration-base.test.ts
+++ b/packages/codev/src/__tests__/bugfix-1113-integration-base.test.ts
@@ -133,6 +133,24 @@ describe('#1113 resolveIntegrationBase precedence', () => {
     writeProjectConfig({ consult: { integrationBranch: 'ci' } });
     expect(resolveIntegrationBase(workDir, 'release-2.0')).toBe('release-2.0');
   });
+
+  it('propagates a malformed-config error instead of silently reverting to gh pr diff', () => {
+    // CMAP (codex) finding: swallowing loadConfig errors would let a broken
+    // consult.integrationBranch quietly fall back to the host base — the exact
+    // overflow this fix prevents. The error must surface like every other
+    // loadConfig caller.
+    const dir = path.join(workDir, '.codev');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'config.json'), '{ not valid json');
+    expect(() => resolveIntegrationBase(workDir, undefined)).toThrow(/parse/i);
+  });
+
+  it('the explicit --base flag still works even with a broken config (short-circuits the read)', () => {
+    const dir = path.join(workDir, '.codev');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'config.json'), '{ not valid json');
+    expect(resolveIntegrationBase(workDir, 'ci')).toBe('ci');
+  });
 });
 
 describe('#1113 --base is rejected outside --type integration (fail-fast)', () => {

--- a/packages/codev/src/__tests__/bugfix-1113-integration-dispatch.test.ts
+++ b/packages/codev/src/__tests__/bugfix-1113-integration-dispatch.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Wiring test for #1113: drives the real `consult --type integration` dispatch
+ * (resolveArchitectQuery → resolveIntegrationBase → computeLocalPRDiff →
+ * buildPRQuery) with a base override set, and asserts the query consumed the
+ * locally-computed three-dot diff rather than `gh pr diff` (the PR's host base).
+ *
+ * The helper-level tests (bugfix-1113-integration-base.test.ts) prove the diff
+ * math in isolation; this proves the command path is actually wired to it.
+ *
+ * The forge layer (PR metadata / `gh pr diff`) is stubbed so PR info, comments,
+ * and the host-base diff are deterministic. `computeLocalPRDiff` uses real git
+ * (node:child_process, NOT forge), so the three-dot diff is computed for real
+ * against the fixture's ci-ahead-of-main topology.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+// Sentinel that only appears in the stubbed `gh pr diff` output — if it shows up
+// in the diff file the model reads, the dispatch wrongly used the host base.
+const GH_PR_DIFF_SENTINEL = 'GH_PR_DIFF_SENTINEL_must_not_be_used';
+
+vi.mock('../lib/forge.js', () => ({
+  executeForgeCommandSync: vi.fn((concept: string, env: Record<string, string>) => {
+    if (concept === 'pr-search') {
+      // findPRForIssue → PR #42, head `feature`, base `main` (the host base).
+      return [{ number: 42, headRefName: 'feature', baseRefName: 'main' }];
+    }
+    if (concept === 'pr-view') {
+      if (env?.CODEV_INCLUDE_COMMENTS) return '(No comments)';
+      return JSON.stringify({ title: 'Test PR', state: 'OPEN' });
+    }
+    if (concept === 'pr-diff') {
+      // Name-only: the ballooned host-base file set (includes ci-over-main files).
+      if (env?.CODEV_DIFF_NAME_ONLY) return ['ci-big.txt', 'feature.txt', 'shared.txt'].join('\n');
+      // Full `gh pr diff`: the host-base diff the fix must NOT use when --base is set.
+      return `diff --git a/ci-big.txt b/ci-big.txt\n+${GH_PR_DIFF_SENTINEL}\n`;
+    }
+    return '';
+  }),
+}));
+
+import { _resolveArchitectQuery as resolveArchitectQuery } from '../commands/consult/index.js';
+
+function shell(cmd: string, cwd: string): void {
+  execSync(cmd, { cwd, stdio: 'pipe' });
+}
+
+describe('#1113 integration dispatch consumes the local three-dot diff (not gh pr diff)', () => {
+  let workDir: string;
+  let originDir: string;
+
+  beforeEach(() => {
+    originDir = fs.mkdtempSync(path.join(os.tmpdir(), 'b1113-disp-origin-'));
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'b1113-disp-work-'));
+
+    execSync(`git init --bare -b main "${originDir}"`, { stdio: 'pipe' });
+    execSync(`git clone "${originDir}" "${workDir}"`, { stdio: 'pipe' });
+    shell('git config user.email "test@test.com"', workDir);
+    shell('git config user.name "Test"', workDir);
+
+    // main: baseline.
+    fs.writeFileSync(path.join(workDir, 'shared.txt'), 'shared baseline\n');
+    shell('git add shared.txt', workDir);
+    shell('git commit -m "initial on main"', workDir);
+    shell('git push origin main', workDir);
+
+    // ci: integration branch, well ahead of main.
+    shell('git checkout -b ci', workDir);
+    fs.writeFileSync(
+      path.join(workDir, 'ci-big.txt'),
+      Array.from({ length: 500 }, (_, i) => `ci line ${i}`).join('\n') + '\n',
+    );
+    shell('git add ci-big.txt', workDir);
+    shell('git commit -m "advance ci far ahead of main"', workDir);
+    shell('git push origin ci', workDir);
+
+    // feature: off ci, the actual PR change. PR #42 targets main on the host.
+    shell('git checkout -b feature', workDir);
+    fs.writeFileSync(path.join(workDir, 'feature.txt'), 'the actual PR change\n');
+    shell('git add feature.txt', workDir);
+    shell('git commit -m "feature work"', workDir);
+    shell('git push origin feature', workDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+    fs.rmSync(originDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it('--base ci anchors the diff on the integration branch end-to-end', () => {
+    const query = resolveArchitectQuery(workDir, 'integration', {
+      model: 'codex',
+      type: 'integration',
+      issue: '42',
+      base: 'ci',
+    });
+
+    // Changed-files list is the local three-dot set (feature.txt only), NOT the
+    // ballooned host-base name-only list (which also had ci-big.txt + shared.txt).
+    expect(query).toContain('## Changed Files (1)');
+    expect(query).toContain('- feature.txt');
+    expect(query).not.toContain('- ci-big.txt');
+    expect(query).not.toContain('- shared.txt');
+
+    // The diff written to disk (what the reviewer reads) is the real local
+    // three-dot diff, NOT the stubbed `gh pr diff` host-base output.
+    const m = query.match(/\*\*Diff file\*\*: `([^`]+)`/);
+    expect(m).toBeTruthy();
+    const diffOnDisk = fs.readFileSync(m![1], 'utf-8');
+    expect(diffOnDisk).toContain('the actual PR change');
+    expect(diffOnDisk).not.toContain(GH_PR_DIFF_SENTINEL);
+    expect(diffOnDisk).not.toContain('ci line 0'); // ci-over-main delta excluded
+  });
+});

--- a/packages/codev/src/cli.ts
+++ b/packages/codev/src/cli.ts
@@ -176,6 +176,7 @@ program
   .option('-t, --type <type>', 'Review type: spec, plan, impl, pr, phase, integration')
   .option('--issue <number>', 'Issue number (required from architect context)')
   .option('--branch <ref>', 'Read spec/plan artifacts from this git ref instead of the local workspace (e.g. `origin/builder/777-foo` or `builder/777-foo`). Defaults to the PR\'s head branch when --issue resolves to a PR. Note: this only changes the artifact source — for --type impl, the diff scope is always the PR\'s head→base, not the --branch ref.')
+  .option('--base <ref>', 'For --type integration: anchor the diff on this base branch (e.g. `ci`), computed locally as `git diff origin/<base>...origin/<head>` (three-dot). Use in repos with a long-lived integration branch ahead of the default branch so the review sees only the PR\'s actual change, not the whole integration-over-trunk delta. Defaults to config `consult.integrationBranch`; unset → the PR\'s host base (`gh pr diff`).')
   .option('--output <path>', 'Write consultation output to file (used by porch)')
   .option('--plan-phase <phase>', 'Scope review to a specific plan phase (used by porch)')
   .option('--context <path>', 'Context file with previous iteration feedback (used by porch)')
@@ -215,6 +216,7 @@ program
         type: options.type,
         issue: options.issue,
         branch: options.branch,
+        base: options.base,
         output: options.output,
         planPhase: options.planPhase,
         context: options.context,

--- a/packages/codev/src/commands/consult/index.ts
+++ b/packages/codev/src/commands/consult/index.ts
@@ -2033,6 +2033,7 @@ export {
   composePRQueryText as _composePRQueryText,
   computeLocalPRDiff as _computeLocalPRDiff,
   resolveIntegrationBase as _resolveIntegrationBase,
+  resolveArchitectQuery as _resolveArchitectQuery,
   computePersistentOutputPath as _computePersistentOutputPath,
   MODEL_CONFIGS as _MODEL_CONFIGS,
   MODEL_ALIASES as _MODEL_ALIASES,

--- a/packages/codev/src/commands/consult/index.ts
+++ b/packages/codev/src/commands/consult/index.ts
@@ -16,6 +16,7 @@ import { query as claudeQuery } from '@anthropic-ai/claude-agent-sdk';
 import { Codex } from '@openai/codex-sdk';
 import { readCodevFile, findWorkspaceRoot } from '../../lib/skeleton.js';
 import { resolveDefaultBranch } from '../../lib/default-branch.js';
+import { loadConfig } from '../../lib/config.js';
 import { getResolver, GitRefResolver, type ArtifactResolver } from '../porch/artifacts.js';
 import { MetricsDB } from './metrics.js';
 import { extractUsage, extractReviewText, type SDKResultLike, type UsageData } from './usage-extractor.js';
@@ -73,6 +74,11 @@ export interface ConsultOptions {
   // Defaults to the PR's headRefName when --issue resolves to a PR.
   // Closes #777 Defect A.
   branch?: string;
+  // Integration-branch override for `--type integration` (#1113). When set,
+  // the integration diff is computed locally as a three-dot diff anchored on
+  // this base (origin/<base>...origin/<head>) instead of `gh pr diff` (the
+  // PR's host-recorded base). Falls back to config `consult.integrationBranch`.
+  base?: string;
   // Porch flags
   output?: string;
   planPhase?: string;
@@ -1188,6 +1194,91 @@ KEY_ISSUES: [List of critical issues if any, or "None"]`;
 }
 
 /**
+ * Resolve the integration-branch base override for `--type integration`.
+ *
+ * Precedence: explicit `--base <ref>` flag → `consult.integrationBranch` from
+ * the merged config (.codev/config.json etc.) → undefined (default behavior,
+ * `gh pr diff`). Returns a bare branch name (e.g. `ci`), which the local-diff
+ * machinery prefixes with `origin/`. (#1113)
+ */
+function resolveIntegrationBase(workspaceRoot: string, baseOption?: string): string | undefined {
+  if (baseOption) return baseOption;
+  try {
+    return loadConfig(workspaceRoot).consult?.integrationBranch;
+  } catch {
+    // A malformed config shouldn't block the default `gh pr diff` path.
+    return undefined;
+  }
+}
+
+/**
+ * Compute the PR diff locally as a three-dot diff anchored on a base-branch
+ * override, instead of relying on the host's `gh pr diff` (which is anchored on
+ * the PR's host-recorded base). Mirrors the `--type impl` machinery: fetch both
+ * refs, verify both resolve, then `git diff origin/<base>...origin/<head>`.
+ *
+ * Three-dot (`A...B`) is `git diff $(git merge-base A B) B` — the meaningful
+ * change set, excluding commits the base branch picked up since head forked.
+ * This is what keeps the diff small in a `ci`-ahead-of-`main` topology (#1113).
+ *
+ * Fails loudly with an actionable `git fetch` hint if either ref is
+ * unresolvable — it never silently degrades to reviewing the checked-out tree
+ * (the cmap-3 degradation guarded against in the impl path). Refs are passed as
+ * single argv elements (execFileSync) so branch names with shell metacharacters
+ * can't break out (#777 cmap-3 follow-up).
+ */
+function computeLocalPRDiff(
+  workspaceRoot: string,
+  baseRef: string,
+  headRef: string,
+): { diff: string; changedFiles: string[] } {
+  // Fetch both refs so the diff has fresh local tracking refs. Fetch failures
+  // are non-fatal (a locally-cached copy may suffice) but surfaced as warnings.
+  for (const ref of [baseRef, headRef]) {
+    try {
+      execFileSync('git', ['fetch', 'origin', ref], { cwd: workspaceRoot, stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (err) {
+      const stderr = err instanceof Error && 'stderr' in err ? String((err as { stderr: unknown }).stderr).trim() : '';
+      console.error(
+        `Warning: \`git fetch origin ${ref}\` failed; proceeding with any locally-cached copy. ` +
+        `Stale refs may produce misleading diffs.` +
+        (stderr ? ` Underlying: ${stderr}` : '')
+      );
+    }
+  }
+
+  // Verify both refs resolve up front. Without this, a later `git diff` against
+  // a missing ref would fail and (in buildImplQuery's case) silently drop the
+  // reviewer into "explore the filesystem" — degrading to whatever's checked
+  // out locally. Crash explicitly with an actionable message instead.
+  try {
+    for (const ref of [baseRef, headRef]) {
+      execFileSync('git', ['rev-parse', '--verify', `origin/${ref}`], {
+        cwd: workspaceRoot,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    }
+  } catch (err) {
+    throw new Error(
+      `Cannot compute integration diff scope (origin/${baseRef}...origin/${headRef}). ` +
+      `Ensure both refs are fetched: \`git fetch origin ${baseRef} ${headRef}\`. ` +
+      `Underlying error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const range = `origin/${baseRef}...origin/${headRef}`;
+  const diff = execFileSync('git', ['diff', range], {
+    cwd: workspaceRoot,
+    encoding: 'utf-8',
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  const nameOnly = execFileSync('git', ['diff', '--name-only', range], { cwd: workspaceRoot, encoding: 'utf-8' });
+  const changedFiles = nameOnly.trim().split('\n').filter(Boolean);
+  return { diff, changedFiles };
+}
+
+/**
  * Build query for PR review.
  *
  * Writes the full PR diff to a temp file and points the model at the path
@@ -1198,10 +1289,15 @@ KEY_ISSUES: [List of critical issues if any, or "None"]`;
  *
  * The temp file is left in place for the model to read during consultation.
  * OS /tmp rotation handles cleanup.
+ *
+ * When `localDiff` is provided (the `--type integration` base-override path,
+ * #1113), its diff and changed-file list are used instead of `gh pr diff` /
+ * the host-recorded base — PR info and comments are still fetched normally.
  */
-function buildPRQuery(prId: string): string {
+function buildPRQuery(prId: string, localDiff?: { diff: string; changedFiles: string[] }): string {
   const prData = fetchPRData(prId);
-  const diff = fetchPRDiff(prId);
+  const diff = localDiff ? localDiff.diff : fetchPRDiff(prId);
+  const changedFiles = localDiff ? localDiff.changedFiles : prData.changedFiles;
 
   // Private-per-user dir to avoid world-readable /tmp diffs + symlink/clobber
   // races: consultSandboxDir() is a fresh mkdtempSync dir owned by us (and the
@@ -1217,7 +1313,7 @@ function buildPRQuery(prId: string): string {
   return composePRQueryText({
     prId,
     info: prData.info,
-    changedFiles: prData.changedFiles,
+    changedFiles,
     comments: prData.comments,
     diffPath,
     diffBytes,
@@ -1569,6 +1665,14 @@ function resolveBuilderQuery(workspaceRoot: string, type: string, options: Consu
     case 'integration': {
       const prId = findPRForCurrentBranch(workspaceRoot);
       console.error(`PR: #${prId} (integration review)`);
+      const base = resolveIntegrationBase(workspaceRoot, options.base);
+      if (base) {
+        // Head is the builder's current branch (== the PR's head by construction).
+        const headRef = execSync('git branch --show-current', { cwd: workspaceRoot, encoding: 'utf-8' }).trim();
+        console.error(`Integration base: origin/${base} (three-dot diff vs origin/${headRef})`);
+        const localDiff = computeLocalPRDiff(workspaceRoot, base, headRef);
+        return buildPRQuery(prId, localDiff);
+      }
       return buildPRQuery(prId);
     }
 
@@ -1740,6 +1844,12 @@ function resolveArchitectQuery(workspaceRoot: string, type: string, options: Con
     case 'integration': {
       const pr = findPRForIssue(workspaceRoot, issueId);
       console.error(`PR: #${pr.number} (integration review)`);
+      const base = resolveIntegrationBase(workspaceRoot, options.base);
+      if (base) {
+        console.error(`Integration base: origin/${base} (three-dot diff vs origin/${pr.headRefName})`);
+        const localDiff = computeLocalPRDiff(workspaceRoot, base, pr.headRefName);
+        return buildPRQuery(String(pr.number), localDiff);
+      }
       return buildPRQuery(String(pr.number));
     }
 
@@ -1774,6 +1884,15 @@ export async function consult(options: ConsultOptions): Promise<void> {
   // --protocol without --type
   if (options.protocol && !options.type) {
     throw new Error('--protocol requires --type. Example: consult -m gemini --protocol spir --type spec');
+  }
+
+  // --base is an integration-review-only override (#1113). Reject it on other
+  // types rather than silently ignoring it (fail-fast).
+  if (options.base && options.type !== 'integration') {
+    throw new Error(
+      '--base only applies to --type integration.\n' +
+      'It overrides the integration diff base, e.g. consult -m codex --type integration --issue 42 --base ci'
+    );
   }
 
   // Neither mode specified
@@ -1910,6 +2029,8 @@ export {
   buildPlanQuery as _buildPlanQuery,
   buildPRQuery as _buildPRQuery,
   composePRQueryText as _composePRQueryText,
+  computeLocalPRDiff as _computeLocalPRDiff,
+  resolveIntegrationBase as _resolveIntegrationBase,
   computePersistentOutputPath as _computePersistentOutputPath,
   MODEL_CONFIGS as _MODEL_CONFIGS,
   MODEL_ALIASES as _MODEL_ALIASES,

--- a/packages/codev/src/commands/consult/index.ts
+++ b/packages/codev/src/commands/consult/index.ts
@@ -1200,15 +1200,17 @@ KEY_ISSUES: [List of critical issues if any, or "None"]`;
  * the merged config (.codev/config.json etc.) → undefined (default behavior,
  * `gh pr diff`). Returns a bare branch name (e.g. `ci`), which the local-diff
  * machinery prefixes with `origin/`. (#1113)
+ *
+ * Config-load errors (malformed `.codev/config.json`, legacy `af-config.json`,
+ * invalid harness config) are NOT swallowed — they propagate, matching every
+ * other `loadConfig` caller. Swallowing them would let a broken
+ * `consult.integrationBranch` silently revert to `gh pr diff` (the overflow this
+ * fix prevents) with no signal why. The explicit `--base` flag short-circuits
+ * before the config read, so it still works even with a broken config.
  */
 function resolveIntegrationBase(workspaceRoot: string, baseOption?: string): string | undefined {
   if (baseOption) return baseOption;
-  try {
-    return loadConfig(workspaceRoot).consult?.integrationBranch;
-  } catch {
-    // A malformed config shouldn't block the default `gh pr diff` path.
-    return undefined;
-  }
+  return loadConfig(workspaceRoot).consult?.integrationBranch;
 }
 
 /**

--- a/packages/codev/src/lib/config.ts
+++ b/packages/codev/src/lib/config.ts
@@ -41,6 +41,16 @@ export interface CodevConfig {
       models?: string | string[];
     };
   };
+  consult?: {
+    /**
+     * Long-lived integration branch to anchor `consult --type integration`
+     * diffs on (e.g. `ci`). When set, integration reviews compute the diff
+     * locally as `git diff origin/<integrationBranch>...origin/<head>` instead
+     * of `gh pr diff` (the PR's host-recorded base). Overridden per-invocation
+     * by the `--base <ref>` flag. Unset → default behavior (`gh pr diff`).
+     */
+    integrationBranch?: string;
+  };
   forge?: Record<string, string | null> & { provider?: string };
   templates?: {
     dir?: string;


### PR DESCRIPTION
## Summary

`consult --type integration pr <N>` could produce a 10k+ line diff that overflows a reviewer model, in repos with a **long-lived integration branch ahead of the default branch** (e.g. a `ci` branch well ahead of `main`). The integration review had **no way to anchor the diff on the integration branch** — it always inherited the PR's host-recorded base.

This adds a base override for the integration path, reusing the verified machinery the `--type impl` path already has (#777/#784), so a `ci`-ahead-of-`main` repo can point integration reviews at `ci` and get a small, correct diff. Everyone else is unaffected.

## Root Cause

`--type integration` (both builder and architect context) → `buildPRQuery(prId)` → `fetchPRDiff` → the `pr-diff` forge concept → **`gh pr diff <N>`**. `gh pr diff` is anchored on the PR's base branch **as recorded on the host** (merge-base of base↔head). When a PR's base is the trunk (`main`) while the head was branched from an integration branch (`ci`) well ahead of trunk, "changes vs main" legitimately swallow the entire `ci`-over-`main` delta. The `impl` path was already hardened for exactly this diff-base class; the `integration` path never received that treatment.

## Fix

Give the integration path a diff-base override, mirroring the hardened `impl` path:

1. **`--base <ref>` flag + `consult.integrationBranch` config** (`.codev/config.json`). Precedence: flag → config → unset.
2. **`computeLocalPRDiff()`** — when a base override is present, fetch both refs, verify both `origin/<ref>` resolve, then compute the diff locally as **`git diff origin/<base>...origin/<head>`** (three-dot, merge-base anchored). Refs are passed as single argv elements (`execFileSync`) so branch names with shell metacharacters can't break out.
3. **Fails loudly** with an actionable `git fetch` hint if either ref is unresolvable — it never silently degrades to reviewing the checked-out tree (the cmap-3 degradation guarded against in the impl path).
4. **`buildPRQuery(prId, localDiff?)`** takes an optional local-diff override; PR info/comments are still fetched normally, and the on-disk diff-file handoff is preserved (no inlining).
5. **Default behavior unchanged**: with no flag/config, the integration review still uses `gh pr diff` (the PR's host base).
6. **Fail-fast**: `--base` is rejected outside `--type integration`. Config-load errors propagate (no silent revert to `gh pr diff`).

The local-diff path computes the diff with plain `git` (provider-agnostic), so it works for GitHub and GitLab alike without touching the `pr-diff` concept.

### Out of scope (follow-ups, per the issue)
Auto-detecting the integration branch without configuration; changing the default base; deeper GitLab-specific work.

## Test Plan

Regression suites `bugfix-1113-integration-base.test.ts` (helpers) and `bugfix-1113-integration-dispatch.test.ts` (wiring):

- **Override path (small diff)**: a git fixture with `main` → `ci` (well ahead) → `feature` (off `ci`); `computeLocalPRDiff(ci, feature)` three-dot yields **only** `feature.txt`, excluding the `ci`-over-`main` delta.
- **Bug demonstration**: anchoring on `main` sweeps in the whole `ci` delta (`ci-big.txt`) — the overflow source.
- **Command-path wiring**: drives the real `--type integration` dispatch (`resolveArchitectQuery` → `resolveIntegrationBase` → `computeLocalPRDiff` → `buildPRQuery`) with `--base ci` (forge `pr-view`/`pr-diff`/comments stubbed); asserts the query consumed the local three-dot diff (changed-file set = `feature.txt` only; the temp diff file contains the real change, **not** the stubbed `gh pr diff` output).
- **Fail-loud**: unresolvable base ref and unresolvable head ref both throw with a `git fetch` hint (no silent local-tree fallback).
- **`resolveIntegrationBase` precedence**: flag > config > undefined (no override → default `gh pr diff`, unchanged); malformed config propagates the error; `--base` works even with a broken config.
- **Guard**: `--base` rejected outside `--type integration`.

### Proven locally vs. deferred ⚠️

- **Proven here**: the diff math, the dispatch wiring (that `--type integration --base <ref>` computes and consumes the local three-dot diff rather than `gh pr diff`), the fail-loud ref checks, precedence/guard, and config error propagation. Full unit suite green (0 failures); `pnpm build` green.
- **Deferred (NOT run locally)**: the true end-to-end headline — that a *genuinely overflowing* PR now **fits** a reviewer model and returns a verdict with `--base ci`. codev itself has no `ci`-ahead-of-`main` topology, so this requires an adopter repo with the real topology. Recommend closing this against the real repro PR after merge.

Fixes #1113
