### PR TITLE
[Bugfix #1174] Keep childless architects visible in Agents view (architect axis)

### DIFF
--- a/codev/projects/bugfix-1174-vscode-architects-disappear-fr/status.yaml
+++ b/codev/projects/bugfix-1174-vscode-architects-disappear-fr/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1174
 title: vscode-architects-disappear-fr
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-15T01:30:06.203Z'
-updated_at: '2026-07-15T01:33:13.909Z'
+updated_at: '2026-07-15T01:38:38.103Z'

--- a/codev/projects/bugfix-1174-vscode-architects-disappear-fr/status.yaml
+++ b/codev/projects/bugfix-1174-vscode-architects-disappear-fr/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1174
 title: vscode-architects-disappear-fr
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-15T01:30:06.203Z'
-updated_at: '2026-07-15T01:30:06.203Z'
+updated_at: '2026-07-15T01:33:13.909Z'

--- a/codev/projects/bugfix-1174-vscode-architects-disappear-fr/status.yaml
+++ b/codev/projects/bugfix-1174-vscode-architects-disappear-fr/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-07-15T01:42:56.921Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-15T01:30:06.203Z'
-updated_at: '2026-07-15T01:38:38.103Z'
+updated_at: '2026-07-15T01:42:56.921Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1174-vscode-architects-disappear-fr/status.yaml
+++ b/codev/projects/bugfix-1174-vscode-architects-disappear-fr/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-15T01:42:56.921Z'
+    approved_at: '2026-07-15T03:23:12.178Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-15T01:30:06.203Z'
-updated_at: '2026-07-15T01:42:56.921Z'
-pr_ready_for_human: true
+updated_at: '2026-07-15T03:23:12.178Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1174-vscode-architects-disappear-fr/status.yaml
+++ b/codev/projects/bugfix-1174-vscode-architects-disappear-fr/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1174
+title: vscode-architects-disappear-fr
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-15T01:30:06.203Z'
+updated_at: '2026-07-15T01:30:06.203Z'

--- a/codev/state/bugfix-1174_thread.md
+++ b/codev/state/bugfix-1174_thread.md
@@ -25,3 +25,14 @@ Verification (from worktree): `pnpm vitest run` → 627 pass (53 files); `pnpm c
 No CHANGELOG edit: that workflow lives on the separate docs/vscode-changelog branch (architect's per-PR job post-merge), not this builder branch.
 
 Committed 2 commits (fix + tests). Next: push, open PR, CMAP.
+
+## PR (in progress)
+
+PR #1175 opened (Fixes #1174).
+
+CMAP verdicts:
+- Gemini: APPROVE (HIGH) — no issues
+- Codex: APPROVE (MEDIUM) — no issues
+- Claude: COMMENT (HIGH) — one non-blocking nit: ternary for collapsibleState → if/else per no-ternaries convention. Applied (commit 4). Re-verified check-types + lint + tests clean.
+
+Requesting `pr` gate next; waiting for human approval before merge.

--- a/codev/state/bugfix-1174_thread.md
+++ b/codev/state/bugfix-1174_thread.md
@@ -1,0 +1,27 @@
+# bugfix-1174 — architects disappear from Agents view (architect axis) when last builder cleaned up
+
+## Investigate (done)
+
+**Root cause** (confirmed by reading source):
+- `packages/vscode/src/views/builder-grouping.ts` `architectGrouping().group(ordered)` buckets architects only from the builders array's `spawnedByArchitect` values. A childless architect contributes no key → no group header. When the last builder is cleaned up, the architect's row vanishes.
+- The architect roster is already available without a second fetch: `OverviewData.architects: ArchitectState[]` (main-first, live sessions only), populated server-side by `liveArchitects` in `packages/codev/src/agent-farm/servers/tower-routes.ts:954` and carried on the overview cache the `BuildersProvider` already holds.
+- Empty-group rollup icon: `rollupGroupState([])` returns `{0,0,0}` → `worstBuilderState` falls through to `active` (green circle) — misleading. Need a neutral idle glyph.
+
+**Fix plan** (architect axis only; stage/area unchanged):
+1. `builder-grouping.ts` — `BuilderGrouping.group` gains optional `roster?: readonly string[]`; `architectGrouping` seeds an empty bucket for every roster architect so childless architects still get a header. Other axes ignore the arg.
+2. `builders.ts` — pass `(data.architects ?? []).map(a => a.name)` into both `group()` call sites; render empty groups (`items.length === 0`) as leaf-like (`CollapsibleState.None`) so they still carry the click-to-open-terminal command.
+3. `builder-tree-item.ts` — `BuilderGroupTreeItem` uses a neutral glyph (`circle-outline` / `disabledForeground`) when the rollup is all-zero, instead of the worst-of tri-state.
+4. Tests: 0-builder architect + populated combos under architect axis; neutral icon; no change for stage/area.
+
+## Fix (done)
+
+Implemented all 4 points. Diff ~88 LOC across 4 files (3 src + 2 test, well under 300):
+- `builder-grouping.ts`: `group(ordered, roster?)`; architectGrouping seeds empty buckets from roster.
+- `builders.ts`: pass `(data.architects ?? []).map(a => a.name)` into both group() calls; empty groups → `CollapsibleState.None` (leaf-like, still carry openArchitectTerminal command).
+- `builder-tree-item.ts`: all-zero rollup → `circle-outline`/`disabledForeground` neutral glyph + "No builders" tooltip.
+
+Verification (from worktree): `pnpm vitest run` → 627 pass (53 files); `pnpm check-types` clean; `pnpm lint` clean. Had to build core/types/artifact-canvas deps first (dist-based subpath exports).
+
+No CHANGELOG edit: that workflow lives on the separate docs/vscode-changelog branch (architect's per-PR job post-merge), not this builder branch.
+
+Committed 2 commits (fix + tests). Next: push, open PR, CMAP.

--- a/packages/vscode/src/__tests__/builder-grouping.test.ts
+++ b/packages/vscode/src/__tests__/builder-grouping.test.ts
@@ -92,11 +92,39 @@ describe('architectGrouping (#1104)', () => {
     expect(g.group(builders).map(x => x.key)).toEqual(['main', 'security', 'vscode']);
   });
 
-  it('only produces a group for an architect that owns builders (childless never appears)', () => {
-    // The strategy never sees the roster — it groups by owner present on
-    // builders, so an architect with no builders simply yields no group.
+  it('without a roster, only owners-of-builders produce groups (back-compat)', () => {
+    // No roster passed → the strategy groups by owner present on builders, so an
+    // architect with no builders yields no group (the pre-1174 behavior, still
+    // the path any pre-roster caller takes).
     const builders = [builder({ id: 'a', spawnedByArchitect: 'main' })];
     expect(g.group(builders).map(x => x.key)).toEqual(['main']);
+  });
+
+  it('emits a header for every roster architect, even childless ones (Issue 1174)', () => {
+    // main owns a builder; reviewer and security are registered but childless.
+    const builders = [builder({ id: 'a', spawnedByArchitect: 'main' })];
+    const groups = g.group(builders, ['main', 'reviewer', 'security']);
+    expect(groups.map(x => x.key)).toEqual(['main', 'reviewer', 'security']);
+    expect(groups.find(x => x.key === 'reviewer')!.items).toEqual([]);
+    expect(groups.find(x => x.key === 'security')!.items).toEqual([]);
+    expect(groups.find(x => x.key === 'main')!.items.map(b => b.id)).toEqual(['a']);
+  });
+
+  it('with a roster and zero builders, every architect still gets an empty header', () => {
+    const groups = g.group([], ['main', 'vscode']);
+    expect(groups.map(x => x.key)).toEqual(['main', 'vscode']);
+    expect(groups.every(x => x.items.length === 0)).toBe(true);
+  });
+
+  it('keeps a builder whose owner is absent from the roster (stale/non-live owner)', () => {
+    // `data.architects` lists only live-session architects; a builder can still
+    // reference a non-live owner. That owner must not be dropped — it gets its
+    // own header from the builder loop alongside the roster-seeded ones.
+    const builders = [builder({ id: 'a', spawnedByArchitect: 'ghost' })];
+    const groups = g.group(builders, ['main']);
+    expect(groups.map(x => x.key)).toEqual(['main', 'ghost']);
+    expect(groups.find(x => x.key === 'main')!.items).toEqual([]);
+    expect(groups.find(x => x.key === 'ghost')!.items.map(b => b.id)).toEqual(['a']);
   });
 
   it('folds a null-owner builder (data-integrity edge) into the main group', () => {

--- a/packages/vscode/src/__tests__/builders-childless-architect-header.test.ts
+++ b/packages/vscode/src/__tests__/builders-childless-architect-header.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Issue 1174 — under the architect axis, every registered architect gets a group
+ * header even when it owns no builders. Before the fix, an architect's row
+ * vanished from the Agents view the moment its last builder was cleaned up
+ * (headers were sourced only from the builders array's `spawnedByArchitect`
+ * values). The fix sources the header set from the architect roster
+ * (`OverviewData.architects`) the overview cache already carries.
+ *
+ * These tests pin, through the provider: a childless architect renders a `(0)`
+ * header that (a) is leaf-like (`None` — no empty accordion), (b) carries the
+ * click-to-open-terminal command, and (c) shows a neutral idle glyph rather than
+ * the worst-of tri-state green/yellow. They also pin that stage/area axes are
+ * unaffected (roster ignored). Mocks `vscode` per the `__tests__` pattern.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { ArchitectState, OverviewBuilder, OverviewData } from '@cluesmith/codev-types';
+
+/** Per-test config overrides the mocked `workspace.getConfiguration` reads. */
+const configValues: Record<string, unknown> = {};
+
+vi.mock('vscode', () => {
+  class FakeEventEmitter<T> {
+    private listeners: Array<(e: T) => void> = [];
+    readonly event = (listener: (e: T) => void): { dispose: () => void } => {
+      this.listeners.push(listener);
+      return { dispose: () => { this.listeners = this.listeners.filter((l) => l !== listener); } };
+    };
+    fire = vi.fn((e: T) => { this.listeners.forEach((l) => l(e)); });
+  }
+  class TreeItem {
+    id?: string;
+    tooltip?: string;
+    contextValue?: string;
+    iconPath?: unknown;
+    command?: unknown;
+    constructor(public label: string, public collapsibleState?: number) {}
+  }
+  class ThemeIcon { constructor(public id: string, public color?: unknown) {} }
+  class ThemeColor { constructor(public id: string) {} }
+  return {
+    EventEmitter: FakeEventEmitter,
+    TreeItem,
+    ThemeIcon,
+    ThemeColor,
+    TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+    workspace: {
+      getConfiguration: () => ({
+        get: (key: string, def: unknown) => (key in configValues ? configValues[key] : def),
+      }),
+    },
+  };
+});
+
+const { BuildersProvider } = await import('../views/builders.js');
+const { BuilderGroupTreeItem } = await import('../views/builder-tree-item.js');
+
+function builder(overrides: Partial<OverviewBuilder>): OverviewBuilder {
+  return {
+    id: 'pir-1', issueId: '1', issueTitle: 't', phase: 'implement', protocolPhase: 'implement',
+    mode: 'strict', gates: {}, worktreePath: '/tmp/wt', roleId: null, protocol: 'pir',
+    planPhases: [], progress: 0, blocked: null, blockedGate: null, blockedSince: null,
+    startedAt: null, idleMs: 0, lastDataAt: null, spawnedByArchitect: null,
+    area: 'Uncategorized', prReady: false,
+    ...overrides,
+  } as OverviewBuilder;
+}
+
+function architect(name: string): ArchitectState {
+  return { name, port: 0, pid: 0 };
+}
+
+function fakeCache(builders: OverviewBuilder[], architects: ArchitectState[]) {
+  const data = { builders, architects, backlog: [], pendingPRs: [], recentlyClosed: [] } as unknown as OverviewData;
+  return { getData: () => data, onDidChange: () => ({ dispose() {} }) } as never;
+}
+
+const fakeDiffCache = {} as never;
+
+type Header = InstanceType<typeof BuilderGroupTreeItem>;
+type ThemeIconLike = { id: string; color?: { id: string } };
+
+async function groupHeaders(provider: InstanceType<typeof BuildersProvider>): Promise<Header[]> {
+  const roots = await provider.getChildren();
+  return roots.filter(r => r instanceof BuilderGroupTreeItem) as Header[];
+}
+
+describe('childless-architect headers under the architect axis (Issue 1174)', () => {
+  it('emits a (0) header for every registered architect when there are no builders', async () => {
+    configValues['buildersGroupBy'] = 'architect';
+    try {
+      const provider = new BuildersProvider(
+        fakeCache([], [architect('main'), architect('reviewer'), architect('security')]),
+        fakeDiffCache,
+      );
+      const headers = await groupHeaders(provider);
+      expect(headers.map(h => h.groupName)).toEqual(['main', 'reviewer', 'security']);
+      // Count in the label + leaf-like state (None) — no empty accordion.
+      for (const h of headers) {
+        expect(h.label).toContain('(0)');
+        expect(h.collapsibleState).toBe(0); // TreeItemCollapsibleState.None
+      }
+    } finally {
+      delete configValues['buildersGroupBy'];
+    }
+  });
+
+  it('keeps a childless architect visible alongside a populated one, each with its count', async () => {
+    configValues['buildersGroupBy'] = 'architect';
+    try {
+      const provider = new BuildersProvider(
+        fakeCache(
+          [
+            builder({ id: 'a', spawnedByArchitect: 'main' }),
+            builder({ id: 'b', spawnedByArchitect: 'main' }),
+          ],
+          [architect('main'), architect('reviewer')],
+        ),
+        fakeDiffCache,
+      );
+      const headers = await groupHeaders(provider);
+      const byName = new Map(headers.map(h => [h.groupName, h]));
+      expect([...byName.keys()]).toEqual(['main', 'reviewer']);
+      expect(byName.get('main')!.label).toContain('(2)');
+      expect(byName.get('main')!.collapsibleState).toBe(2); // Expanded
+      expect(byName.get('reviewer')!.label).toContain('(0)');
+      expect(byName.get('reviewer')!.collapsibleState).toBe(0); // None
+    } finally {
+      delete configValues['buildersGroupBy'];
+    }
+  });
+
+  it('a childless header still opens the architect terminal on click', async () => {
+    configValues['buildersGroupBy'] = 'architect';
+    try {
+      const provider = new BuildersProvider(
+        fakeCache([], [architect('main'), architect('reviewer')]),
+        fakeDiffCache,
+      );
+      const headers = await groupHeaders(provider);
+      const reviewer = headers.find(h => h.groupName === 'reviewer')!;
+      expect(reviewer.command).toEqual({
+        command: 'codev.openArchitectTerminal',
+        title: 'Open Architect Terminal',
+        arguments: ['reviewer'],
+      });
+    } finally {
+      delete configValues['buildersGroupBy'];
+    }
+  });
+
+  it('a childless header uses a neutral idle glyph, not the yellow attention bell', async () => {
+    configValues['buildersGroupBy'] = 'architect';
+    try {
+      const provider = new BuildersProvider(
+        fakeCache([], [architect('main')]),
+        fakeDiffCache,
+      );
+      const [header] = await groupHeaders(provider);
+      const icon = header.iconPath as ThemeIconLike;
+      expect(icon.id).toBe('circle-outline');
+      expect(icon.color?.id).toBe('disabledForeground');
+      expect(header.tooltip).toBe('No builders');
+    } finally {
+      delete configValues['buildersGroupBy'];
+    }
+  });
+
+  it('stage axis ignores the roster — no childless-architect headers appear', async () => {
+    configValues['buildersGroupBy'] = 'stage';
+    try {
+      const provider = new BuildersProvider(
+        fakeCache(
+          [builder({ id: 'a', spawnedByArchitect: 'main', protocolPhase: 'implement' })],
+          [architect('main'), architect('reviewer'), architect('security')],
+        ),
+        fakeDiffCache,
+      );
+      const headers = await groupHeaders(provider);
+      // Stage headers are lifecycle stages, never architect names.
+      expect(headers.map(h => h.groupName)).not.toContain('reviewer');
+      expect(headers.map(h => h.groupName)).not.toContain('security');
+      for (const h of headers) {
+        expect(h.command).toBeUndefined();
+      }
+    } finally {
+      delete configValues['buildersGroupBy'];
+    }
+  });
+});

--- a/packages/vscode/src/views/builder-grouping.ts
+++ b/packages/vscode/src/views/builder-grouping.ts
@@ -32,8 +32,16 @@ export interface BuilderGroup {
 export interface BuilderGrouping {
   /** Axis id, matching the `codev.buildersGroupBy` setting value. */
   readonly id: BuildersGroupBy;
-  /** Bucket already-ordered builders into display groups (header order preserved). */
-  group(ordered: OverviewBuilder[]): BuilderGroup[];
+  /**
+   * Bucket already-ordered builders into display groups (header order preserved).
+   *
+   * `roster` is the set of registered architect names (from `OverviewData.architects`),
+   * used only by the architect axis to emit a header for every architect — including
+   * childless ones (Issue 1174). The stage and area axes ignore it: their groups are
+   * builder-intrinsic (a phase / an area only exists as a property of a builder), so
+   * there is no "empty stage" or "empty area" to seed.
+   */
+  group(ordered: OverviewBuilder[], roster?: readonly string[]): BuilderGroup[];
   /**
    * The row prefix for this axis — the COMPLEMENTARY axis to the group header,
    * already bracketed with a trailing space (or `''` when omitted). Stage mode
@@ -78,17 +86,23 @@ export function areaGrouping(): BuilderGrouping {
 }
 
 /**
- * Architect axis (Issue 1104): groups are the architects that own in-flight work
- * (`spawnedByArchitect`), `main` first, then the rest alphabetically. Because a
- * flat group only exists when it holds builders, a *childless* architect
- * produces no group and simply doesn't appear — the work view shows owners of
- * work, not the full roster (the full roster lives in Workspace > Architects).
+ * Architect axis (Issue 1104): groups are the workspace's architects, `main`
+ * first, then the rest alphabetically. Every registered architect in `roster`
+ * gets a header even when it currently owns no builders (Issue 1174) — a
+ * childless architect renders as `MAIN (0)` with the same click-to-open-terminal
+ * affordance the populated headers carry, so cleaning up an architect's last
+ * builder no longer makes its row vanish out from under the user mid-session.
+ * (The `roster` reflects live-session architects from `OverviewData.architects`;
+ * when it is absent — e.g. pre-roster callers — only architects owning builders
+ * appear, the pre-1174 behavior.)
  *
  * Every builder has an owner: `afx spawn` always records one, defaulting to
  * `main` (spawn.ts). A null `spawnedByArchitect` is only a data-integrity edge
  * (a discovered worktree with no `state.db` row, or a pre-#755 legacy row), so
  * there is no "unassigned" group — a null owner folds into `main`, matching the
- * affinity router's same fallback (`lookupBuilderSpawningArchitect`).
+ * affinity router's same fallback (`lookupBuilderSpawningArchitect`). A builder
+ * whose owner isn't in `roster` (stale / non-live architect) still gets that
+ * owner's header from the builder loop, so no builder is ever dropped.
  *
  * The row prefix carries the complementary lifecycle stage (`[implement]`, etc.)
  * so a row still reads "where in the lifecycle" under its owner. A lone group is
@@ -97,8 +111,13 @@ export function areaGrouping(): BuilderGrouping {
 export function architectGrouping(): BuilderGrouping {
   return {
     id: 'architect',
-    group: ordered => {
+    group: (ordered, roster = []) => {
       const buckets = new Map<string, OverviewBuilder[]>();
+      // Seed an empty bucket for every registered architect first, so childless
+      // architects still produce a header (Issue 1174).
+      for (const name of roster) {
+        if (!buckets.has(name)) { buckets.set(name, []); }
+      }
       for (const b of ordered) {
         const key = b.spawnedByArchitect || 'main';
         const bucket = buckets.get(key);

--- a/packages/vscode/src/views/builder-tree-item.ts
+++ b/packages/vscode/src/views/builder-tree-item.ts
@@ -52,6 +52,15 @@ export class BuilderGroupTreeItem extends AreaGroupTreeItem {
     rollup: GroupRollup,
   ) {
     super(groupName, 'builder', count, collapsibleState);
+    // An empty rollup means a childless group — only the architect axis produces
+    // one (a registered architect with no builders, Issue 1174). Short-circuit
+    // the worst-of tri-state, which would read all-zero as green `active`, and
+    // use a neutral idle glyph instead (never the yellow "needs attention" bell).
+    if (rollup.blocked + rollup.idle + rollup.active === 0) {
+      this.iconPath = new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('disabledForeground'));
+      this.tooltip = 'No builders';
+      return;
+    }
     const { icon, color } = BUILDER_STATE_GLYPH[worstBuilderState(rollup)];
     this.iconPath = new vscode.ThemeIcon(icon, new vscode.ThemeColor(color));
     this.tooltip = `${rollup.blocked} blocked · ${rollup.idle} waiting · ${rollup.active} active`;

--- a/packages/vscode/src/views/builders.ts
+++ b/packages/vscode/src/views/builders.ts
@@ -282,7 +282,13 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
 
     const now = Date.now();
     const grouping = this.active();
-    const groups = grouping.group(orderForDisplay(data.builders, now));
+    // The registered-architect roster (live sessions, main-first) — sourced from
+    // the overview cache the provider already holds, no second fetch. Only the
+    // architect axis consumes it, to emit a header for every architect including
+    // childless ones (Issue 1174); the other axes ignore the arg. Guard `??` for
+    // a pre-roster overview payload so `.map` never throws.
+    const roster = (data.architects ?? []).map(a => a.name);
+    const groups = grouping.group(orderForDisplay(data.builders, now), roster);
 
     // A repo that doesn't use `area/*` labels yields a single `Uncategorized`
     // group; in area mode its header adds no information, so flatten to root rows
@@ -292,9 +298,10 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
       return groups[0].items.map(b => this.makeBuilderRow(b, now));
     }
 
-    // Groups always render Expanded (#913) — no persisted state. VSCode's
+    // Populated groups render Expanded (#913) — no persisted state. VSCode's
     // native per-id memory keeps a user-collapsed group collapsed for the
     // rest of the session; on a fresh session this default applies again.
+    // Childless architect groups (Issue 1174) render as leaf-like rows (`None`).
     //
     // Architect-axis headers get a click-to-open-terminal `command` (#1108):
     // the architect is first-class in this mode, so its header should match the
@@ -306,10 +313,18 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
     // already accepts; it warns gracefully on a stale owner not in the roster.
     const isArchitectAxis = grouping.id === 'architect';
     return groups.map(g => {
+      // A childless architect group (Issue 1174) has no builders to expand into,
+      // so render it as a leaf-like row (`None`) rather than an empty accordion.
+      // The click-to-open-terminal command below still fires on the row body.
+      // Populated groups stay Expanded (#913). Only the architect axis ever
+      // yields an empty group; stage/area groups always hold ≥1 builder.
+      const collapsibleState = g.items.length === 0
+        ? vscode.TreeItemCollapsibleState.None
+        : vscode.TreeItemCollapsibleState.Expanded;
       const groupItem = new BuilderGroupTreeItem(
         g.key,
         g.items.length,
-        vscode.TreeItemCollapsibleState.Expanded,
+        collapsibleState,
         rollupGroupState(g.items, now),
       );
       if (isArchitectAxis) {
@@ -332,7 +347,8 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
 
     const now = Date.now();
     const ordered = orderForDisplay(data.builders, now);
-    const group = this.active().group(ordered).find(g => g.key === key);
+    const roster = (data.architects ?? []).map(a => a.name);
+    const group = this.active().group(ordered, roster).find(g => g.key === key);
     if (!group) { return []; }
 
     return group.items.map(b => this.makeBuilderRow(b, now));

--- a/packages/vscode/src/views/builders.ts
+++ b/packages/vscode/src/views/builders.ts
@@ -318,9 +318,12 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
       // The click-to-open-terminal command below still fires on the row body.
       // Populated groups stay Expanded (#913). Only the architect axis ever
       // yields an empty group; stage/area groups always hold ≥1 builder.
-      const collapsibleState = g.items.length === 0
-        ? vscode.TreeItemCollapsibleState.None
-        : vscode.TreeItemCollapsibleState.Expanded;
+      let collapsibleState: vscode.TreeItemCollapsibleState;
+      if (g.items.length === 0) {
+        collapsibleState = vscode.TreeItemCollapsibleState.None;
+      } else {
+        collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+      }
       const groupItem = new BuilderGroupTreeItem(
         g.key,
         g.items.length,


### PR DESCRIPTION
Fixes #1174

## Summary

Under the **architect axis** of the Agents view, an architect disappeared from the tree the moment its last builder was cleaned up. The row was present while any builder was attached and vanished at zero builders — so a common triage flow (watch an architect's work, its last builder finishes, click to open its terminal) lost the row out from under the user mid-session, forcing a two-view-hop back to Workspace > Architects.

This sources the architect-axis group-header set from the **registered-architect roster** rather than from the `spawnedByArchitect` values observed on the builders array. Every registered architect now gets a header, populated or not. Scope is architect-axis only; stage and area axes are unchanged.

## Root Cause

`packages/vscode/src/views/builder-grouping.ts` — `architectGrouping().group()` bucketed architects solely from `spawnedByArchitect` values present on the current builders array. A childless architect contributes no key → no group header. The v3.2.2 CHANGELOG documented this "hide childless architects" behavior as intentional; this issue documents the user-facing cost (rows disappearing mid-session) that outweighs that rationale for the architect axis.

## Fix

- **`builder-grouping.ts`**: `BuilderGrouping.group` gains an optional `roster?: readonly string[]`. `architectGrouping` seeds an empty bucket for every roster architect first, so childless architects still produce a header. A builder whose owner isn't in the roster (stale / non-live) still gets its owner header from the builder loop — no builder is ever dropped. Stage/area axes ignore the arg.
- **`builders.ts`**: passes the roster — `(data.architects ?? []).map(a => a.name)`, already on the overview cache the provider holds (no second fetch; `??` guards a pre-roster payload) — into both `group()` call sites. Empty groups render as leaf-like rows (`CollapsibleState.None`) rather than empty accordions, while still carrying the existing `codev.openArchitectTerminal` click command.
- **`builder-tree-item.ts`**: an all-zero rollup (only the architect axis produces one) short-circuits the worst-of tri-state — which would read all-zero as the green `active` glyph — and uses a neutral idle glyph (`circle-outline` / `disabledForeground`) with a `No builders` tooltip. Never the yellow attention bell.

Net diff ~88 LOC across 3 source + 2 test files.

## Test Plan

New/updated tests (`pnpm vitest run` → **627 pass**, 53 files; `check-types` + `lint` clean):

- `builder-grouping.test.ts` — every roster architect gets a header incl. childless ones; zero-builders-with-roster yields all-empty headers; a stale non-roster owner is never dropped; the no-roster back-compat path still shows only owners-of-builders.
- `builders-childless-architect-header.test.ts` (new, provider-level) — a childless architect renders a `(0)` leaf-like (`None`) header, carries `codev.openArchitectTerminal` with the right name, shows the neutral `circle-outline`/`disabledForeground` glyph (not the bell), and the stage axis ignores the roster (no architect-name headers).

## Acceptance (from the issue)

- ✅ N architects, 0 builders → N `(0)` headers
- ✅ N architects with builders spread across some → all N headers, correct counts
- ✅ Cleaning up an architect's last builder keeps it visible
- ✅ Stage / area axes: no change
- ✅ Single-architect workspace: no change (axis picker gating untouched)
- ✅ Click on a `(0)` header opens the architect's terminal
- ✅ Neutral / idle glyph on empty groups, not the yellow bell