### PR TITLE
chore(porch): 1210 verify-approval gate-approved (restore stranded state)

### DIFF
--- a/codev/projects/1210-codev-doctor-detect-protocol-f/status.yaml
+++ b/codev/projects/1210-codev-doctor-detect-protocol-f/status.yaml
@@ -1,7 +1,7 @@
 id: '1210'
 title: codev-doctor-detect-protocol-f
 protocol: aspir
-phase: review
+phase: verify
 plan_phases:
   - id: phase_1
     title: protocol-drift-audit library (shadow drift + staleness)
@@ -19,10 +19,12 @@ gates:
     requested_at: '2026-07-22T13:32:55.614Z'
     approved_at: '2026-07-22T13:36:09.759Z'
   verify-approval:
-    status: pending
+    status: approved
+    requested_at: '2026-07-22T14:02:27.130Z'
+    approved_at: '2026-07-22T21:53:20.490Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-07-22T12:28:50.210Z'
-updated_at: '2026-07-22T13:36:17.274Z'
+updated_at: '2026-07-22T21:53:20.490Z'
 pr_ready_for_human: false


### PR DESCRIPTION
Bookkeeping only: restores the final porch state for project 1210 (doctor drift detector, merged as PR #1223) to main.

Porch recorded the verify-approval approval at 21:53Z in commit fc088c4e on the builder branch, but that branch was deleted before the state commit reached main, stranding main's snapshot at `verify-approval: pending`. This PR restores porch's own file byte-for-byte from fc088c4e — no hand-authored state.

Waleed approved the verify gate explicitly (conversation, 2026-07-22).

Exposes a lifecycle gap worth an issue: ASPIR's post-merge verify state has no path back to main once the builder branch is gone.