### PR TITLE
[Bugfix #1169] Collapse Pull Requests / Recently Closed / Team / Status sidebar views by default

### DIFF
--- a/codev/projects/bugfix-1169-vscode-collapse-pull-requests-/status.yaml
+++ b/codev/projects/bugfix-1169-vscode-collapse-pull-requests-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1169
 title: vscode-collapse-pull-requests-
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-13T03:33:32.344Z'
-updated_at: '2026-07-13T03:34:11.887Z'
+updated_at: '2026-07-13T03:49:33.222Z'

--- a/codev/projects/bugfix-1169-vscode-collapse-pull-requests-/status.yaml
+++ b/codev/projects/bugfix-1169-vscode-collapse-pull-requests-/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-13T03:55:54.046Z'
+    approved_at: '2026-07-13T06:03:16.699Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-13T03:33:32.344Z'
-updated_at: '2026-07-13T03:55:54.046Z'
-pr_ready_for_human: true
+updated_at: '2026-07-13T06:03:16.700Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1169-vscode-collapse-pull-requests-/status.yaml
+++ b/codev/projects/bugfix-1169-vscode-collapse-pull-requests-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1169
 title: vscode-collapse-pull-requests-
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-13T03:33:32.344Z'
-updated_at: '2026-07-13T03:33:32.344Z'
+updated_at: '2026-07-13T03:34:11.887Z'

--- a/codev/projects/bugfix-1169-vscode-collapse-pull-requests-/status.yaml
+++ b/codev/projects/bugfix-1169-vscode-collapse-pull-requests-/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-07-13T03:55:54.046Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-13T03:33:32.344Z'
-updated_at: '2026-07-13T03:49:33.222Z'
+updated_at: '2026-07-13T03:55:54.046Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1169-vscode-collapse-pull-requests-/status.yaml
+++ b/codev/projects/bugfix-1169-vscode-collapse-pull-requests-/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1169
+title: vscode-collapse-pull-requests-
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-13T03:33:32.344Z'
+updated_at: '2026-07-13T03:33:32.344Z'

--- a/codev/state/bugfix-1169_thread.md
+++ b/codev/state/bugfix-1169_thread.md
@@ -27,8 +27,20 @@ branch, but repo workflow keeps those on the divergent `docs/vscode-changelog` b
 the architect/human: decision = leave changelog to that branch. This builder branch ships
 ONLY the manifest fix. Architect handles CHANGELOG.md [Unreleased] + UNRELEASED.md Polish.
 
-No unit test: declarative manifest-only change, no runtime behavior. Verify via VS Code
-Extension Development Host smoke (first-install shows the 4 views collapsed to headers).
+Verify via VS Code Extension Development Host smoke (first-install shows the 4 views
+collapsed to headers).
+
+## PR
+
+PR #1171 opened. CMAP: gemini=APPROVE, claude=APPROVE, codex=REQUEST_CHANGES.
+
+Codex was right: I'd waved off a regression test as "declarative, nothing to test", but
+the repo already pins manifest contracts with Vitest (`contributes-view-gating.test.ts`,
+`contributes-panel.test.ts`). Added a regression block to `contributes-view-gating.test.ts`
+asserting the 4 lower-priority views carry `visibility: "collapsed"` and the 3 primary
+views keep no override. `visibility` is a first-render-only string VS Code reads at
+runtime — no compile error catches a dropped "collapsed" — so pinning it is warranted.
+21 tests pass. Committed + pushed, PR body updated. Requested `pr` gate via porch done.
 
 **Scope**: single declarative manifest change (4 keys added) + dual-accumulate release
 notes (packages/vscode/CHANGELOG.md `[Unreleased]` + docs/releases/UNRELEASED.md Polish).

--- a/codev/state/bugfix-1169_thread.md
+++ b/codev/state/bugfix-1169_thread.md
@@ -1,0 +1,35 @@
+# bugfix-1169 — vscode: collapse lower-priority sidebar views by default
+
+## Investigate
+
+**Issue**: 4 of the 7 Codev sidebar views (Pull Requests, Recently Closed, Team, Status)
+default to fully-expanded on first install, crowding the primary surfaces
+(Workspace, Agents, Backlog). VS Code gives no manifest lever for height ratios;
+the only lever is defaulting lower-priority views to `visibility: "collapsed"`.
+
+**Root cause**: `packages/vscode/package.json` `contributes.views.codev[]` — the four
+views omit `"visibility"`, so VS Code applies the default (`visible`).
+
+**Note on the issue snippet**: the real file's view entries carry `"when"` clauses
+(e.g. `"codev.hasWorkspace"`) that the issue's simplified snippet dropped. Fix must
+ADD `"visibility": "collapsed"` while PRESERVING each existing `when`.
+
+**Precedent**: `codev.placeholder` in `codevPanel` already uses `"visibility": "collapsed"`.
+
+## Fix
+
+Added `"visibility": "collapsed"` to the four lower-priority views (pullRequests,
+recentlyClosed, team, status), preserving each existing `when` clause. JSON validates.
+
+**Release notes decision**: issue scoped dual-accumulate release-notes entries onto this
+branch, but repo workflow keeps those on the divergent `docs/vscode-changelog` branch
+(worktrees/changelog) so code + changelog branches reconcile cleanly at release. Asked
+the architect/human: decision = leave changelog to that branch. This builder branch ships
+ONLY the manifest fix. Architect handles CHANGELOG.md [Unreleased] + UNRELEASED.md Polish.
+
+No unit test: declarative manifest-only change, no runtime behavior. Verify via VS Code
+Extension Development Host smoke (first-install shows the 4 views collapsed to headers).
+
+**Scope**: single declarative manifest change (4 keys added) + dual-accumulate release
+notes (packages/vscode/CHANGELOG.md `[Unreleased]` + docs/releases/UNRELEASED.md Polish).
+No source, no tests (declarative). Well within BUGFIX scope (<300 LOC).

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -864,10 +864,10 @@
         { "id": "codev.workspace", "name": "Workspace", "when": "codev.hasWorkspace" },
         { "id": "codev.agents", "name": "Agents" },
         { "id": "codev.backlog", "name": "Backlog", "when": "codev.hasWorkspace" },
-        { "id": "codev.pullRequests", "name": "Pull Requests", "when": "codev.hasWorkspace" },
-        { "id": "codev.recentlyClosed", "name": "Recently Closed", "when": "codev.hasWorkspace" },
-        { "id": "codev.team", "name": "Team", "when": "codev.teamEnabled && codev.hasWorkspace" },
-        { "id": "codev.status", "name": "Status", "when": "codev.hasWorkspace || codev.ideMode" }
+        { "id": "codev.pullRequests", "name": "Pull Requests", "when": "codev.hasWorkspace", "visibility": "collapsed" },
+        { "id": "codev.recentlyClosed", "name": "Recently Closed", "when": "codev.hasWorkspace", "visibility": "collapsed" },
+        { "id": "codev.team", "name": "Team", "when": "codev.teamEnabled && codev.hasWorkspace", "visibility": "collapsed" },
+        { "id": "codev.status", "name": "Status", "when": "codev.hasWorkspace || codev.ideMode", "visibility": "collapsed" }
       ],
       "codevPanel": [
         { "id": "codev.placeholder", "name": "Codev", "when": "codev.panelContainerEmpty", "visibility": "collapsed" },

--- a/packages/vscode/src/__tests__/contributes-view-gating.test.ts
+++ b/packages/vscode/src/__tests__/contributes-view-gating.test.ts
@@ -20,6 +20,7 @@ const PKG = JSON.parse(
 interface ViewContribution {
   id: string;
   when?: string;
+  visibility?: string;
 }
 interface ViewsWelcomeContribution {
   view: string;
@@ -70,6 +71,25 @@ describe('workspace-bound views are gated on codev.hasWorkspace', () => {
   it('codev.agents stays ungated: it anchors the container and carries the welcome content', () => {
     expect(viewById('codev.agents').when).toBeUndefined();
   });
+});
+
+describe('default view visibility (#1169: reclaim sidebar vertical space)', () => {
+  // `visibility` is a first-render-only default string VS Code reads from the
+  // manifest — no compile error catches a dropped "collapsed", and it only
+  // affects fresh installs, so a regression would silently ship. Pin it.
+  it.each(['codev.pullRequests', 'codev.recentlyClosed', 'codev.team', 'codev.status'])(
+    'lower-priority view %s defaults to collapsed',
+    (id) => {
+      expect(viewById(id).visibility).toBe('collapsed');
+    },
+  );
+
+  it.each(['codev.workspace', 'codev.agents', 'codev.backlog'])(
+    'primary view %s stays expanded (no visibility override)',
+    (id) => {
+      expect(viewById(id).visibility).toBeUndefined();
+    },
+  );
 });
 
 describe('viewsWelcome (empty-window surfaces)', () => {


### PR DESCRIPTION
## Summary

Adds `"visibility": "collapsed"` to four lower-priority Codev VS Code sidebar views so they render as ~22px headers on first install instead of fully expanded. Reclaims vertical space for the primary workload surfaces (Workspace, Agents, Backlog).

## Root Cause

In `packages/vscode/package.json`, all seven `contributes.views.codev[]` entries omitted `"visibility"`, so VS Code applied its default (`visible`). VS Code exposes no manifest lever for view height ratios, so the only way to bias the first-render distribution toward the primary surfaces is defaulting lower-priority views to `collapsed`.

## Fix

Added `"visibility": "collapsed"` to the four lower-priority views, preserving each existing `when` clause:

- `codev.pullRequests` (Pull Requests)
- `codev.recentlyClosed` (Recently Closed)
- `codev.team` (Team)
- `codev.status` (Status)

Workspace, Agents, and Backlog stay expanded. Uses `collapsed` (not `hideByDefault`) so discoverability is preserved: the header row stays visible, one click to expand. Follows the existing precedent set by `codev.placeholder` in the `codevPanel` container.

**Scope discipline:** manifest + test only, no source changes. Release-notes entries (CHANGELOG.md `[Unreleased]` + docs/releases/UNRELEASED.md Polish) are handled on the repo's dedicated `docs/vscode-changelog` branch per the established dual-accumulate workflow, not on this code branch.

## Caveat for existing users

`visibility: "collapsed"` only applies to first-install / new-workspace state. Users who have already interacted with these views keep their persisted layout, and can manually collapse if they want the new distribution.

## Test Plan

- **Regression test** added to `packages/vscode/src/__tests__/contributes-view-gating.test.ts` (the existing #1144 manifest-invariant suite): asserts the four lower-priority views contribute `"visibility": "collapsed"` and the three primary views keep no override. Fails without the fix, passes with it. `pnpm vitest run` → 21 passed.
- `npm run build` — passes (porch checks: build ✓, tests ✓)
- JSON validity of `package.json` confirmed
- Manual: VS Code Extension Development Host smoke on a fresh workspace shows the four views collapsed to headers, primary views expanded.

## CMAP Review

- **Gemini**: APPROVE (HIGH)
- **Claude**: APPROVE (HIGH)
- **Codex**: REQUEST_CHANGES (HIGH) → resolved by adding the manifest-invariant regression test above.

Fixes #1169