### PR TITLE
fix: Replace SSE eviction with rejection to prevent thundering herd

### DIFF
--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -143,7 +143,7 @@ export interface RouteContext {
   hasReactDashboard: boolean;
   getShellperManager: () => SessionManager | null;
   broadcastNotification: (notification: { type: string; title: string; body: string; workspace?: string }) => void;
-  addSseClient: (client: SSEClient) => void;
+  addSseClient: (client: SSEClient) => boolean;
   removeSseClient: (id: string) => void;
 }
 
@@ -1179,6 +1179,16 @@ function handleSSEEvents(
   ctx: RouteContext,
 ): void {
   const clientId = crypto.randomBytes(8).toString('hex');
+  const client: SSEClient = { res, id: clientId, connectedAt: Date.now(), maxAge: 0 };
+
+  if (!ctx.addSseClient(client)) {
+    res.writeHead(503, {
+      'Content-Type': 'application/json',
+      'Retry-After': '5',
+    });
+    res.end(JSON.stringify({ error: 'SSE capacity reached', retryAfter: 5 }));
+    return;
+  }
 
   res.writeHead(200, {
     'Content-Type': 'text/event-stream',
@@ -1186,13 +1196,8 @@ function handleSSEEvents(
     Connection: 'keep-alive',
   });
 
-  // Send initial connection event
   res.write(`data: ${JSON.stringify({ type: 'connected', id: clientId })}\n\n`);
-
-  const client: SSEClient = { res, id: clientId, connectedAt: Date.now() };
-  ctx.addSseClient(client);
-
-  ctx.log('INFO', `SSE client connected: ${clientId}`);
+  res.write('retry: 5000\n\n');
 
   // Clean up on disconnect — guard against duplicate cleanup (Bugfix #580)
   let cleaned = false;
@@ -1200,7 +1205,6 @@ function handleSSEEvents(
     if (cleaned) return;
     cleaned = true;
     ctx.removeSseClient(clientId);
-    ctx.log('INFO', `SSE client disconnected: ${clientId}`);
   };
   req.on('close', cleanup);
   res.on('close', cleanup);

--- a/packages/codev/src/agent-farm/servers/tower-server.ts
+++ b/packages/codev/src/agent-farm/servers/tower-server.ts
@@ -243,6 +243,7 @@ function broadcastNotification(notification: { type: string; title: string; body
 // tunnel-proxied clients that don't properly close (clients auto-reconnect).
 const SSE_HEARTBEAT_INTERVAL_MS = 30_000;
 const SSE_MAX_AGE_MS = 5 * 60_000; // 5 minutes
+const SSE_MAX_AGE_JITTER_MS = 60_000; // ±1 min jitter → 4–6 min range
 const sseHeartbeatInterval = setInterval(() => {
   if (sseClients.length === 0) return;
   const now = Date.now();
@@ -252,9 +253,7 @@ const sseHeartbeatInterval = setInterval(() => {
       deadIds.push(client.id);
       continue;
     }
-    // Evict connections older than max-age — tunnel-proxied SSE connections
-    // can leak because both ends are localhost and TCP never detects the close.
-    if (now - client.connectedAt > SSE_MAX_AGE_MS) {
+    if (now - client.connectedAt > client.maxAge) {
       try { client.res.end(); } catch { /* already dead */ }
       deadIds.push(client.id);
       continue;
@@ -318,19 +317,14 @@ const routeCtx: RouteContext = {
   hasReactDashboard,
   getShellperManager: () => shellperManager,
   broadcastNotification,
-  addSseClient: (client: SSEClient) => {
-    // Hard cap: evict oldest connections when over limit to prevent
-    // unbounded accumulation (tunnel-proxied EventSource reconnects
-    // can leak because TCP close doesn't propagate reliably).
-    const SSE_MAX_CLIENTS = 50;
-    while (sseClients.length >= SSE_MAX_CLIENTS) {
-      const oldest = sseClients.shift();
-      if (oldest) {
-        try { oldest.res.end(); } catch { /* already dead */ }
-        log('WARN', `SSE cap reached (${SSE_MAX_CLIENTS}), evicted oldest client: ${oldest.id}`);
-      }
+  addSseClient: (client: SSEClient): boolean => {
+    const SSE_MAX_CLIENTS = 200;
+    if (sseClients.length >= SSE_MAX_CLIENTS) {
+      return false;
     }
+    client.maxAge = SSE_MAX_AGE_MS + Math.floor(Math.random() * 2 * SSE_MAX_AGE_JITTER_MS) - SSE_MAX_AGE_JITTER_MS;
     sseClients.push(client);
+    return true;
   },
   removeSseClient: (id: string) => {
     const index = sseClients.findIndex(c => c.id === id);

--- a/packages/codev/src/agent-farm/servers/tower-types.ts
+++ b/packages/codev/src/agent-farm/servers/tower-types.ts
@@ -50,6 +50,8 @@ export interface SSEClient {
   res: http.ServerResponse;
   id: string;
   connectedAt: number;
+  /** Per-client max-age with jitter to prevent synchronized eviction bursts */
+  maxAge: number;
 }
 
 /** Rate limiting entry for activation requests */


### PR DESCRIPTION
## Summary

- Replace evict-on-cap with reject-on-cap (503 + `Retry-After: 5`) to break the SSE reconnection cascade
- Raise `SSE_MAX_CLIENTS` from 50 to 200
- Add per-client max-age jitter (4–6 min range) to prevent synchronized eviction bursts after Tower restarts
- Send `retry: 5000` SSE directive to space out browser reconnections
- Remove per-connection INFO-level connect/disconnect logging (heartbeat every 30s is sufficient)

## Problem

When SSE client count exceeded the cap of 50, the oldest client was evicted (`sseClients.shift()` + `res.end()`). The evicted client auto-reconnected, pushing the count back to the cap, evicting another — creating a thundering herd loop at up to 800 conn/sec. Each short-lived TCP connection left a `TIME_WAIT` socket for ~60s, accumulating 2,900+ sockets and consuming ~10% of the ephemeral port range, causing intermittent `EADDRNOTAVAIL` for all localhost services.

Fixes #1124

## Test plan

- [ ] Connect 200 SSE clients → 201st receives `503` with `Retry-After: 5` (no eviction of existing clients)
- [ ] Verify `TIME_WAIT` sockets stay under 100 during normal operation: `ss -tn state time-wait dst 127.0.0.1:4100 | wc -l`
- [ ] Verify heartbeat logs show stable client count (no churn): `tail -f ~/.agent-farm/tower.log | grep 'SSE heartbeat'`
- [ ] Dashboard, VSCode, and terminal SSE connections work normally
- [ ] Start 10 clients simultaneously → they expire over a 2-minute window (jitter), not all at once

🤖 Generated with [Claude Code](https://claude.com/claude-code)