### PR TITLE
[Bugfix #1122] Align editor Comments-API review-comment write to append (markerAppendLine)

### DIFF
--- a/codev/projects/bugfix-1122-vscode-align-editor-comments-a/status.yaml
+++ b/codev/projects/bugfix-1122-vscode-align-editor-comments-a/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1122
 title: vscode-align-editor-comments-a
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-01T23:26:06.527Z'
-updated_at: '2026-07-01T23:27:42.045Z'
+updated_at: '2026-07-01T23:36:02.914Z'

--- a/codev/projects/bugfix-1122-vscode-align-editor-comments-a/status.yaml
+++ b/codev/projects/bugfix-1122-vscode-align-editor-comments-a/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1122
+title: vscode-align-editor-comments-a
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-01T23:26:06.527Z'
+updated_at: '2026-07-01T23:26:06.528Z'

--- a/codev/projects/bugfix-1122-vscode-align-editor-comments-a/status.yaml
+++ b/codev/projects/bugfix-1122-vscode-align-editor-comments-a/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1122
 title: vscode-align-editor-comments-a
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-01T23:26:06.527Z'
-updated_at: '2026-07-01T23:26:06.528Z'
+updated_at: '2026-07-01T23:27:42.045Z'

--- a/codev/projects/bugfix-1122-vscode-align-editor-comments-a/status.yaml
+++ b/codev/projects/bugfix-1122-vscode-align-editor-comments-a/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-07-01T23:38:49.596Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-01T23:26:06.527Z'
-updated_at: '2026-07-01T23:36:02.914Z'
+updated_at: '2026-07-01T23:38:49.597Z'
+pr_ready_for_human: true

--- a/codev/state/bugfix-1122_thread.md
+++ b/codev/state/bugfix-1122_thread.md
@@ -42,3 +42,25 @@ Lesson: NEVER `git stash pop` in a worktree that carries a foreign pre-existing
 stash — a bare pop targets `stash@{0}` regardless of intent. Use explicit file
 backups (cp to /tmp) instead of stash for temporary set-aside, which is what I
 should have done from the start.
+
+## PR
+
+- PR #1130 opened against main (Fixes #1122). Branch pushed, in sync with origin.
+- CMAP (gemini/codex/claude, --type pr --issue 1122) running in background.
+- `afx send architect` FAILED: "Workspace: not active in tower" / cannot resolve
+  canonical builder id (#1094). This worktree isn't registered in Tower's state,
+  so builder→architect messaging is down. Not fixing from the worktree (afx
+  tower/workspace commands must run from the main root). Architect can see PR
+  #1130 on GitHub; will retry `afx send` if the workspace gets activated.
+- STASH HEADS-UP for architect (since messaging is down): stash@{0} (GitHub
+  Desktop, on main) is intact and was never dropped — see the Incident section
+  above. No action needed; flagging for transparency.
+
+## CMAP verdicts (PR #1130)
+
+- Gemini: SKIPPED (agy unavailable/unauthenticated — non-blocking).
+- Codex: APPROVE, no key issues.
+- Claude: APPROVE (HIGH), no key issues; confirmed the regression test fails under
+  the old `markerInsertionLine` behaviour and parity with the preview composer.
+- No REQUEST_CHANGES, no new defects. Posted summary as a PR comment.
+- Next: `porch done bugfix-1122` to request the `pr` gate, then STOP for human approval.

--- a/codev/state/bugfix-1122_thread.md
+++ b/codev/state/bugfix-1122_thread.md
@@ -1,0 +1,44 @@
+# bugfix-1122 thread
+
+Issue #1122 — vscode: align editor Comments-API review-comment write to append (`markerAppendLine`) for parity with the preview composer (#1107 follow-up).
+
+## Investigate
+
+Root cause confirmed (single site):
+- `packages/vscode/src/comments/plan-review.ts` imports `markerInsertionLine` (line 24) and uses it at line 171 inside `submitReviewComment`. `markerInsertionLine(line)` = `line + 1`, so a new comment lands BEFORE an existing stacked run (newest-first / prepend).
+- Preview composer (`markdown-preview/preview-provider.ts`) already uses `markerAppendLine(text, line)` which scans past the contiguous marker run → newest-last / append.
+- `markerAppendLine` already exists in core (`packages/core/src/review-markers.ts:102`) with 3 passing regression tests. No core change needed.
+
+Fix plan (fix phase):
+1. Swap import `markerInsertionLine` → `markerAppendLine`.
+2. In `submitReviewComment`, `document` is already loaded via `openTextDocument`; add `const text = document.getText();` and call `markerAppendLine(text, line)`.
+3. Regression test: `submitReviewComment` is not currently exported. Export it (minimal) and add a vitest test under `src/__tests__/` mocking `vscode`, asserting a reply to a thread with two existing stacked markers inserts at line N+run (past the run), and that the zero-marker first-comment case is unchanged.
+
+Scope: ~1 LOC behavioural change + test. Well within BUGFIX.
+
+## Incident (self-inflicted, recovered)
+
+While proving the regression test fails without the fix, I ran a `git stash push`
+(to temporarily set my changes aside) that errored on an untracked-file pathspec,
+then a paired `git stash pop` — which popped the PRE-EXISTING `stash@{0}: On main:
+!!GitHub_Desktop<main>` (the user's uncommitted GitHub Desktop work) INTO this
+worktree. That partially applied 44 files (32 new under `apps/codev-desktop/`,
+`dev_docs/`, `.claude/settings.local.json`; 12 tracked modifications) with
+conflicts, leaving conflict markers in `packages/codev/package.json` etc. and
+breaking the build (EJSONPARSE on the conflict marker).
+
+Recovery (surgical, non-destructive to user data):
+- The pop hit conflicts, so the stash was KEPT — `stash@{0}` never dropped; the
+  user's work was never at risk.
+- Confirmed all 44 files are preserved in `stash@{0}` and that `apps/`, `dev_docs/`,
+  `.claude/settings.local.json` are absent from HEAD (`git ls-tree HEAD`).
+- `git reset --hard HEAD` reverted the 12 tracked modifications and removed the 32
+  staged-new files (they were staged by the pop, so hard-reset deletes them).
+- Restored my own `plan-review.ts` fix from a backup; test file + thread survived
+  (untracked, untouched by reset).
+- Verified `git stash list` still shows `stash@{0}` intact afterward.
+
+Lesson: NEVER `git stash pop` in a worktree that carries a foreign pre-existing
+stash — a bare pop targets `stash@{0}` regardless of intent. Use explicit file
+backups (cp to /tmp) instead of stash for temporary set-aside, which is what I
+should have done from the start.

--- a/packages/vscode/src/__tests__/plan-review-append.test.ts
+++ b/packages/vscode/src/__tests__/plan-review-append.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression tests for #1122: the editor Comments-API write path must append a
+ * new review marker BELOW any existing markers stacked on the annotated line
+ * (newest-last), matching the preview composer. Previously it used
+ * `markerInsertionLine` (prepend / newest-first), diverging from the composer.
+ *
+ * We drive `submitReviewComment` directly with a mocked `vscode` (the
+ * established pattern from command-relay.test.ts) and inspect the position
+ * handed to `WorkspaceEdit.insert`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('vscode', () => {
+  class Position {
+    constructor(public line: number, public character: number) {}
+  }
+  class WorkspaceEdit {
+    inserts: Array<{ uri: unknown; position: Position; text: string }> = [];
+    insert(uri: unknown, position: Position, text: string): void {
+      this.inserts.push({ uri, position, text });
+    }
+  }
+  return {
+    Position,
+    WorkspaceEdit,
+    workspace: {
+      openTextDocument: vi.fn(),
+      applyEdit: vi.fn(async () => true),
+    },
+  };
+});
+
+const vscode = (await import('vscode')) as unknown as {
+  workspace: {
+    openTextDocument: ReturnType<typeof vi.fn>;
+    applyEdit: ReturnType<typeof vi.fn>;
+  };
+};
+const { submitReviewComment } = await import('../comments/plan-review.js');
+
+/** A minimal TextDocument backed by a plain string. */
+function makeDoc(text: string) {
+  const lines = text.split('\n');
+  return {
+    uri: { toString: () => 'file:///codev/plans/1.md', fsPath: '/codev/plans/1.md' },
+    getText: () => text,
+    lineAt: (n: number) => ({ text: lines[n] ?? '' }),
+    get lineCount() {
+      return lines.length;
+    },
+    save: vi.fn(async () => true),
+  };
+}
+
+/** A reply targeting `annotatedLine` (the block the "+" thread sits on). */
+function makeReply(doc: ReturnType<typeof makeDoc>, annotatedLine: number, body: string) {
+  return {
+    thread: {
+      uri: doc.uri,
+      range: { start: { line: annotatedLine, character: 0 } },
+      dispose: vi.fn(),
+    },
+    text: body,
+  };
+}
+
+const overviewCache = { getData: () => ({ currentUser: 'alice' }) } as never;
+
+/** The line index of the single insert applied during the last call. */
+function insertedLine(): number {
+  const edit = vscode.workspace.applyEdit.mock.calls[0][0] as {
+    inserts: Array<{ position: { line: number }; text: string }>;
+  };
+  expect(edit.inserts).toHaveLength(1);
+  return edit.inserts[0].position.line;
+}
+
+describe('submitReviewComment append behaviour (#1122)', () => {
+  beforeEach(() => {
+    vscode.workspace.openTextDocument.mockReset();
+    vscode.workspace.applyEdit.mockClear();
+  });
+
+  it('appends below an existing run of two markers (newest-last), not at the top of the run', async () => {
+    const text = [
+      '## Heading', // line 0 — annotated block
+      '<!-- REVIEW(@bob): first -->', // line 1
+      '<!-- REVIEW(@carol): second -->', // line 2
+      'body text', // line 3
+    ].join('\n');
+    const doc = makeDoc(text);
+    vscode.workspace.openTextDocument.mockResolvedValue(doc);
+
+    await submitReviewComment(makeReply(doc, 0, 'third') as never, overviewCache);
+
+    // Past the two-marker run (line 3), NOT prepended at line 1.
+    expect(insertedLine()).toBe(3);
+  });
+
+  it('writes the first comment at the insertion line (unchanged when no markers exist)', async () => {
+    const text = ['## Heading', 'body text'].join('\n');
+    const doc = makeDoc(text);
+    vscode.workspace.openTextDocument.mockResolvedValue(doc);
+
+    await submitReviewComment(makeReply(doc, 0, 'first') as never, overviewCache);
+
+    // markerAppendLine === markerInsertionLine when there is no run to skip.
+    expect(insertedLine()).toBe(1);
+  });
+});

--- a/packages/vscode/src/comments/plan-review.ts
+++ b/packages/vscode/src/comments/plan-review.ts
@@ -21,7 +21,7 @@
 import * as vscode from 'vscode';
 import {
   serializeReviewMarker,
-  markerInsertionLine,
+  markerAppendLine,
   isEligibleReviewPath,
 } from '@cluesmith/codev-core/review-markers';
 import type { OverviewCache } from '../views/overview-data.js';
@@ -147,7 +147,9 @@ export function activateReviewComments(
   );
 }
 
-async function submitReviewComment(
+// Exported for unit testing (regression for #1122: append vs prepend). The
+// runtime entry point is the `codev.submitReviewComment` command above.
+export async function submitReviewComment(
   reply: vscode.CommentReply,
   overviewCache: OverviewCache,
 ): Promise<void> {
@@ -165,10 +167,16 @@ async function submitReviewComment(
   // normalization and the "marker on the line after the anchor" rule live there).
   const commentLine = serializeReviewMarker(author, reply.text, indent);
 
+  // Append below any existing markers stacked on this line so the newest
+  // comment lands LAST in render order — parity with the preview composer
+  // (#1122). markerAppendLine scans the document text past the contiguous
+  // marker run; with no existing markers it equals markerInsertionLine(line),
+  // so the first-comment case is unchanged.
+  const text = document.getText();
   const edit = new vscode.WorkspaceEdit();
   edit.insert(
     thread.uri,
-    new vscode.Position(markerInsertionLine(line), 0),
+    new vscode.Position(markerAppendLine(text, line), 0),
     commentLine + '\n',
   );
   await vscode.workspace.applyEdit(edit);


### PR DESCRIPTION
## Summary

Aligns the editor Comments-API review-comment write path with the preview composer so both authoring surfaces stack new comments in the same order (newest-last). Completes the parity work started in PR #1121 (PIR #1107).

Fixes #1122

## Root Cause

Two surfaces write the same on-disk `<!-- REVIEW(@author): ... -->` markers but computed the insert position differently:

- **Preview composer** (`markdown-preview/preview-provider.ts`) uses `markerAppendLine(text, line)` — appends *after* the existing marker run → newest-last, matching where the composer renders.
- **Editor Comments-API** (`comments/plan-review.ts`) used `markerInsertionLine(line)` = `line + 1` — inserts *before* the run → newest-first (prepended).

Same bytes, divergent stack semantics depending on which surface the reviewer used.

## Fix

`packages/vscode/src/comments/plan-review.ts`:
- Import `markerAppendLine` instead of `markerInsertionLine`.
- In `submitReviewComment`, the document is already loaded via `openTextDocument`, so pass `document.getText()` to `markerAppendLine(text, line)`. `markerAppendLine` scans past the contiguous marker run; with zero existing markers it equals `markerInsertionLine(line)`, so the first-comment case is unchanged.
- Exported `submitReviewComment` for unit testing (the runtime entry stays the `codev.submitReviewComment` command).

No change to core (`markerAppendLine` / `markerInsertionLine` already correct and tested).

## Test Plan

New `packages/vscode/src/__tests__/plan-review-append.test.ts` (vitest, mocked `vscode`) drives `submitReviewComment` and inspects the `WorkspaceEdit.insert` position:

- **Append past a run of two existing markers**: new marker lands at line N (past the run), not line 1 (top of run). This test fails under the old `markerInsertionLine` behaviour (asserts 3, old code yields 1) and passes with the fix — a true regression test.
- **First-comment case (zero markers)**: insert position unchanged (equals the insertion line).

Verified: `porch check` (build + tests) passes; full vitest unit suite passes (3 unrelated pre-existing suite failures in `command-relay` / `reconnect-link-provider` / `terminal-adapter`, all `ws`-mock env errors, confirmed failing on the base commit too).
