### PR TITLE
[Bugfix #1182] Group idle sibling architects under 'Idle Architects' node (main always separate)

### DIFF
--- a/codev/projects/bugfix-1182-vscode-group-idle-sibling-arch/status.yaml
+++ b/codev/projects/bugfix-1182-vscode-group-idle-sibling-arch/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1182
 title: vscode-group-idle-sibling-arch
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-15T06:35:44.603Z'
-updated_at: '2026-07-15T06:35:44.603Z'
+updated_at: '2026-07-15T06:38:10.956Z'

--- a/codev/projects/bugfix-1182-vscode-group-idle-sibling-arch/status.yaml
+++ b/codev/projects/bugfix-1182-vscode-group-idle-sibling-arch/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-15T06:52:54.782Z'
+    approved_at: '2026-07-15T08:19:06.004Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-15T06:35:44.603Z'
-updated_at: '2026-07-15T06:52:54.783Z'
-pr_ready_for_human: true
+updated_at: '2026-07-15T08:19:06.005Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1182-vscode-group-idle-sibling-arch/status.yaml
+++ b/codev/projects/bugfix-1182-vscode-group-idle-sibling-arch/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1182
+title: vscode-group-idle-sibling-arch
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-15T06:35:44.603Z'
+updated_at: '2026-07-15T06:35:44.603Z'

--- a/codev/projects/bugfix-1182-vscode-group-idle-sibling-arch/status.yaml
+++ b/codev/projects/bugfix-1182-vscode-group-idle-sibling-arch/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-07-15T06:52:54.782Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-15T06:35:44.603Z'
-updated_at: '2026-07-15T06:47:45.945Z'
+updated_at: '2026-07-15T06:52:54.783Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1182-vscode-group-idle-sibling-arch/status.yaml
+++ b/codev/projects/bugfix-1182-vscode-group-idle-sibling-arch/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1182
 title: vscode-group-idle-sibling-arch
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-15T06:35:44.603Z'
-updated_at: '2026-07-15T06:38:10.956Z'
+updated_at: '2026-07-15T06:47:45.945Z'

--- a/codev/state/bugfix-1182_thread.md
+++ b/codev/state/bugfix-1182_thread.md
@@ -56,3 +56,24 @@ Implemented all 3 points. Net ~145 LOC src + ~314 test (well under 300 for src):
 Verification (from worktree): built deps (types/core/artifact-canvas), then
 `pnpm check-types` clean, `pnpm lint` clean, `pnpm vitest run` → 638 pass (54 files),
 `node esbuild.js --production` bundles. 2 commits (fix + tests). Next: push, PR, CMAP.
+
+## PR (in progress)
+
+PR #1183 opened (Fixes #1182). Porch ran its checks (build + tests) at the fix→pr
+transition; both green.
+
+Note: `consult` couldn't auto-detect the project (the worktree carries every project's
+`status.yaml` from main → "Multiple projects found"), so ran CMAP with explicit
+`--project-id bugfix-1182`.
+
+CMAP verdicts — all APPROVE, no changes requested:
+- Gemini: APPROVE (HIGH) — no issues.
+- Codex: APPROVE (MEDIUM) — no issues.
+- Claude: APPROVE (HIGH) — one non-blocking theoretical note: `getParent` returns
+  undefined for `BuilderGroupTreeItem` children of the idle container, so a
+  hypothetical `reveal()` on one would have an incomplete parent chain. Not a change
+  request — `reveal()` only targets `BuilderTreeItem` (accordion) and
+  `BuilderFileTreeItem` (active-file sync), never group headers. Matches my own
+  design analysis; no action taken.
+
+Requesting `pr` gate next; waiting for human approval before merge.

--- a/codev/state/bugfix-1182_thread.md
+++ b/codev/state/bugfix-1182_thread.md
@@ -1,0 +1,37 @@
+# bugfix-1182 — group idle sibling architects under "Idle Architects" collapsed node
+
+Follow-up to #1174 / PR #1175. Now that childless architects stay visible under the
+architect axis, several idle siblings each take a row and displace real builder work.
+
+## Investigate (done)
+
+**Where the architect axis renders** (all in `packages/vscode/src/views/`):
+- `builder-grouping.ts` `architectGrouping().group(ordered, roster)` — buckets builders
+  by `spawnedByArchitect` (null → `main`), seeds an empty bucket for every roster
+  architect (childless-visible, #1174). Returns `BuilderGroup[]` ordered `main` first,
+  then rest alphabetically (populated + idle mixed).
+- `builders.ts` `rootChildren()` — for the architect axis, maps each group to a
+  `BuilderGroupTreeItem`: empty groups → `None` (leaf-like), populated → `Expanded`;
+  every architect header gets the `codev.openArchitectTerminal` command (`g.key` arg).
+- `builder-tree-item.ts` `BuilderGroupTreeItem` — all-zero rollup → neutral
+  `circle-outline`/`disabledForeground` glyph + "No builders" tooltip (#1174).
+
+**Plan (architect axis only; stage/area untouched):**
+1. `builder-tree-item.ts` — new `IdleArchitectsGroupTreeItem` (title-cased
+   "Idle Architects (N)", Collapsed, neutral idle glyph, stable id for persistence,
+   no command bound → header click = expand/collapse only).
+2. `builders.ts` — split architect-axis rendering into a dedicated method:
+   partition groups into `main` (always own row), populated siblings (own rows),
+   idle siblings (0 builders, key !== main). Emit the Idle group only when idle
+   siblings ≥ 2, else render the lone idle sibling as its own row. Ordering:
+   main, populated siblings, then the idle group / lone idle at the bottom.
+   `getChildren(IdleArchitectsGroupTreeItem)` returns the individual idle architect
+   rows (reusing the childless `BuilderGroupTreeItem` + openArchitectTerminal).
+3. Tests: 0 / 1 / ≥2 idle-sibling cases, main-always-separate under all combos,
+   populated+idle mix, transitions, group header carries no command, individual
+   rows inside the group carry openArchitectTerminal.
+
+No `extension.ts` change needed: the accordion `onDidExpandElement` only acts on
+`BuilderTreeItem`; the idle group toggles natively (VSCode persists per-id).
+No `package.json` menu change: no menu `when`-clause targets `group-builder` in the
+Agents view.

--- a/codev/state/bugfix-1182_thread.md
+++ b/codev/state/bugfix-1182_thread.md
@@ -35,3 +35,24 @@ No `extension.ts` change needed: the accordion `onDidExpandElement` only acts on
 `BuilderTreeItem`; the idle group toggles natively (VSCode persists per-id).
 No `package.json` menu change: no menu `when`-clause targets `group-builder` in the
 Agents view.
+
+## Fix (done)
+
+Implemented all 3 points. Net ~145 LOC src + ~314 test (well under 300 for src):
+- `builder-tree-item.ts`: new `IdleArchitectsGroupTreeItem` — "Idle Architects (N)",
+  Collapsed, `id='idle-architects-group'` (persistence), `contextValue='group-idle-architects'`,
+  neutral `circle-outline`/`disabledForeground` glyph, NO command (toggle-only).
+- `builders.ts`: extracted `makeGroupRow(g, now, isArchitectAxis)` from the old inline
+  map; new `architectRootChildren(groups, now)` partitions main/populated/idle-siblings
+  and emits the container only when idle ≥ 2; new `idleArchitectRows(now)` recomputes the
+  container's children on expansion; `getChildren` dispatches on the new item type.
+- Tests: new `builders-idle-architects-group.test.ts` (11 cases: 0/1/≥2 siblings,
+  main-always-separate, ordering, glyph/command, expansion children, both transitions,
+  stage-axis unaffected). Updated one #1174 test in
+  `builders-childless-architect-header.test.ts` that pinned the pre-#1182 behavior
+  (3 childless → all top-level) to the lone-idle-sibling case (its interaction is now
+  covered by the #1182 file).
+
+Verification (from worktree): built deps (types/core/artifact-canvas), then
+`pnpm check-types` clean, `pnpm lint` clean, `pnpm vitest run` → 638 pass (54 files),
+`node esbuild.js --production` bundles. 2 commits (fix + tests). Next: push, PR, CMAP.

--- a/packages/vscode/src/__tests__/builders-childless-architect-header.test.ts
+++ b/packages/vscode/src/__tests__/builders-childless-architect-header.test.ts
@@ -86,15 +86,19 @@ async function groupHeaders(provider: InstanceType<typeof BuildersProvider>): Pr
 }
 
 describe('childless-architect headers under the architect axis (Issue 1174)', () => {
-  it('emits a (0) header for every registered architect when there are no builders', async () => {
+  it('emits a (0) header for a childless architect when it is the only idle sibling', async () => {
+    // A single idle sibling stays a top-level (0) header (Issue 1174). With ≥ 2
+    // idle siblings they fold into the "Idle Architects" container instead (Issue
+    // 1182) — covered by builders-idle-architects-group.test.ts. Here `main` is
+    // its own row and `reviewer` is the lone idle sibling.
     configValues['buildersGroupBy'] = 'architect';
     try {
       const provider = new BuildersProvider(
-        fakeCache([], [architect('main'), architect('reviewer'), architect('security')]),
+        fakeCache([], [architect('main'), architect('reviewer')]),
         fakeDiffCache,
       );
       const headers = await groupHeaders(provider);
-      expect(headers.map(h => h.groupName)).toEqual(['main', 'reviewer', 'security']);
+      expect(headers.map(h => h.groupName)).toEqual(['main', 'reviewer']);
       // Count in the label + leaf-like state (None) — no empty accordion.
       for (const h of headers) {
         expect(h.label).toContain('(0)');

--- a/packages/vscode/src/__tests__/builders-idle-architects-group.test.ts
+++ b/packages/vscode/src/__tests__/builders-idle-architects-group.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Issue 1182 — under the architect axis, idle **sibling** architects (zero
+ * builders, never `main`) roll up under a single collapsed "Idle Architects"
+ * container, but only when ≥ 2 are idle. This follows #1174 (childless
+ * architects stay visible): with several quiet siblings, each childless row
+ * displaced actual builder work, so they now fold into one collapsible node.
+ *
+ * These tests pin, through the provider:
+ *  - 0 idle siblings → no container;
+ *  - 1 idle sibling → its own top-level row (skip the container);
+ *  - ≥ 2 idle siblings → a collapsed "Idle Architects (N)" container with a
+ *    neutral idle glyph and NO command (header click only toggles), whose
+ *    children are the individual architect rows (each opening its own terminal);
+ *  - `main` is always its own row (populated or idle), never inside the group;
+ *  - populated siblings stay their own top-level rows; ordering is
+ *    main → populated siblings → idle container (bottom);
+ *  - transitions (a builder appearing / disappearing) move an architect between
+ *    the group and its own row on the next render;
+ *  - stage/area axes are unaffected.
+ *
+ * Mocks `vscode` per the established `__tests__` pattern.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type * as vscode from 'vscode';
+import type { ArchitectState, OverviewBuilder, OverviewData } from '@cluesmith/codev-types';
+
+/** Per-test config overrides the mocked `workspace.getConfiguration` reads. */
+const configValues: Record<string, unknown> = {};
+
+vi.mock('vscode', () => {
+  class FakeEventEmitter<T> {
+    private listeners: Array<(e: T) => void> = [];
+    readonly event = (listener: (e: T) => void): { dispose: () => void } => {
+      this.listeners.push(listener);
+      return { dispose: () => { this.listeners = this.listeners.filter((l) => l !== listener); } };
+    };
+    fire = vi.fn((e: T) => { this.listeners.forEach((l) => l(e)); });
+  }
+  class TreeItem {
+    id?: string;
+    tooltip?: string;
+    contextValue?: string;
+    iconPath?: unknown;
+    command?: unknown;
+    constructor(public label: string, public collapsibleState?: number) {}
+  }
+  class ThemeIcon { constructor(public id: string, public color?: unknown) {} }
+  class ThemeColor { constructor(public id: string) {} }
+  return {
+    EventEmitter: FakeEventEmitter,
+    TreeItem,
+    ThemeIcon,
+    ThemeColor,
+    TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+    workspace: {
+      getConfiguration: () => ({
+        get: (key: string, def: unknown) => (key in configValues ? configValues[key] : def),
+      }),
+    },
+  };
+});
+
+const { BuildersProvider } = await import('../views/builders.js');
+const { BuilderGroupTreeItem, IdleArchitectsGroupTreeItem } = await import('../views/builder-tree-item.js');
+
+function builder(overrides: Partial<OverviewBuilder>): OverviewBuilder {
+  return {
+    id: 'pir-1', issueId: '1', issueTitle: 't', phase: 'implement', protocolPhase: 'implement',
+    mode: 'strict', gates: {}, worktreePath: '/tmp/wt', roleId: null, protocol: 'pir',
+    planPhases: [], progress: 0, blocked: null, blockedGate: null, blockedSince: null,
+    startedAt: null, idleMs: 0, lastDataAt: null, spawnedByArchitect: null,
+    area: 'Uncategorized', prReady: false,
+    ...overrides,
+  } as OverviewBuilder;
+}
+
+function architect(name: string): ArchitectState {
+  return { name, port: 0, pid: 0 } as ArchitectState;
+}
+
+function fakeCache(builders: OverviewBuilder[], architects: ArchitectState[]) {
+  const data = { builders, architects, backlog: [], pendingPRs: [], recentlyClosed: [] } as unknown as OverviewData;
+  return { getData: () => data, onDidChange: () => ({ dispose() {} }) } as never;
+}
+
+const fakeDiffCache = {} as never;
+
+type Group = InstanceType<typeof BuilderGroupTreeItem>;
+type IdleGroup = InstanceType<typeof IdleArchitectsGroupTreeItem>;
+type ThemeIconLike = { id: string; color?: { id: string } };
+
+/** Architect axis over the given builders/roster; returns the root rows. */
+async function roots(builders: OverviewBuilder[], architects: ArchitectState[]) {
+  configValues['buildersGroupBy'] = 'architect';
+  try {
+    const provider = new BuildersProvider(fakeCache(builders, architects), fakeDiffCache);
+    return { provider, rows: await provider.getChildren() };
+  } finally {
+    delete configValues['buildersGroupBy'];
+  }
+}
+
+function architectRows(rows: vscode.TreeItem[]): Group[] {
+  return rows.filter(r => r instanceof BuilderGroupTreeItem) as Group[];
+}
+
+function idleContainer(rows: vscode.TreeItem[]): IdleGroup | undefined {
+  return rows.find(r => r instanceof IdleArchitectsGroupTreeItem) as IdleGroup | undefined;
+}
+
+describe('idle-architects grouping under the architect axis (Issue 1182)', () => {
+  it('fresh workspace (main only, no siblings): MAIN renders, no idle container', async () => {
+    const { rows } = await roots([], [architect('main')]);
+    expect(idleContainer(rows)).toBeUndefined();
+    const groups = architectRows(rows);
+    expect(groups.map(g => g.groupName)).toEqual(['main']);
+    expect(groups[0].label).toContain('(0)');
+  });
+
+  it('1 idle sibling: renders as its own top-level row, no container', async () => {
+    const { rows } = await roots(
+      [builder({ id: 'a', spawnedByArchitect: 'main' })],
+      [architect('main'), architect('reviewer')],
+    );
+    expect(idleContainer(rows)).toBeUndefined();
+    const groups = architectRows(rows);
+    expect(groups.map(g => g.groupName)).toEqual(['main', 'reviewer']);
+    expect(groups.find(g => g.groupName === 'reviewer')!.collapsibleState).toBe(0); // None
+  });
+
+  it('2 idle siblings: folds into a collapsed "Idle Architects (2)" container', async () => {
+    const { rows } = await roots(
+      [builder({ id: 'a', spawnedByArchitect: 'main' })],
+      [architect('main'), architect('reviewer'), architect('demos')],
+    );
+    // MAIN stays its own row; the two idle siblings are NOT top-level rows.
+    const groups = architectRows(rows);
+    expect(groups.map(g => g.groupName)).toEqual(['main']);
+    const container = idleContainer(rows);
+    expect(container).toBeDefined();
+    expect(container!.label).toBe('Idle Architects (2)');
+    expect(container!.collapsibleState).toBe(1); // Collapsed by default
+  });
+
+  it('4 idle siblings, everyone idle: MAIN own row + "Idle Architects (4)"', async () => {
+    const { rows } = await roots(
+      [],
+      [architect('main'), architect('reviewer'), architect('demos'), architect('ide'), architect('mobile')],
+    );
+    const groups = architectRows(rows);
+    expect(groups.map(g => g.groupName)).toEqual(['main']);
+    expect(groups[0].label).toContain('(0)');
+    expect(idleContainer(rows)!.label).toBe('Idle Architects (4)');
+  });
+
+  it('main is always its own row, never inside the idle container, even at zero builders', async () => {
+    const { rows } = await roots(
+      [],
+      [architect('main'), architect('reviewer'), architect('demos')],
+    );
+    const groups = architectRows(rows);
+    expect(groups.map(g => g.groupName)).toEqual(['main']);
+    expect(idleContainer(rows)!.label).toBe('Idle Architects (2)');
+  });
+
+  it('ordering: main, then populated siblings, then the idle container at the bottom', async () => {
+    const { rows } = await roots(
+      [
+        builder({ id: 'm', spawnedByArchitect: 'main' }),
+        builder({ id: 'v', spawnedByArchitect: 'vscode' }),
+      ],
+      [architect('main'), architect('vscode'), architect('reviewer'), architect('demos')],
+    );
+    // Row order: MAIN (populated) → VSCODE (populated sibling) → Idle Architects (2).
+    const kinds = rows.map(r => {
+      if (r instanceof IdleArchitectsGroupTreeItem) { return 'idle-group'; }
+      if (r instanceof BuilderGroupTreeItem) { return r.groupName; }
+      return 'other';
+    });
+    expect(kinds).toEqual(['main', 'vscode', 'idle-group']);
+  });
+
+  it('the idle container has a neutral idle glyph and NO command (header click only toggles)', async () => {
+    const { rows } = await roots(
+      [],
+      [architect('main'), architect('reviewer'), architect('demos')],
+    );
+    const container = idleContainer(rows)!;
+    const icon = container.iconPath as ThemeIconLike;
+    expect(icon.id).toBe('circle-outline');
+    expect(icon.color?.id).toBe('disabledForeground');
+    expect(container.command).toBeUndefined();
+    expect(container.contextValue).toBe('group-idle-architects');
+  });
+
+  it('expanding the container yields the individual idle architect rows, each opening its terminal', async () => {
+    // The container's children are recomputed from the cache on expansion, so the
+    // axis config must stay set across BOTH getChildren calls (roots() restores it
+    // in its finally, so drive the provider directly here).
+    configValues['buildersGroupBy'] = 'architect';
+    try {
+      const provider = new BuildersProvider(
+        fakeCache([], [architect('main'), architect('reviewer'), architect('demos')]),
+        fakeDiffCache,
+      );
+      const container = idleContainer(await provider.getChildren())!;
+      const children = architectRows(await provider.getChildren(container));
+      // reviewer + demos, sorted alphabetically (main is excluded — it is its own row).
+      expect(children.map(c => c.groupName).sort()).toEqual(['demos', 'reviewer']);
+      for (const c of children) {
+        expect(c.collapsibleState).toBe(0); // None — leaf-like, no empty accordion
+        expect(c.command).toEqual({
+          command: 'codev.openArchitectTerminal',
+          title: 'Open Architect Terminal',
+          arguments: [c.groupName],
+        });
+      }
+    } finally {
+      delete configValues['buildersGroupBy'];
+    }
+  });
+
+  it('transition — a sibling gaining a builder graduates out of the idle container into its own row', async () => {
+    // reviewer is populated; demos + ide idle → only 2 idle siblings → container of 2.
+    const { rows } = await roots(
+      [
+        builder({ id: 'a', spawnedByArchitect: 'main' }),
+        builder({ id: 'r', spawnedByArchitect: 'reviewer' }),
+      ],
+      [architect('main'), architect('reviewer'), architect('demos'), architect('ide')],
+    );
+    const groups = architectRows(rows);
+    // main + reviewer are populated top-level rows; demos + ide fold into the container.
+    expect(groups.map(g => g.groupName)).toEqual(['main', 'reviewer']);
+    expect(idleContainer(rows)!.label).toBe('Idle Architects (2)');
+  });
+
+  it('transition — dropping to 1 idle sibling dissolves the container back to a lone row', async () => {
+    // demos populated, ide populated → only reviewer idle → 1 idle sibling → no container.
+    const { rows } = await roots(
+      [
+        builder({ id: 'd', spawnedByArchitect: 'demos' }),
+        builder({ id: 'i', spawnedByArchitect: 'ide' }),
+      ],
+      [architect('main'), architect('reviewer'), architect('demos'), architect('ide')],
+    );
+    expect(idleContainer(rows)).toBeUndefined();
+    const groups = architectRows(rows);
+    expect(groups.map(g => g.groupName)).toEqual(['main', 'demos', 'ide', 'reviewer']);
+    expect(groups.find(g => g.groupName === 'reviewer')!.collapsibleState).toBe(0); // None
+  });
+
+  it('stage axis is unaffected — no idle container regardless of idle architects', async () => {
+    configValues['buildersGroupBy'] = 'stage';
+    try {
+      const provider = new BuildersProvider(
+        fakeCache(
+          [builder({ id: 'a', spawnedByArchitect: 'main', protocolPhase: 'implement' })],
+          [architect('main'), architect('reviewer'), architect('demos')],
+        ),
+        fakeDiffCache,
+      );
+      const rows = await provider.getChildren();
+      expect(idleContainer(rows)).toBeUndefined();
+    } finally {
+      delete configValues['buildersGroupBy'];
+    }
+  });
+});

--- a/packages/vscode/src/views/builder-tree-item.ts
+++ b/packages/vscode/src/views/builder-tree-item.ts
@@ -66,3 +66,33 @@ export class BuilderGroupTreeItem extends AreaGroupTreeItem {
     this.tooltip = `${rollup.blocked} blocked · ${rollup.idle} waiting · ${rollup.active} active`;
   }
 }
+
+/**
+ * Container header that rolls up idle **sibling** architects (never `main`) under
+ * the architect axis (Issue 1182). Emitted only when ≥ 2 siblings are idle (zero
+ * builders); a lone idle sibling keeps its own top-level row. Without this, a
+ * workspace running several quiet siblings (reviewer, demos, ide, …) accumulates
+ * childless rows (each ~22px) that push actual builder work below the fold — the
+ * proportion cost the childless-visible fix (#1174) traded for never losing a row
+ * mid-session. `main` is exempt: it is the always-present workspace home base, so
+ * burying it behind a chevron is a bad trade for one row of space.
+ *
+ * Distinct from `BuilderGroupTreeItem` (which names one architect and opens its
+ * terminal): this is a pure meta-container of N architects, so it binds NO
+ * command — a header click only toggles expansion. Its children are the
+ * individual idle-architect rows, each a childless `BuilderGroupTreeItem` that
+ * still opens its own terminal. Default `Collapsed`; VSCode persists per-id
+ * expansion off the stable `id`, so a user who expands it stays expanded until
+ * they collapse. The rollup glyph is the same neutral idle glyph a childless
+ * architect carries — idle architects have no builders, so there is no
+ * attention state to roll up.
+ */
+export class IdleArchitectsGroupTreeItem extends vscode.TreeItem {
+  constructor(count: number) {
+    super(`Idle Architects (${count})`, vscode.TreeItemCollapsibleState.Collapsed);
+    this.id = 'idle-architects-group';
+    this.contextValue = 'group-idle-architects';
+    this.iconPath = new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('disabledForeground'));
+    this.tooltip = `${count} idle architects · no builders attached`;
+  }
+}

--- a/packages/vscode/src/views/builders.ts
+++ b/packages/vscode/src/views/builders.ts
@@ -7,12 +7,13 @@ import { UNCATEGORIZED_AREA } from '@cluesmith/codev-core/constants';
 import type { OverviewCache } from './overview-data.js';
 import { builderWithWorktree, type OverviewBuilderWithWorktree } from '../builder-lookup.js';
 import { readBuildersFileViewAsTree } from '../builders-config.js';
-import { BuilderGroupTreeItem, BuilderTreeItem } from './builder-tree-item.js';
+import { BuilderGroupTreeItem, BuilderTreeItem, IdleArchitectsGroupTreeItem } from './builder-tree-item.js';
 import { BuilderFileTreeItem } from './builder-file-tree-item.js';
 import { BuilderFolderTreeItem } from './builder-folder-tree-item.js';
 import { buildFilePathTree, type FilePathNode } from './file-path-tree.js';
 import type { BuilderDiffCache } from './builder-diff-cache.js';
 import {
+  type BuilderGroup,
   type BuilderGrouping,
   type BuildersGroupBy,
   stageGrouping,
@@ -263,6 +264,11 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
     if (element instanceof BuilderFileTreeItem) {
       return [];
     }
+    // The Idle Architects container (architect axis, Issue 1182) expands to the
+    // individual idle-sibling architect rows.
+    if (element instanceof IdleArchitectsGroupTreeItem) {
+      return this.idleArchitectRows(Date.now());
+    }
     // Group rows expand to their builders.
     if (element instanceof BuilderGroupTreeItem) {
       return this.rowsForGroup(element.groupName);
@@ -298,50 +304,120 @@ export class BuildersProvider implements vscode.TreeDataProvider<vscode.TreeItem
       return groups[0].items.map(b => this.makeBuilderRow(b, now));
     }
 
+    // The architect axis rolls idle siblings into an "Idle Architects" container
+    // (Issue 1182), so it renders through its own method. Stage/area render every
+    // group as its own header.
+    if (grouping.id === 'architect') {
+      return this.architectRootChildren(groups, now);
+    }
     // Populated groups render Expanded (#913) — no persisted state. VSCode's
     // native per-id memory keeps a user-collapsed group collapsed for the
     // rest of the session; on a fresh session this default applies again.
-    // Childless architect groups (Issue 1174) render as leaf-like rows (`None`).
-    //
-    // Architect-axis headers get a click-to-open-terminal `command` (#1108):
-    // the architect is first-class in this mode, so its header should match the
-    // builder-row affordance (row click opens the terminal; the chevron still
-    // toggles expand/collapse — VSCode routes the two gestures independently).
-    // Stage/area headers stay pure containers — they name no launchable entity.
-    // The `g.key` (architect name; null owners folded into `main` by
-    // architectGrouping) is the optional name arg `codev.openArchitectTerminal`
-    // already accepts; it warns gracefully on a stale owner not in the roster.
-    const isArchitectAxis = grouping.id === 'architect';
-    return groups.map(g => {
-      // A childless architect group (Issue 1174) has no builders to expand into,
-      // so render it as a leaf-like row (`None`) rather than an empty accordion.
-      // The click-to-open-terminal command below still fires on the row body.
-      // Populated groups stay Expanded (#913). Only the architect axis ever
-      // yields an empty group; stage/area groups always hold ≥1 builder.
-      let collapsibleState: vscode.TreeItemCollapsibleState;
-      if (g.items.length === 0) {
-        collapsibleState = vscode.TreeItemCollapsibleState.None;
+    // Stage/area groups always hold ≥1 builder (no empty groups on these axes),
+    // so they never carry a command — they name no launchable entity.
+    return groups.map(g => this.makeGroupRow(g, now, false));
+  }
+
+  /**
+   * Root rows for the architect axis (Issue 1182). `main` and every populated
+   * sibling render as their own top-level group (unchanged from #1174); idle
+   * siblings (zero builders, not `main`) roll up under a single collapsed
+   * "Idle Architects" container — but only when ≥ 2 are idle. A lone idle
+   * sibling keeps its own row (the group would save no space for one row and
+   * only adds a click). Ordering: `main` first, then populated siblings, then
+   * the idle container / lone idle sibling at the bottom — "primary work first,
+   * roster second."
+   *
+   * `groups` arrives from `architectGrouping` already ordered `main`-first then
+   * the rest alphabetically. Iterating it preserves that order for the rows that
+   * stay top-level; the idle siblings are peeled off and re-emitted last.
+   *
+   * `main` is always its own row regardless of builder count: it is the
+   * always-present workspace home base (created by `launchInstance` on any
+   * workspace; every sibling is opt-in via `add-architect`), so burying it
+   * behind a chevron is a bad trade for one row of vertical space.
+   */
+  private architectRootChildren(groups: BuilderGroup[], now: number): vscode.TreeItem[] {
+    const topLevel: vscode.TreeItem[] = [];
+    const idleSiblings: BuilderGroup[] = [];
+    for (const g of groups) {
+      const isIdleSibling = g.key !== 'main' && g.items.length === 0;
+      if (isIdleSibling) {
+        idleSiblings.push(g);
       } else {
-        collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+        topLevel.push(this.makeGroupRow(g, now, true));
       }
-      const groupItem = new BuilderGroupTreeItem(
-        g.key,
-        g.items.length,
-        collapsibleState,
-        rollupGroupState(g.items, now),
-      );
-      if (isArchitectAxis) {
-        groupItem.command = {
-          command: 'codev.openArchitectTerminal',
-          title: 'Open Architect Terminal',
-          arguments: [g.key],
-        };
+    }
+    if (idleSiblings.length >= 2) {
+      topLevel.push(new IdleArchitectsGroupTreeItem(idleSiblings.length));
+    } else {
+      // 0 → nothing; 1 → the lone idle sibling renders as its own top-level row.
+      for (const g of idleSiblings) {
+        topLevel.push(this.makeGroupRow(g, now, true));
       }
-      for (const b of g.items) {
-        this.groupParentByBuilderId.set(b.id, groupItem);
-      }
-      return groupItem;
-    });
+    }
+    return topLevel;
+  }
+
+  /**
+   * The individual idle-sibling architect rows shown when the "Idle Architects"
+   * container is expanded (Issue 1182). Each is a childless
+   * `BuilderGroupTreeItem` — the same leaf-like `(0)` row #1174 renders at top
+   * level — carrying its own `codev.openArchitectTerminal` command, so clicking a
+   * name inside the group opens that architect's terminal. Recomputed from the
+   * cache (not cached from `rootChildren`) so it stays correct across overview
+   * ticks; harmlessly returns `[]` if the axis is no longer `architect`.
+   */
+  private idleArchitectRows(now: number): vscode.TreeItem[] {
+    const data = this.cache.getData();
+    if (!data) { return []; }
+    const grouping = this.active();
+    if (grouping.id !== 'architect') { return []; }
+    const roster = (data.architects ?? []).map(a => a.name);
+    const groups = grouping.group(orderForDisplay(data.builders, now), roster);
+    return groups
+      .filter(g => g.key !== 'main' && g.items.length === 0)
+      .map(g => this.makeGroupRow(g, now, true));
+  }
+
+  /**
+   * Build one group header row. `isArchitectAxis` headers get a
+   * click-to-open-terminal `command` (#1108): the architect is first-class in
+   * this mode, so its header matches the builder-row affordance (row click opens
+   * the terminal; the chevron still toggles expand/collapse — VSCode routes the
+   * two gestures independently). A childless architect group (Issue 1174) has no
+   * builders to expand into, so it renders as a leaf-like row (`None`) rather
+   * than an empty accordion; the command still fires on the row body. Populated
+   * groups render Expanded (#913). Stage/area headers stay command-less
+   * containers. Registers each builder's parent group for `getParent`.
+   */
+  private makeGroupRow(g: BuilderGroup, now: number, isArchitectAxis: boolean): BuilderGroupTreeItem {
+    let collapsibleState: vscode.TreeItemCollapsibleState;
+    if (g.items.length === 0) {
+      collapsibleState = vscode.TreeItemCollapsibleState.None;
+    } else {
+      collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+    }
+    const groupItem = new BuilderGroupTreeItem(
+      g.key,
+      g.items.length,
+      collapsibleState,
+      rollupGroupState(g.items, now),
+    );
+    if (isArchitectAxis) {
+      // The `g.key` (architect name; null owners folded into `main` by
+      // architectGrouping) is the optional name arg `codev.openArchitectTerminal`
+      // already accepts; it warns gracefully on a stale owner not in the roster.
+      groupItem.command = {
+        command: 'codev.openArchitectTerminal',
+        title: 'Open Architect Terminal',
+        arguments: [g.key],
+      };
+    }
+    for (const b of g.items) {
+      this.groupParentByBuilderId.set(b.id, groupItem);
+    }
+    return groupItem;
   }
 
   private rowsForGroup(key: string): vscode.TreeItem[] {


### PR DESCRIPTION
Fixes #1182

## Summary

Follow-up to #1174 / PR #1175. Now that childless architects stay visible under the **architect axis** of the Agents view, a workspace running several quiet siblings (reviewer, demos, ide, mobile, …) accumulates 3-5 childless architect rows that displace real builder work below the fold. This groups **idle sibling architects** (zero builders, never `main`) under a single collapsed **"Idle Architects (N)"** container — but only when ≥ 2 are idle. Scope is architect-axis only; stage and area axes are unchanged.

Behavior:

| Idle sibling count | Rendering |
|---|---|
| 0 | No container, no visual change |
| 1 | The lone idle sibling keeps its own top-level `(0)` row (a container would save no space for one row) |
| ≥ 2 | All idle siblings fold under `▶ Idle Architects (N)`, collapsed by default |

`main` is **always its own row** regardless of builder count — it is the always-present workspace home base (created by `launchInstance` on every workspace; siblings are opt-in via `add-architect`), so burying it behind a chevron is a bad trade for one row of space. Populated architects (main + siblings) render as their own top-level groups with builders expanded, unchanged from #1174. Ordering: main → populated siblings → idle container (bottom).

## Root Cause

`packages/vscode/src/views/builders.ts` `rootChildren()` mapped every architect group (including the childless ones #1174 made visible) to its own top-level header. With N idle siblings that is N rows of chevron-less `(0)` headers, each ~22px, pushing actual builder rows off-screen — the proportion cost #1174 traded for never losing an architect row mid-session.

## Fix

- **`builder-tree-item.ts`**: new `IdleArchitectsGroupTreeItem` — label `Idle Architects (N)`, `Collapsed` by default, a stable `id` (`idle-architects-group`) so VSCode persists expansion, `contextValue` `group-idle-architects`, the same neutral `circle-outline`/`disabledForeground` idle glyph a childless architect carries, and **no** command bound (a header click only toggles — there is no single terminal for a container of N architects).
- **`builders.ts`**: extracted the inline group-row builder into `makeGroupRow(g, now, isArchitectAxis)` (unchanged rendering: `None` for childless, `Expanded` for populated, `openArchitectTerminal` command on architect headers). New `architectRootChildren()` partitions groups into `main` (always own row), populated siblings (own rows), and idle siblings — emitting the container only when idle ≥ 2, else rendering the lone idle sibling as its own row. New `idleArchitectRows()` recomputes the container's children on expansion (each a childless `BuilderGroupTreeItem` that still opens its own terminal), so a click on a name inside the group opens that architect's terminal. `getChildren` dispatches on the new item type.

No `extension.ts` change (the accordion's `onDidExpandElement` only acts on `BuilderTreeItem`; the container toggles natively). No `package.json` menu change (no menu `when`-clause targets a Builders-view group `contextValue`).

Net diff: ~145 LOC src (2 files), ~277 LOC tests.

## Test Plan

`pnpm check-types` clean, `pnpm lint` clean, `pnpm vitest run` → **638 pass** (54 files), `node esbuild.js --production` bundles.

- New `builders-idle-architects-group.test.ts` (11 cases): fresh workspace (main only, no container); 1 idle sibling → own row, no container; 2 idle siblings → collapsed `Idle Architects (2)`; 4 idle / everyone idle; main-always-separate under every combo; ordering (main → populated → container); the container's neutral glyph + no-command + `contextValue`; expansion yields the individual architect rows each opening its terminal; both transitions (sibling gains a builder → graduates out; drops to 1 idle → container dissolves to a lone row); stage axis unaffected.
- Updated one #1174 test in `builders-childless-architect-header.test.ts` that pinned the pre-#1182 behavior (3 childless architects all top-level) to the lone-idle-sibling case — the ≥2 interaction is now covered by the new file.
