### PR TITLE
research: Expo LAN spike results + docs amendment (tower-sdk retired for codev-sdk #1189)

### DIFF
--- a/codev/research/mobile/decisions/q5-multi-workspace.md
+++ b/codev/research/mobile/decisions/q5-multi-workspace.md
@@ -18,9 +18,9 @@
 2. **Feed and chat are workspace-scoped**, behind a workspace switcher (current-workspace context persisted per device). Rationale: an interleaved multi-workspace activity feed is noise — activity volume is high (every phase change, spawn, message) and cross-workspace interleaving destroys glanceability. Chat targets (`architect:main`) are only meaningful within a workspace.
 3. **Multi-tower is Phase 2** and composes the same way: tower switcher above workspace switcher, inbox unified across both. v0 (LAN PoC) is single-Tower by construction.
 
-## Consequence for tower-sdk
+## Consequence for codev-sdk (#1189)
 
-Hooks take explicit `workspacePath` (already required by the extraction — the dashboard's implicit-URL-scoping knot), and the inbox hook is the one deliberately cross-workspace query (`usePendingAttention()` aggregating across `GET /api/workspaces`).
+Client calls take explicit `baseUrl` + `workspacePath` (the dashboard's implicit-URL-scoping knot, now a #1189 design requirement), and the inbox is the one deliberately cross-workspace query: a pending-attention client aggregating across `GET /api/workspaces`. (The sdk is framework-free; each surface wraps this in its own state idiom — a hook on web/mobile, a tree provider in vscode.)
 
 ## Related
 

--- a/codev/research/mobile/feasibility-2026-07.md
+++ b/codev/research/mobile/feasibility-2026-07.md
@@ -14,7 +14,7 @@
 - **The defining use case is unchanged**: run your AI dev team during the 30-second attention windows of your day. Approval inbox, glanceable status, structured question-answering. Replicating the desktop UI on a smaller screen remains the failure mode.
 - **The terminal-substrate/interface split stands**: the PTY remains the source of truth; mobile renders projections (chat bubbles, feed rows, decision cards) with the raw terminal one tap away. New ground truth strengthens this: Tower today does *zero* PTY content parsing, so the projection layer is genuinely new plumbing — and it benefits web and VS Code equally, which changes who should design it (main, not mobile alone).
 - **The security posture is unchanged and the warning stands**: `isRequestAllowed` still returns `true` unconditionally; there is no in-tower defense in depth. Closing this gap remains a hard prerequisite for any credential living on a phone. Verified current, not just a May snapshot.
-- **Recommended path (updated):** spike-driven LAN PoC first (`packages/tower-sdk` extraction → `apps/mobile` scaffold → feed/chat/question flows against a LAN Tower), with cloud/push as a separately-specced phase coordinated with issue #655. Do not let mobile silently become "build Tower Cloud."
+- **Recommended path (updated 2026-07-16):** spike-driven LAN PoC. The `apps/mobile` scaffold + LAN reachability spike is complete and green (`spikes/expo-lan-reachability-2026-07.md`); feed/chat/question flows against a LAN Tower come next. The shared client layer arrives via the `codev-sdk` split (#1189), not a dashboard extraction. Cloud/push stays a separately-specced phase coordinated with issue #655. Do not let mobile silently become "build Tower Cloud."
 
 ---
 
@@ -48,7 +48,7 @@ Six weeks of platform evolution that the May doc predates, each with a mobile co
 
 The May analysis of RN vs PWA vs Capacitor vs native vs Flutter stands; nothing in six weeks moved it. RN + Expo (managed workflow, EAS) remains the recommendation. Three updates:
 
-1. **The code-sharing story is now concrete.** The `packages/tower-sdk` extraction was audited (2026-07-07): the dashboard's data layer is plain React hooks (no Redux/React Query/Zustand), snapshot-polling + SSE-refetch, with **all wire contracts in `@cluesmith/codev-types`**. ~70-75% ports as-is. The three knots are all transport/glue, not business logic: (a) workspace identity implied by browser URL (`getApiBase() = './'`, reverse-proxy prefix) — SDK must take explicit `baseUrl` + `workspacePath`; (b) the module-global `EventSource` singleton with `document.visibilitychange` lifecycle — needs an injected transport + RN `AppState`; (c) three divergent auth/storage paths (browser `localStorage`, Node `~/.agent-farm/local-key`, and nothing for RN) — needs injected `getToken()`/storage interfaces.
+1. **The code-sharing story is now concrete.** The client data layer was audited (2026-07-07; the findings now drive the `codev-sdk` design in #1189, which superseded the tower-sdk extraction idea — see `interaction-model.md` §7.2): the dashboard's data layer is plain React hooks (no Redux/React Query/Zustand), snapshot-polling + SSE-refetch, with **all wire contracts in `@cluesmith/codev-types`**. ~70-75% ports as-is. The three knots are all transport/glue, not business logic: (a) workspace identity implied by browser URL (`getApiBase() = './'`, reverse-proxy prefix) — SDK must take explicit `baseUrl` + `workspacePath`; (b) the module-global `EventSource` singleton with `document.visibilitychange` lifecycle — needs an injected transport + RN `AppState`; (c) three divergent auth/storage paths (browser `localStorage`, Node `~/.agent-farm/local-key`, and nothing for RN) — needs injected `getToken()`/storage interfaces.
 2. **Terminal rendering is settled by decision, not by WebView benchmarking.** v0 ships a read-only monospace snapshot (the `/ws/terminal/:id` byte bridge exists; rendering read-only is a client choice) and no interactive terminal. The May doc's §5.5 substrate-vs-interface argument is preserved in `interaction-model.md` §2/§5 as the design principle.
 3. **Markdown/code rendering has a fork in it** (#1029): RN-native markdown vs WebView-hosted artifact-canvas. Spike question, not a blocker.
 
@@ -57,10 +57,10 @@ The May analysis of RN vs PWA vs Capacitor vs native vs Flutter stands; nothing 
 ### 4.1 The three-layer split is the whole game
 
 - `apps/mobile` (Expo/RN, view layer) — new
-- `packages/tower-sdk` (framework-agnostic hooks + API/WS clients) — extracted from the dashboard; consumed by web, mobile, and eventually VS Code
+- `packages/codev-sdk` (#1189) — the single Tower client implementation (API + WS/message-bus, injected transport/auth, framework-free); consumed by `apps/web`, `apps/vscode`, the CLI's Tower-facing commands, and mobile. Replaces the earlier tower-sdk extraction idea (see `interaction-model.md` §7.2 for the supersession rationale)
 - Tower plumbing (structured events, question detection, gate-approval endpoint) — new, **shared with web**, designed with main
 
-Issue #855 (`apps/*` split: `packages/dashboard` → `apps/web`, `packages/vscode` → `apps/vscode`, `apps/mobile` lands fresh) is the layout this assumes. Sequencing (before first mobile PR vs bundled with it) is main's call.
+Issue #855 (`apps/*` split) **merged 2026-07-16** (PR #1188): `apps/web` and `apps/vscode` exist; `apps/mobile` lands fresh into the established layout.
 
 ### 4.2 Backend changes — reframed by what exists
 
@@ -116,9 +116,9 @@ The May doc's four narrative use-case flows (8am decision sweep, commute spec, c
 
 ## 8. Phasing (updated for the spike-first reality)
 
-**Phase S — spikes (EXPERIMENT protocol, LAN-only, no shipped code).** Priority order per the mobile workstream mandate: tower-sdk extraction; apps/mobile Expo scaffold + LAN WS/SSE reachability; AskUserQuestion detection design (with main); push wiring sandbox (APNs/FCM feasibility only); RN real-time feed; native diff viewer eval; chat/card rendering (RN-native vs WebView artifact-canvas, feeds #1029). Output: research notes in `codev/research/mobile/spikes/`.
+**Phase S — spikes (LAN-only, no shipped code).** Status as of 2026-07-16: ~~tower-sdk extraction~~ (retired; replaced by the #1189 codev-sdk split, which is scheduled implementation work, not a spike); **apps/mobile Expo scaffold + LAN reachability — DONE, green** (`spikes/expo-lan-reachability-2026-07.md`; device-verification half pending a BRIDGE_MODE Tower session). Remaining, in order: AskUserQuestion detection design (with main); RN real-time feed; chat/card rendering (RN-native vs WebView artifact-canvas, feeds #1029); native diff viewer eval; push wiring sandbox (APNs/FCM feasibility only). Output: research notes in `codev/research/mobile/spikes/`.
 
-**Phase 1 — LAN PoC** (PIR specs, real implementation): feed + chat + question cards + gate approval against a LAN Tower. Cold-tester round (3 testers, timed tasks) mirroring the IDE PoC pattern. #855 lands before or with the first PR — main's call.
+**Phase 1 — LAN PoC** (PIR specs, real implementation): feed + chat + question cards + gate approval against a LAN Tower. Cold-tester round (3 testers, timed tasks) mirroring the IDE PoC pattern. #855 merged 2026-07-16, so `apps/mobile` has its home.
 
 **Phase 2 — cloud-connected mobile**: per-device auth, push, offline semantics, handoff at distance. Gated on Tower Cloud work (its own spec; seeded by #655 and the security-profile mitigations). This phase's timeline is owned by the cloud workstream, not mobile.
 
@@ -136,7 +136,7 @@ Of the May doc's seven strategic questions:
 4. **Self-host story** — the `--service <url>` override already exists in `afx tower connect`; mobile should honor arbitrary cloud URLs from day one of Phase 2. Affirmed.
 5. **Store distribution** — Phase 2 concern; v0 is Expo dev builds.
 6. **iOS-first vs simultaneous** — RN keeps both open; v0 PoC targets whatever device is on the desk (pragmatically iOS); no store commitment implied.
-7. **Separate codebase vs shared with web** — **decided**: separate view layers, shared `packages/tower-sdk` + `packages/types`. See `interaction-model.md` §7.
+7. **Separate codebase vs shared with web** — **decided**: separate view layers; sharing happens through `codev-types` (contracts) and `codev-sdk` (#1189, the single Tower client). See `interaction-model.md` §7.
 
 The seven *interaction-design* open questions from the interaction-model draft are separately answered in `codev/research/mobile/decisions/` (q1–q7).
 

--- a/codev/research/mobile/interaction-model.md
+++ b/codev/research/mobile/interaction-model.md
@@ -214,52 +214,38 @@ Rejected. Reasons:
 - **Rewriting the dashboard** as RN Web is a rewrite, not a refactor. Weeks of work with regression surface, blocking mobile from shipping while the migration lands.
 - **Build tooling complexity** — Metro + Expo Router + web adapter vs. clean per-platform toolchains (Vite for web, Expo for mobile).
 
-### 7.2 DO share the state / data layer
+### 7.2 DO share the client layer — via `codev-sdk` (#1189), not the original tower-sdk
 
-Extract a framework-agnostic package with React hooks that both apps (and the VS Code extension) consume. Each platform owns its view layer natively.
+**Superseded (2026-07-16).** This section originally proposed `packages/tower-sdk`: a React-hooks state layer extracted from the dashboard, consumed by web, mobile, and VS Code. That design was retired after review with Amr, for three reasons:
 
-**Proposed**: `packages/tower-sdk`
+- The VS Code extension host is not React — hooks fit at most two of the three claimed consumers.
+- The dashboard would need migrating onto the extracted layer to get any sharing benefit: a refactor of a working surface for the benefit of an app that doesn't exist yet.
+- It contradicted the repo's own extract-on-committed-need precedent (#1029).
 
-Exports hooks like:
+**The replacement is issue #1189: `packages/codev-sdk`** — a dependency-isolation split of `codev-core` rather than a dashboard extraction. Taxonomy: `codev-types` is the only package both sides share (wire contracts); `codev-core` becomes server-side implementation only; `codev-sdk` is the single client implementation of "how anything talks to Tower" (evolved `tower-client` with injected auth/transport, WS/message-bus client, and the client-side pure helpers). Its consumers exist today: the web dashboard, the VS Code extension, and the CLI's Tower-facing commands — mobile joins as the fourth. The sdk is framework-free in v1 (no React hooks; the extension host and CLI can't use them); an optional `/react` subpath may come later if web and mobile demonstrably duplicate hook logic.
 
-- `useBuilderList()` — real-time builder roster
-- `useSendMessage(target)` — send to architect / builder
-- `useArchitectActivity(name)` — event stream for a given architect
-- `useOverview(baseUrl, workspacePath)` — same shape the dashboard consumes today
-- `useGateApproval(gateId)` — approve / reject flow
-- `usePendingQuestion()` — active `AskUserQuestion` awaiting response
+The knots identified in the 2026-07-07 dashboard audit remain the sdk's design requirements (validated from the consuming side by the Expo spike, `spikes/expo-lan-reachability-2026-07.md`):
 
-Framework-agnostic (no DOM, no RN specifics). Same hook, three different view renderings:
-
-- **web** — resizable table with sortable columns
-- **mobile** — swipeable card feed with pull-to-refresh
-- **vscode** — sidebar tree items with context menus
-
-Bug fixes in message routing, schema changes in `packages/types`, new WebSocket events — all land in `packages/tower-sdk` once, every surface picks them up.
-
-**Extraction feasibility (audited 2026-07-07)** — favorable, with three known knots:
-
-- The dashboard has no state library (no React Query/Zustand): plain `useState` + fetch + `setInterval` polling + SSE-triggered refetch, snapshot-deduped. ~70-75% of the data layer is portable as-is; **all wire contracts already live in `@cluesmith/codev-types`** (the dashboard defines none of its own), which is the single biggest asset.
-- **Knot 1 — implicit workspace scoping.** The dashboard's API base is `'./'`; workspace identity rides the browser URL (reverse-proxy prefix `/workspace/<base64>/`), and WS/SSE URLs are built from `window.location`. RN has no URL context — the SDK must take explicit `baseUrl` + `workspacePath` (the hook signature above reflects this).
-- **Knot 2 — the SSE singleton.** `useSSE` is a module-global `EventSource` with `document.visibilitychange` lifecycle (browser 6-connection-limit workaround). RN has no `EventSource`; the transport must be an injected adapter, with RN `AppState` replacing visibility.
-- **Knot 3 — divergent auth/persistence.** Browser reads `localStorage['codev-web-key']`; the Node `TowerClient` in `packages/core` reads `~/.agent-farm/local-key` via `node:fs`; neither is RN-usable. The SDK needs injected `getToken()` + storage interfaces, unifying all three environments.
+- **Explicit scoping.** The dashboard's API base is `'./'`; workspace identity rides the browser URL. RN has no URL context — the sdk takes explicit `baseUrl` + `workspacePath`.
+- **Injected transport.** The dashboard's `useSSE` is a module-global `EventSource` with `document.visibilitychange` lifecycle. RN has no `EventSource` — transport arrives as an adapter, with `AppState` replacing visibility on RN.
+- **Injected auth/storage.** Browser reads `localStorage['codev-web-key']`; the Node client reads `~/.agent-farm/local-key` via `node:fs`; neither is RN-usable. The sdk takes `getToken()` + storage interfaces.
 
 ### 7.3 Resulting monorepo layout
 
-Aligned with issue #855 (introduce `apps/*`):
+`apps/*` landed via #855 (merged 2026-07-16, PR #1188); `codev-sdk` is proposed in #1189:
 
 ```
 apps/
-  web/         Vite + React DOM. xterm.js, multi-panel, keyboard shortcuts.
-  mobile/      Expo + React Native. Chat, feed, actions, push notifications.
-  vscode/      Existing extension.
+  web/         Vite + React DOM. xterm.js, multi-panel, keyboard shortcuts. (was packages/dashboard)
+  mobile/      Expo + React Native. Chat, feed, actions, push notifications. (future)
+  vscode/      Extension. (was packages/vscode)
 
 packages/
-  codev/       CLI + orchestration (unchanged per #855)
-  core/        Forge / VCS abstraction
-  types/       Wire contracts
+  codev/       CLI + orchestration (Tower-facing commands consume codev-sdk)
+  core/        Server-side implementation (post-#1189)
+  codev-sdk/   PROPOSED (#1189). Tower API client + WS/message-bus client + client pure helpers. Framework-free.
+  types/       Wire contracts — the only package shared by server and client
   config/      Workspace config
-  tower-sdk/   NEW. React-hooks-based state layer + WebSocket + API client.
 ```
 
 ---
@@ -284,7 +270,7 @@ Consumed by:
 - Web dashboard → renders inline picker in the relevant terminal / chat view
 - VS Code extension → surface as a notification or sidebar prompt
 
-All three consume through `packages/tower-sdk`'s `usePendingQuestion()` hook.
+All three consume through `codev-sdk`'s pending-question client (#1189; framework-free — each surface wraps it in its own state idiom).
 
 ### 8.3 Response routing
 

--- a/codev/research/mobile/spikes/expo-lan-reachability-2026-07.md
+++ b/codev/research/mobile/spikes/expo-lan-reachability-2026-07.md
@@ -1,0 +1,216 @@
+# Spike: Expo scaffold + LAN Tower reachability
+
+**Date**: 2026-07-16
+**Status**: Headless phase complete (green). Device phase pending (requires a physical phone + a BRIDGE_MODE Tower; procedure below).
+**Executed by**: mobile architect directly at Amr's instruction (deviation from the spike-as-EXPERIMENT-builder default, recorded per protocol).
+**Spike code**: discarded per policy (scaffold lived in a session scratchpad). The recipe and key source below are the deliverable; the real `apps/mobile` starts fresh through PIR gates.
+
+## Question this spike answers
+
+Can an Expo / React Native app on a phone (1) fetch Tower's REST surface and (2) hold the `/ws/messages` WebSocket, over LAN, with a config a PIR builder can copy verbatim?
+
+## Verdict
+
+Everything verifiable without a physical device is green:
+
+- TypeScript strict check passes; Metro produces a 1.4MB Hermes iOS bundle (451 modules) via `npx expo export`.
+- Tower's global `GET /api/overview` requires no parameters (HTTP 200 with cross-workspace builders); `GET /health`, `GET /api/version`, and the workspace-scoped overview route all respond as documented.
+- RN's built-in `WebSocket` covers `/ws/messages` (no library needed). RN has **no `EventSource`**, so Tower's SSE channel is unavailable on mobile as-is: the mobile client uses WS + polling, or Tower grows a WS equivalent of the SSE refetch ticks (a small item to fold into the structured-events design, interaction-model §8).
+- `AppState` replaces the browser's `visibilitychange` for the reconnect-on-foreground seam; iOS suspends sockets in background, so foreground-reconnect is mandatory, not optional.
+- The `baseUrl` must be explicit user-supplied config (no `window.location` on RN): the exact seam issue #1189's codev-sdk formalizes.
+
+## Recipe (exact versions, 2026-07-16)
+
+```bash
+npx create-expo-app@latest codev-mobile --template blank-typescript
+```
+
+Resulting versions: Expo SDK `~57.0.6`, React Native `0.86.0`, React `19.2.3`, TypeScript `~6.0.3`. Toolchain: Node 22.19.0, pnpm 10.33.0, watchman + Xcode present.
+
+### app.json — the LAN-access block (the part that is easy to get wrong)
+
+```json
+"ios": {
+  "infoPlist": {
+    "NSLocalNetworkUsageDescription": "Codev connects to your Tower server on the local network to show builder status and messages.",
+    "NSAppTransportSecurity": { "NSAllowsLocalNetworking": true }
+  }
+},
+"android": {
+  "usesCleartextTraffic": true
+}
+```
+
+Three settings, three different failure modes if missing:
+
+1. **`NSLocalNetworkUsageDescription` (iOS)**: required for the iOS 14+ local-network permission prompt. Without it, a release/dev-client build crashes or silently fails on first LAN access.
+2. **`NSAppTransportSecurity.NSAllowsLocalNetworking` (iOS)**: ATS blocks cleartext `http://` by default; this scoped exception permits it for local hosts without the blanket `NSAllowsArbitraryLoads`.
+3. **`usesCleartextTraffic` (Android)**: Android 9+ blocks cleartext by default; `http://<lan-ip>:4100` needs this (or a narrower networkSecurityConfig later).
+
+**Expo Go nuance**: `infoPlist` keys only land in *built* binaries (`npx expo run:ios`, dev-client, EAS). Expo Go ignores them and relies on its own already-granted local-network entitlement, which is why quick Expo Go testing works before any of this is configured, and why a first dev-client build "mysteriously" breaks without these keys. Configure them from day one.
+
+## The codev-core Metro experiment (evidence for #1189)
+
+Installed `@cluesmith/codev-core@3.2.3` from a tarball into the spike app and bundled twice:
+
+- `import { EscapeBuffer } from '@cluesmith/codev-core/escape-buffer'` → **bundles clean** (pure leaf).
+- `import { DEFAULT_TOWER_PORT } from '@cluesmith/codev-core/constants'` → **Metro fails**: `Unable to resolve module node:path ... dist/constants.js`. `DEFAULT_TOWER_PORT = 4100` sits on line 3, one line below the `node:path`/`node:os` imports that kill the bundle.
+
+This empirically confirms issue #1189's two claims: core's pure leaves are RN-consumable today, and the `constants` module traps pure values behind Node builtins. The failure is loud (bundle-time), not a silent runtime break.
+
+## Device-verification procedure (remaining half, needs Amr)
+
+1. **Tower on the LAN**: restart Tower with `BRIDGE_MODE=1` so it binds beyond localhost. ⚠️ A Tower restart kills live builder PTYs and any dev PTY: coordinate timing with main, do it between builder sessions.
+2. In the scaffold: `npx expo start`, open in Expo Go on a phone on the same Wi-Fi.
+3. Enter `http://<laptop-lan-ip>:4100`, tap **Probe REST**: expect health/version/builder list + latency reading.
+4. Tap **Connect WS**, then from the laptop run any `afx send`: the frame should appear in the message-bus list within ~a second.
+5. For the permission-prompt validation specifically, use a dev build (`npx expo run:ios`), not Expo Go, and confirm the local-network prompt shows the `NSLocalNetworkUsageDescription` text.
+6. Background the app 30s, foreground it: WS should reconnect via the `AppState` handler.
+
+## What this de-risks for the PoC
+
+- The scaffold + LAN config recipe is copy-paste ready for the real `apps/mobile` (which now has a home: #855 merged, `apps/` exists).
+- The client seam list for codev-sdk (#1189) is validated from the consuming side: explicit `baseUrl`, injected storage, WS-not-SSE, `AppState` lifecycle.
+- No third-party networking libraries needed for v0 transport.
+
+## Appendix: spike client source (App.tsx, 187 lines)
+
+Kept for reference; wire types were inlined to keep the spike dependency-free (the real app imports `@cluesmith/codev-types`).
+
+```tsx
+import { StatusBar } from 'expo-status-bar';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  AppState, FlatList, Pressable, StyleSheet, Text, TextInput, View,
+} from 'react-native';
+
+type OverviewBuilder = {
+  issueId?: number; issueTitle?: string; phase?: string; blocked?: boolean;
+};
+type MessageFrame = {
+  type: 'message'; timestamp: string;
+  from: { project?: string; agent?: string };
+  to: { project?: string; agent?: string };
+  content: string;
+};
+type ConnState = 'idle' | 'connecting' | 'open' | 'error' | 'closed';
+
+export default function App() {
+  const [baseUrl, setBaseUrl] = useState('http://192.168.1.10:4100');
+  const [health, setHealth] = useState<string>('-');
+  const [version, setVersion] = useState<string>('-');
+  const [latencyMs, setLatencyMs] = useState<number | null>(null);
+  const [builders, setBuilders] = useState<OverviewBuilder[]>([]);
+  const [wsState, setWsState] = useState<ConnState>('idle');
+  const [frames, setFrames] = useState<MessageFrame[]>([]);
+  const [error, setError] = useState<string>('');
+  const wsRef = useRef<WebSocket | null>(null);
+
+  const probe = useCallback(async () => {
+    setError('');
+    try {
+      const t0 = Date.now();
+      const h = await fetch(`${baseUrl}/health`);
+      setLatencyMs(Date.now() - t0);
+      setHealth(h.ok ? (await h.json()).status : `HTTP ${h.status}`);
+      const v = await fetch(`${baseUrl}/api/version`);
+      if (v.ok) setVersion((await v.json()).version);
+      const o = await fetch(`${baseUrl}/api/overview`);
+      if (o.ok) setBuilders((await o.json()).builders ?? []);
+    } catch (e) {
+      setError(String(e));
+      setHealth('-');
+      setLatencyMs(null);
+    }
+  }, [baseUrl]);
+
+  const connectWs = useCallback(() => {
+    wsRef.current?.close();
+    setWsState('connecting');
+    const ws = new WebSocket(`${baseUrl.replace(/^http/, 'ws')}/ws/messages`);
+    ws.onopen = () => setWsState('open');
+    ws.onerror = () => setWsState('error');
+    ws.onclose = () => setWsState('closed');
+    ws.onmessage = (ev) => {
+      try {
+        const frame = JSON.parse(String(ev.data));
+        if (frame.type === 'message') setFrames((p) => [frame, ...p].slice(0, 20));
+      } catch { /* non-JSON frame: ignore */ }
+    };
+    wsRef.current = ws;
+  }, [baseUrl]);
+
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active' && wsRef.current?.readyState !== WebSocket.OPEN) {
+        connectWs();
+        probe();
+      }
+    });
+    return () => sub.remove();
+  }, [connectWs, probe]);
+
+  return (
+    <View style={styles.container}>
+      <StatusBar style="light" />
+      <Text style={styles.title}>Codev Tower LAN spike</Text>
+      <TextInput
+        style={styles.input} value={baseUrl} onChangeText={setBaseUrl}
+        autoCapitalize="none" autoCorrect={false}
+        placeholder="http://<tower-lan-ip>:4100" placeholderTextColor="#666"
+      />
+      <View style={styles.row}>
+        <Pressable style={styles.button} onPress={probe}>
+          <Text style={styles.buttonText}>Probe REST</Text>
+        </Pressable>
+        <Pressable style={styles.button} onPress={connectWs}>
+          <Text style={styles.buttonText}>Connect WS</Text>
+        </Pressable>
+      </View>
+      <Text style={styles.stat}>
+        health: {health}  version: {version}
+        {latencyMs !== null ? `  ${latencyMs}ms` : ''}
+      </Text>
+      <Text style={styles.stat}>ws: {wsState}  frames: {frames.length}</Text>
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      <Text style={styles.section}>Builders ({builders.length})</Text>
+      <FlatList
+        data={builders}
+        keyExtractor={(b, i) => `${b.issueId ?? i}`}
+        renderItem={({ item }) => (
+          <Text style={styles.rowText}>
+            #{item.issueId} {item.phase ?? '?'}
+            {item.blocked ? ' [blocked]' : ''} {item.issueTitle ?? ''}
+          </Text>
+        )}
+      />
+      <Text style={styles.section}>Message bus (latest {frames.length})</Text>
+      <FlatList
+        data={frames}
+        keyExtractor={(f, i) => `${f.timestamp}-${i}`}
+        renderItem={({ item }) => (
+          <Text style={styles.rowText}>
+            {item.from.agent ?? '?'} → {item.to.agent ?? '?'}: {item.content}
+          </Text>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#0d1117', paddingTop: 64, paddingHorizontal: 16 },
+  title: { color: '#e6edf3', fontSize: 20, fontWeight: '600', marginBottom: 12 },
+  input: {
+    color: '#e6edf3', borderColor: '#30363d', borderWidth: 1, borderRadius: 8,
+    padding: 10, fontFamily: 'Menlo', marginBottom: 8,
+  },
+  row: { flexDirection: 'row', gap: 8, marginBottom: 12 },
+  button: { backgroundColor: '#238636', borderRadius: 8, paddingVertical: 8, paddingHorizontal: 14 },
+  buttonText: { color: '#fff', fontWeight: '600' },
+  stat: { color: '#8b949e', fontFamily: 'Menlo', fontSize: 12, marginBottom: 4 },
+  error: { color: '#f85149', fontSize: 12, marginVertical: 4 },
+  section: { color: '#e6edf3', fontWeight: '600', marginTop: 12, marginBottom: 4 },
+  rowText: { color: '#8b949e', fontSize: 12, fontFamily: 'Menlo', marginBottom: 2 },
+});
+```


### PR DESCRIPTION
## What

Results of the first mobile spike plus the docs amendment retiring the tower-sdk design in favor of #1189.

**New: `codev/research/mobile/spikes/expo-lan-reachability-2026-07.md`** — the Expo scaffold + LAN Tower reachability spike. Headless phase complete and green:

- Copy-paste recipe with exact versions (Expo SDK 57.0.6, RN 0.86.0, React 19.2.3, TS 6.0.3): typecheck passes, Metro produces a 1.4MB Hermes iOS bundle.
- The LAN-access `app.json` block with all three required settings and their distinct failure modes: `NSLocalNetworkUsageDescription` (iOS local-network prompt), `NSAppTransportSecurity.NSAllowsLocalNetworking` (ATS cleartext exception), `usesCleartextTraffic` (Android). Includes the Expo Go nuance: `infoPlist` keys land only in built binaries, so Expo Go testing works before configuration and a first dev-client build breaks without it.
- Client findings: RN's built-in WebSocket covers `/ws/messages`; RN has no `EventSource` so Tower's SSE channel is unavailable as-is (WS + polling for mobile); `AppState` replaces `visibilitychange`; global `GET /api/overview` needs no params.
- Empirical evidence for #1189: `@cluesmith/codev-core/escape-buffer` bundles clean in Metro; `@cluesmith/codev-core/constants` fails on `node:path` with `DEFAULT_TOWER_PORT` trapped one line below the import.
- Device-verification procedure (needs a phone + a BRIDGE_MODE Tower session; includes the Tower-restart-kills-builders warning).

Spike code was discarded per the discard-by-default policy; the note embeds the full 187-line client source as the recipe's reference implementation.

## Docs amendment (tower-sdk → codev-sdk #1189)

- `interaction-model.md` §7.2 rewritten: records the supersession rationale (vscode isn't React; dashboard migration was a hidden cost; #1029 extract-on-committed-need precedent) and describes the #1189 taxonomy (types = only shared contract, core = server-side, codev-sdk = the single framework-free Tower client). §7.3 layout updated for the merged #855 (`apps/web`, `apps/vscode` exist; PR #1188). §8.2 hook reference updated.
- `feasibility-2026-07.md`: TL;DR recommended path, §3.1 audit framing, §4.1 three-layer split, §8 Phase S spike statuses (scaffold spike done; tower-sdk spike retired), §9.7 decision record.
- `decisions/q5-multi-workspace.md`: consequence section retargeted from tower-sdk hooks to #1189's framework-free client.

## Related

- #1189 (codev-sdk proposal; this PR's spike supplies its empirical evidence)
- #1147 (mobile v0 scope-lock context), #855/#1188 (apps/* split, merged), #1029 (rendering-split precedent)
