### PR TITLE
research: Codev Mobile July refresh (interaction model, feasibility, 7 design-decision notes)

### DIFF
--- a/codev/research/mobile/decisions/q1-pairing-model.md
+++ b/codev/research/mobile/decisions/q1-pairing-model.md
@@ -1,0 +1,33 @@
+# Decision note — Q1: Pairing model for desktop handoff
+
+**Status**: Proposed (needs main's ratification before any implementation)
+**Date**: 2026-07-07
+**Question** (interaction-model §9.1): When mobile shows "Continue on Desktop", how does it know which laptop to `codev://` deep-link to? Per-user Tower Cloud account? QR pairing? Shared workspace token?
+
+## Decision
+
+**No pairing subsystem. The Tower Cloud account IS the pairing; the handoff target is a URL, not a device.**
+
+The three options in the question all assume mobile must address a *device*. It doesn't — it must address a *view*. Reframe:
+
+1. **Primary handoff: a cloud URL.** "Continue on Desktop" produces `https://<cloud>/t/<towerId>/<view-path>` (the tunnel proxy path that already exists for browser access — see issue #655's `/t/{towerId}/...` reference). Any signed-in browser on any of the user's machines opens it. Share-sheet / copy-link semantics; no device registry needed.
+2. **Progressive enhancement: `codev://` on top.** If the Codev IDE registered the `codev://` scheme on a desktop (that work lives in the external codev-ide repo now), the *desktop side* can claim those links. Mobile never needs to know whether the claim succeeded — it fires the same URL either way; the browser link is the universal fallback the interaction-model doc already specified.
+3. **Devices-as-consequence, not devices-as-registry.** The per-device tokens from [[q2-auth-model]] give the cloud a device list for *revocation*; we do not build a "which laptop is mine" picker on top of it. If a user has three desktops, all three can open the link; whichever they're sitting at wins. That is the correct UX and it costs nothing.
+
+## Why not QR pairing or shared workspace tokens
+
+- **QR pairing** solves proximity bootstrap for *unauthenticated* devices (TV login pattern). Both ends here are already signed in to the same cloud account; QR adds a ceremony that authenticates nothing new. (QR *may* reappear later as a convenience for the initial app sign-in itself — that's Q2/first-run territory, not handoff.)
+- **Shared workspace token** creates a second credential system parallel to the account, with all the revocation/rotation burden and none of the attribution. Rejected on the same grounds `ctk_`-on-phone was rejected in [[q2-auth-model]].
+
+## v0 (LAN PoC) carve-out
+
+No cloud in v0 → handoff button renders `http://<tower-lan-host>:4100/<view-path>` (dashboard URL). Works on the same LAN, which is the only place v0 works anyway. Handoff is therefore v0-includable at trivial cost, but only as "open the dashboard URL" — no `codev://`, no cloud links.
+
+## Open remainder (deferred, small)
+
+- Exact `<view-path>` grammar: mobile and web must agree on canonical view URLs (e.g. `/workspace/<ws>/builder/<id>?view=cmap`). This is a web-dashboard routing question first; mobile consumes whatever the dashboard canonicalizes. Coordinate with main when the dashboard routes stabilize.
+
+## Related
+
+- [[q2-auth-model]] — account anchor and device tokens.
+- Issue #855 — `apps/web` rename lands the URL surface this leans on.

--- a/codev/research/mobile/decisions/q2-auth-model.md
+++ b/codev/research/mobile/decisions/q2-auth-model.md
@@ -1,0 +1,42 @@
+# Decision note — Q2: Mobile auth model
+
+**Status**: Proposed (needs main's ratification before any implementation)
+**Date**: 2026-07-07
+**Question** (interaction-model §9.2): How does mobile authenticate to Tower Cloud? Same identity as the CLI? Separate token per device?
+
+## Ground truth (verified against repo, 2026-07-07)
+
+- The cloud relay exists in code today: `afx tower connect` (`packages/codev/src/agent-farm/commands/tower-cloud.ts`) registers the tower with `cloud.codevos.ai` and stores `~/.agent-farm/cloud-config.json` (`tower_id`, `ctk_...` api key, `server_url`, perms 0600).
+- The `ctk_` key authenticates **tower → cloud**, not user → tower. There is no user→tower credential anywhere in the system.
+- Tower's own HTTP surface is unauthenticated by design (`server-utils.ts` `isRequestAllowed` returns true); the perimeter (localhost bind, or the cloud edge) is the security boundary.
+- Issue #655 (cloud messaging) already anticipates this question: "Could reuse the existing `ctk_` tower keys, or introduce separate…" — it must NOT reuse `ctk_`.
+
+## Decision
+
+**Per-device mobile tokens, issued by Tower Cloud, distinct from `ctk_` tower keys. The user's cloud account is the identity anchor; devices are revocable children of it.**
+
+Concretely:
+
+1. **Identity**: the user's Tower Cloud account (the same one that authorizes `afx tower connect` in the browser today). Mobile does not get a separate identity; it gets a separate *credential*.
+2. **Credential**: a device-scoped refresh token (`cmd_` prefix proposed, "codev mobile device") issued via OAuth-style sign-in in the app. Short-lived access tokens derived from it. Never a `ctk_` key on a phone: `ctk_` grants tower-level control with no user attribution and no per-device revocation.
+3. **Storage**: platform secure store (Keychain / Keystore via expo-secure-store). Biometric gate on foreground.
+4. **Revocation**: per-device list in the cloud account UI. Lost phone = revoke one row, desktop and other devices unaffected.
+5. **Attribution**: every cloud→tunnel→tower request carries the device/user principal so Tower's (future) audit log can record it. This aligns with the two in-tower mitigations already identified in the May-2026 security review: make `isRequestAllowed` a real check using an edge-propagated session token, and add an audit log for state-changing endpoints.
+
+## Why not "same identity as the CLI"
+
+The CLI has no user identity — it has a *tower* credential. Reusing it would mean: no per-device revocation, no user attribution, and a stolen phone equals a stolen tower. The question as posed in §9 embeds a false premise; the refresh doc should correct it.
+
+## v0 (LAN PoC) carve-out
+
+For the local-Tower LAN PoC, there is no cloud and therefore no auth issuer. v0 connects directly to `http://<lan-ip>:4100` and inherits Tower's existing perimeter model (same trust as the web dashboard on the LAN — requires deliberate non-localhost bind, which already warns). This is acceptable for a developer PoC and explicitly unacceptable for anything shipped. The scope-lock issue must state this in writing so PoC convenience doesn't become shipped policy.
+
+## Dependencies / sequencing
+
+- Hard prerequisite for shipped mobile: close the in-tower auth gap (`isRequestAllowed` returning `true` unconditionally) — Tower must verify the edge-propagated principal, not trust the tunnel unconditionally. The full gap analysis is in `feasibility-2026-07.md` §5.
+- Coordinate with #655 (cloud messaging), which needs the same user-level (not tower-level) auth story.
+
+## Related
+
+- [[q1-pairing-model]] — pairing rides on the same account anchor.
+- Tower Cloud security review (2026-05-26; local research note, unpublished) §4–6 — findings restated with code citations in `feasibility-2026-07.md` §5.

--- a/codev/research/mobile/decisions/q3-offline-behavior.md
+++ b/codev/research/mobile/decisions/q3-offline-behavior.md
@@ -1,0 +1,33 @@
+# Decision note — Q3: Offline behavior
+
+**Status**: Proposed (needs main's ratification before any implementation)
+**Date**: 2026-07-07
+**Question** (interaction-model §9.3): Feed cache? Outbound message queue? What happens to an `AskUserQuestion` fired while the user is offline for two hours?
+
+## Ground truth (verified against repo, 2026-07-07)
+
+- Tower's real-time channel to the dashboard is an SSE bus whose events are *refetch triggers*, not payloads (`packages/types/src/sse.ts`: `overview-changed | notification | builder-spawned | connected | heartbeat`). The dashboard's hooks poll + refetch on any event. There is no replayable, cursored event log today.
+- Server state is snapshot-shaped: `GET /api/overview` returns the full current picture (builders, gates, pending PRs, backlog, architects) on every call.
+- `question_pending` persistence (interaction-model §8.1) does not exist yet; it is proposed plumbing.
+
+## Decision
+
+**Design offline around snapshots + server-held pending state, not around an event-log sync protocol.**
+
+1. **Feed cache: last-snapshot, not event replay.** On reconnect/foreground, refetch `/api/overview` (and the feed's backing queries) and re-render. Cache the last successful snapshot locally so the app opens instantly to slightly-stale data with a staleness banner. Do NOT build client-side event-log reconciliation — Tower has no cursored log to reconcile against, and the snapshot model makes it unnecessary. (If a true activity feed ships Tower-side later, revisit; the feed itself should still be server-materialized, arriving as a paginated query, not a client-assembled event fold.)
+2. **Outbound queue: single-slot draft, not a mailbox.** Offline sends are held locally and flagged "will send when connected", with a visible pending chip and a cancel affordance. Cap the queue small (one per conversation target). Rationale: messages to an *agent* are time-sensitive context — a 2-hour-old "yes go ahead" auto-firing into a conversation that has moved on is actively harmful. On reconnect, if the target's state changed materially since composing (new gate, new phase), require a confirm-before-send tap instead of auto-flushing.
+3. **`AskUserQuestion` while offline 2 hours: the question is server-held pending state, answered late or expired — never queued client-side.**
+   - The pending question lives in Tower (the proposed `pending_question` persistence, §8.1) with a state machine: `pending → answered | expired | superseded`.
+   - When the user comes back online, `usePendingQuestion()` refetches: if still `pending`, show the card (with an "asked 2h ago" timestamp); if `expired`/`superseded` (the agent timed out, moved on, or the question was answered from another surface), show it as a historical feed row, not an actionable card.
+   - Answer submission must be **compare-and-set** on the question id + state, so a stale card can never inject an answer into a conversation that moved on. `question_resolved` (§8.3) is the cross-surface invalidation signal.
+   - Push (v1+, cloud-dependent) is the wake mechanism; offline delivery is simply "the push waits on APNs/FCM and the truth is re-fetched on open." No client-side question queue exists in any version.
+4. **Approvals are never queued.** Gate approve/reject taps require a live connection; offline tap = immediate "you're offline" feedback. A queued approval is an approval of a state you can no longer see.
+
+## Consequence for Tower plumbing (coordinate with main)
+
+The `pending_question` design (§8.1–8.3) must include from day one: `created_at`, a terminal state (`answered | expired | superseded`), the resolving surface, and compare-and-set semantics on resolution. This benefits the web dashboard identically (two browser tabs have the same double-answer race today-by-construction once the feature exists).
+
+## Related
+
+- [[q6-session-presence]] — presence is derived from the same snapshot/refetch model.
+- interaction-model §8 (Tower-side plumbing), §9.3.

--- a/codev/research/mobile/decisions/q4-push-controls.md
+++ b/codev/research/mobile/decisions/q4-push-controls.md
@@ -1,0 +1,22 @@
+# Decision note — Q4: Per-architect / per-builder push controls
+
+**Status**: Proposed (needs main's ratification; implementation is Phase 2 / cloud-gated)
+**Date**: 2026-07-07
+**Question** (interaction-model §9.4): User opts in to `main` but not `demos`; per-gate-type controls; DND schedules?
+
+## Decision
+
+**Two-axis matrix — event class × source — with attention-demanding defaults on and everything else off. DND delegates to the OS.**
+
+1. **Axis 1, event class** (the primary control): `needs-you` (gates pending, `AskUserQuestion`, builder blocked, sibling-architect ping addressed to you) vs `informational` (phase changes, PR merged, spawns, cleanups). Default: `needs-you` ON, `informational` OFF. This is the May feasibility doc's "do not over-notify" anti-pattern made concrete: informational push is the churn vector.
+2. **Axis 2, source scoping**: per-architect toggles (the multi-architect model makes architects the natural unit — `main` yes, `demos` no), with builders inheriting from their `spawned_by_architect` (the column exists in `global.db`). Per-builder overrides are v2; per-architect inheritance covers the stated use case without a settings jungle.
+3. **No per-gate-type granularity in v1.** Gate types (spec-approval / plan-approval / dev-approval / pr) are all `needs-you` by definition; a user who doesn't want plan-approval pushes from an architect doesn't want that architect's pushes. Revisit only if usage data shows demand.
+4. **DND: use the platform's.** iOS Focus modes and Android DND already do schedules, exceptions, and location awareness better than we ever will, and users already have them configured. We ship notification *channels/categories* (Android channels, iOS interruption levels) so the OS controls can discriminate; we do not build an in-app scheduler.
+
+## Where the preference lives
+
+Per-device, stored cloud-side with the device token record (from [[q2-auth-model]]) — the push fan-out must consult it *before* sending (server-side filtering), not deliver-then-mute (client-side filtering leaks content to APNs/FCM unnecessarily and burns battery).
+
+## Related
+
+- [[q2-auth-model]] (device records), [[q5-multi-workspace]] (workspace is a third implicit axis — a muted workspace mutes all its sources), issue #655 (cloud messaging carries the same event taxonomy).

--- a/codev/research/mobile/decisions/q5-multi-workspace.md
+++ b/codev/research/mobile/decisions/q5-multi-workspace.md
@@ -1,0 +1,27 @@
+# Decision note — Q5: Multi-workspace UX
+
+**Status**: Proposed (needs main's ratification)
+**Date**: 2026-07-07
+**Question** (interaction-model §9.5): User has three workspaces — per-workspace tabs? Unified feed with workspace tags?
+
+## Ground truth
+
+- Since #1118, one `~/.agent-farm/global.db` holds all workspaces (composite `(workspace_path, id)` keys), and Tower serves `GET /api/workspaces` plus per-workspace scoped routes. One Tower = many workspaces is the native shape.
+- Cross-workspace addressing already exists in the messaging grammar (`afx send <workspace>:architect`).
+- A user may ALSO have multiple Towers (home/office) once cloud-connected — that's a different axis (May doc's "multi-tower switching", Tier 2).
+
+## Decision
+
+**Unified `needs-you` inbox across workspaces; everything else workspace-scoped behind a switcher.**
+
+1. **The approval inbox is unified.** Pending gates and questions from all workspaces in one list, each row tagged with its workspace. Rationale: the 30-second use case is "what needs me?" — the user should never have to check three tabs to find out the answer is "nothing." This is the screen push notifications deep-link into, and pushes arrive workspace-agnostic.
+2. **Feed and chat are workspace-scoped**, behind a workspace switcher (current-workspace context persisted per device). Rationale: an interleaved multi-workspace activity feed is noise — activity volume is high (every phase change, spawn, message) and cross-workspace interleaving destroys glanceability. Chat targets (`architect:main`) are only meaningful within a workspace.
+3. **Multi-tower is Phase 2** and composes the same way: tower switcher above workspace switcher, inbox unified across both. v0 (LAN PoC) is single-Tower by construction.
+
+## Consequence for tower-sdk
+
+Hooks take explicit `workspacePath` (already required by the extraction — the dashboard's implicit-URL-scoping knot), and the inbox hook is the one deliberately cross-workspace query (`usePendingAttention()` aggregating across `GET /api/workspaces`).
+
+## Related
+
+- [[q4-push-controls]] (muted workspace mutes its sources), interaction-model §7.2.

--- a/codev/research/mobile/decisions/q6-session-presence.md
+++ b/codev/research/mobile/decisions/q6-session-presence.md
@@ -1,0 +1,30 @@
+# Decision note — Q6: Session presence ("waiting for input" indicator)
+
+**Status**: Proposed (needs main's ratification)
+**Date**: 2026-07-07
+**Question** (interaction-model §9.6): When a builder is "waiting for input," does mobile show a typing-indicator-style presence?
+
+## Ground truth
+
+Tower has no ground-truth "waiting for input" signal. What exists (verified 2026-07-07):
+
+- `lastDataAt` — wall-clock timestamp of the last PTY output frame per builder; the dashboard flags builders silent past a threshold as *possibly* waiting.
+- `OverviewBuilder.blocked` / `blockedGate` / `blockedSince` — porch-derived, reliable, but only covers *gate* blockage, not "the harness asked a free-form question and is idle."
+- `idleMs` on the overview payload.
+
+So there are two signal qualities: **reliable** (gate-blocked, pending `AskUserQuestion` once §8.1 plumbing exists) and **heuristic** (output-silence).
+
+## Decision
+
+**Yes to presence, but honest about signal quality: definitive states get definitive UI; the silence heuristic gets a soft hint, never a demand.**
+
+1. **Definitive** — `blocked` on a gate, or a pending structured question: render as an explicit attention state ("Waiting for your approval", "Asked you a question · 4m"). These are inbox items ([[q5-multi-workspace]]) and push triggers ([[q4-push-controls]]), not just presence dots.
+2. **Heuristic** — output-silence past threshold: render as a quiet "idle 6m" badge on the builder row. Do NOT phrase it as "waiting for you" (false positives: long test runs with buffered output, thinking pauses) and do NOT push-notify on it.
+3. **Working** — recent output: a subtle activity shimmer/dot, the closest analog to a typing indicator. Derived from `lastDataAt` recency; costs nothing.
+4. **No new plumbing for v0.** All three render from the existing overview snapshot on the normal poll/refetch cadence. If the structured-event work (§8.1) later adds harness-side "awaiting input" signals, the heuristic tier upgrades to definitive for free.
+
+The typing-indicator framing from the question is the right instinct scoped to tier 3 (working shimmer); presenting tier-2 heuristics with tier-1 confidence would teach users to distrust the app.
+
+## Related
+
+- [[q3-offline-behavior]] (same snapshot-derived model), interaction-model §8.1.

--- a/codev/research/mobile/decisions/q7-notification-permission.md
+++ b/codev/research/mobile/decisions/q7-notification-permission.md
@@ -1,0 +1,23 @@
+# Decision note — Q7: Notification permission on first launch
+
+**Status**: Proposed (needs main's ratification; implementation is Phase 2 / cloud-gated)
+**Date**: 2026-07-07
+**Question** (interaction-model §9.7): How and when do we ask for notification permission? First-run flow?
+
+## Decision
+
+**Never on first launch. Ask at the first moment a notification would have helped, with a pre-permission explainer card.**
+
+1. **First run** (Phase 2 cloud build): sign in → pick workspace → land in the inbox/feed. Zero permission prompts. The app is fully usable pull-based (open it, look), so nothing is blocked.
+2. **Trigger point**: the first time a `needs-you` event exists (a gate goes pending, or a question fires) while the user has the app open, show an in-app card: *"A gate just hit. Want a push next time so you don't have to check? [Enable notifications] [Not now]"* — tapping Enable fires the OS prompt. This is the classic pre-permission pattern: the OS prompt appears only after an in-context yes, so acceptance is near-certain and an OS-level "Don't Allow" (which iOS makes expensive to reverse) is rarely burned on a cold ask.
+3. **"Not now"** is remembered and re-offered sparingly (next trigger ≥ a few days later), plus a permanent switch in settings.
+4. **Provisional notifications on iOS** (deliver-quietly, no prompt) are NOT used in v1: quiet delivery to the notification center defeats the whole needs-you value (time-sensitive interruption), and juggling provisional→full upgrade flows adds states for no win. Revisit only if prompt-acceptance data disappoints.
+5. **Defaults on grant**: exactly the [[q4-push-controls]] defaults — `needs-you` on, informational off, all architects on. The permission prompt is never a settings wizard.
+
+## v0 note
+
+The LAN PoC has no push at all, so this whole flow is Phase 2. It's decided now because the first-run experience shapes the Phase 1 → Phase 2 upgrade path (Phase 1 users must not be prompted on update; the trigger-point rule handles that automatically).
+
+## Related
+
+- [[q4-push-controls]], [[q2-auth-model]] (sign-in precedes any permission ask).

--- a/codev/research/mobile/feasibility-2026-07.md
+++ b/codev/research/mobile/feasibility-2026-07.md
@@ -1,0 +1,150 @@
+# Codev Mobile: Feasibility and Use-Case Strategy — July 2026 Refresh
+
+**Date:** 2026-07-07
+**Supersedes:** the May-2026 feasibility snapshot (2026-05-26; a local pre-implementation exploration, not committed to the repo). This refresh is self-contained; the May doc is not required reading.
+**Companion:** `codev/research/mobile/interaction-model.md` (the interaction design), `codev/research/mobile/decisions/` (design-decision notes for the open questions).
+**Audience:** Strategy / product planning, plus enough repo ground truth to sequence spikes. ~2,200 commits landed between the May snapshot and this refresh; every repo claim below was re-verified on 2026-07-07.
+
+---
+
+## 0. TL;DR
+
+- **Technical feasibility remains high and is now better evidenced.** The cloud-relay tunnel is real, working code (HTTP/2 role-reversal over WSS to codevos.ai). The dashboard's data layer audit shows ~70-75% is portable to React Native, and all wire contracts already live in `@cluesmith/codev-types`. React Native + Expo remains the stack call.
+- **The honest constraint is still scope, not engineering — but the sequencing insight has sharpened.** A LAN-only PoC (local Tower, no cloud, no push) proves the interaction model in weeks, not months. Everything cloud-dependent (push, per-device auth, offline questions, desktop handoff at distance) is a separate workstream gated on Tower Cloud maturing.
+- **The defining use case is unchanged**: run your AI dev team during the 30-second attention windows of your day. Approval inbox, glanceable status, structured question-answering. Replicating the desktop UI on a smaller screen remains the failure mode.
+- **The terminal-substrate/interface split stands**: the PTY remains the source of truth; mobile renders projections (chat bubbles, feed rows, decision cards) with the raw terminal one tap away. New ground truth strengthens this: Tower today does *zero* PTY content parsing, so the projection layer is genuinely new plumbing — and it benefits web and VS Code equally, which changes who should design it (main, not mobile alone).
+- **The security posture is unchanged and the warning stands**: `isRequestAllowed` still returns `true` unconditionally; there is no in-tower defense in depth. Closing this gap remains a hard prerequisite for any credential living on a phone. Verified current, not just a May snapshot.
+- **Recommended path (updated):** spike-driven LAN PoC first (`packages/tower-sdk` extraction → `apps/mobile` scaffold → feed/chat/question flows against a LAN Tower), with cloud/push as a separately-specced phase coordinated with issue #655. Do not let mobile silently become "build Tower Cloud."
+
+---
+
+## 1. Current state baseline (re-verified 2026-07-07)
+
+- **Tower** runs locally (`127.0.0.1:4100` default; `BRIDGE_MODE=1` opt-in for LAN binding, with startup warning). Plain Node `http.Server` + `ws`, ~30 HTTP routes, three WS routes.
+- **Cloud relay exists in code**: `afx tower connect` (`packages/codev/src/agent-farm/commands/tower-cloud.ts`) registers with `cloud.codevos.ai`; the Tower daemon dials an outbound WSS tunnel and serves HTTP/2 over it (`lib/tunnel-client.ts`, `servers/tower-tunnel.ts`). `ctk_` keys authenticate tower→cloud. Browser access via the tunnel proxy (`/t/{towerId}/...`).
+- **Web dashboard** (`@cluesmith/codev-dashboard`) is the browser surface; it is what mobile users reach for today. Data layer: plain React hooks, polling + SSE-triggered refetch of the `GET /api/overview` snapshot; typed contracts all in `@cluesmith/codev-types`.
+- **VS Code extension** is the polished desktop UX.
+- **No native mobile client.**
+
+The implication stands from May: a mobile app is not bridging a connectivity gap. It must be meaningfully better than "the web UI on your phone" — via native pickers, push (eventually), and a feed built for glancing — or it has no reason to exist.
+
+## 2. What changed since May (staleness audit)
+
+Six weeks of platform evolution that the May doc predates, each with a mobile consequence:
+
+| Change | What it is | Mobile consequence |
+|---|---|---|
+| **Multi-architect workspaces** (Spec 755, #786, #826) | A workspace hosts named sibling architects (`main`, `mobile`, `reviewer`…); `afx send architect:<name>`; spoofing check on builder senders | The May doc's mental model of "the architect" is stale. Feed, chat targets, and notification scoping are all **per-architect**. The mobile chat UI needs an architect switcher, not a single thread |
+| **global.db consolidation** (#1118/#1127) | Per-workspace `state.db` retired; single `~/.agent-farm/global.db`, composite-keyed `(workspace_path, id)` tables, `spawned_by_architect` column | One DB serving all workspaces makes multi-workspace mobile UX (decisions/q5) natural server-side; `pending_question` persistence has an established home and migration path |
+| **Sibling-architect messaging** | Architects message each other; the message bus carries these frames | The feed should render architect↔architect traffic (e.g. `mobile → main: scope-lock ready`) — a feed row type the May doc never anticipated |
+| **artifact-canvas + review-comment codec** (spec 945, #1055, #1029) | Shared markdown + inline-review-comment rendering package for DOM hosts; native split explicitly deferred (#1029) until native rendering is committed | The "review comments as inline speech bubbles" pattern now has a reference implementation. Mobile's rendering spike decides RN-native vs WebView-hosted artifact-canvas, and feeds #1029 |
+| **Runnable worktrees / `afx dev`** | Builders' worktrees can run dev servers; single-slot dev PTY | Marginal for mobile v0; a "dev server running" feed row is a nice-to-have |
+| **IDE workstream externalized** | Codev IDE fork moved to `amrmelsayed/codev-ide` | `codev://` deep-link registration is now an *external* dependency; handoff design (decisions/q1) deliberately makes it optional enhancement, browser-URL fallback primary |
+| **PIR protocol matured; Stream Deck integration shipped** | More gate-heavy protocols in daily use (`plan-approval`, `dev-approval`, `pr`); a physical-button approval surface exists in the sibling codev-integrations repo | Confirms the approval-inbox thesis with usage evidence: gates are the highest-frequency human touchpoint. Stream Deck is the desk-bound cousin of the mobile approval card; a Tower-side gate-approval endpoint (interaction-model §8.5) serves both |
+
+**What did NOT change:** the security gaps (§5 below) — re-verified, all four still present. The tunnel architecture. The types-first contract discipline (strengthened, if anything: the dashboard defines zero wire types of its own).
+
+## 3. Technical feasibility — React Native + Expo (unchanged call, sharper evidence)
+
+The May analysis of RN vs PWA vs Capacitor vs native vs Flutter stands; nothing in six weeks moved it. RN + Expo (managed workflow, EAS) remains the recommendation. Three updates:
+
+1. **The code-sharing story is now concrete.** The `packages/tower-sdk` extraction was audited (2026-07-07): the dashboard's data layer is plain React hooks (no Redux/React Query/Zustand), snapshot-polling + SSE-refetch, with **all wire contracts in `@cluesmith/codev-types`**. ~70-75% ports as-is. The three knots are all transport/glue, not business logic: (a) workspace identity implied by browser URL (`getApiBase() = './'`, reverse-proxy prefix) — SDK must take explicit `baseUrl` + `workspacePath`; (b) the module-global `EventSource` singleton with `document.visibilitychange` lifecycle — needs an injected transport + RN `AppState`; (c) three divergent auth/storage paths (browser `localStorage`, Node `~/.agent-farm/local-key`, and nothing for RN) — needs injected `getToken()`/storage interfaces.
+2. **Terminal rendering is settled by decision, not by WebView benchmarking.** v0 ships a read-only monospace snapshot (the `/ws/terminal/:id` byte bridge exists; rendering read-only is a client choice) and no interactive terminal. The May doc's §5.5 substrate-vs-interface argument is preserved in `interaction-model.md` §2/§5 as the design principle.
+3. **Markdown/code rendering has a fork in it** (#1029): RN-native markdown vs WebView-hosted artifact-canvas. Spike question, not a blocker.
+
+## 4. Architecture implications (updated)
+
+### 4.1 The three-layer split is the whole game
+
+- `apps/mobile` (Expo/RN, view layer) — new
+- `packages/tower-sdk` (framework-agnostic hooks + API/WS clients) — extracted from the dashboard; consumed by web, mobile, and eventually VS Code
+- Tower plumbing (structured events, question detection, gate-approval endpoint) — new, **shared with web**, designed with main
+
+Issue #855 (`apps/*` split: `packages/dashboard` → `apps/web`, `packages/vscode` → `apps/vscode`, `apps/mobile` lands fresh) is the layout this assumes. Sequencing (before first mobile PR vs bundled with it) is main's call.
+
+### 4.2 Backend changes — reframed by what exists
+
+The May doc's backend list assumed more cloud than exists. Reframed:
+
+**Tower-side (local, benefits all surfaces, v0-relevant):**
+- Structured event emission (question_pending/question_resolved at minimum; activity events eventually). Tower currently does zero PTY content inspection — detection mechanism (PTY parsing vs harness-hook emission) is itself a spike question.
+- Gate approve/reject HTTP endpoint preserving human-only semantics (today porch-CLI-only).
+- Overview/state already rich enough for the v0 feed (OverviewBuilder carries phase, gates, blocked, prReady, spawnedByArchitect).
+
+**Cloud-side (v1+, gates shipped mobile, coordinate with #655):**
+- User-level identity + per-device mobile tokens (decisions/q2) — distinct from `ctk_` tower keys.
+- Push infrastructure (APNs/FCM registration, event→push wiring, per-type/per-architect controls — decisions/q4).
+- In-tower verification of edge-propagated principals (closing §5's gap) + audit logging.
+
+### 4.3 What mobile must NOT become
+
+The scope trap, named plainly: push, auth, offline questions, and handoff-at-distance are all Tower Cloud features. If mobile's critical path runs through all of them, mobile *is* the Tower Cloud project wearing a costume. The v0 scope-lock exists precisely to sever that: LAN PoC proves interaction value with zero cloud dependency; cloud work proceeds on its own track with its own spec (#655 is the seed).
+
+## 5. Security (re-verified 2026-07-07 — unchanged, warning stands)
+
+All four gaps identified in the May-2026 Tower Cloud security review (a local research note, unpublished; its findings are restated here with code citations so this doc stands alone) remain current:
+
+1. `isRequestAllowed` (`packages/codev/src/agent-farm/utils/server-utils.ts`) returns `true` unconditionally — zero in-tower auth.
+2. Admitted requests reach the full control plane (`/api/launch`, `/api/send`, `/api/stop`, terminal WS attach).
+3. CORS allows any `https://` origin.
+4. No audit logging of state-changing operations.
+
+Consequences for mobile, restated as decisions:
+- **v0 (LAN PoC)** inherits the existing perimeter model — same trust as the LAN dashboard, acceptable for a developer PoC, stated in writing in the scope-lock as unacceptable to ship.
+- **Shipped mobile** hard-requires: in-tower principal verification, per-device tokens (decisions/q2), audit trail with device attribution. Non-negotiable, unchanged from May.
+
+## 6. Core use cases and feature tiers (carried forward, trimmed to what survives contact with ground truth)
+
+The May doc's four narrative use-case flows (8am decision sweep, commute spec, car update, cafe conflict resolution) and its tiered feature inventory remain the north star; they are not re-litigated here. What ground truth changes:
+
+- **The approval inbox is even more central than May thought.** PIR's three human gates are now the daily-driver protocol shape, and the Stream Deck integration is independent evidence that fast gate approval is the highest-frequency human loop. Tier 1 = approval inbox + feed + chat + question cards. Unchanged.
+- **AI-summarized cards move from "backend feature" to "open design question."** May assumed server-side summaries; there is no summarization infrastructure in Tower and none planned. v0 renders what exists (gate names, issue titles, PR metadata from overview). Summarization is v1+, unspecced.
+- **Voice, Watch, CarPlay, widgets, Live Activities**: all still Tier 2/3, all cloud-and-after. Nothing new.
+- **The single sharpest claim stands**: *a first-class Codev mobile app turns "managing your AI dev team" into something you can do during the time it takes to drink a coffee.* Every scope decision tests against it.
+
+## 7. Anti-patterns (carried forward verbatim in spirit)
+
+1. Do not port the desktop UI screen-for-screen.
+2. Do not make the raw terminal the default rendering (keep it one tap away).
+3. Do not optimize for long-form editing.
+4. Do not duplicate VS Code extension features.
+5. Do not require API-key copy-paste (mobile auth is account + biometric; see decisions/q2).
+6. Do not ship before the in-tower auth gap is closed.
+7. Do not over-notify (defaults in decisions/q4).
+8. Do not build a chat interface that tries to replace the architect — mobile is a remote control, not a duplicate brain.
+9. **New:** do not design Tower's structured-event/question plumbing mobile-shaped — it serves web and VS Code equally, and its design belongs with main.
+
+## 8. Phasing (updated for the spike-first reality)
+
+**Phase S — spikes (EXPERIMENT protocol, LAN-only, no shipped code).** Priority order per the mobile workstream mandate: tower-sdk extraction; apps/mobile Expo scaffold + LAN WS/SSE reachability; AskUserQuestion detection design (with main); push wiring sandbox (APNs/FCM feasibility only); RN real-time feed; native diff viewer eval; chat/card rendering (RN-native vs WebView artifact-canvas, feeds #1029). Output: research notes in `codev/research/mobile/spikes/`.
+
+**Phase 1 — LAN PoC** (PIR specs, real implementation): feed + chat + question cards + gate approval against a LAN Tower. Cold-tester round (3 testers, timed tasks) mirroring the IDE PoC pattern. #855 lands before or with the first PR — main's call.
+
+**Phase 2 — cloud-connected mobile**: per-device auth, push, offline semantics, handoff at distance. Gated on Tower Cloud work (its own spec; seeded by #655 and the security-profile mitigations). This phase's timeline is owned by the cloud workstream, not mobile.
+
+**Phase 3 — differentiation**: voice, Watch, widgets, summaries. Unchanged from May Tier 2/3; unscheduled.
+
+The May doc's calendar estimates (12-16 weeks MVP, 9-12 months first-class, ~35 person-months) assumed a staffed human team and predate agent-farm delivery capacity; they are retired rather than revised. Sequencing above replaces them; re-estimate after the first three spikes land.
+
+## 9. Strategic open questions — status update
+
+Of the May doc's seven strategic questions:
+
+1. **Primary persona** — still open, but the de-facto answer for v0 is "the solo Codev power user" (i.e., dogfooding). Formal persona decision deferred to Phase 2 when pricing/packaging matter.
+2. **Pricing** — deferred to commercialization strategy; not a v0 concern.
+3. **Single-user vs team** — v0 is single-user by construction (LAN, own Tower).
+4. **Self-host story** — the `--service <url>` override already exists in `afx tower connect`; mobile should honor arbitrary cloud URLs from day one of Phase 2. Affirmed.
+5. **Store distribution** — Phase 2 concern; v0 is Expo dev builds.
+6. **iOS-first vs simultaneous** — RN keeps both open; v0 PoC targets whatever device is on the desk (pragmatically iOS); no store commitment implied.
+7. **Separate codebase vs shared with web** — **decided**: separate view layers, shared `packages/tower-sdk` + `packages/types`. See `interaction-model.md` §7.
+
+The seven *interaction-design* open questions from the interaction-model draft are separately answered in `codev/research/mobile/decisions/` (q1–q7).
+
+## 10. References
+
+- `codev/research/mobile/interaction-model.md` — the interaction design (refreshed same day)
+- `codev/research/mobile/decisions/q1..q7` — design-decision notes
+- Tower Cloud security review (2026-05-26; local research note, unpublished) — tunnel mechanics + threat model. Its load-bearing findings are restated with code citations in §5, so it is background, not a dependency
+- Commercialization strategy (2026-05-21; local research note, unpublished) — Tower Cloud revenue frame
+- Issues: #855 (apps/* split), #655 (cloud messaging), #1029 (artifact-canvas native split deferral), #1118/#1127 (global.db)
+- Historical: the May-2026 feasibility snapshot this refresh supersedes (local pre-implementation exploration, not committed)

--- a/codev/research/mobile/interaction-model.md
+++ b/codev/research/mobile/interaction-model.md
@@ -1,0 +1,350 @@
+# Codev Mobile — Interaction Model
+
+**Status**: Design, pre-implementation. Ground-truthed against the repo on 2026-07-07.
+**Last updated**: 2026-07-07 (revised from a 2026-07-05 local draft, with repo verification and corrections)
+**Prior context**: `codev/research/mobile/feasibility-2026-07.md` — the strategic frame (refreshed from the May-2026 snapshot).
+**Open questions**: the seven §9 questions now have decision notes in `codev/research/mobile/decisions/`.
+
+---
+
+## 1. Positioning
+
+The mobile app is scoped as **"Codev on the go"** — 30-second attention windows, glance + tap + short chat, then close. It is a **complement** to the desktop web dashboard and VS Code extension, not a portable replacement for either.
+
+Explicitly:
+
+- **Not a full IDE.** No editor surface, no file browser deep enough for authoring.
+- **Not a portable dashboard.** Multi-panel management workflows stay on desktop.
+- **Not a general terminal.** Free-form shell interaction is not a mobile use case.
+
+What the mobile app *is*: the surface a user reaches for to answer a Claude question at a coffee shop, approve a gate from a train, glance at builder status between meetings, or send a short message to the architect while away from the laptop.
+
+---
+
+## 2. Interaction primitives
+
+Four primitives carry the entire user-facing interaction surface. All built with native RN components; none require xterm.js or DOM-only libraries.
+
+Each primitive is annotated below with its **plumbing status** as of 2026-07-07 (see §8 and Appendix A for detail): what Tower already provides vs. what must be built.
+
+### 2.1 Chat interface
+
+- Text input at the bottom of the screen; message bubbles above.
+- User's typed message is routed under the hood as `afx send architect "..."` (or to a specific builder id) — concretely, `POST /api/send` with the same affinity-checked resolver the CLI uses.
+- Architect / builder responses appear as bubbles.
+- Full markdown rendering: bold, code blocks, links, lists, inline formatting.
+- Long messages collapse to a preview with an expand affordance; short ones render inline.
+- Same mental model as ChatGPT / Claude mobile apps.
+
+**Plumbing status: mostly exists.** The architect ↔ user relationship is already message-passing, and Tower already has a **typed message bus**: `broadcastMessage` mirrors every routed message to `/ws/messages` subscribers as a `MessageFrame` (`{type:'message', timestamp, from:{project,agent}, to:{project,agent}, content, metadata}` — `tower-messages.ts`). Mobile chat = `POST /api/send` outbound + `/ws/messages` subscription inbound. The gap: agent→user *responses* are not on the bus (they're raw PTY output); surfacing them as chat bubbles needs the structured-event work in §8.
+
+#### Voice input (STT) — decision note (2026-07-07)
+
+"Voice" is three different-sized things, and only the largest is genuinely deferred. Conflating them (as the May feasibility doc's Tier-2 "voice spec drafting" framing did) undersells what chat gets for free:
+
+1. **OS dictation into the chat input — free, present in v0 by construction.** The composer is a standard text field; the iOS / Android keyboard mic provides speech-to-text into it with zero engineering. This tier requires no code and must never be "built" — it exists the moment chat ships. Recorded here so nobody specs it later.
+2. **First-class mic affordance — cheap, deliberately NOT in v0; first candidate for v1.** A dedicated mic button on the composer using platform STT (SFSpeechRecognizer / Android SpeechRecognizer via an Expo module), making "talk to your architect" one tap. Days of work, no cloud dependency, and it strengthens the core 30-second story — dictating "looks good, merge it and start on the next issue" beats typing it while walking. Kept out of v0 purely for scope discipline; named here as the first v1 scope question for main.
+3. **Voice-first authoring ("commute spec") — expensive, Phase 3, unchanged.** Earbuds-only operation, AI spec drafting from a spoken description, audio readback, hands-free issue filing. Needs summarization/readback infrastructure that doesn't exist; a differentiation feature, not a PoC feature. This is the only tier the scope-lock's "voice: deferred" line actually costs.
+
+### 2.2 Activity feed
+
+- Slack-style scrollable timeline of every architect / builder event: messages, phase changes, gate hits, spawns, PR merges, cleanup events.
+- Real-time updates via WebSocket.
+- Each row taps into its underlying content: message row → full text, gate row → approve/reject card, PR row → PR card.
+- Filterable by architect, by builder, by event type (v2 concern).
+
+**Plumbing status: does not exist as an event stream.** Verified 2026-07-07: Tower's SSE channel (`GET /api/events`) emits only coarse refetch triggers (`overview-changed`, `notification`, `builder-spawned`, `architects-updated`, `connected`, plus ad-hoc `POST /api/notify` types). There is **no** typed, replayable activity log — the dashboard polls `GET /api/overview` (a rich snapshot: builders with phase/gates/blocked/prReady, pendingPRs, backlog, architects) and refetches on any SSE tick. Two consequences: (a) v0 mobile should render the feed **from overview snapshots + the message bus**, not wait for an event log; (b) a true Tower-side activity event stream is new plumbing that benefits web equally — coordinate with main (§8).
+
+### 2.3 Structured action tiles
+
+Tap-first flows for common actions that would be tedious to type:
+
+- **Approve gate** — one tap on the notification / gate card
+- **Reject gate with comment** — tap → short text input → send
+- **Quick preset messages** — "ship it" / "need to think" / "blocked, will look tonight"
+- **Spawn builder** — pick issue → pick protocol → confirm
+- **Cleanup builder** — swipe on builder row → confirm
+
+**Plumbing status: partial.** Send, spawn (`POST /api/launch`), stop, issue search (`GET /api/issue-search`) exist as Tower routes. Gate approve/reject is **not** a Tower HTTP endpoint today — `porch approve` is a CLI operating on worktree state; exposing an approval route (with the human-approval semantics preserved) is new, coordinated work.
+
+### 2.4 Push notifications
+
+- Gate ready for approval
+- Builder blocked / hit `dev-approval`
+- Architect asked a question via `AskUserQuestion`
+- Sibling architect pinged you (`afx send architect:main "..."` from another architect)
+- PR merged / release published
+
+Tap the notification → app opens directly to the relevant card. This is where mobile *wins* over desktop: proactive attention when the user isn't watching the terminal. Coffee-shop approval flows.
+
+**Plumbing status: cloud-dependent, v1+.** Requires Tower Cloud push infrastructure (APNs/FCM). The tunnel itself is real, working code today (`tunnel-client.ts` — HTTP/2 role-reversal over WSS to codevos.ai), but there is no push wiring and no per-device identity (see `decisions/q2-auth-model.md`). Out of v0 scope by decision.
+
+---
+
+## 3. Response review — spectrum by content type
+
+Users need to review a range of response types, from one-line events to multi-page CMAP verdicts. Different lengths call for different UIs:
+
+| Response type | Length / density | Mobile pattern |
+|---|---|---|
+| Direct message from architect / builder | short-medium | **Chat bubble** — markdown-rendered, tap for full timestamp / author details |
+| Phase / status change | one-line event | **Feed row** — glance-scanable |
+| Gate hit requiring attention | short + action | **Push notification + action card** with Approve / Reject / View |
+| CMAP verdict (3-lane review) | medium (200-1000 words) | **Expandable card** — preview in feed, tap for full-screen markdown reader |
+| Architect explanation | medium (100-500 words) | **Chat bubble** — same rendering as short messages, just taller |
+| Builder review summary | medium | **Card** — title, verdict, tap for full body |
+| PR body + files changed | structured | **PR card** — title, status, files count, tap to native diff viewer |
+| Individual file diff | structured code | **Native diff viewer** — syntax-highlighted, unified / split toggle |
+| Review comments on spec / plan | annotated | **Inline speech bubbles** near annotated line (Google Docs mobile pattern) |
+| Raw terminal output (edge case) | long text | **Read-only monospace snapshot** — last N lines, non-interactive |
+| Full CMAP consultation output | very long, dense | **Summary + "Continue on desktop"** deep-link |
+| Multi-file review, spec authoring | very long | **Summary + "Continue on desktop"** deep-link |
+
+**Rendering note (new since the draft)**: `@cluesmith/codev-artifact-canvas` (spec 945) settled the markdown/review-comment rendering question for DOM hosts, and issue #1029 records the decision to **defer a core/web/native split until native rendering is a committed requirement**. Mobile is the thing that makes it committed. The chat/card-rendering spike must therefore evaluate: (a) RN-native markdown (react-native-markdown-display et al.) vs. (b) hosting artifact-canvas in a WebView (works unchanged today per #1029) — and its outcome should feed back into #1029's deferred decision.
+
+### 3.1 Three UI primitives carry most of the load
+
+- **Chat with expandable messages** — short exchanges inline, long ones full-screen on tap
+- **Feed with tap-through cards** — glance, then drill in as needed
+- **Native diff viewer** — GitHub's mobile diff viewer is a reference implementation
+
+### 3.2 Honest desktop-deferral
+
+Some content types are worse on mobile no matter what UI ships:
+
+- CMAP verdicts with three lanes of dense analysis (often 2000+ words total)
+- 20+ file PR reviews
+- Spec authoring / plan editing (long-form writing on phone is painful)
+- Debugging with raw scrollback (needs pattern-matching over lots of text)
+
+For these, mobile's job is: **surface that it happened, show a summary, hand off to desktop**. The card in the feed says *"CMAP complete: 2 APPROVE / 1 REQUEST_CHANGES"* with a **Continue on Desktop** button (handoff mechanics: `decisions/q1-pairing-model.md` — a cloud/dashboard URL, not a device-pairing subsystem).
+
+This is not a mobile failure — it's mobile playing to its strengths. The 30-second attention model means "give me signal, defer the deep dive." Trying to make mobile serve a 20-minute review session would make the app worse at the 30-second use cases without meaningfully winning the 20-minute ones.
+
+---
+
+## 4. `AskUserQuestion` → native picker (mobile's sweet spot)
+
+Structured multiple-choice questions from Claude (via the `AskUserQuestion` tool) map to native mobile picker UI cleanly — this is one of mobile's clearest wins over desktop.
+
+### 4.1 Why it maps well
+
+`AskUserQuestion` has a well-defined schema: question string + 2-4 options (each with label + optional description) + optional multi-select + optional preview content per option. Tower can detect these tool calls in the architect / builder streams and route the STRUCTURED payload (not free-form text) to whichever surface is watching.
+
+Mobile receives `{question, options[]}` as a structured event, not prose. It renders native picker UI, not text parsing.
+
+**Plumbing status: does not exist.** Verified 2026-07-07: zero `AskUserQuestion` detection anywhere in the codebase; Tower does no content inspection of PTY streams (the only content-derived signal is `lastDataAt`, a last-output timestamp used to flag possibly-waiting builders). §8.1 is therefore a from-scratch design, and because it benefits the web dashboard and VS Code equally, its design belongs with main, not mobile-shaped.
+
+### 4.2 The mobile question card
+
+```
+┌─────────────────────────────────────┐
+│ From: pir-1140                      │
+│                                     │
+│ Preserve the caller env for         │
+│ legacy-row recoveries?              │
+│                                     │
+│ ● Yes, use shell architect          │
+│     if DB row has no spawnedBy      │
+│ ○ No, always fall back to 'main'    │
+│ ○ Other...                          │
+│                                     │
+│            [ Submit ]               │
+└─────────────────────────────────────┘
+```
+
+- **Radio buttons for single-select, checkboxes for multi-select** — standard native primitives
+- **Descriptions collapsible** — tap the label to see the full option description
+- **"Other" option** always available → routes to free-form text input, same as desktop
+- **Preview content** (code snippets, mockups) renders inline as a small code block, or tap-to-expand to full-screen
+
+Answer submits, Tower feeds back into the AI's `tool_result`, conversation continues.
+
+### 4.3 Why mobile is *better* than desktop for this pattern
+
+- **Proactive attention**: push notification means Claude can ask a question while the user is in a meeting or on the train. Answer in 8 seconds, move on. Desktop requires the user to be looking at the terminal.
+- **Discrete taps beat typing** option labels or number keys.
+- **Native pickers are more accessible** — VoiceOver, larger touch targets, keyboard-optional.
+- **Fits the 30-second window perfectly** — this is exactly the "Codev on the go" use case landing well.
+
+### 4.4 The free-form-list edge case
+
+Sometimes Claude writes *"Would you like A, B, or C?"* as prose in a regular message rather than calling `AskUserQuestion`. Tower can't detect that as structured — it looks like normal chat text. Same problem exists on desktop today.
+
+**Mitigation**: encourage / train architects to use `AskUserQuestion` for genuine option-choice questions, and keep prose for open-ended asks. When structured, mobile UX is excellent. When prose, it degrades gracefully to a chat bubble with a typed response.
+
+Not a mobile-side fix; it's a prompt / architect-behavior concern.
+
+---
+
+## 5. What mobile should NOT try to do
+
+Explicit non-goals — trying to do these would degrade the primary use cases without winning the deep ones:
+
+- **Full terminal emulator.** Even with a native RN bridge to SwiftTerm / Android Terminal Emulator, mobile terminal UX is bad regardless of implementation (tiny text, no keyboard shortcuts, poor selection, no chord support). More importantly, the mobile use case doesn't need it — architect / builder communication is message-passing at heart, not raw shell.
+- **Multi-file PR review with deep diff analysis.** Fine up to ~5 files; beyond that, hand off to desktop.
+- **CMAP-verdict multi-lane review sessions.** Read the summary; defer the full lanes.
+- **Spec authoring / plan editing.** Long-form writing on phone is painful; not worth serving.
+- **Debugging with raw scrollback.** Needs pattern-matching over lots of text; desktop territory.
+
+The pattern: **mobile serves the 30-second use cases exceptionally well and hands off honestly for the 20-minute ones.**
+
+---
+
+## 6. Desktop handoff pattern
+
+**Decided** — see `decisions/q1-pairing-model.md`. Summary:
+
+1. Mobile shows summary + "Continue on Desktop" button.
+2. The button carries a **URL, not a device address**: the cloud tunnel-proxy path (`https://<cloud>/t/<towerId>/<view-path>`) when cloud-connected, or the LAN dashboard URL in v0.
+3. `codev://` deep-linking (registered by the Codev IDE, now in the external `amrmelsayed/codev-ide` repo) is a desktop-side progressive enhancement that claims those links when installed; the browser is the universal fallback. Mobile never needs a pairing registry.
+
+---
+
+## 7. Architectural implications
+
+### 7.1 Do NOT merge `apps/web` and `apps/mobile`
+
+Considered in this exploration: could React Native + React Native Web give us one codebase for iOS + Android + web from a single Expo project?
+
+Rejected. Reasons:
+
+- **RN Web fits feed-based touch-first apps** (Bluesky, X, Discord). The web dashboard is the opposite profile: desktop management console, multi-panel, keyboard-heavy, xterm.js terminal attach, complex hover / right-click / drag-drop affordances.
+- **Trying to unify** produces either lowest-common-denominator UX (bad on both platforms) or per-platform branches everywhere (which defeats the merger's premise).
+- **Rewriting the dashboard** as RN Web is a rewrite, not a refactor. Weeks of work with regression surface, blocking mobile from shipping while the migration lands.
+- **Build tooling complexity** — Metro + Expo Router + web adapter vs. clean per-platform toolchains (Vite for web, Expo for mobile).
+
+### 7.2 DO share the state / data layer
+
+Extract a framework-agnostic package with React hooks that both apps (and the VS Code extension) consume. Each platform owns its view layer natively.
+
+**Proposed**: `packages/tower-sdk`
+
+Exports hooks like:
+
+- `useBuilderList()` — real-time builder roster
+- `useSendMessage(target)` — send to architect / builder
+- `useArchitectActivity(name)` — event stream for a given architect
+- `useOverview(baseUrl, workspacePath)` — same shape the dashboard consumes today
+- `useGateApproval(gateId)` — approve / reject flow
+- `usePendingQuestion()` — active `AskUserQuestion` awaiting response
+
+Framework-agnostic (no DOM, no RN specifics). Same hook, three different view renderings:
+
+- **web** — resizable table with sortable columns
+- **mobile** — swipeable card feed with pull-to-refresh
+- **vscode** — sidebar tree items with context menus
+
+Bug fixes in message routing, schema changes in `packages/types`, new WebSocket events — all land in `packages/tower-sdk` once, every surface picks them up.
+
+**Extraction feasibility (audited 2026-07-07)** — favorable, with three known knots:
+
+- The dashboard has no state library (no React Query/Zustand): plain `useState` + fetch + `setInterval` polling + SSE-triggered refetch, snapshot-deduped. ~70-75% of the data layer is portable as-is; **all wire contracts already live in `@cluesmith/codev-types`** (the dashboard defines none of its own), which is the single biggest asset.
+- **Knot 1 — implicit workspace scoping.** The dashboard's API base is `'./'`; workspace identity rides the browser URL (reverse-proxy prefix `/workspace/<base64>/`), and WS/SSE URLs are built from `window.location`. RN has no URL context — the SDK must take explicit `baseUrl` + `workspacePath` (the hook signature above reflects this).
+- **Knot 2 — the SSE singleton.** `useSSE` is a module-global `EventSource` with `document.visibilitychange` lifecycle (browser 6-connection-limit workaround). RN has no `EventSource`; the transport must be an injected adapter, with RN `AppState` replacing visibility.
+- **Knot 3 — divergent auth/persistence.** Browser reads `localStorage['codev-web-key']`; the Node `TowerClient` in `packages/core` reads `~/.agent-farm/local-key` via `node:fs`; neither is RN-usable. The SDK needs injected `getToken()` + storage interfaces, unifying all three environments.
+
+### 7.3 Resulting monorepo layout
+
+Aligned with issue #855 (introduce `apps/*`):
+
+```
+apps/
+  web/         Vite + React DOM. xterm.js, multi-panel, keyboard shortcuts.
+  mobile/      Expo + React Native. Chat, feed, actions, push notifications.
+  vscode/      Existing extension.
+
+packages/
+  codev/       CLI + orchestration (unchanged per #855)
+  core/        Forge / VCS abstraction
+  types/       Wire contracts
+  config/      Workspace config
+  tower-sdk/   NEW. React-hooks-based state layer + WebSocket + API client.
+```
+
+---
+
+## 8. Tower-side plumbing required
+
+Not mobile-specific — benefits web dashboard equally. **All of §8.1–8.3 is new work** (verified absent, 2026-07-07); design coordination with main required so it isn't mobile-shaped.
+
+### 8.1 `AskUserQuestion` detection
+
+Tower listens for `AskUserQuestion` tool call events in each architect / builder's stream. (Note: Tower does **not** currently parse PTY content at all — this introduces content-derived structured events for the first time, so the detection mechanism itself is a design question: PTY-stream parsing vs. harness-side hooks emitting to Tower. The spike should evaluate both.) When one is detected:
+
+1. Extract `{question, options[], multiSelect, preview?}` from the tool call
+2. Emit a `question_pending` WebSocket event with the structured payload + a message id + the source (which architect / builder asked)
+3. Persist a `pending_question` row in `global.db` so late-joining subscribers see it — with the lifecycle fields required by `decisions/q3-offline-behavior.md`: `created_at`, terminal state (`answered | expired | superseded`), resolving surface, compare-and-set resolution.
+
+### 8.2 `question_pending` WebSocket event
+
+Consumed by:
+
+- Mobile app → renders question card
+- Web dashboard → renders inline picker in the relevant terminal / chat view
+- VS Code extension → surface as a notification or sidebar prompt
+
+All three consume through `packages/tower-sdk`'s `usePendingQuestion()` hook.
+
+### 8.3 Response routing
+
+- User selects an option (or types "other" free-form) on any surface
+- Response sent to Tower with `{message_id, selected_option_index, other_text?}`
+- Tower injects into the AI's context as a `tool_result`, conversation continues
+- Other subscribers get a `question_resolved` event so they can update their UI
+
+### 8.4 Push notification delivery
+
+- Requires Tower Cloud SaaS (out of scope for local-only Tower)
+- APNs (iOS) + FCM (Android) integration
+- User controls per-notification-type opt-in — see `decisions/q4-push-controls.md`
+- Deferred to a separate mobile-cloud spec; overlaps issue #655 (cloud messaging), which should be the coordination point
+
+### 8.5 Gate approval endpoint (new since draft)
+
+§2.3's approve/reject tiles need a Tower route that does what `porch approve` does today, preserving the human-only gate semantics (the `--a-human-explicitly-approved-this` contract must survive the trip through a mobile tap — i.e., the endpoint is authenticated as a human principal, never callable by an agent). Design with main; the web dashboard wants the same affordance.
+
+---
+
+## 9. Open questions → decisions
+
+The seven open questions from the 2026-07-05 draft now have decision notes (status: proposed, pending main's ratification):
+
+1. **Pairing model for desktop handoff** → `decisions/q1-pairing-model.md` — no pairing subsystem; the cloud account is the anchor and handoff is a URL.
+2. **Auth model** → `decisions/q2-auth-model.md` — per-device mobile tokens under the cloud account; never `ctk_` on a phone; v0 LAN carve-out.
+3. **Offline behavior** → `decisions/q3-offline-behavior.md` — snapshot cache, single-slot confirmed outbound draft, questions are server-held pending state with expiry/supersession; approvals never queue.
+4. **Per-architect / per-builder push controls** → `decisions/q4-push-controls.md`
+5. **Multi-workspace UX** → `decisions/q5-multi-workspace.md`
+6. **Session presence** → `decisions/q6-session-presence.md`
+7. **Notification permission on first launch** → `decisions/q7-notification-permission.md`
+
+---
+
+## 10. Prior art references
+
+- `codev/research/mobile/feasibility-2026-07.md` — strategic frame (refresh of the May-2026 snapshot)
+- Commercialization strategy (2026-05-21; local research note, unpublished) — Tower Cloud as the revenue line that mobile connects to
+- Tower Cloud security review (2026-05-26; local research note, unpublished) — tunnel mechanics + the in-tower auth gap; the load-bearing findings are restated with code citations in `feasibility-2026-07.md` §5 (verified still open 2026-07-07: `server-utils.ts` `isRequestAllowed` returns true)
+- Issue #855 — `apps/*` monorepo split; determines where mobile ends up living
+- Issue #655 — cloud messaging (send/receive afx-style messages via Codev Cloud); the closest existing issue to mobile's backend needs
+- Issue #1029 — artifact-canvas core/web/native split deferred until native rendering is committed; mobile's rendering spike feeds this
+- Codev IDE fork (external: `amrmelsayed/codev-ide`) — desktop-side of the handoff story
+- `packages/types` — wire contracts mobile consumes (already comprehensive; verified)
+- `AskUserQuestion` tool schema — reference implementation in the Codev main harness
+
+---
+
+## Appendix A — Ground-truth verification log (2026-07-07)
+
+Claims in the 2026-07-05 draft, checked against the repo:
+
+| Draft claim | Verdict | Evidence |
+|---|---|---|
+| Chat maps onto existing message-passing | **Confirmed, better than claimed** | `/ws/messages` typed bus with `MessageFrame` exists (`tower-messages.ts`); `POST /api/send` with affinity/spoofing checks (`tower-messages.ts`, spoofing at the resolver) |
+| "Same event stream the web dashboard consumes" for the feed | **Corrected** | SSE (`/api/events`) is coarse refetch triggers only (`packages/types/src/sse.ts`); dashboard polls `GET /api/overview` snapshots. No typed activity log exists |
+| Tower "already parsed for phase / status changes" (§8.1 premise) | **Corrected** | Tower does zero PTY content inspection; only `lastDataAt` timestamps. `builders.status/phase` DB columns exist but the state path hardcodes `running`/`''` |
+| `AskUserQuestion` detection feasible Tower-side | **Confirmed as design, absent as code** | Zero matches repo-wide; §8.1 is from-scratch |
+| `pending_question` row in `global.db` | **Viable** | #1118 confirmed done: single `~/.agent-farm/global.db`, composite-keyed `architect`/`builders` tables with `spawned_by_architect`; adding a table follows the established migration path |
+| Every action tile maps to an existing Tower API | **Partially corrected** | send/launch/stop/issue-search exist; gate approve/reject has no HTTP route (porch CLI only) — new §8.5 |
+| Cloud relay for push/handoff | **Confirmed real code** | `tunnel-client.ts` HTTP/2-over-WSS, `afx tower connect`, `ctk_` keys, `cloud-config.json`; push wiring itself absent |
+| Terminal WS could feed a read-only monospace snapshot | **Confirmed** | `/ws/terminal/:id` byte bridge with control frames (`pause/resume/seq`); read-only rendering is a client choice |


### PR DESCRIPTION
## What

Nine pre-implementation research documents for the Codev Mobile workstream, submitted as a PR so the team can decide whether the repo should carry them (versus keeping pre-implementation exploration local-only):

- `codev/research/mobile/interaction-model.md`: the four interaction primitives (chat, activity feed, action tiles, push), response-review spectrum, `AskUserQuestion` native picker design, non-goals, desktop handoff, architecture implications (`packages/tower-sdk`, do-not-merge web+mobile), Tower-side plumbing required, and a ground-truth verification appendix.
- `codev/research/mobile/feasibility-2026-07.md`: self-contained July refresh of the May-2026 feasibility snapshot. Staleness audit (multi-architect model, global.db consolidation, artifact-canvas, IDE externalization), tower-sdk extraction audit, security posture re-verification, use-case tiers, and spike-first phasing.
- `codev/research/mobile/decisions/q1..q7`: one decision note per open design question (pairing, auth, offline, push controls, multi-workspace, presence, notification permission). All marked Proposed, pending ratification.

## Why a PR

The architect view is that SPIR/PIR builders will later recreate much of this content as formal specs/plans, so committing research now is a judgment call for the team. Merge if the repo should carry the design record; close if research stays local until specs exist.

## Ground truth

Every repo claim in these docs was verified against the codebase on 2026-07-07 (Tower routes, WS/SSE event surface, message bus, global.db schema, cloud tunnel code, dashboard data layer). Notable corrections to earlier drafts: Tower does no PTY content parsing and has no `AskUserQuestion` detection; there is no gate-approval HTTP endpoint; the typed `/ws/messages` bus already exists for chat. No references to gitignored `tmp/` paths remain in these files.

## Related

- #1147 (mobile v0 scope-lock; these docs are its design context)
- #855, #655, #1029 (coordination points referenced throughout)
