### PR TITLE
hotfix(doctor): resolve formatBytes duplicate-identifier collision from #1242 × #1243

### DIFF
--- a/packages/codev/src/commands/doctor.ts
+++ b/packages/codev/src/commands/doctor.ts
@@ -33,7 +33,7 @@ import { AGENT_FARM_DIR } from '@cluesmith/codev-core/constants';
 import {
   measureSessionLogs,
   resolveLogRetentionDays,
-  formatBytes,
+  formatBytes as formatLogBytes,
 } from '../agent-farm/servers/session-log-sweep.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -108,7 +108,7 @@ export function checkSessionLogs(
     };
   }
 
-  const summary = `${files} file(s), ${formatBytes(bytes)}`;
+  const summary = `${files} file(s), ${formatLogBytes(bytes)}`;
   if (bytes < SESSION_LOG_WARN_BYTES) {
     return { status: 'ok', files, bytes, retentionDays, summary, retentionNote };
   }


### PR DESCRIPTION
**Main is red**: PR #1242 and PR #1243 each added a `formatBytes` helper and each imported it into `doctor.ts`. Git merged the two import statements cleanly (no textual conflict); each PR's CI was green against its own pre-other base; nothing tested the combination (`strict=false`). Result: `TS2300: Duplicate identifier 'formatBytes'` — main does not build.

**Fix (minimal for red-main urgency):** alias the session-log-sweep import to `formatLogBytes` and move its single call site (line 111) with it. Line 847 keeps the migration-backup formatter. Alias direction chosen deliberately — the two helpers differ at ≥10 units (`19.0 GB` vs `19 GB`), so each call site must keep its own module's formatter; both do (credit: air-1239 flagged the silent-rebind trap before it could happen).

**Verified:** full root build green in a clean worktree off broken main (deps installed first — no silent-tsc pass). Zero behavior change.

**Follow-up (not this PR):** consolidate the two duplicate helpers into one shared util; and consider a merge queue or `strict=true` — per-PR required checks structurally cannot catch cross-PR semantic collisions.