### PR TITLE
fix(forge/gitea): route concepts through correct tea CLI/api commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ For detailed release notes, see [docs/releases/](docs/releases/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`gitea` forge preset now works against the real `tea` CLI** (#1137): the gitea concept scripts were written against the Gitea REST API JSON shape but invoke the `tea` CLI, whose `--output json` emits a different, flattened shape (and in places references a flag/field/subcommand `tea` doesn't have). Verified against `tea` 0.14.2 + a live Gitea/Forgejo instance:
+  - `user-identity`: `tea whoami --output json` → `tea api user | jq .login` (`tea whoami` has no `--output json` flag).
+  - `pr-exists` / `recently-merged`: `.head.ref` → `.head` (the CLI list output flattens `head` to a branch-name string) and `state=="closed" && .merged` → `state=="merged"`; `pr-exists` also gains `--limit` so the default page can't hide the branch.
+  - `pr-list`: dropped the invalid `description` field (was erroring with `invalid field 'description'`, breaking the whole concept); `body` is `""` since `tea pulls list` exposes no body field.
+  - `pr-view`: `tea pulls view` (returns an empty array) → `tea api repos/:owner/:repo/pulls/:index`, yielding the full PR object incl. additions/deletions and head/base refs.
+  - `issue-view`: `tea issues view` (list-shaped array, no body) → singular `tea issue <id>`.
+  - `issue-comment`: `tea issues comment` (no such subcommand) → `tea comments add`.
+  - `issue-search`: removed the "unverified" caveat — confirmed `--state` and the `body` field work.
+
 ### Added (Spec 786 — Multi-architect lifecycle, persistence, and UX)
 
 - **`afx workspace remove-architect <name>`**: first-class CLI to evict a sibling architect. Refuses to remove `main`. Removing an architect with in-flight builders proceeds; those builders fall back to `main` routing.

--- a/packages/codev/scripts/forge/gitea/issue-comment.sh
+++ b/packages/codev/scripts/forge/gitea/issue-comment.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 # Forge concept: issue-comment (Gitea via tea CLI)
-exec tea issues comment "$CODEV_ISSUE_ID" "$CODEV_COMMENT_BODY"
+#
+# `tea issues` has no `comment` subcommand; comments are managed under
+# `tea comments` (`tea comments add <issue/pr index> <body>`).
+exec tea comments add "$CODEV_ISSUE_ID" "$CODEV_COMMENT_BODY"

--- a/packages/codev/scripts/forge/gitea/issue-search.sh
+++ b/packages/codev/scripts/forge/gitea/issue-search.sh
@@ -1,11 +1,10 @@
 #!/bin/sh
 # Forge concept: issue-search (Gitea via tea CLI)
 #
-# ⚠️ UNVERIFIED — mirrors gitea/issue-list.sh with `body` added to --fields,
-#    a --state parameter, and `body` mapped in the jq normalization. `tea` is
-#    not available in the authoring environment (#920); smoke-test before
-#    relying on it. Confirm: tea's `--state` accepts open|closed|all and the
-#    issue body field is named `body`.
+# Mirrors gitea/issue-list.sh with `body` added to --fields, a --state
+# parameter, and `body` mapped in the jq normalization. Verified against
+# tea 0.14.2: `--state` accepts open|closed|all and `body` is a valid
+# issues-list field.
 #
 # Input (optional): CODEV_ISSUE_STATE — open|closed|all (default: open)
 # Output: JSON [{number, title, url, labels, createdAt, author, assignees, body}]

--- a/packages/codev/scripts/forge/gitea/issue-view.sh
+++ b/packages/codev/scripts/forge/gitea/issue-view.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 # Forge concept: issue-view (Gitea via tea CLI)
+#
+# `tea issues view` (plural) returns a list-style array without the issue body,
+# so use the singular `tea issue <id>`, which returns the full issue object.
+#
 # Sets `url` to the issue's browser page (`html_url`). Gitea's own `url` field is
 # the API endpoint (would render raw JSON in a browser), so we prefer `html_url`
 # and fall back to the existing `url` only if `html_url` is absent.
-tea issues view "$CODEV_ISSUE_ID" --output json | jq '.url = (.html_url // .url)'
+tea issue "$CODEV_ISSUE_ID" --output json | jq '.url = (.html_url // .url)'

--- a/packages/codev/scripts/forge/gitea/pr-exists.sh
+++ b/packages/codev/scripts/forge/gitea/pr-exists.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 # Forge concept: pr-exists (Gitea via tea CLI)
-# Returns true for open or merged pulls only. Closed-not-merged pulls are excluded.
-# --state all fetches pulls in all states; without it, only open pulls are returned.
-# Gitea: merged PRs have state="closed" + merged=true; abandoned PRs have state="closed" + merged=false
-tea pulls list --state all --fields index --output json | jq "[.[] | select(.head.ref == \"$CODEV_BRANCH_NAME\" and (.state == \"open\" or (.state == \"closed\" and .merged == true)))] | length > 0"
+# Returns true when an open or merged pull exists for the current branch.
+#
+# In `tea pulls list --output json`, `head` is the branch-name STRING (not a
+# {ref} object), and a merged pull is reported as state="merged" (the CLI list
+# output has no `.merged` boolean). `--state all` includes closed pulls;
+# `--limit` is required because the default page size (30) can miss the branch.
+tea pulls list --state all --limit 200 --fields index,head,state --output json \
+  | jq --arg b "$CODEV_BRANCH_NAME" \
+      '[.[] | select(.head == $b and (.state == "open" or .state == "merged"))] | length > 0'

--- a/packages/codev/scripts/forge/gitea/pr-list.sh
+++ b/packages/codev/scripts/forge/gitea/pr-list.sh
@@ -4,23 +4,24 @@
 # Normalize tea's PR shape to the GitHub-compatible shape codev expects
 # (see PrListItem in codev/src/lib/forge-contracts.ts):
 #   index            -> number (int)
-#   description      -> body
 #   created          -> createdAt
 #   author (string)  -> author.login
 #   reviewDecision   -> ""  (Gitea has no GitHub-equivalent review-decision summary)
-#   reviewRequests   -> []  (verified against tea 0.14.1: `pulls list` exposes
-#                            no `reviewers` field, and its JSON output is limited
-#                            to the selectable `--fields`, so requested reviewers
-#                            are unreachable here. The VSCode sort silently skips
-#                            the review-requested bucket when empty.)
-#   isDraft          -> false (verified: tea 0.14.1 `pulls list` exposes no
-#                              `draft` field among its selectable `--fields`.)
-# The underlying Gitea API PR object does carry `draft` and `requested_reviewers`,
-# but only the raw `tea api` passthrough can reach them — populating these two
-# fields for Gitea would mean reworking this concept onto `tea api`, which is a
-# separate, larger change than #787's scope.
+#   body             -> ""  (`tea pulls list` exposes no body/description field;
+#                            requesting `description` fails with
+#                            `Error: invalid field 'description'`. The per-PR body
+#                            is only reachable via
+#                            `tea api repos/:owner/:repo/pulls/:index` — out of
+#                            scope for the list overview.)
+#   reviewRequests   -> []  (`pulls list` exposes no `reviewers` field, so
+#                            requested reviewers are unreachable here. The VSCode
+#                            sort silently skips the review-requested bucket when
+#                            empty.)
+#   isDraft          -> false (`pulls list` exposes no `draft` field.)
+# The underlying Gitea API PR object carries `body`, `draft`, and
+# `requested_reviewers`, but only the raw `tea api` passthrough can reach them.
 exec tea pulls list --limit 200 \
-  --fields index,title,state,author,url,created,description \
+  --fields index,title,state,author,url,created \
   --output json \
   | jq '[.[] | {
       number: (.index | tonumber),
@@ -28,7 +29,7 @@ exec tea pulls list --limit 200 \
       state,
       url,
       reviewDecision: "",
-      body: (.description // ""),
+      body: "",
       createdAt: .created,
       author: {login: .author},
       reviewRequests: [],

--- a/packages/codev/scripts/forge/gitea/pr-view.sh
+++ b/packages/codev/scripts/forge/gitea/pr-view.sh
@@ -1,3 +1,26 @@
 #!/bin/sh
 # Forge concept: pr-view (Gitea via tea CLI)
-exec tea pulls view "$CODEV_PR_NUMBER" --output json
+#
+# `tea pulls view` renders a list-style table (an empty JSON array under
+# --output json) and cannot produce the single-PR PrViewResult shape (see
+# forge-contracts.ts). Use the REST API passthrough, which returns the full
+# Gitea PR object including additions/deletions and head/base refs.
+#
+# `tea api` requires an explicit repos/:owner/:repo path (there is no
+# {owner}/{repo} substitution like gh's). codev passes CODEV_REPO to some
+# concepts (e.g. repo-archive) but not pr-view, so fall back to deriving
+# owner/repo from the origin remote (handles https and scp-like SSH URLs).
+REPO="${CODEV_REPO:-$(git config --get remote.origin.url \
+  | sed -e 's#\.git$##' -e 's#^[a-z][a-z0-9+.-]*://[^/]*/##' -e 's#^[^/@]*@[^:]*:##')}"
+
+tea api "repos/${REPO}/pulls/${CODEV_PR_NUMBER}" \
+  | jq '{
+      title,
+      body: (.body // ""),
+      state,
+      author: {login: .user.login},
+      baseRefName: .base.ref,
+      headRefName: .head.ref,
+      additions,
+      deletions
+    }'

--- a/packages/codev/scripts/forge/gitea/recently-merged.sh
+++ b/packages/codev/scripts/forge/gitea/recently-merged.sh
@@ -1,27 +1,28 @@
 #!/bin/sh
 # Forge concept: recently-merged (Gitea via tea CLI)
 #
-# `tea pulls list --state closed` returns both merged PRs and closed-without-
-# merge PRs. Filter to merged only via `.merged == true` (the same predicate
-# scripts/forge/gitea/pr-exists.sh already relies on), then map to the
-# GitHub-compatible shape:
-#   index           -> number (int)
-#   created         -> createdAt
-#   updated         -> mergedAt  (tea exposes no merged_at field via --fields;
-#                                 close-then-edit overestimates merged time
-#                                 but is acceptable for the 24h overview window)
-#   head.ref        -> headRefName
-#   description     -> body
+# `tea pulls list --state closed` returns both merged and closed-without-merge
+# pulls. In the CLI's flattened list output a merged pull is reported as
+# state="merged" (there is no `.merged` boolean), and `head` is the branch-name
+# STRING (not a {ref} object). Filter to merged, then map to the
+# GitHub-compatible shape (see MergedPrItem in forge-contracts.ts):
+#   index    -> number (int)
+#   created  -> createdAt
+#   updated  -> mergedAt  (tea exposes no merged_at field via --fields;
+#                          close-then-edit overestimates merged time but is
+#                          acceptable for the 24h overview window)
+#   head     -> headRefName
+#   body     -> ""  (`tea pulls list` exposes no body/description field)
 exec tea pulls list --state closed --limit 1000 \
-  --fields index,title,state,author,url,created,updated,head,description,merged \
+  --fields index,title,state,author,url,created,updated,head \
   --output json \
-  | jq '[.[] | select(.merged == true) | {
+  | jq '[.[] | select(.state == "merged") | {
       number: (.index | tonumber),
       title,
       state,
       url,
-      body: (.description // ""),
+      body: "",
       createdAt: .created,
       mergedAt: .updated,
-      headRefName: (.head.ref // "")
+      headRefName: (.head // "")
     }]'

--- a/packages/codev/scripts/forge/gitea/user-identity.sh
+++ b/packages/codev/scripts/forge/gitea/user-identity.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 # Forge concept: user-identity (Gitea via tea CLI)
-tea whoami --output json | jq -r ".login"
+#
+# `tea whoami` has no `--output json` flag (any tea version — its only option is
+# `--help`), so read the login from the REST API passthrough instead. Mirrors
+# the github preset's `gh api user --jq .login`.
+tea api user | jq -r ".login"


### PR DESCRIPTION
Fixes #1137.

The `gitea` forge preset was authored against the **Gitea REST API** JSON shape,
but the scripts invoke the **`tea` CLI**, whose `--output json` emits a different,
flattened shape — and in several places references a flag / field / subcommand
that `tea` does not have. Per the in-repo `#920` note, `tea` wasn't available in
the authoring environment, so the preset was never run end-to-end.

This is **not environment-specific**: the failing flags/subcommands are defined
in the `tea` binary itself (independent of any server), and the canonical Gitea
REST shape the jq assumes is confirmed against public `gitea.com`. Details +
repro in #1137.

### Fixes (verified against `tea` 0.14.2 + a live Gitea/Forgejo instance)

| Concept | Before | After |
|---|---|---|
| `user-identity` | `tea whoami --output json` (no such flag) | `tea api user \| jq .login` |
| `pr-list` | `--fields …,description` → `invalid field 'description'` (concept errored) | drop field; `body:""` |
| `pr-view` | `tea pulls view` → empty array | `tea api repos/:owner/:repo/pulls/:index` (incl. additions/deletions) |
| `issue-view` | `tea issues view` → list array, no body | singular `tea issue <id>` |
| `issue-comment` | `tea issues comment` (no subcommand) | `tea comments add` |
| `pr-exists` | `.head.ref` + `closed&&merged` | `.head` (string) + `state=="merged"`, `--limit` |
| `recently-merged` | `.head.ref`, `description`, `.merged` | `.head`, `state=="merged"`, drop field |
| `issue-search` | marked "unverified" | confirmed working; caveat removed |

Design note: the preset stays **CLI-based** (consistent with the working concepts
and the original design); `tea api` is used only where the CLI can't produce the
contract (`pr-view`, `user-identity`). Output shapes were checked against
`forge-contracts.ts`.

### Testing

Each concept was run against a live instance and its output validated:
`user-identity` → login string; `pr-exists` → correct `true`/`false`; `pr-list`
→ valid `PrListItem[]` (int `number`); `pr-view` → `PrViewResult` with real
additions/deletions; `issue-view` → object with body+browser url;
`recently-merged` → `MergedPrItem[]` (all merged); `issue-search` → array with
body. `issue-comment` syntax confirmed (not executed — mutating).

The gitea `.sh` scripts are not exercised by CI (`forge.test.ts` uses mock
scripts), so validation is necessarily manual against a real forge.
