### PR TITLE
Fix SSE thundering herd causing ephemeral port exhaustion

### DIFF
--- a/codev/projects/bugfix-1124-tower-sse-thundering-herd-caus/status.yaml
+++ b/codev/projects/bugfix-1124-tower-sse-thundering-herd-caus/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1124
+title: tower-sse-thundering-herd-caus
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-01T01:22:39.407Z'
+updated_at: '2026-07-01T01:22:39.408Z'

--- a/codev/projects/bugfix-1124-tower-sse-thundering-herd-caus/status.yaml
+++ b/codev/projects/bugfix-1124-tower-sse-thundering-herd-caus/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1124
 title: tower-sse-thundering-herd-caus
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-01T01:22:39.407Z'
-updated_at: '2026-07-01T01:22:39.408Z'
+updated_at: '2026-07-01T01:24:38.461Z'

--- a/codev/projects/bugfix-1124-tower-sse-thundering-herd-caus/status.yaml
+++ b/codev/projects/bugfix-1124-tower-sse-thundering-herd-caus/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1124
 title: tower-sse-thundering-herd-caus
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-01T01:22:39.407Z'
-updated_at: '2026-07-01T01:24:38.461Z'
+updated_at: '2026-07-01T01:35:15.992Z'

--- a/codev/state/bugfix-1124_thread.md
+++ b/codev/state/bugfix-1124_thread.md
@@ -28,3 +28,9 @@ Three regression tests added to tower-routes.test.ts:
 - No cleanup listeners registered after rejection
 
 All 87 tower-routes tests pass. Build passes.
+
+## CMAP review — Gemini finding addressed
+
+Gemini identified that browser `EventSource` transitions to `CLOSED` (readyState === 2) on a non-200 response (our 503) and does NOT auto-reconnect. The dashboard's `useSSE.ts` hook assumed auto-reconnect on all errors. Fixed by adding manual reconnection with 2-5s jitter when `readyState === EventSource.CLOSED`. VSCode extension and legacy `tower.html` already use fetch-based SSE with their own retry logic — no change needed there.
+
+Added regression test in `useSSE.reconnect.test.ts`. All 6 dashboard SSE tests pass.

--- a/codev/state/bugfix-1124_thread.md
+++ b/codev/state/bugfix-1124_thread.md
@@ -1,0 +1,30 @@
+# bugfix-1124 thread — SSE thundering herd / ephemeral port exhaustion
+
+## Investigate phase started
+
+Issue #1124: Tower SSE endpoint evicts oldest client when at cap (50), causing a reconnect cascade that exhausts ephemeral ports via TIME_WAIT accumulation.
+
+Reading the four code locations identified in the issue to confirm root cause.
+
+Root cause confirmed across all five vectors. Bug fits BUGFIX scope (< 300 LOC).
+
+## Fix phase
+
+Five changes applied:
+
+1. **Reject instead of evict** (tower-server.ts `addSseClient`): Returns `false` at cap instead of `sseClients.shift()` + `res.end()`. The handler (tower-routes.ts `handleSSEEvents`) now checks the return value and responds 503 + `Retry-After: 5` before writing SSE headers. Rejection is a dead end; eviction was a chain reaction.
+
+2. **Cap raised 50 → 200**: SSE connections are lightweight (one open response per client). 50 was too low for workstations with many builders + dashboard tabs.
+
+3. **`retry: 5000` SSE directive**: Sent immediately after SSE connection setup. Browsers respect this field and wait 5 seconds before reconnecting, reducing churn.
+
+4. **Logging throttled**: Removed per-client connect/disconnect INFO logs. Heartbeat log also removed (the heartbeat still runs for dead-client detection and max-age eviction, just doesn't log every 30s cycle).
+
+5. **Jitter on max-age eviction**: `SSEClient.maxAgeJitterMs` field assigned randomly in [-60s, +60s] at connect time. The heartbeat interval uses `SSE_MAX_AGE_BASE_MS + client.maxAgeJitterMs` instead of a fixed 5-minute cutoff. Prevents synchronized eviction bursts.
+
+Three regression tests added to tower-routes.test.ts:
+- 503 rejection when addSseClient returns false
+- `retry: 5000` directive present in SSE stream
+- No cleanup listeners registered after rejection
+
+All 87 tower-routes tests pass. Build passes.

--- a/packages/codev/src/agent-farm/__tests__/tower-routes.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tower-routes.test.ts
@@ -138,7 +138,7 @@ function makeCtx(overrides: Partial<RouteContext> = {}): RouteContext {
     hasReactDashboard: false,
     getShellperManager: () => null,
     broadcastNotification: vi.fn(),
-    addSseClient: vi.fn(),
+    addSseClient: vi.fn(() => true),
     removeSseClient: vi.fn(),
     ...overrides,
   };
@@ -418,6 +418,41 @@ describe('tower-routes', () => {
 
       // Should only clean up once despite three events
       expect(ctx.removeSseClient).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns 503 when addSseClient rejects at capacity (Bugfix #1124)', async () => {
+      const ctx = makeCtx({ addSseClient: vi.fn(() => false) });
+      const req = makeReq('GET', '/api/events');
+      const { res, statusCode, headers, body } = makeRes();
+
+      await handleRequest(req, res, ctx);
+
+      expect(statusCode()).toBe(503);
+      expect(headers()['Retry-After']).toBe('5');
+      expect(body()).toContain('capacity');
+      expect(ctx.removeSseClient).not.toHaveBeenCalled();
+    });
+
+    it('sends retry directive to space out reconnections (Bugfix #1124)', async () => {
+      const ctx = makeCtx();
+      const req = makeReq('GET', '/api/events');
+      const { res, body } = makeRes();
+
+      await handleRequest(req, res, ctx);
+
+      expect(body()).toContain('retry: 5000');
+    });
+
+    it('does not register cleanup listeners when rejected (Bugfix #1124)', async () => {
+      const ctx = makeCtx({ addSseClient: vi.fn(() => false) });
+      const req = makeReq('GET', '/api/events');
+      const { res } = makeRes();
+
+      await handleRequest(req, res, ctx);
+
+      // After rejection, close events should not call removeSseClient
+      req.emit('close');
+      expect(ctx.removeSseClient).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -143,7 +143,7 @@ export interface RouteContext {
   hasReactDashboard: boolean;
   getShellperManager: () => SessionManager | null;
   broadcastNotification: (notification: { type: string; title: string; body: string; workspace?: string }) => void;
-  addSseClient: (client: SSEClient) => void;
+  addSseClient: (client: SSEClient) => boolean;
   removeSseClient: (id: string) => void;
 }
 
@@ -1180,19 +1180,33 @@ function handleSSEEvents(
 ): void {
   const clientId = crypto.randomBytes(8).toString('hex');
 
+  // Bugfix #1124: check capacity BEFORE writing 200 headers.
+  // Once headers are sent the client thinks it's connected; rejecting
+  // pre-headers lets us return 503 + Retry-After, which is a dead end
+  // (no reconnect cascade).
+  const client: SSEClient = { res, id: clientId, connectedAt: Date.now() };
+  const accepted = ctx.addSseClient(client);
+  if (!accepted) {
+    res.writeHead(503, {
+      'Content-Type': 'text/plain',
+      'Retry-After': '5',
+    });
+    res.end('SSE capacity reached. Retry later.\n');
+    return;
+  }
+
   res.writeHead(200, {
     'Content-Type': 'text/event-stream',
     'Cache-Control': 'no-cache',
     Connection: 'keep-alive',
   });
 
+  // Bugfix #1124: send retry directive to space out browser reconnections.
+  // Without this, browsers default to ~3s which amplifies churn.
+  res.write('retry: 5000\n\n');
+
   // Send initial connection event
   res.write(`data: ${JSON.stringify({ type: 'connected', id: clientId })}\n\n`);
-
-  const client: SSEClient = { res, id: clientId, connectedAt: Date.now() };
-  ctx.addSseClient(client);
-
-  ctx.log('INFO', `SSE client connected: ${clientId}`);
 
   // Clean up on disconnect — guard against duplicate cleanup (Bugfix #580)
   let cleaned = false;
@@ -1200,7 +1214,6 @@ function handleSSEEvents(
     if (cleaned) return;
     cleaned = true;
     ctx.removeSseClient(clientId);
-    ctx.log('INFO', `SSE client disconnected: ${clientId}`);
   };
   req.on('close', cleanup);
   res.on('close', cleanup);

--- a/packages/codev/src/agent-farm/servers/tower-server.ts
+++ b/packages/codev/src/agent-farm/servers/tower-server.ts
@@ -242,7 +242,8 @@ function broadcastNotification(notification: { type: string; title: string; body
 // Also evicts connections older than max-age to prevent leaks from
 // tunnel-proxied clients that don't properly close (clients auto-reconnect).
 const SSE_HEARTBEAT_INTERVAL_MS = 30_000;
-const SSE_MAX_AGE_MS = 5 * 60_000; // 5 minutes
+const SSE_MAX_AGE_BASE_MS = 5 * 60_000; // 5 minutes base
+const SSE_MAX_AGE_JITTER_MS = 60_000;    // ±1 minute jitter (Bugfix #1124)
 const sseHeartbeatInterval = setInterval(() => {
   if (sseClients.length === 0) return;
   const now = Date.now();
@@ -252,9 +253,11 @@ const sseHeartbeatInterval = setInterval(() => {
       deadIds.push(client.id);
       continue;
     }
-    // Evict connections older than max-age — tunnel-proxied SSE connections
-    // can leak because both ends are localhost and TCP never detects the close.
-    if (now - client.connectedAt > SSE_MAX_AGE_MS) {
+    // Bugfix #1124: per-client jitter prevents synchronized eviction bursts.
+    // Each client gets a max-age in the range [4min, 6min] instead of a
+    // fixed 5 minutes, so evictions are spread over a 2-minute window.
+    const maxAge = SSE_MAX_AGE_BASE_MS + (client.maxAgeJitterMs ?? 0);
+    if (now - client.connectedAt > maxAge) {
       try { client.res.end(); } catch { /* already dead */ }
       deadIds.push(client.id);
       continue;
@@ -266,9 +269,6 @@ const sseHeartbeatInterval = setInterval(() => {
     }
   }
   if (deadIds.length > 0) removeDeadSseClients(deadIds);
-  if (sseClients.length > 0) {
-    log('INFO', `SSE heartbeat: ${sseClients.length} active client(s)`);
-  }
 }, SSE_HEARTBEAT_INTERVAL_MS);
 sseHeartbeatInterval.unref();
 
@@ -319,18 +319,19 @@ const routeCtx: RouteContext = {
   getShellperManager: () => shellperManager,
   broadcastNotification,
   addSseClient: (client: SSEClient) => {
-    // Hard cap: evict oldest connections when over limit to prevent
-    // unbounded accumulation (tunnel-proxied EventSource reconnects
-    // can leak because TCP close doesn't propagate reliably).
-    const SSE_MAX_CLIENTS = 50;
-    while (sseClients.length >= SSE_MAX_CLIENTS) {
-      const oldest = sseClients.shift();
-      if (oldest) {
-        try { oldest.res.end(); } catch { /* already dead */ }
-        log('WARN', `SSE cap reached (${SSE_MAX_CLIENTS}), evicted oldest client: ${oldest.id}`);
-      }
+    // Bugfix #1124: reject instead of evict to prevent thundering herd.
+    // Eviction causes the evicted client to reconnect, which pushes the
+    // count back to the cap and evicts another — a chain reaction that
+    // exhausts ephemeral ports via TIME_WAIT accumulation.
+    const SSE_MAX_CLIENTS = 200;
+    if (sseClients.length >= SSE_MAX_CLIENTS) {
+      log('WARN', `SSE cap reached (${SSE_MAX_CLIENTS}), rejecting client: ${client.id}`);
+      return false;
     }
+    // Bugfix #1124: assign per-client jitter for max-age eviction
+    client.maxAgeJitterMs = Math.floor(Math.random() * SSE_MAX_AGE_JITTER_MS * 2) - SSE_MAX_AGE_JITTER_MS;
     sseClients.push(client);
+    return true;
   },
   removeSseClient: (id: string) => {
     const index = sseClients.findIndex(c => c.id === id);

--- a/packages/codev/src/agent-farm/servers/tower-types.ts
+++ b/packages/codev/src/agent-farm/servers/tower-types.ts
@@ -50,6 +50,8 @@ export interface SSEClient {
   res: http.ServerResponse;
   id: string;
   connectedAt: number;
+  /** Bugfix #1124: per-client jitter for max-age eviction (ms, range [-JITTER, +JITTER]) */
+  maxAgeJitterMs?: number;
 }
 
 /** Rate limiting entry for activation requests */

--- a/packages/dashboard/__tests__/useSSE.reconnect.test.ts
+++ b/packages/dashboard/__tests__/useSSE.reconnect.test.ts
@@ -13,11 +13,14 @@ import type { DashboardState, OverviewData } from '../src/lib/api.js';
 let eventSourceInstances: Array<{ onmessage: ((ev: MessageEvent) => void) | null; close: () => void }> = [];
 
 class MockEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
   onmessage: ((ev: MessageEvent) => void) | null = null;
   onerror: ((ev: Event) => void) | null = null;
   onopen: ((ev: Event) => void) | null = null;
   readyState = 1;
-  close = vi.fn();
+  close = vi.fn(() => { this.readyState = MockEventSource.CLOSED; });
   constructor(_url: string) {
     eventSourceInstances.push(this);
   }
@@ -174,6 +177,37 @@ describe('SSE reconnect triggers immediate refresh (bugfix #472)', () => {
     });
 
     expect(eventSourceInstances.length).toBeGreaterThan(baseCount);
+    unmount();
+  });
+
+  it('schedules reconnect when EventSource enters CLOSED state (Bugfix #1124)', async () => {
+    const { useSSE } = await import('../src/hooks/useSSE.js');
+    const listener = vi.fn();
+    const { unmount } = renderHook(() => useSSE(listener));
+
+    const baseCount = eventSourceInstances.length;
+    expect(baseCount).toBeGreaterThanOrEqual(1);
+    const currentES = eventSourceInstances[baseCount - 1] as MockEventSource;
+
+    // Simulate a 503 rejection: EventSource transitions to CLOSED
+    currentES.readyState = MockEventSource.CLOSED;
+    act(() => {
+      if (currentES.onerror) {
+        currentES.onerror(new Event('error'));
+      }
+    });
+
+    // Should have disconnected the dead EventSource
+    expect(currentES.close).toHaveBeenCalled();
+
+    // Advance past the jittered reconnect window (max 5s)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6000);
+    });
+
+    // Should have reconnected (new EventSource instance)
+    expect(eventSourceInstances.length).toBeGreaterThan(baseCount);
+
     unmount();
   });
 

--- a/packages/dashboard/src/hooks/useSSE.ts
+++ b/packages/dashboard/src/hooks/useSSE.ts
@@ -21,6 +21,7 @@ type Listener = () => void;
 let eventSource: EventSource | null = null;
 const listeners = new Set<Listener>();
 let visibilityListenerInstalled = false;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
 function notify(): void {
   for (const fn of listeners) fn();
@@ -32,11 +33,30 @@ function connect(): void {
   eventSource = new EventSource(getSSEEventsUrl());
   eventSource.onmessage = () => notify();
   eventSource.onerror = () => {
-    // EventSource automatically reconnects on error; no action needed.
+    // Bugfix #1124: EventSource auto-reconnects after a successful 200 stream
+    // drops, but transitions to CLOSED (readyState === 2) on a non-200
+    // response (e.g. 503 at capacity). Schedule a manual retry with jitter.
+    if (eventSource && eventSource.readyState === EventSource.CLOSED) {
+      disconnect();
+      scheduleReconnect();
+    }
   };
 }
 
+function scheduleReconnect(): void {
+  if (reconnectTimer || listeners.size === 0) return;
+  const jitter = 2000 + Math.floor(Math.random() * 3000); // 2-5s
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    connect();
+  }, jitter);
+}
+
 function disconnect(): void {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
   if (eventSource) {
     eventSource.close();
     eventSource = null;


### PR DESCRIPTION
## Summary

- Replace evict-on-cap with reject-on-cap (503 + `Retry-After: 5`) to break the reconnect cascade
- Raise `SSE_MAX_CLIENTS` from 50 to 200
- Send `retry: 5000` SSE directive to space out browser reconnections
- Add per-client jitter (±1 min) to max-age eviction to prevent synchronized eviction bursts
- Remove per-client connect/disconnect INFO logging (774K lines in 2.5 days)

## Root Cause

The SSE endpoint evicts the oldest client when at cap (50). The evicted client auto-reconnects, pushing count back to cap, evicting another — a chain reaction at up to ~800 connections/second. Each short-lived TCP connection leaves a TIME_WAIT socket for ~60s, accumulating 2,900+ sockets and consuming ~10% of the ephemeral port range.

## Fix

**Reject instead of evict**: Return 503 + Retry-After when at capacity. Rejection is a dead end; eviction was a chain reaction.

**Raise cap**: 50 → 200. SSE connections are lightweight; 50 was too low for workstations with multiple builders + dashboard tabs + VSCode.

**Retry directive**: `retry: 5000` tells browsers to wait 5s before reconnecting instead of the default ~3s.

**Jitter**: Per-client `maxAgeJitterMs` in [-60s, +60s] prevents synchronized max-age eviction bursts.

**Logging**: Removed per-client connect/disconnect logs. Heartbeat still runs for dead-client detection.

## Test Plan

- [x] 3 regression tests added to `tower-routes.test.ts`
  - 503 rejection when at capacity (verifies status code, Retry-After header, body)
  - `retry: 5000` directive present in SSE stream
  - No cleanup listeners registered after rejection
- [x] All 87 tower-routes tests pass
- [x] Build passes
- [x] Net diff: 76 insertions, 25 deletions (well under 300 LOC guideline)

Fixes #1124