### PR TITLE
[Bugfix #1180] Raise per-window terminal cap + expose as codev.maxTerminals (default 25)

### DIFF
--- a/codev/projects/bugfix-1180-vscode-raise-per-window-termin/status.yaml
+++ b/codev/projects/bugfix-1180-vscode-raise-per-window-termin/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1180
+title: vscode-raise-per-window-termin
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-15T06:18:14.337Z'
+updated_at: '2026-07-15T06:18:14.337Z'

--- a/codev/projects/bugfix-1180-vscode-raise-per-window-termin/status.yaml
+++ b/codev/projects/bugfix-1180-vscode-raise-per-window-termin/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1180
 title: vscode-raise-per-window-termin
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-15T06:18:14.337Z'
-updated_at: '2026-07-15T06:19:38.359Z'
+updated_at: '2026-07-15T06:26:48.299Z'

--- a/codev/projects/bugfix-1180-vscode-raise-per-window-termin/status.yaml
+++ b/codev/projects/bugfix-1180-vscode-raise-per-window-termin/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-07-15T06:32:14.967Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-15T06:18:14.337Z'
-updated_at: '2026-07-15T06:26:48.299Z'
+updated_at: '2026-07-15T06:32:14.968Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1180-vscode-raise-per-window-termin/status.yaml
+++ b/codev/projects/bugfix-1180-vscode-raise-per-window-termin/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-15T06:32:14.967Z'
+    approved_at: '2026-07-15T06:34:08.544Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-15T06:18:14.337Z'
-updated_at: '2026-07-15T06:32:14.968Z'
-pr_ready_for_human: true
+updated_at: '2026-07-15T06:34:08.545Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1180-vscode-raise-per-window-termin/status.yaml
+++ b/codev/projects/bugfix-1180-vscode-raise-per-window-termin/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1180
 title: vscode-raise-per-window-termin
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-15T06:18:14.337Z'
-updated_at: '2026-07-15T06:18:14.337Z'
+updated_at: '2026-07-15T06:19:38.359Z'

--- a/codev/state/bugfix-1180_thread.md
+++ b/codev/state/bugfix-1180_thread.md
@@ -1,0 +1,40 @@
+# bugfix-1180 — vscode: raise per-window terminal cap + expose as codev.maxTerminals
+
+## Investigate
+
+Issue #1180: VS Code extension caps concurrent terminals at 10 via static
+`MAX_TERMINALS = 10` (`packages/vscode/src/terminal-manager.ts:10`), enforced in
+`openTerminal` at `:465-468`. Impractical in multi-architect workspaces (each
+architect consumes a slot). Tower's own backstop is 100, so nothing infra-side
+requires the client cap to be 10.
+
+Root cause confirmed: static constant, no config surface.
+
+Fix (per issue):
+1. New `codev.maxTerminals` setting in package.json (default 25, min 5, max 100).
+2. Read it in the enforcement path; updated toast points at the setting.
+3. Replace static constant with `DEFAULT_MAX_TERMINALS = 25` used as the getter default.
+
+Test harness: `src/__tests__/terminal-manager.test.ts` uses source-level regex
+guards (constructing TerminalManager needs heavy vscode mocking). Will add a
+source-level guard verifying the setting is read and the cap enforced at the
+configured value, matching the file's established pattern.
+
+Scope: 2 files + test. Well within BUGFIX.
+
+## Fix
+
+Implemented:
+- `terminal-manager.ts`: `MAX_TERMINALS = 10` → `DEFAULT_MAX_TERMINALS = 25`;
+  `openTerminal` now reads `codev.maxTerminals` via config getter; toast points at
+  the setting. Two doc-comment references updated to `codev.maxTerminals`.
+- `package.json`: new `codev.maxTerminals` number setting (default 25, min 5,
+  max 100) with a memory-vs-capacity markdownDescription.
+- Test: added `#1180` source-level guards + a package.json schema assertion to
+  `terminal-manager.test.ts` (matches the file's existing source-guard harness).
+
+Verification: full vscode vitest suite green — 632 tests / 53 files pass.
+(Note: a fresh worktree needs `@cluesmith/codev-core` + `@cluesmith/codev-types`
+built first, else 16 suites fail on module resolution — unrelated to this fix.)
+check-types clean. Net diff ~67 lines across 3 files.
+

--- a/codev/state/bugfix-1180_thread.md
+++ b/codev/state/bugfix-1180_thread.md
@@ -38,3 +38,17 @@ Verification: full vscode vitest suite green — 632 tests / 53 files pass.
 built first, else 16 suites fail on module resolution — unrelated to this fix.)
 check-types clean. Net diff ~67 lines across 3 files.
 
+## PR
+
+PR #1181 opened (Fixes #1180).
+
+CMAP verdicts (all HIGH confidence, no REQUEST_CHANGES):
+- gemini: APPROVE
+- codex: COMMENT — non-blocking nit: the "~10 architects + ~20 builders" (=30)
+  rationale in the code comment didn't add up to the default of 25. Addressed by
+  rewording the comment to "several architect terminals plus one per active
+  builder" (no misleading arithmetic).
+- claude: APPROVE
+
+Requested the `pr` gate via `porch done`. Waiting for human approval to merge.
+

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -915,6 +915,13 @@
           "default": "editor",
           "description": "Where to open Codev terminals (editor area or bottom panel)"
         },
+        "codev.maxTerminals": {
+          "type": "number",
+          "default": 25,
+          "minimum": 5,
+          "maximum": 100,
+          "markdownDescription": "Maximum number of concurrent Codev terminals per window. Each terminal is a live PTY + browser-style render surface, so a higher cap costs more memory. Sized for multi-architect workspaces (several architect terminals plus one per active builder); raise it if you routinely run more, lower it if memory is tight. The ceiling of `100` matches Tower's own server-side session backstop."
+        },
         "codev.autoConnect": {
           "type": "boolean",
           "default": true,

--- a/packages/vscode/src/__tests__/terminal-manager.test.ts
+++ b/packages/vscode/src/__tests__/terminal-manager.test.ts
@@ -168,3 +168,48 @@ describe('PIR #1052 — repaint all terminals on window refocus', () => {
     expect(repaintBody).toMatch(/entry\.pty\.forceRepaint\(\)/);
   });
 });
+
+describe('#1180 — terminal cap is a configurable setting, not a static constant', () => {
+  // The pre-#1180 static `MAX_TERMINALS = 10` silently punished multi-architect
+  // workspaces (each architect consumes a slot). The cap is now the
+  // `codev.maxTerminals` setting (default 25). Source-level guards per this
+  // file's harness rationale (constructing TerminalManager needs heavy vscode
+  // mocking); the config schema itself is asserted in package.json below.
+  const openBody = TM_SRC.split('private async openTerminal')[1] ?? '';
+
+  it('reads the cap from the codev.maxTerminals setting', () => {
+    expect(openBody).toMatch(
+      /getConfiguration\('codev'\)[\s\S]*\.get<number>\('maxTerminals', DEFAULT_MAX_TERMINALS\)/,
+    );
+  });
+
+  it('enforces the configured value (not a hardcoded 10)', () => {
+    expect(openBody).toMatch(/if \(this\.terminals\.size >= maxTerminals\)/);
+  });
+
+  it('toast points users at the setting they can raise', () => {
+    expect(openBody).toMatch(/raise codev\.maxTerminals/);
+  });
+
+  it('no longer defines the pre-#1180 static MAX_TERMINALS = 10 constant', () => {
+    // Regression guard: the fix must replace the constant, not shadow it.
+    expect(TM_SRC).not.toMatch(/const MAX_TERMINALS = 10/);
+    expect(TM_SRC).toMatch(/const DEFAULT_MAX_TERMINALS = 25/);
+  });
+});
+
+describe('#1180 — package.json exposes codev.maxTerminals', () => {
+  const PKG = JSON.parse(
+    readFileSync(resolve(__dirname, '../../package.json'), 'utf8'),
+  );
+  const prop =
+    PKG.contributes?.configuration?.properties?.['codev.maxTerminals'];
+
+  it('declares the setting with the documented default/min/max', () => {
+    expect(prop).toBeDefined();
+    expect(prop.type).toBe('number');
+    expect(prop.default).toBe(25);
+    expect(prop.minimum).toBe(5);
+    expect(prop.maximum).toBe(100);
+  });
+});

--- a/packages/vscode/src/terminal-manager.ts
+++ b/packages/vscode/src/terminal-manager.ts
@@ -7,7 +7,12 @@ import { resolveAgentName } from '@cluesmith/codev-core/agent-names';
 import type { TerminalType } from '@cluesmith/codev-core/tower-client';
 import { resolveBuilderTerminal, mainCheckoutRoot } from './terminal-resolve.js';
 
-const MAX_TERMINALS = 10;
+/**
+ * Default per-window terminal cap, overridable via the `codev.maxTerminals`
+ * setting. Sized for multi-architect workspaces (~10 architects + ~20 builders),
+ * well below Tower's own `maxSessions: 100` backstop. See issue #1180.
+ */
+const DEFAULT_MAX_TERMINALS = 25;
 
 interface ManagedTerminal {
   terminal: vscode.Terminal;
@@ -419,7 +424,7 @@ export class TerminalManager {
   /**
    * Resolve the currently-focused VSCode terminal to its Codev PTY, or null
    * if the active terminal is not a Codev-managed one. Linear scan over the
-   * (≤ MAX_TERMINALS) map — no reverse index to keep in sync. Used by the
+   * (≤ codev.maxTerminals) map — no reverse index to keep in sync. Used by the
    * image-paste command (#736) and the `codev.terminalFocused` context key.
    */
   getActiveManagedPty(): CodevPseudoterminal | null {
@@ -462,8 +467,13 @@ export class TerminalManager {
     key?: string,
     focus = false,
   ): Promise<void> {
-    if (this.terminals.size >= MAX_TERMINALS) {
-      vscode.window.showWarningMessage(`Too many terminals (${MAX_TERMINALS} max) — close unused terminals`);
+    const maxTerminals = vscode.workspace
+      .getConfiguration('codev')
+      .get<number>('maxTerminals', DEFAULT_MAX_TERMINALS);
+    if (this.terminals.size >= maxTerminals) {
+      vscode.window.showWarningMessage(
+        `Too many terminals (${maxTerminals} max) — close unused terminals or raise codev.maxTerminals`,
+      );
       return;
     }
 
@@ -556,7 +566,7 @@ export class TerminalManager {
    * `codev.terminal.repaintOnRefocus` (see extension.ts). The initial-render fix
    * (replay buffer-and-flush) covers the confirmed corruption; this path is only
    * for setups that still report stale content after refocus. It nudges *all*
-   * managed terminals (≤ MAX_TERMINALS) rather than just the active one — a
+   * managed terminals (≤ codev.maxTerminals) rather than just the active one — a
    * coarse choice, acceptable because it's off by default and `forceRepaint`
    * no-ops on a disconnected/replaying adapter. If it ever ships on by default,
    * narrow this to the visible/active terminal(s) first.

--- a/packages/vscode/src/terminal-manager.ts
+++ b/packages/vscode/src/terminal-manager.ts
@@ -9,8 +9,9 @@ import { resolveBuilderTerminal, mainCheckoutRoot } from './terminal-resolve.js'
 
 /**
  * Default per-window terminal cap, overridable via the `codev.maxTerminals`
- * setting. Sized for multi-architect workspaces (~10 architects + ~20 builders),
- * well below Tower's own `maxSessions: 100` backstop. See issue #1180.
+ * setting. Sized for multi-architect workspaces (several architect terminals
+ * plus one per active builder), well below Tower's own `maxSessions: 100`
+ * backstop. See issue #1180.
  */
 const DEFAULT_MAX_TERMINALS = 25;
 


### PR DESCRIPTION
## Summary

The VS Code extension capped concurrent terminals at 10 via a static `MAX_TERMINALS = 10` constant. In multi-architect workspaces this is impractical: main + sibling architects consume several slots before any builder terminal opens, and architect terminals are the least-closeable type (closing one loses AI conversation state until the next reconciliation).

This exposes the cap as a `codev.maxTerminals` setting (default **25**, min 5, max 100) so users can tune it. 25 accommodates ~10 architects + ~20 builders, well above realistic demand and comfortably below Tower's own `maxSessions: 100` server-side backstop.

## Root Cause

Static constant `MAX_TERMINALS = 10` at `packages/vscode/src/terminal-manager.ts:10`, enforced in `openTerminal` (`:465`), with no configuration surface. The cap dates from Spec 0602 (single-architect era); sibling architects arrived later (Spec 755/786) but the cap was never re-scoped. The client-side 10 was the binding constraint — Tower already backstops at 100.

## Fix

- `terminal-manager.ts`: replace `MAX_TERMINALS = 10` with `DEFAULT_MAX_TERMINALS = 25`; `openTerminal` reads `codev.maxTerminals` via the config getter (falling back to the default). The over-cap toast now reads `Too many terminals (N max) — close unused terminals or raise codev.maxTerminals` so users know the knob exists. Two doc-comment references updated to `codev.maxTerminals`.
- `package.json`: new `codev.maxTerminals` number setting (default 25, min 5, max 100) with a markdownDescription explaining the memory-vs-capacity trade-off.

Net diff: ~67 lines across 3 files. No change to Tower's server-side cap (out of scope).

## Test Plan

- Added `#1180` source-level guards in `terminal-manager.test.ts` (matching the file's existing source-guard harness, since a full `TerminalManager` needs heavy vscode mocking): verify the setting is read via `getConfiguration('codev').get<number>('maxTerminals', DEFAULT_MAX_TERMINALS)`, that enforcement uses the configured value (not a hardcoded 10), that the toast points at the setting, and that the pre-#1180 constant is gone.
- Added a `package.json` schema assertion for the new setting's default/min/max.
- Full vscode vitest suite green: **632 tests / 53 files pass**. `check-types` clean. Porch build + test checks pass.

Fixes #1180