### PR TITLE
[AIR #1220] arch-init: architect auto-state-saving lifecycle

### DIFF
--- a/.claude/skills/arch-init/SKILL.md
+++ b/.claude/skills/arch-init/SKILL.md
@@ -54,6 +54,51 @@ name in a multi-architect workspace).
    on resume. Do not invent a new agenda — resume the one the state file
    describes.
 
+## Saving your state (and knowing when to `/clear`)
+
+Recovery is only half the loop. `/arch-init` reads state; **you** write it. The
+state file is not crash insurance — it is your deliberate memory-management
+mechanism. Auto-compaction happens at an arbitrary moment with content you did
+not choose; a state save happens at a boundary **you** pick, with a summary
+**you** curate. That is strictly better, so use it:
+
+```
+/arch-init (recover) → work → save at a checkpoint → suggest /clear → human /clears → /arch-init → …
+```
+
+**When to save.** Save at a *resumable boundary* — a point a fresh session
+could pick up cleanly from. Good moments, judged by you: a gate approval, a PR
+merge, a completed investigation, the end of a long tool-heavy stretch.
+**Never save mid-task.** The state file must describe a point you can resume
+*from*, not a half-finished action; a mid-task snapshot resumes into confusion.
+
+**How to save (write format = read format).** Recovery reads *the role banner
+plus the most recent dated section*, so a save must leave exactly that behind:
+
+1. **Rewrite the current-state / open-loops section in place** — overwrite it
+   with where things actually stand now (current focus + open loops + how to
+   resume). Do not accumulate stale "current state" blocks.
+2. **Append one short dated log entry** capturing what changed this stretch.
+3. **Keep it to one screen (compaction discipline).** The state file is a
+   summary, not a transcript. When you append, prune stale dated sections so
+   the file stays readable at a glance.
+
+**Content guardrails.** No secrets (tokens, keys, credentials). No transcript
+dumps or raw tool output. Include only: current focus, open loops, and the
+instructions a fresh session needs to resume.
+
+**Then — and only then — suggest `/clear`.** Save first, *then* tell the human
+it is a good time to clear. You cannot clear your own context and must never
+decide unilaterally to lose it; keeping the irreversible step behind a human
+keystroke means accepting the suggestion can never lose anything, because the
+save already happened. Make the suggestion **advisory, never nagging**, and
+only right after a save — e.g.:
+
+> State saved to `codev/state/<name>.md` — good time to `/clear` if this
+> session is feeling heavy.
+
+Do not repeat it, and do not prompt to `/clear` at any other time.
+
 ## Guardrails (architect-wide; the state file may add more)
 
 - **Never auto-approve porch gates.** A gate notification is for the human,

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ worktrees/
 .update-hashes.json
 .architect-role.md
 .codev/config.json
+.codev/config.local.json
 
 # Architect state files are per-person; builder *_thread.md files ARE versioned (#1192)
 codev/state/*.md

--- a/codev-skeleton/.claude/skills/arch-init/SKILL.md
+++ b/codev-skeleton/.claude/skills/arch-init/SKILL.md
@@ -54,6 +54,51 @@ name in a multi-architect workspace).
    on resume. Do not invent a new agenda — resume the one the state file
    describes.
 
+## Saving your state (and knowing when to `/clear`)
+
+Recovery is only half the loop. `/arch-init` reads state; **you** write it. The
+state file is not crash insurance — it is your deliberate memory-management
+mechanism. Auto-compaction happens at an arbitrary moment with content you did
+not choose; a state save happens at a boundary **you** pick, with a summary
+**you** curate. That is strictly better, so use it:
+
+```
+/arch-init (recover) → work → save at a checkpoint → suggest /clear → human /clears → /arch-init → …
+```
+
+**When to save.** Save at a *resumable boundary* — a point a fresh session
+could pick up cleanly from. Good moments, judged by you: a gate approval, a PR
+merge, a completed investigation, the end of a long tool-heavy stretch.
+**Never save mid-task.** The state file must describe a point you can resume
+*from*, not a half-finished action; a mid-task snapshot resumes into confusion.
+
+**How to save (write format = read format).** Recovery reads *the role banner
+plus the most recent dated section*, so a save must leave exactly that behind:
+
+1. **Rewrite the current-state / open-loops section in place** — overwrite it
+   with where things actually stand now (current focus + open loops + how to
+   resume). Do not accumulate stale "current state" blocks.
+2. **Append one short dated log entry** capturing what changed this stretch.
+3. **Keep it to one screen (compaction discipline).** The state file is a
+   summary, not a transcript. When you append, prune stale dated sections so
+   the file stays readable at a glance.
+
+**Content guardrails.** No secrets (tokens, keys, credentials). No transcript
+dumps or raw tool output. Include only: current focus, open loops, and the
+instructions a fresh session needs to resume.
+
+**Then — and only then — suggest `/clear`.** Save first, *then* tell the human
+it is a good time to clear. You cannot clear your own context and must never
+decide unilaterally to lose it; keeping the irreversible step behind a human
+keystroke means accepting the suggestion can never lose anything, because the
+save already happened. Make the suggestion **advisory, never nagging**, and
+only right after a save — e.g.:
+
+> State saved to `codev/state/<name>.md` — good time to `/clear` if this
+> session is feeling heavy.
+
+Do not repeat it, and do not prompt to `/clear` at any other time.
+
 ## Guardrails (architect-wide; the state file may add more)
 
 - **Never auto-approve porch gates.** A gate notification is for the human,

--- a/codev/projects/1220-arch-init-architect-auto-state/status.yaml
+++ b/codev/projects/1220-arch-init-architect-auto-state/status.yaml
@@ -1,0 +1,14 @@
+id: '1220'
+title: arch-init-architect-auto-state
+protocol: air
+phase: implement
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-22T11:31:20.070Z'
+updated_at: '2026-07-22T11:31:20.071Z'

--- a/codev/projects/1220-arch-init-architect-auto-state/status.yaml
+++ b/codev/projects/1220-arch-init-architect-auto-state/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-07-22T11:37:36.782Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-22T11:31:20.070Z'
-updated_at: '2026-07-22T11:35:40.454Z'
+updated_at: '2026-07-22T11:37:36.783Z'
+pr_ready_for_human: true

--- a/codev/projects/1220-arch-init-architect-auto-state/status.yaml
+++ b/codev/projects/1220-arch-init-architect-auto-state/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-22T11:37:36.782Z'
+    approved_at: '2026-07-22T11:43:42.776Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-22T11:31:20.070Z'
-updated_at: '2026-07-22T11:37:36.783Z'
-pr_ready_for_human: true
+updated_at: '2026-07-22T11:43:42.777Z'
+pr_ready_for_human: false

--- a/codev/projects/1220-arch-init-architect-auto-state/status.yaml
+++ b/codev/projects/1220-arch-init-architect-auto-state/status.yaml
@@ -1,7 +1,7 @@
 id: '1220'
 title: arch-init-architect-auto-state
 protocol: air
-phase: implement
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-22T11:31:20.070Z'
-updated_at: '2026-07-22T11:31:20.071Z'
+updated_at: '2026-07-22T11:35:40.454Z'

--- a/codev/state/air-1220_thread.md
+++ b/codev/state/air-1220_thread.md
@@ -24,3 +24,9 @@ no runtime code. Two-tree rule: instance + skeleton SKILL.md byte-identical.
 - Installing workspace deps (fresh worktree, no node_modules) to run vitest.
 
 Open loop: run the test file green, then porch check → done → PR.
+
+### 2026-07-22 — PR ready, at pr gate
+- tsc clean, 19/19 skill tests pass, byte-identity verified.
+- porch check (build, tests) ✓; PR phase check (pr_exists, e2e_tests) ✓.
+- Opened PR #1221 with review embedded in the body (AIR: no separate review file).
+- Reached `pr` gate → STOP, waiting for human approval. Not running porch gate.

--- a/codev/state/air-1220_thread.md
+++ b/codev/state/air-1220_thread.md
@@ -1,0 +1,26 @@
+# air-1220 thread — /arch-init architect auto-state-saving (#1220)
+
+Protocol: AIR (strict). Supersedes #1212 (wontfix). Area: area/scaffold.
+
+## What the change is
+Add an auto-save lifecycle to the `/arch-init` skill: architect saves a curated
+summary to `codev/state/<name>.md` at resumable checkpoints, then suggests
+`/clear` (save-then-suggest ordering is the core safety property). Skill only —
+no runtime code. Two-tree rule: instance + skeleton SKILL.md byte-identical.
+
+## Log
+
+### 2026-07-22 — implement
+- Read both SKILL.md copies + spec-1134-arch-init-skill.test.ts.
+- Added a new "## Saving your state (and knowing when to `/clear`)" section to
+  `.claude/skills/arch-init/SKILL.md` covering all five issue requirements:
+  when-to-save (resumable boundary, never mid-task), write=read format
+  (rewrite current-state + append dated), compaction (one screen / prune),
+  advisory-not-nagging suggestion, content guardrails (no secrets/transcripts).
+- `cp` to skeleton tree → verified byte-identical.
+- Extended the test with #1220 required-content assertions (save target,
+  save-then-suggest, never-mid-task, write=read symmetry, compaction, guardrails,
+  advisory framing). Kept all existing assertions untouched.
+- Installing workspace deps (fresh worktree, no node_modules) to run vitest.
+
+Open loop: run the test file green, then porch check → done → PR.

--- a/codev/state/air-1220_thread.md
+++ b/codev/state/air-1220_thread.md
@@ -30,3 +30,10 @@ Open loop: run the test file green, then porch check → done → PR.
 - porch check (build, tests) ✓; PR phase check (pr_exists, e2e_tests) ✓.
 - Opened PR #1221 with review embedded in the body (AIR: no separate review file).
 - Reached `pr` gate → STOP, waiting for human approval. Not running porch gate.
+
+### 2026-07-22 — pr gate approved, merge blocked by branch protection
+- Human approved via architect relay; ran `porch approve 1220 pr --a-human-explicitly-approved-this` → gate approved, checks green.
+- `gh pr merge 1221 --merge` BLOCKED: base branch policy. mergeStateStatus=BLOCKED, reviewDecision=REVIEW_REQUIRED, CI checks pending.
+- `--auto` rejected: repo has auto-merge disabled (enablePullRequestAutoMerge).
+- Did NOT use `--admin` (won't bypass branch protection without explicit go-ahead).
+- Reported to architect; awaiting a GitHub review approval + CI green, or an explicit --admin instruction.

--- a/packages/codev/src/agent-farm/__tests__/spec-1134-arch-init-skill.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/spec-1134-arch-init-skill.test.ts
@@ -9,6 +9,10 @@
  *   - no Shannon-specific wording (workspace-agnostic)
  *   - builder-thread exclusion in the missing-state-file flow
  *   - the four architect guardrails
+ *
+ * Issue #1220 extends this with the architect auto-state-saving lifecycle:
+ * save at resumable checkpoints (write format = read format), then suggest
+ * `/clear` — never mid-task, no secrets, compaction discipline.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -68,6 +72,49 @@ describe('Spec 1134 — /arch-init skill ships in both trees', () => {
 
     it('never defaults to main', () => {
       expect(text()).toMatch(/do NOT default to `main`/i);
+    });
+
+    // Issue #1220 — architect auto-state-saving lifecycle.
+    it('instructs saving to codev/state/<name>.md at checkpoints', () => {
+      const t = text();
+      // The save target is the same per-name state file, referenced with the
+      // <name> placeholder as in the read flow.
+      expect(t).toMatch(/save/i);
+      expect(t).toContain('codev/state/<name>.md');
+      expect(t).toMatch(/checkpoint|resumable boundary/i);
+    });
+
+    it('suggests /clear only after a save (save-then-suggest ordering)', () => {
+      const t = text();
+      expect(t).toContain('/clear');
+      // Ordering property: save first, then suggest.
+      expect(t).toMatch(/save first.*then|then .*only then.*suggest|good time to `\/clear`/i);
+    });
+
+    it('forbids saving mid-task', () => {
+      expect(text()).toMatch(/never save mid-task/i);
+    });
+
+    it('carries the write-format = read-format symmetry (rewrite + append dated)', () => {
+      const t = text();
+      expect(t).toMatch(/rewrite the current-state/i);
+      expect(t).toMatch(/append.*dated/i);
+    });
+
+    it('carries compaction discipline (one screen / prune stale sections)', () => {
+      const t = text();
+      expect(t).toMatch(/one screen/i);
+      expect(t).toMatch(/prune stale/i);
+    });
+
+    it('carries save content guardrails (no secrets, no transcript dumps)', () => {
+      const t = text();
+      expect(t).toMatch(/no secrets/i);
+      expect(t).toMatch(/transcript/i);
+    });
+
+    it('frames the /clear suggestion as advisory, not nagging', () => {
+      expect(text()).toMatch(/advisory, never nagging/i);
     });
   });
 


### PR DESCRIPTION
## Summary

Makes `/arch-init` instruct a complete context-lifecycle loop, not just recovery. Today the skill reads `codev/state/<name>.md` at session start and never writes — so the recovery flow assumes a file nothing tells anyone to write (the durability gap named in #1212). This change adds an **architect auto-save** section: the architect curates its state file at a resumable checkpoint, then suggests the human `/clear`.

```
/arch-init (recover) → work → save at checkpoint → suggest /clear → human /clears → /arch-init → …
```

The state file stops being crash insurance and becomes deliberate memory management: a summary written at a moment the architect chooses, at a resumable boundary — better than auto-compaction because both timing and content are intentional. Self-reinforcing: every recovery re-reads the skill and re-primes the save habit, so the gap closes after each architect's first `/arch-init`.

Supersedes #1212 (closed wontfix — approach switched from "separate save command / standing instruction" to "auto-saving built into `/arch-init` itself").

## Key decisions

- **Save-then-suggest ordering is the core safety property.** The agent cannot clear its own context and must never decide unilaterally to lose it. The skill instructs: save first, *then* tell the human it is a good time to `/clear`. The irreversible action stays behind a human keystroke, and accepting the suggestion can never lose anything because the save already happened.
- **Write format = read format** (symmetry with the Spec 1134 minimum contract). Recovery reads "role banner + most recent dated section", so a save *rewrites the current-state/open-loops section in place* and *appends one short dated log entry* — leaving exactly what recovery expects.
- **Placed inside `/arch-init`, not a new `/arch-save` skill** — per the issue's self-reinforcement rationale.
- **Skill-text only, both trees.** No runtime code. `codev-skeleton/.claude/skills/arch-init/SKILL.md` and `.claude/skills/arch-init/SKILL.md` are byte-identical (drift guard test enforces it).

## What the skill now instructs (all five issue requirements)

1. **When to save** — resumable boundaries (gate approval, PR merge, completed investigation, end of a long tool-heavy stretch); **never mid-task**.
2. **How to save** — rewrite current-state section in place + append one dated entry.
3. **Compaction discipline** — keep it to one screen; prune stale dated sections when appending (summary, not transcript).
4. **Advisory, never nagging** — the `/clear` suggestion appears only right after a save, phrased softly, and is not repeated.
5. **Content guardrails** — no secrets, no transcript dumps; only current focus + open loops + resume instructions.

Existing recovery behavior (identity resolution via `afx whoami`, name validation / path-traversal guard, missing-file flow with `_thread.md` exclusion, four architect guardrails) is unchanged.

## Test plan

`packages/codev/src/agent-farm/__tests__/spec-1134-arch-init-skill.test.ts` — all existing assertions preserved (two-tree byte-equality, required/forbidden content), plus new #1220 required-content assertions:

- save target `codev/state/<name>.md` at checkpoints
- save-then-suggest `/clear` ordering
- never save mid-task
- write=read symmetry (rewrite current-state + append dated)
- compaction (one screen / prune stale)
- content guardrails (no secrets / no transcript dumps)
- advisory-not-nagging framing

Verification:
- `vitest run spec-1134-arch-init-skill.test.ts` → **19 passed**
- `tsc --noEmit` → clean
- `porch check 1220` → build ✓, tests ✓

## Acceptance criteria

- [x] Both SKILL.md copies byte-identical, tests green.
- [x] Skill text instructs: save at resumable checkpoints → then suggest `/clear`; save = rewrite current-state + append dated; prune stale; never mid-task; no secrets.
- [x] Existing recovery behavior (identity resolution, missing-file flow, four guardrails) unchanged.

Closes #1220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
