### PR TITLE
Fix TS2300 duplicate formatBytes import in doctor.ts (broken build on main)

### DIFF
--- a/codev/projects/bugfix-1077-consult-pre-flight-auth-state-/status.yaml
+++ b/codev/projects/bugfix-1077-consult-pre-flight-auth-state-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1077
 title: consult-pre-flight-auth-state-
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-25T12:49:13.351Z'
-updated_at: '2026-07-25T12:49:13.351Z'
+updated_at: '2026-07-25T12:54:44.131Z'

--- a/codev/projects/bugfix-1077-consult-pre-flight-auth-state-/status.yaml
+++ b/codev/projects/bugfix-1077-consult-pre-flight-auth-state-/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1077
+title: consult-pre-flight-auth-state-
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-25T12:49:13.351Z'
+updated_at: '2026-07-25T12:49:13.351Z'

--- a/codev/state/task-08Gm_thread.md
+++ b/codev/state/task-08Gm_thread.md
@@ -1,0 +1,9 @@
+# Builder task-08Gm — thread
+
+## Task
+Fix broken build on main: `packages/codev/src/commands/doctor.ts` imported `formatBytes` twice (from `../lib/migration-backup-audit.js` and `../agent-farm/servers/session-log-sweep.js`), causing TS2300 duplicate identifier. Landed via PR #1243.
+
+## Work log
+- Confirmed both imports and both call sites: line 111 (session-log summary, uses `measureSessionLogs` data) and line 847 (migration-backup reclaimable bytes).
+- Aliased the session-log-sweep import as `formatBytes as formatLogBytes` and updated line 111 to `formatLogBytes(bytes)`. The migration-backup import and its call site (line 847) are unchanged.
+- Verifying with `npx tsc --noEmit` in `packages/codev` before creating the PR.

--- a/codev/state/task-08Gm_thread.md
+++ b/codev/state/task-08Gm_thread.md
@@ -7,3 +7,7 @@ Fix broken build on main: `packages/codev/src/commands/doctor.ts` imported `form
 - Confirmed both imports and both call sites: line 111 (session-log summary, uses `measureSessionLogs` data) and line 847 (migration-backup reclaimable bytes).
 - Aliased the session-log-sweep import as `formatBytes as formatLogBytes` and updated line 111 to `formatLogBytes(bytes)`. The migration-backup import and its call site (line 847) are unchanged.
 - Verifying with `npx tsc --noEmit` in `packages/codev` before creating the PR.
+
+## PR
+- PR #1249 created: https://github.com/cluesmith/codev/pull/1249 — verified with `pnpm exec tsc --noEmit` (clean after building codev-core).
+- `afx send architect` failed with NOT_FOUND (workspace not active in Tower from this nested worktree); architect notification could not be delivered via afx.

--- a/packages/codev/src/commands/doctor.ts
+++ b/packages/codev/src/commands/doctor.ts
@@ -33,7 +33,7 @@ import { AGENT_FARM_DIR } from '@cluesmith/codev-core/constants';
 import {
   measureSessionLogs,
   resolveLogRetentionDays,
-  formatBytes,
+  formatBytes as formatLogBytes,
 } from '../agent-farm/servers/session-log-sweep.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -108,7 +108,7 @@ export function checkSessionLogs(
     };
   }
 
-  const summary = `${files} file(s), ${formatBytes(bytes)}`;
+  const summary = `${files} file(s), ${formatLogBytes(bytes)}`;
   if (bytes < SESSION_LOG_WARN_BYTES) {
     return { status: 'ok', files, bytes, retentionDays, summary, retentionNote };
   }


### PR DESCRIPTION
## Problem
Main fails to compile: `packages/codev/src/commands/doctor.ts` imports `formatBytes` twice — from `../lib/migration-backup-audit.js` (line 27) and `../agent-farm/servers/session-log-sweep.js` (line 36) — causing a TS2300 duplicate identifier. Introduced by PR #1243 (session-log sweep doctor check).

## Root Cause
Two independent `formatBytes` implementations were imported under the same name after the session-log-sweep check merged alongside the existing migration-backup check.

## Fix
Aliased the session-log-sweep import as `formatBytes as formatLogBytes` and updated its single call site (the session-log summary at line 111, which formats bytes from `measureSessionLogs`). The migration-backup import and its call site (line 847) are unchanged. One file, 2-line diff.

## Testing
`pnpm exec tsc --noEmit` in `packages/codev` (after building `@cluesmith/codev-core`) passes with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)