### PR TITLE
[Bugfix #1279] Docs: carry post-merge thread addendum and porch completion state to main

### DIFF
--- a/codev/projects/bugfix-1279-spir-spec-template-is-dead-cod/status.yaml
+++ b/codev/projects/bugfix-1279-spir-spec-template-is-dead-cod/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1279
 title: spir-spec-template-is-dead-cod
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,5 +13,5 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-28T17:44:57.015Z'
-updated_at: '2026-07-29T02:22:18.545Z'
+updated_at: '2026-07-29T11:27:18.708Z'
 pr_ready_for_human: false

--- a/codev/state/bugfix-1279_thread.md
+++ b/codev/state/bugfix-1279_thread.md
@@ -168,3 +168,44 @@ a regression. CLAUDE.md says it: never run npm/test commands from the repo root,
 run them from `packages/codev`. Package-scoped run was green throughout.
 
 Final: 3793 passed / 48 skipped / 0 failed. Awaiting the `pr` gate.
+
+## Merged
+
+PR #1283 merged 2026-07-29T11:26:39Z as merge commit `54118ef0` (regular merge,
+not squash). Issue #1279 auto-closed by `Fixes #1279`.
+
+Verified live on `main` after the merge, not just assumed from a green PR: all
+three new includes are present in the shipped skeleton
+(`spir/prompts/specify.md:95`, `spir/prompts/review.md:62`,
+`maintain/protocol.md:190`) and `codev-skeleton/protocols/aspir/` no longer has
+a `templates/` directory.
+
+### Merge path — worth recording for the next builder
+
+The porch `pr` gate approving is **not** sufficient to merge in this repo.
+GitHub branch protection on `main` independently requires:
+
+- 1 approving review (`reviewDecision: REVIEW_REQUIRED`) — a builder cannot
+  self-approve its own PR; bypass allowance is limited to `waleedkadous` and
+  `amrmelsayed`
+- 6 status checks: Unit Tests, CLI Tests (ubuntu + macos), CLI Integration
+  Tests, Tower Integration Tests, Package Install Verification
+
+`gh pr merge --merge` fails with "the base branch policy prohibits the merge"
+until both clear. I escalated rather than reaching for `--admin` myself; the
+human's explicit ruling ("use admin here") came back and I merged with
+`--admin` only after CI was green, so the bypass covered the review requirement
+alone and never the checks.
+
+### CI flake, resolved
+
+Two `Tests` runs on this branch failed at 18:07:53 and 18:08:09 —
+`send-integration.e2e.test.ts`, "Hook timed out in 10000ms", Tower Integration
+Tests. I called it pre-existing flake on the evidence (file untouched by this
+PR; same workflow failing intermittently on `bugfix-1264`, `bugfix-1077`,
+`docs/arch-init-compaction`, `air-1239` and one `main` merge; same content
+passing at 18:06:56 then failing twice minutes later). The final run confirmed
+it: Tower Integration Tests passed in 1m23s on the same content. Nothing was
+skipped or worked around.
+
+Worktree is clean and stays put — cleanup is the architect's call.


### PR DESCRIPTION
## Summary

Docs-only follow-up to PR #1283 (the template-delivery fix for #1279), which merged as `54118ef0`. Carries two post-merge artifacts to `main` that the merge itself couldn't include, following the `[AIR #1239] Carry post-merge thread addendum to main` precedent.

No code, no tests, no framework files. 43 lines across 2 files.

## What's here

**1. `codev/state/bugfix-1279_thread.md` — the closeout section (+41 lines)**

I wrote the thread's final section *after* PR #1283 merged, so it landed on the builder branch instead of `main`. The version currently on `main` stops at the CMAP section, missing:

- the merge outcome (commit `54118ef0`, issue auto-closed) and the post-merge verification done against `main` itself rather than inferred from a green PR
- **the branch-protection merge path** — that an approved porch `pr` gate is *not* sufficient to merge in this repo: `main` independently requires 1 approving review (which a builder cannot self-supply) plus 6 status checks, so `gh pr merge --merge` fails with "the base branch policy prohibits the merge" until both clear. This is the part most worth having on `main` — the next builder will hit it.
- **the CI flake resolution** — `send-integration.e2e.test.ts` ("Hook timed out in 10000ms", Tower Integration Tests) failed twice on the branch and was called pre-existing flake on evidence; the final run passing that job in 1m23s on the same content confirmed it. Recording both the call and the confirmation, so the next person who sees this test fail has the history.

**2. `codev/projects/bugfix-1279-.../status.yaml` (+2/−2)**

Porch's own completion write: `phase: pr → verified` and a timestamp bump, emitted by `porch done` after the merge. Per the repo's data-capture convention, project state is committed to `main`.

## Test Plan

Not applicable — no executable content changes. The framework files, protocol definitions, and test suite are untouched by this PR; all of that shipped in #1283 and is already on `main` (verified there: includes present at `spir/prompts/specify.md:95`, `spir/prompts/review.md:62`, `maintain/protocol.md:190`; `codev-skeleton/protocols/aspir/templates/` absent).

## Note for the reviewer

Opened from the same `builder/bugfix-1279` branch rather than a fresh docs branch, deliberately: the branch already contains exactly these two commits and nothing else beyond `main`, and cutting a new branch would have meant moving the worktree's HEAD while the architect is holding the worktree pending a cleanup decision.

I am **not** merging this myself — it will hit the same branch protection as #1283, and merge authorization is the architect's to obtain.

Related to #1279 (already closed by #1283). Intentionally no `Fixes` keyword.
