### PR TITLE
[Bugfix #1154] vscode:prepublish: build all workspace deps via topological filter

### DIFF
--- a/codev/projects/bugfix-1154-vscode-prepublish-filter-misse/status.yaml
+++ b/codev/projects/bugfix-1154-vscode-prepublish-filter-misse/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1154
+title: vscode-prepublish-filter-misse
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-08T04:55:47.036Z'
+updated_at: '2026-07-08T04:55:47.037Z'

--- a/codev/projects/bugfix-1154-vscode-prepublish-filter-misse/status.yaml
+++ b/codev/projects/bugfix-1154-vscode-prepublish-filter-misse/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1154
 title: vscode-prepublish-filter-misse
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-08T04:55:47.036Z'
-updated_at: '2026-07-08T04:55:47.037Z'
+updated_at: '2026-07-08T04:57:43.427Z'

--- a/codev/projects/bugfix-1154-vscode-prepublish-filter-misse/status.yaml
+++ b/codev/projects/bugfix-1154-vscode-prepublish-filter-misse/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-07-08T05:05:09.146Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-08T04:55:47.036Z'
-updated_at: '2026-07-08T05:01:27.942Z'
+updated_at: '2026-07-08T05:05:09.147Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1154-vscode-prepublish-filter-misse/status.yaml
+++ b/codev/projects/bugfix-1154-vscode-prepublish-filter-misse/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-08T05:05:09.146Z'
+    approved_at: '2026-07-08T05:05:30.071Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-08T04:55:47.036Z'
-updated_at: '2026-07-08T05:05:09.147Z'
-pr_ready_for_human: true
+updated_at: '2026-07-08T05:05:30.072Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1154-vscode-prepublish-filter-misse/status.yaml
+++ b/codev/projects/bugfix-1154-vscode-prepublish-filter-misse/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1154
 title: vscode-prepublish-filter-misse
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-08T04:55:47.036Z'
-updated_at: '2026-07-08T04:57:43.427Z'
+updated_at: '2026-07-08T05:01:27.942Z'

--- a/codev/projects/bugfix-1154-vscode-prepublish-filter-misse/status.yaml
+++ b/codev/projects/bugfix-1154-vscode-prepublish-filter-misse/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1154
 title: vscode-prepublish-filter-misse
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,5 +13,5 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-08T04:55:47.036Z'
-updated_at: '2026-07-08T05:05:30.072Z'
+updated_at: '2026-07-08T05:05:38.933Z'
 pr_ready_for_human: false

--- a/codev/state/bugfix-1154_thread.md
+++ b/codev/state/bugfix-1154_thread.md
@@ -37,3 +37,11 @@ Investigation results:
   accepts the topological filter form; if the script reverts to an explicit
   `--filter` list, asserts the list covers every `workspace:*` dep.
   Verified red without the fix, green with it.
+
+## PR
+
+- Porch fix-phase checks passed (build 5.9s, tests 20.6s).
+- PR #1155 opened with Summary / Root Cause / Fix / Test Plan, `Fixes #1154`.
+- CMAP (3-way, `--issue 1154`): gemini=APPROVE, codex=APPROVE, claude=APPROVE,
+  all HIGH confidence, no key issues raised.
+- Requested `pr` gate via `porch done`; waiting on human approval.

--- a/codev/state/bugfix-1154_thread.md
+++ b/codev/state/bugfix-1154_thread.md
@@ -1,0 +1,39 @@
+# Builder thread — bugfix-1154
+
+## Investigate
+
+Issue #1154: `vscode:prepublish` in `packages/vscode/package.json` builds only
+`@cluesmith/codev-core` and `@cluesmith/codev-types`, missing
+`@cluesmith/codev-artifact-canvas` (a third `workspace:*` dep genuinely imported
+by the markdown-preview webview at `src/markdown-preview/webview/main.ts:34-35`).
+
+Reproduction in this worktree (fresh, no dists built):
+- `pnpm --filter codev-vscode run check-types` fails with TS2307 on
+  `@cluesmith/codev-core/*` subpath imports (no .d.ts emitted yet) — confirms
+  the fresh-clone failure class.
+- Next step: build core+types only (what the current prepublish filter does),
+  re-run check-types, expect the surviving error to be the artifact-canvas
+  TS2307 — that isolates the exact bug.
+
+Planned fix (per issue, future-proof flavor): switch the prepublish filter to
+pnpm's topological form `pnpm --filter 'codev-vscode^...' build`, which builds
+all workspace deps of codev-vscode transitively.
+
+Investigation results:
+- Reproduced: with no dists built, check-types fails on codev-core subpath
+  imports; after building core+types only (the old prepublish set), the
+  surviving error is exactly `TS2307: Cannot find module
+  '@cluesmith/codev-artifact-canvas'` at main.ts:34. Bug isolated.
+- Confirmed `pnpm --filter 'codev-vscode^...'` selects exactly
+  {artifact-canvas, types, core} and artifact-canvas has a tsup build script.
+
+## Fix
+
+- `packages/vscode/package.json`: `vscode:prepublish` now uses
+  `pnpm --filter 'codev-vscode^...' build && pnpm package`.
+- Verified from fresh-clone state (all three dists removed): the new dep
+  build emits all dists and `check-types` passes both tsc passes.
+- Regression test `src/__tests__/prepublish-workspace-deps.test.ts`:
+  accepts the topological filter form; if the script reverts to an explicit
+  `--filter` list, asserts the list covers every `workspace:*` dep.
+  Verified red without the fix, green with it.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1038,7 +1038,7 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "pnpm --filter @cluesmith/codev-core --filter @cluesmith/codev-types build && pnpm package",
+    "vscode:prepublish": "pnpm --filter 'codev-vscode^...' build && pnpm package",
     "compile": "pnpm check-types && pnpm lint && node esbuild.js",
     "watch": "pnpm run --parallel '/^watch:/'",
     "watch:esbuild": "node esbuild.js --watch",

--- a/packages/vscode/src/__tests__/prepublish-workspace-deps.test.ts
+++ b/packages/vscode/src/__tests__/prepublish-workspace-deps.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression for issue #1154: `vscode:prepublish` must build every
+ * `workspace:*` dependency before type-checking and bundling. The script
+ * once listed `--filter` targets by hand and missed
+ * `@cluesmith/codev-artifact-canvas`, so a fresh clone failed check-types
+ * with TS2307 on the markdown-preview webview's imports.
+ *
+ * The topological form (`--filter 'codev-vscode^...'`) selects all
+ * workspace deps transitively and passes trivially. If the script ever
+ * reverts to an explicit `--filter` list, this asserts the list covers
+ * every `workspace:*` dep so a newly added dep cannot silently regress.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const PKG = JSON.parse(
+  readFileSync(resolve(__dirname, '../../package.json'), 'utf8'),
+);
+
+const workspaceDeps = Object.entries({
+  ...(PKG.dependencies ?? {}),
+  ...(PKG.devDependencies ?? {}),
+})
+  .filter(([, version]) => String(version).startsWith('workspace:'))
+  .map(([name]) => name);
+
+describe('vscode:prepublish workspace dep coverage (issue #1154)', () => {
+  const script: string = PKG.scripts['vscode:prepublish'];
+
+  it('has workspace:* deps to guard (sanity)', () => {
+    expect(workspaceDeps.length).toBeGreaterThan(0);
+  });
+
+  it('builds every workspace:* dependency before packaging', () => {
+    if (/--filter\s+['"]?codev-vscode\^\.\.\.['"]?/.test(script)) {
+      // Topological form: pnpm builds all workspace deps transitively.
+      return;
+    }
+    const filters = [...script.matchAll(/--filter\s+['"]?([^\s'"]+)['"]?/g)].map(
+      (m) => m[1],
+    );
+    for (const dep of workspaceDeps) {
+      expect(filters, `prepublish must build ${dep}`).toContain(dep);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fresh clones failed `pnpm --filter codev-vscode run check-types` with `TS2307: Cannot find module '@cluesmith/codev-artifact-canvas'` because `vscode:prepublish` only built two of the extension's three `workspace:*` dependencies. This switches the script to pnpm's topological filter form so all workspace deps build, now and for any dep added later.

Fixes #1154

## Root Cause

`packages/vscode/package.json`'s `vscode:prepublish` listed `--filter` targets by hand:

```
pnpm --filter @cluesmith/codev-core --filter @cluesmith/codev-types build && pnpm package
```

It missed `@cluesmith/codev-artifact-canvas`, a `workspace:*` dependency genuinely imported by the markdown-preview webview (`src/markdown-preview/webview/main.ts:34-35`). Without its `dist/*.d.ts` emitted first, the webview tsc pass in `check-types` cannot resolve the import.

Reproduction confirmed in a clean worktree: after building only core + types (the old filter set), `check-types` still fails with exactly the artifact-canvas TS2307.

## Fix

Use the future-proof flavor recommended in the issue: the topological filter selects all workspace dependencies of `codev-vscode` transitively.

```
pnpm --filter 'codev-vscode^...' build && pnpm package
```

Verified the filter selects exactly `{artifact-canvas, types, core}` on the current tree. This also converges with the filter form the codev-ide bundling script already uses.

## Test Plan

- Manual repro: removed `packages/{core,types,artifact-canvas}/dist`, ran the new dep build, then `check-types` — both tsc passes succeed (previously failed with TS2307).
- Regression test `packages/vscode/src/__tests__/prepublish-workspace-deps.test.ts`: passes with the topological filter form; if the script ever reverts to an explicit `--filter` list, it asserts the list covers every `workspace:*` dep. Verified red without the fix, green with it.
- `pnpm lint` and full vitest suite (51 files, 580 tests) pass; porch phase checks (build + tests) pass.