### PR TITLE
[Bugfix #1128] Bump @openai/codex-sdk to ^0.142.5: restore the codex consult lane on macOS (XProtect kill)

### DIFF
--- a/codev/projects/bugfix-1128-consult-codex-xprotect-gatekee/status.yaml
+++ b/codev/projects/bugfix-1128-consult-codex-xprotect-gatekee/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-07-06T04:27:28.416Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-06T04:10:10.979Z'
-updated_at: '2026-07-06T04:22:19.561Z'
+updated_at: '2026-07-06T04:27:28.416Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1128-consult-codex-xprotect-gatekee/status.yaml
+++ b/codev/projects/bugfix-1128-consult-codex-xprotect-gatekee/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1128
 title: consult-codex-xprotect-gatekee
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-06T04:10:10.979Z'
-updated_at: '2026-07-06T04:10:10.980Z'
+updated_at: '2026-07-06T04:16:12.037Z'

--- a/codev/projects/bugfix-1128-consult-codex-xprotect-gatekee/status.yaml
+++ b/codev/projects/bugfix-1128-consult-codex-xprotect-gatekee/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-06T04:27:28.416Z'
+    approved_at: '2026-07-08T04:18:18.890Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-06T04:10:10.979Z'
-updated_at: '2026-07-06T04:27:28.416Z'
-pr_ready_for_human: true
+updated_at: '2026-07-08T04:18:18.891Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1128-consult-codex-xprotect-gatekee/status.yaml
+++ b/codev/projects/bugfix-1128-consult-codex-xprotect-gatekee/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1128
 title: consult-codex-xprotect-gatekee
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,5 +13,5 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-06T04:10:10.979Z'
-updated_at: '2026-07-08T04:18:18.891Z'
+updated_at: '2026-07-08T04:18:30.434Z'
 pr_ready_for_human: false

--- a/codev/projects/bugfix-1128-consult-codex-xprotect-gatekee/status.yaml
+++ b/codev/projects/bugfix-1128-consult-codex-xprotect-gatekee/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1128
+title: consult-codex-xprotect-gatekee
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-06T04:10:10.979Z'
+updated_at: '2026-07-06T04:10:10.980Z'

--- a/codev/projects/bugfix-1128-consult-codex-xprotect-gatekee/status.yaml
+++ b/codev/projects/bugfix-1128-consult-codex-xprotect-gatekee/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1128
 title: consult-codex-xprotect-gatekee
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-06T04:10:10.979Z'
-updated_at: '2026-07-06T04:16:12.037Z'
+updated_at: '2026-07-06T04:22:19.561Z'

--- a/codev/state/bugfix-1128_thread.md
+++ b/codev/state/bugfix-1128_thread.md
@@ -1,0 +1,67 @@
+# Builder thread — bugfix-1128 (consult: codex XProtect/Gatekeeper kill)
+
+## Investigate phase (2026-07-06)
+
+**Reproduced.** `consult -m codex --prompt "..."` fails with raw
+`spawn .../node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex/codex ENOENT`
+(exit 1, no explanation). The vendor binary under the global `@cluesmith/codev`
+install is gone — XProtect trashed it, exactly as the issue describes. The
+`vendor/aarch64-apple-darwin/codex/` directory exists but is empty.
+
+**Root cause confirmed**, with one major new finding that changes the fix shape:
+
+- `@cluesmith/codev` depends on `@openai/codex-sdk ^0.130.0`, which pins
+  `@openai/codex 0.130.0` exactly. That version's darwin-arm64 vendor binary is
+  unsigned → XProtect (macOS 26) SIGKILLs it and auto-trashes it.
+- **`@openai/codex 0.142.5` ships a Developer ID-signed binary.** Verified on this
+  machine with `codesign -dvv`: `Authority=Developer ID Application: OpenAI OpCo, LLC
+  (2DC432GLL2)`, hardened runtime flag set, `codesign --verify --strict` passes.
+  Upstream fixed the root cause between 0.130.0 and 0.142.5.
+- Latest stable `@openai/codex-sdk` is `0.142.5`, pinning `@openai/codex 0.142.5`.
+- SDK 0.142.5 API surface verified compatible with our `runCodexConsultation`
+  usage (Codex config object, startThread options, event types, usage fields —
+  checked against the published .d.ts).
+
+**Revised fix plan** (differs from the issue's "primary fix (a)" recommendation,
+based on the signing evidence):
+
+1. **(b) becomes the primary fix**: bump `@openai/codex-sdk` → `^0.142.5`. The
+   signed binary is the actual root-cause fix for both the npm-install and
+   local-install paths. npm tarball extraction preserves the embedded Mach-O
+   signature; nothing to "restore" post-install.
+2. **(a) is dropped**: ad-hoc codesigning (`--remove-signature` + `--sign -`)
+   over a valid Developer ID signature would *downgrade* it — actively harmful
+   now that upstream signs. No conditional variant needed either.
+3. **(c) stays as the safety net**: detect the two Gatekeeper symptoms in
+   `runCodexConsultation` — spawn `ENOENT` on the codex vendor path, and
+   `Codex Exec exited with signal SIGKILL` — and emit a legible error naming
+   macOS Gatekeeper/XProtect, pointing at issue #1128 and the reinstall fix.
+
+Error surfaces confirmed from SDK source: spawn failure rethrows the raw Node
+error (`code === 'ENOENT'`); a killed process throws
+`Codex Exec exited with signal SIGKILL: <stderr>`.
+
+Scope: well under 300 LOC (dep bump + lockfile, ~30 lines of detection in
+consult/index.ts, regression tests). Proceeding to fix phase; architect notified
+of the deviation from the issue's recommendation.
+
+## Fix phase (2026-07-06)
+
+Architect responded: **ship only (b), the SDK bump.**
+
+- (a) codesign fixup: deferred, not killed. If Apple revokes a future 0.142.x
+  hash (the 0.130.0 revocation was per-hash, not per team ID), (a) may return
+  as a conditional fixup (apply only when spctl reports revocation). Architect
+  will re-scope on #1128 after this PR lands.
+- (c) legible Gatekeeper error in consult: out of scope for this bugfix; stays
+  as an open recommendation on #1128 for a follow-on PR.
+
+Change: `packages/codev/package.json` `@openai/codex-sdk` `^0.130.0` → `^0.142.5`
+(caret on 0.x only spans the same minor, so the old range could never pick up
+the signed binary on its own) + `pnpm-lock.yaml` refresh.
+
+No regression test added: this is a pure dependency bump with no code change.
+The failure mode (XProtect trashing an unsigned vendor binary) is environmental
+(macOS + XProtect definitions + signing state of a third-party binary), not
+reachable from unit tests. Verification is manual: codesign/spctl on the
+resolved vendor binary + launching it, recorded in the PR body.

--- a/codev/state/bugfix-1128_thread.md
+++ b/codev/state/bugfix-1128_thread.md
@@ -65,3 +65,26 @@ The failure mode (XProtect trashing an unsigned vendor binary) is environmental
 (macOS + XProtect definitions + signing state of a third-party binary), not
 reachable from unit tests. Verification is manual: codesign/spctl on the
 resolved vendor binary + launching it, recorded in the PR body.
+
+Verification results (macOS 26, darwin-arm64, worktree):
+- codesign --verify --strict passes; full Developer ID chain, hardened runtime.
+- spctl "rejected (the code is valid but does not seem to be an app)" is the
+  standard response for any signed non-app-bundle CLI (identical output for the
+  known-good standalone codex used daily on this machine), not a failure.
+- Binary launches (codex-cli 0.142.5, exit 0), no SIGKILL, survives on disk.
+- End-to-end: worktree `consult -m codex` round-trips in 7s.
+- Root `pnpm build` clean; 3432 tests pass; porch phase checks green.
+
+## PR phase (2026-07-06)
+
+PR #1141: https://github.com/cluesmith/codev/pull/1141 (Fixes #1128).
+
+CMAP (all three lanes run through the worktree build; the codex lane ran on the
+fixed SDK, which doubles as live validation of the fix):
+- gemini: APPROVE (HIGH confidence, no key issues)
+- codex: APPROVE (HIGH confidence, no key issues)
+- claude: APPROVE (HIGH confidence; non-blocking note that "Fixes #1128"
+  auto-closes the issue while the architect plans follow-on scope, (a)
+  conditional fixup and (c) legible error, on that same issue)
+
+Requested the pr gate via porch done; waiting for human approval.

--- a/packages/codev/package.json
+++ b/packages/codev/package.json
@@ -40,7 +40,7 @@
     "@cluesmith/codev-core": "workspace:*",
     "@anthropic-ai/claude-agent-sdk": "^0.2.41",
     "@google/genai": "^1.0.0",
-    "@openai/codex-sdk": "^0.130.0",
+    "@openai/codex-sdk": "^0.142.5",
     "better-sqlite3": "^12.10.0",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^1.0.0
         version: 1.50.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))
       '@openai/codex-sdk':
-        specifier: ^0.130.0
-        version: 0.130.0
+        specifier: ^0.142.5
+        version: 0.142.5
       better-sqlite3:
         specifier: ^12.10.0
         version: 12.10.0
@@ -1012,47 +1012,47 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@openai/codex-sdk@0.130.0':
-    resolution: {integrity: sha512-ICKaZ5zrIDg71AiQcsUToVoe5Icmrc3LwSM5+2z7Cf8F1x6nOaY7/ucpFlr4aH8oDe7t3dangc+MsWZTkdvDFw==}
+  '@openai/codex-sdk@0.142.5':
+    resolution: {integrity: sha512-MConZ+eoBoZmkc4reezuzOgLtoI1BQBzo/nVYsSjtAIBpwKcgeEm1rfmqfUnTfFaBNHFTxBntcS7ZeQYuDPbWA==}
     engines: {node: '>=18'}
 
-  '@openai/codex@0.130.0':
-    resolution: {integrity: sha512-WGDj+RZ3TXWC/7MlwprgLWOqzpwatPIINPhP3IRzHA0ni+o3QZ4i4xrS2uWwGmHUJ395J5JHwoZAAZYyfJyz6w==}
+  '@openai/codex@0.142.5':
+    resolution: {integrity: sha512-WQEpD7l3k68eIAP0aq28EdR18ENBAf8DyprzFhzNwCOQJSv4nHzpwT8Fl30IJacprko2ZCmUBZjM2u941l2yLw==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.130.0-darwin-arm64':
-    resolution: {integrity: sha512-R9pkGC7kwC8yQ8el5hvBlmugQlcsG/pHMEFgZluu03X9fD2TezGxdq3KqRDRCZuMYl07ILamVEoqknuJ0cq7MA==}
+  '@openai/codex@0.142.5-darwin-arm64':
+    resolution: {integrity: sha512-l43p8xv+Z/2/b6fCUc7/FmcQZsaPB7RFizLponGwHAnFOWe3i9Vky69p+up3BUam9AetoQQUv7Mo+2KdaFEqhA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.130.0-darwin-x64':
-    resolution: {integrity: sha512-gJ+7J8djevgtdra+NgDAiQQPW+O3KTsgGfE3E5dpDfww3zS5OCeV0V2dhxqnJdlOjOSDw99o0P2LqBv19mhpRw==}
+  '@openai/codex@0.142.5-darwin-x64':
+    resolution: {integrity: sha512-yk6A06/VmW7NFsa48OVPaj//g/zeSpd79wjuqfXZwW8ZKRYQm3+wCd3hWjPl79F3QnXvDvM2j3JMIBL3m3GXXg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.130.0-linux-arm64':
-    resolution: {integrity: sha512-tFtH0V9/hEI3d9y7zP92BXI9FM4Z3+STNQaOR52Czv18TRtCFUp7CbIUYaToopuq6UBfnE1VKr8RLhwT5FcbmA==}
+  '@openai/codex@0.142.5-linux-arm64':
+    resolution: {integrity: sha512-77ka5PSnm5HdxdBT99IwntCasmbqevlS0eiC0AtEb6ZXCLkim2gm0AWm+jNYy0EhbssvNK+KghayWo34HMgXeA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.130.0-linux-x64':
-    resolution: {integrity: sha512-3VcNlez99xdnEf+kB1IOpWv9fICYV9PiGj4sLCO4TCcShLnyxe+YBGa3poknkvXLnMG0qiN9SMnYS2FGrMxQcA==}
+  '@openai/codex@0.142.5-linux-x64':
+    resolution: {integrity: sha512-pxY+d3NgNE57Y/MApD3/TZUAygxJN6I9h3ZeDUwe67mxWjUxsuapxMRFTKSznCalYbRAeZp752+AAXmUbmguEg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.130.0-win32-arm64':
-    resolution: {integrity: sha512-vdpmiNp57L/arZabltLXn8TyEtNa7W1meOEkr+3R6W/8ZyBt++wuqz1Orv134OT2grrcFJsIVCAIPiqUxCvBkA==}
+  '@openai/codex@0.142.5-win32-arm64':
+    resolution: {integrity: sha512-65BEqGbUZ7r0ayunIHdBjo5crwgbwKX/6puOcO+VCswUw/dXvDsN2IGcbXB52+bS9U5+FxP783cUHfTT6m40DQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.130.0-win32-x64':
-    resolution: {integrity: sha512-FzMznm7fr5/nbjZgOujZ9Y9AbdGm7ji1FOoWiY3U+srqauvZaTgn6o6aCheSL7kuymu7nTLOO/cAyWV6NuesqQ==}
+  '@openai/codex@0.142.5-win32-x64':
+    resolution: {integrity: sha512-a+wI4PEx9a2fg6V5ueTTDkOkr1XpEvA5RFXIbo/L2hOfzMmGtyRnbG24bCGu5Q2RSgVxSQV0aLkdb3vdYMNH9A==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -4148,35 +4148,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@openai/codex-sdk@0.130.0':
+  '@openai/codex-sdk@0.142.5':
     dependencies:
-      '@openai/codex': 0.130.0
+      '@openai/codex': 0.142.5
 
-  '@openai/codex@0.130.0':
+  '@openai/codex@0.142.5':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.130.0-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.130.0-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.130.0-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.130.0-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.130.0-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.130.0-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.142.5-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.142.5-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.142.5-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.142.5-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.142.5-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.142.5-win32-x64'
 
-  '@openai/codex@0.130.0-darwin-arm64':
+  '@openai/codex@0.142.5-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.130.0-darwin-x64':
+  '@openai/codex@0.142.5-darwin-x64':
     optional: true
 
-  '@openai/codex@0.130.0-linux-arm64':
+  '@openai/codex@0.142.5-linux-arm64':
     optional: true
 
-  '@openai/codex@0.130.0-linux-x64':
+  '@openai/codex@0.142.5-linux-x64':
     optional: true
 
-  '@openai/codex@0.130.0-win32-arm64':
+  '@openai/codex@0.142.5-win32-arm64':
     optional: true
 
-  '@openai/codex@0.130.0-win32-x64':
+  '@openai/codex@0.142.5-win32-x64':
     optional: true
 
   '@pkgjs/parseargs@0.11.0':


### PR DESCRIPTION
## Summary

Bumps `@openai/codex-sdk` from `^0.130.0` to `^0.142.5` in `packages/codev`. This restores the `consult -m codex` lane on macOS 26, where XProtect SIGKILLs the unsigned 0.130.0 vendor binary on first launch, auto-trashes it, and leaves every subsequent invocation failing with a raw `spawn ... ENOENT`.

Fixes #1128

## Root Cause

`@openai/codex-sdk 0.130.0` pins `@openai/codex 0.130.0` exactly, and that version's darwin vendor binary (~192 MB Mach-O) is not code-signed. macOS 26 XProtect flags it as malware at exec time, kills it, and the default dialog action moves it to Trash, which is why the first failure is SIGKILL and every later one is ENOENT.

Investigation finding that reshaped the fix: **`@openai/codex 0.142.5` ships the same binary Developer ID-signed** (`Developer ID Application: OpenAI OpCo, LLC (2DC432GLL2)`, hardened runtime, full Apple chain). Upstream fixed the root cause between 0.130.0 and 0.142.5. The old caret range could never pick this up on its own: for 0.x versions, `^0.130.0` only spans `0.130.x`.

## Fix

- `packages/codev/package.json`: `@openai/codex-sdk` `^0.130.0` → `^0.142.5`
- `pnpm-lock.yaml`: refreshed; zero remaining references to `0.130.0`
- No code changes: SDK 0.142.5's API surface is unchanged for everything `runCodexConsultation` uses (verified against the published `.d.ts`, and by clean TypeScript compile + full test suite)

Scope decisions agreed with the architect on #1128:
- **(a) ad-hoc codesign fixup: deferred, not shipped.** `codesign --remove-signature && --sign -` over a valid Developer ID signature would downgrade it to an ad-hoc identity. May return later as a conditional fixup if Apple revokes a future hash; architect will re-scope on #1128.
- **(c) legible Gatekeeper error message in consult: follow-on PR**, tracked on #1128.

No regression test added: this is a pure dependency bump. The failure mode (XProtect trashing an unsigned third-party binary) is environmental and not reachable from unit tests; verification below is the evidence.

## Test Plan

All on macOS 26, darwin-arm64, in the builder worktree:

- [x] Reproduced the bug pre-fix: `consult -m codex` fails with `spawn .../codex-darwin-arm64/vendor/aarch64-apple-darwin/codex/codex ENOENT` (binary already trashed by XProtect)
- [x] `codesign --verify --strict` passes on the 0.142.5 vendor binary; authority chain is OpenAI OpCo, LLC (2DC432GLL2) → Developer ID CA → Apple Root CA, hardened runtime flag set
- [x] `spctl --assess --type execute` returns "rejected (the code is valid but does not seem to be an app)": identical output to the known-good standalone codex CLI used daily on this machine; this is spctl's standard response for any signed non-app-bundle CLI, not a Gatekeeper failure
- [x] Binary launches cleanly (`codex-cli 0.142.5`, exit 0) with no SIGKILL and no XProtect dialog, and survives on disk after exec (the old failure mode deleted it at this point)
- [x] End-to-end user path: `node ./bin/consult.js -m codex --prompt "Reply with the single word: ping"` from the worktree build round-trips in 7s, exit 0
- [x] `pnpm build` (root, core first) clean; full `pnpm test` in `packages/codev`: 3432 passed, 0 failed
- [x] porch phase checks (build + tests) green