### PR TITLE
Fix #1199: Recommend workspace start for unregistered workspaces

### DIFF
--- a/codev/projects/bugfix-1199-afx-status-recommends-afx-towe/status.yaml
+++ b/codev/projects/bugfix-1199-afx-status-recommends-afx-towe/status.yaml
@@ -6,16 +6,17 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-18T21:12:37.974Z'
+    approved_at: '2026-07-18T21:16:42.226Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-18T09:04:23.549Z'
-updated_at: '2026-07-18T21:12:37.974Z'
+updated_at: '2026-07-18T21:16:42.226Z'
 pr_history:
   - phase: pr
     pr_number: 1200
     branch: builder/bugfix-1199
     created_at: '2026-07-18T09:16:31.778Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1199-afx-status-recommends-afx-towe/status.yaml
+++ b/codev/projects/bugfix-1199-afx-status-recommends-afx-towe/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1199
 title: afx-status-recommends-afx-towe
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-18T09:04:23.549Z'
-updated_at: '2026-07-18T09:06:46.202Z'
+updated_at: '2026-07-18T09:15:02.783Z'

--- a/codev/projects/bugfix-1199-afx-status-recommends-afx-towe/status.yaml
+++ b/codev/projects/bugfix-1199-afx-status-recommends-afx-towe/status.yaml
@@ -11,4 +11,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-18T09:04:23.549Z'
-updated_at: '2026-07-18T09:15:02.783Z'
+updated_at: '2026-07-18T09:16:31.779Z'
+pr_history:
+  - phase: pr
+    pr_number: 1200
+    branch: builder/bugfix-1199
+    created_at: '2026-07-18T09:16:31.778Z'

--- a/codev/projects/bugfix-1199-afx-status-recommends-afx-towe/status.yaml
+++ b/codev/projects/bugfix-1199-afx-status-recommends-afx-towe/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1199
 title: afx-status-recommends-afx-towe
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-18T09:04:23.549Z'
-updated_at: '2026-07-18T09:04:23.549Z'
+updated_at: '2026-07-18T09:06:46.202Z'

--- a/codev/projects/bugfix-1199-afx-status-recommends-afx-towe/status.yaml
+++ b/codev/projects/bugfix-1199-afx-status-recommends-afx-towe/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1199
+title: afx-status-recommends-afx-towe
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-18T09:04:23.549Z'
+updated_at: '2026-07-18T09:04:23.549Z'

--- a/codev/projects/bugfix-1199-afx-status-recommends-afx-towe/status.yaml
+++ b/codev/projects/bugfix-1199-afx-status-recommends-afx-towe/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1199
 title: afx-status-recommends-afx-towe
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,7 +13,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-18T09:04:23.549Z'
-updated_at: '2026-07-18T21:16:42.226Z'
+updated_at: '2026-07-18T21:17:09.868Z'
 pr_history:
   - phase: pr
     pr_number: 1200

--- a/codev/projects/bugfix-1199-afx-status-recommends-afx-towe/status.yaml
+++ b/codev/projects/bugfix-1199-afx-status-recommends-afx-towe/status.yaml
@@ -7,13 +7,15 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-07-18T21:12:37.974Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-18T09:04:23.549Z'
-updated_at: '2026-07-18T09:16:31.779Z'
+updated_at: '2026-07-18T21:12:37.974Z'
 pr_history:
   - phase: pr
     pr_number: 1200
     branch: builder/bugfix-1199
     created_at: '2026-07-18T09:16:31.778Z'
+pr_ready_for_human: true

--- a/codev/state/bugfix-1199_thread.md
+++ b/codev/state/bugfix-1199_thread.md
@@ -17,5 +17,5 @@
 ## PR
 
 - Published the branch through the contributor fork and opened upstream PR #1200.
-- CMAP results so far: Gemini `APPROVE` (high confidence); Codex `APPROVE` (high confidence).
-- Blocked before the PR gate: the required Claude lane was attempted twice but the Claude CLI quota is exhausted until 9am America/Toronto. The architect was notified; no verdict was fabricated and the gate was not requested.
+- CMAP completed with all three required verdicts: Gemini `APPROVE` (high confidence), Codex `APPROVE` (high confidence), and Claude `APPROVE` (high confidence).
+- The Claude lane initially hit its CLI quota, then succeeded when retried after the quota window reset. No reviewer requested changes.

--- a/codev/state/bugfix-1199_thread.md
+++ b/codev/state/bugfix-1199_thread.md
@@ -13,3 +13,9 @@
 - Added deterministic unit coverage for both required branches and their distinct recommendations in `spec-1057-status-owner.test.ts`.
 - Focused regression suite passed: 17/17 tests.
 - Porch build and full test checks passed. The shared environment's `/tmp/.git` marker and global `~/.codev/config.json` initially contaminated unrelated non-hermetic tests; isolating `TMPDIR` and `HOME` made the unchanged baseline tests pass without out-of-scope edits.
+
+## PR
+
+- Published the branch through the contributor fork and opened upstream PR #1200.
+- CMAP results so far: Gemini `APPROVE` (high confidence); Codex `APPROVE` (high confidence).
+- Blocked before the PR gate: the required Claude lane was attempted twice but the Claude CLI quota is exhausted until 9am America/Toronto. The architect was notified; no verdict was fabricated and the gate was not requested.

--- a/codev/state/bugfix-1199_thread.md
+++ b/codev/state/bugfix-1199_thread.md
@@ -1,0 +1,15 @@
+# Bugfix #1199 Thread
+
+## Investigate
+
+- Confirmed no existing PR or prior implementation for issue #1199.
+- Reproduced the bug against the running Tower from a temporary, unregistered Codev workspace: `status()` reported `Workspace: not active in tower` and recommended `afx tower start`.
+- Root cause: the Tower-running/unregistered-workspace branch in `packages/codev/src/agent-farm/commands/status.ts` contains a stale hard-coded `afx tower start` recommendation. The separate Tower-down branch correctly uses `afx tower start` to start the daemon.
+- Fix scope is BUGFIX-appropriate: one production string plus focused unit coverage for the Tower-running/unregistered and Tower-down branches. No architectural changes are needed.
+
+## Fix
+
+- Changed only the unregistered-workspace recommendation to `afx workspace start`.
+- Added deterministic unit coverage for both required branches and their distinct recommendations in `spec-1057-status-owner.test.ts`.
+- Focused regression suite passed: 17/17 tests.
+- Porch build and full test checks passed. The shared environment's `/tmp/.git` marker and global `~/.codev/config.json` initially contaminated unrelated non-hermetic tests; isolating `TMPDIR` and `HOME` made the unchanged baseline tests pass without out-of-scope edits.

--- a/packages/codev/src/agent-farm/__tests__/spec-1057-status-owner.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/spec-1057-status-owner.test.ts
@@ -323,3 +323,46 @@ describe('afx status — Tower-running human path (Spec 1057)', () => {
     expect(rows.map((r) => r[0])).toEqual(['builder-feedback-1']);
   });
 });
+
+// ============================================================================
+// Startup recommendations (Bugfix #1199)
+// ============================================================================
+
+describe('afx status — startup recommendations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoadState.mockReturnValue({
+      architect: null,
+      architects: [],
+      builders: [],
+      utils: [],
+      annotations: [],
+    });
+  });
+
+  it('recommends workspace start when Tower is running but the workspace is unregistered', async () => {
+    mockIsRunning.mockResolvedValue(true);
+    mockGetHealth.mockResolvedValue({
+      uptime: 100,
+      activeWorkspaces: 1,
+      memoryUsage: 1024 * 1024,
+    });
+    mockGetWorkspaceStatus.mockResolvedValue(null);
+
+    await status();
+
+    const info = mockLoggerInfo.mock.calls.map((c) => stripAnsi(String(c[0])));
+    expect(info).toContain(`Run 'afx workspace start' to activate this workspace`);
+    expect(info).not.toContain(`Run 'afx tower start' to activate this workspace`);
+  });
+
+  it('continues to recommend tower start when Tower is not running', async () => {
+    mockIsRunning.mockResolvedValue(false);
+
+    await status();
+
+    const info = mockLoggerInfo.mock.calls.map((c) => stripAnsi(String(c[0])));
+    expect(info).toContain(`Run 'afx tower start' to start the tower daemon`);
+    expect(info).not.toContain(`Run 'afx workspace start' to start the tower daemon`);
+  });
+});

--- a/packages/codev/src/agent-farm/commands/status.ts
+++ b/packages/codev/src/agent-farm/commands/status.ts
@@ -265,7 +265,7 @@ export async function status(options: StatusOptions = {}): Promise<void> {
 
     // Workspace not found in tower, show "not active"
     logger.kv('Workspace', chalk.gray('not active in tower'));
-    logger.info(`Run 'afx tower start' to activate this workspace`);
+    logger.info(`Run 'afx workspace start' to activate this workspace`);
     return;
   }
 


### PR DESCRIPTION
## Summary

Corrects `afx status` guidance when Tower is already running but the current workspace is not registered. The command now directs users to activate the workspace rather than redundantly starting Tower.

Fixes #1199

## Root Cause

The Tower-running/unregistered-workspace branch retained a stale hard-coded `afx tower start` recommendation after workspace activation moved to `afx workspace start`. The separate Tower-not-running branch was already correct.

## Fix

- Recommend `afx workspace start` only when Tower is running and the workspace is unregistered.
- Preserve the `afx tower start` recommendation when the Tower daemon is not running.
- Add regression coverage for both branches and their distinct messages.

## Test Plan

- [x] Focused regression suite: `pnpm --filter @cluesmith/codev test --run src/agent-farm/__tests__/spec-1057-status-owner.test.ts` (17 passed)
- [x] Build: `porch check bugfix-1199`
- [x] Full test suite: `porch check bugfix-1199`
