### PR TITLE
[#1288] consult: ship claude-opus-5 and gpt-5.6-sol as default lane models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,7 +344,10 @@ Use sequential numbering with descriptive names (no leading zeros):
   `~/.cache/codev/agy-auth.json`, because each spawn opens an OAuth browser tab before Codev can
   detect the missing login (#1077). Sign in with `agy` in any terminal and the lane recovers on its
   own; see `codev/resources/commands/consult.md` for the TTL/opt-out env vars.
-- **GPT-5.4 Codex** (gpt-5.4-codex) for coding and architecture perspective
+- **GPT-5.6 Sol** (`gpt-5.6-sol`, medium reasoning effort) via the Codex SDK for coding and
+  architecture perspective. The `-sol` suffix is load-bearing — plain `gpt-5.6` and
+  `gpt-5.6-codex` are both rejected by Codex on a ChatGPT account.
+- **Claude Opus 5** (`claude-opus-5`) via the Claude Agent SDK for balanced analysis with tool use
 
 To disable: User must explicitly say "without multi-agent consultation"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,7 +344,10 @@ Use sequential numbering with descriptive names (no leading zeros):
   `~/.cache/codev/agy-auth.json`, because each spawn opens an OAuth browser tab before Codev can
   detect the missing login (#1077). Sign in with `agy` in any terminal and the lane recovers on its
   own; see `codev/resources/commands/consult.md` for the TTL/opt-out env vars.
-- **GPT-5.4 Codex** (gpt-5.4-codex) for coding and architecture perspective
+- **GPT-5.6 Sol** (`gpt-5.6-sol`, medium reasoning effort) via the Codex SDK for coding and
+  architecture perspective. The `-sol` suffix is load-bearing — plain `gpt-5.6` and
+  `gpt-5.6-codex` are both rejected by Codex on a ChatGPT account.
+- **Claude Opus 5** (`claude-opus-5`) via the Claude Agent SDK for balanced analysis with tool use
 
 To disable: User must explicitly say "without multi-agent consultation"
 

--- a/codev-skeleton/resources/commands/consult.md
+++ b/codev-skeleton/resources/commands/consult.md
@@ -17,12 +17,24 @@ consult stats [options]
 
 ## Models
 
-| Model | Alias | Backend | Notes |
-|-------|-------|---------|-------|
-| `gemini` | `pro` | Antigravity CLI (`agy`) | Agentic file access (`--sandbox --add-dir`), OAuth/subscription login. Skips non-blockingly if `agy` is missing/unauthed. |
-| `codex` | `gpt` | @openai/codex | Read-only sandbox, thorough |
-| `claude` | `opus` | Claude Agent SDK | Balanced analysis with tool use |
-| `hermes` | - | hermes CLI (`hermes chat -q`) | Uses Hermes agent as consult backend |
+| Model | Alias | Backend | Shipped default model id | Notes |
+|-------|-------|---------|--------------------------|-------|
+| `gemini` | `pro` | Antigravity CLI (`agy`) | *(agy's own default — no pinned id)* | Agentic file access (`--sandbox --add-dir`), OAuth/subscription login. Skips non-blockingly if `agy` is missing/unauthed. |
+| `codex` | `gpt` | @openai/codex | `gpt-5.6-sol` (medium reasoning effort) | Read-only sandbox, thorough |
+| `claude` | `opus` | Claude Agent SDK | `claude-opus-5` | Balanced analysis with tool use |
+| `hermes` | - | hermes CLI (`hermes chat -q`) | *(hermes' own default)* | Uses Hermes agent as consult backend |
+
+> **The codex lane's `-sol` suffix is load-bearing.** Plain `gpt-5.6` and `gpt-5.6-codex` are both
+> rejected by Codex when running on a ChatGPT account (`The '<id>' model is not supported when
+> using Codex with a ChatGPT account.`). Don't "simplify" the id — a unit test pins it.
+
+### Cost reporting
+
+Codex consultation cost is computed from OpenAI's published per-1M-token rates for the lane's
+model. If a model has no rates recorded in Codev, the consultation still runs and its token counts
+are still recorded, but `cost_usd` is stored as `null` rather than billed at some other model's
+rates. Only OpenAI's standard pricing tier is modelled — costs for consultations large enough to
+enter the long-context tier are under-reported.
 
 ## Modes
 

--- a/codev/projects/1288-consult-change-shipped-default/status.yaml
+++ b/codev/projects/1288-consult-change-shipped-default/status.yaml
@@ -1,0 +1,14 @@
+id: '1288'
+title: consult-change-shipped-default
+protocol: air
+phase: implement
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-07-30T09:59:39.378Z'
+updated_at: '2026-07-30T09:59:39.379Z'

--- a/codev/projects/1288-consult-change-shipped-default/status.yaml
+++ b/codev/projects/1288-consult-change-shipped-default/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-07-30T10:11:02.615Z'
+    approved_at: '2026-07-30T10:33:43.250Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-30T09:59:39.378Z'
-updated_at: '2026-07-30T10:11:02.615Z'
-pr_ready_for_human: true
+updated_at: '2026-07-30T10:33:43.251Z'
+pr_ready_for_human: false

--- a/codev/projects/1288-consult-change-shipped-default/status.yaml
+++ b/codev/projects/1288-consult-change-shipped-default/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-07-30T10:11:02.615Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-30T09:59:39.378Z'
-updated_at: '2026-07-30T10:08:39.073Z'
+updated_at: '2026-07-30T10:11:02.615Z'
+pr_ready_for_human: true

--- a/codev/projects/1288-consult-change-shipped-default/status.yaml
+++ b/codev/projects/1288-consult-change-shipped-default/status.yaml
@@ -1,7 +1,7 @@
 id: '1288'
 title: consult-change-shipped-default
 protocol: air
-phase: implement
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-07-30T09:59:39.378Z'
-updated_at: '2026-07-30T09:59:39.379Z'
+updated_at: '2026-07-30T10:08:39.073Z'

--- a/codev/resources/commands/consult.md
+++ b/codev/resources/commands/consult.md
@@ -17,12 +17,24 @@ consult stats [options]
 
 ## Models
 
-| Model | Alias | Backend | Notes |
-|-------|-------|---------|-------|
-| `gemini` | `pro` | Antigravity CLI (`agy`) | Agentic file access (`--sandbox --add-dir`), OAuth/subscription login. Skips non-blockingly if `agy` is missing/unauthed. |
-| `codex` | `gpt` | @openai/codex | Read-only sandbox, thorough |
-| `claude` | `opus` | Claude Agent SDK | Balanced analysis with tool use |
-| `hermes` | - | hermes CLI (`hermes chat -q`) | Uses Hermes agent as consult backend |
+| Model | Alias | Backend | Shipped default model id | Notes |
+|-------|-------|---------|--------------------------|-------|
+| `gemini` | `pro` | Antigravity CLI (`agy`) | *(agy's own default — no pinned id)* | Agentic file access (`--sandbox --add-dir`), OAuth/subscription login. Skips non-blockingly if `agy` is missing/unauthed. |
+| `codex` | `gpt` | @openai/codex | `gpt-5.6-sol` (medium reasoning effort) | Read-only sandbox, thorough |
+| `claude` | `opus` | Claude Agent SDK | `claude-opus-5` | Balanced analysis with tool use |
+| `hermes` | - | hermes CLI (`hermes chat -q`) | *(hermes' own default)* | Uses Hermes agent as consult backend |
+
+> **The codex lane's `-sol` suffix is load-bearing.** Plain `gpt-5.6` and `gpt-5.6-codex` are both
+> rejected by Codex when running on a ChatGPT account (`The '<id>' model is not supported when
+> using Codex with a ChatGPT account.`). Don't "simplify" the id — a unit test pins it.
+
+### Cost reporting
+
+Codex consultation cost is computed from OpenAI's published per-1M-token rates for the lane's
+model. If a model has no rates recorded in Codev, the consultation still runs and its token counts
+are still recorded, but `cost_usd` is stored as `null` rather than billed at some other model's
+rates. Only OpenAI's standard pricing tier is modelled — costs for consultations large enough to
+enter the long-context tier are under-reported.
 
 ## Modes
 

--- a/codev/state/air-1288_thread.md
+++ b/codev/state/air-1288_thread.md
@@ -47,3 +47,29 @@ which the section had simply omitted, and verified the two files stay byte-ident
 
 #1286 has no PR open as of 2026-07-30, so this lands first. Per the issue, #1286's
 "default preservation" vectors must then assert the NEW ids.
+
+## PR — at the `pr` gate
+
+PR #1301. porch checks all green (build, tests, pr_exists, e2e_tests). Stopped at the gate;
+have not run `porch approve`.
+
+**Worth knowing for anyone else building in this repo today:** a fresh builder worktree here has
+**no `node_modules`**. `pnpm build` and `pnpm test` both "succeed" with exit 0 when you pipe them
+through `tail`, because the pipeline reports tail's status — the real output is `sh: tsc: command
+not found`. I briefly believed the build was green off exactly that. Run `pnpm install` from the
+worktree root first, and capture exit codes explicitly (`cmd > log 2>&1; echo $?`) rather than
+piping. Also: `cd packages/codev && pnpm ...` in a backgrounded Bash call didn't take — `pnpm -C
+packages/codev ...` did.
+
+**CI red, not ours.** `Tower Integration Tests` fails on this branch (twice). Diagnosed rather than
+re-rolled: `send-integration.e2e.test.ts` declares its `afterAll` with an explicit `10_000` budget
+(line 273) that overrides the config's `hookTimeout: 300000`. Teardown makes two *unbounded*
+deactivate `fetch`es plus a 2s SIGTERM wait plus four `rmSync` — over 10s on a loaded ubuntu runner.
+All 5 tests pass; only teardown blows up. The suite runs 5/5 in 1.76s locally on this branch, and
+our diff touches no Tower code. Same file already carries a "fix flaky" commit (1546ced5), and its
+`beforeAll` gets `120_000` — the asymmetry reads as an oversight.
+
+Deliberately did **not** fix or skip it: skipping costs 5 real integration tests to land a two-line
+model-id change, and both edits are outside #1288. Escalated to the architect at the gate with the
+PRFT and a fix proposal (raise the budget, bound the fetches). If a sibling builder hits the same
+red job, this is why — it is not your diff.

--- a/codev/state/air-1288_thread.md
+++ b/codev/state/air-1288_thread.md
@@ -1,0 +1,49 @@
+# air-1288 — consult: shipped default lane models → claude-opus-5 / gpt-5.6-sol
+
+Protocol: AIR (strict). Issue #1288.
+
+## Implement
+
+Scope was exactly as issued — two hardcoded ids, pricing, docs, a guard test.
+
+**Model ids.** Rather than inlining the new strings at the two call sites, hoisted them to
+exported constants in `consult/index.ts`:
+
+- `DEFAULT_CLAUDE_MODEL = 'claude-opus-5'`
+- `DEFAULT_CODEX_MODEL = 'gpt-5.6-sol'`
+- `DEFAULT_CODEX_REASONING_EFFORT = 'medium'`
+
+Two reasons: the guard test (issue item 4) needs something CI-safe to assert against, and #1286
+turns these exact values into config *fallback defaults* — having them already named makes that
+rebase a one-liner instead of a re-extraction.
+
+**Pricing.** Verified against OpenAI's own pricing page (`developers.openai.com/api/docs/pricing`,
+fetched 2026-07-30), not an aggregator: gpt-5.6-sol standard tier is **$5.00 input / $0.50 cached
+/ $30.00 output** per 1M. (Aggregator results agreed, but the issue asked for the official page.)
+
+Turned `CODEX_PRICING` from a bare rate triple into a `Record<modelId, rates>` and exported
+`computeCodexCost(model, input, cached, output): number | null`. An unknown model id now returns
+`null` instead of being billed at another model's rates — which is the issue's stated cost rule,
+and it also means #1286's configurable models can't silently inherit gpt-5.6-sol's rates once a
+workspace points the lane elsewhere. Documented the one known gap: OpenAI publishes a separate
+higher long-context tier that we don't model, so very large consultations under-report.
+
+**Test hygiene.** `codex-sdk.test.ts` had a *copy* of `CODEX_PRICING` and its own local
+`computeCodexCost` — so its "cost computation" suite would have kept passing against gpt-5.4 rates
+forever while the shipped rates drifted. Rewired it to import the real exported function. Worth
+knowing this pattern exists elsewhere: a test that reproduces the constant it's testing is testing
+nothing.
+
+New `consult/__tests__/default-models.test.ts` pins both ids + the effort. The `-sol` suffix is the
+thing most likely to get "corrected" by a future drive-by (plain `gpt-5.6` and `gpt-5.6-codex` were
+both live-probed and rejected on a ChatGPT account), so the test comment says so explicitly.
+
+**Docs.** `consult.md` Models table gained a "Shipped default model id" column plus a cost-reporting
+note; copied verbatim to the skeleton. CLAUDE.md/AGENTS.md's Multi-Agent Consultation section named
+GPT-5.4 with a wrong id (`gpt-5.4-codex` — the code never used that); fixed, added the claude lane
+which the section had simply omitted, and verified the two files stay byte-identical.
+
+## Coordination
+
+#1286 has no PR open as of 2026-07-30, so this lands first. Per the issue, #1286's
+"default preservation" vectors must then assert the NEW ids.

--- a/packages/codev/src/__tests__/consult.test.ts
+++ b/packages/codev/src/__tests__/consult.test.ts
@@ -536,7 +536,7 @@ describe('consult command', () => {
       expect(mockQueryFn).toHaveBeenCalledTimes(1);
       const callArgs = mockQueryFn.mock.calls[0][0];
       expect(callArgs.options.allowedTools).toEqual(['Read', 'Glob', 'Grep']);
-      expect(callArgs.options.model).toBe('claude-opus-4-6');
+      expect(callArgs.options.model).toBe('claude-opus-5');
       expect(callArgs.options.maxTurns).toBe(200);
       expect(callArgs.options.maxBudgetUsd).toBe(25);
       expect(callArgs.options.permissionMode).toBe('bypassPermissions');

--- a/packages/codev/src/commands/consult/__tests__/codex-sdk.test.ts
+++ b/packages/codev/src/commands/consult/__tests__/codex-sdk.test.ts
@@ -6,53 +6,12 @@ import { tmpdir } from 'node:os';
 /**
  * Tests for the Codex SDK integration (Phase 1).
  *
- * Part 1: Cost computation logic (CODEX_PRICING formula)
+ * Part 1: Cost computation logic (the real computeCodexCost() from index.ts)
  * Part 2: Mocked runCodexConsultation() — event handling, error paths, temp file cleanup
+ *
+ * Part 1 exercises the shipped implementation rather than a copy of it, so a
+ * pricing change can't pass here while the real rates drift (#1288).
  */
-
-// Reproduce the CODEX_PRICING constant from index.ts for unit testing
-const CODEX_PRICING = { inputPer1M: 2.00, cachedInputPer1M: 1.00, outputPer1M: 8.00 };
-
-function computeCodexCost(
-  inputTokens: number,
-  cachedInputTokens: number,
-  outputTokens: number,
-): number {
-  const uncached = inputTokens - cachedInputTokens;
-  return (uncached / 1_000_000) * CODEX_PRICING.inputPer1M
-       + (cachedInputTokens / 1_000_000) * CODEX_PRICING.cachedInputPer1M
-       + (outputTokens / 1_000_000) * CODEX_PRICING.outputPer1M;
-}
-
-describe('Codex SDK cost computation', () => {
-  it('computes correct cost for sample token counts', () => {
-    const cost = computeCodexCost(24763, 24448, 122);
-    expect(cost).toBeCloseTo(0.026054, 5);
-  });
-
-  it('computes correct cost when all tokens are uncached', () => {
-    const cost = computeCodexCost(10000, 0, 5000);
-    expect(cost).toBeCloseTo(0.06, 5);
-  });
-
-  it('computes correct cost when all tokens are cached', () => {
-    const cost = computeCodexCost(5000, 5000, 100);
-    expect(cost).toBeCloseTo(0.0058, 5);
-  });
-
-  it('computes zero cost for zero tokens', () => {
-    expect(computeCodexCost(0, 0, 0)).toBe(0);
-  });
-
-  it('handles large token counts correctly', () => {
-    const cost = computeCodexCost(1_000_000, 900_000, 100_000);
-    expect(cost).toBeCloseTo(1.90, 5);
-  });
-});
-
-// ============================================================================
-// Part 2: Mocked runCodexConsultation() tests
-// ============================================================================
 
 // Helper to create an async generator from an array of events
 async function* mockEvents(events: unknown[]): AsyncGenerator<unknown> {
@@ -82,7 +41,44 @@ vi.mock('@openai/codex-sdk', () => {
 });
 
 // Import after mocking
-const { runCodexConsultation } = await import('../index.js');
+const { runCodexConsultation, computeCodexCost, DEFAULT_CODEX_MODEL } = await import('../index.js');
+
+// ============================================================================
+// Part 1: Cost computation
+// ============================================================================
+
+describe('Codex SDK cost computation', () => {
+  // Rates for the default model: $5.00 uncached / $0.50 cached / $30.00 output per 1M.
+  const cost = (input: number, cached: number, output: number): number => {
+    const value = computeCodexCost(DEFAULT_CODEX_MODEL, input, cached, output);
+    if (value === null) throw new Error(`no published rates for ${DEFAULT_CODEX_MODEL}`);
+    return value;
+  };
+
+  it('computes correct cost for sample token counts', () => {
+    expect(cost(24763, 24448, 122)).toBeCloseTo(0.017459, 5);
+  });
+
+  it('computes correct cost when all tokens are uncached', () => {
+    expect(cost(10000, 0, 5000)).toBeCloseTo(0.2, 5);
+  });
+
+  it('computes correct cost when all tokens are cached', () => {
+    expect(cost(5000, 5000, 100)).toBeCloseTo(0.0055, 5);
+  });
+
+  it('computes zero cost for zero tokens', () => {
+    expect(cost(0, 0, 0)).toBe(0);
+  });
+
+  it('handles large token counts correctly', () => {
+    expect(cost(1_000_000, 900_000, 100_000)).toBeCloseTo(3.95, 5);
+  });
+});
+
+// ============================================================================
+// Part 2: Mocked runCodexConsultation() tests
+// ============================================================================
 
 function setupMockCodex(events: unknown[]) {
   mockRunStreamedFn = vi.fn().mockResolvedValue({
@@ -265,7 +261,8 @@ describe('runCodexConsultation() with mocked SDK', () => {
     // Verify startThread receives model, sandboxMode, and workingDirectory
     expect(mockStartThreadArgs).toBeDefined();
     const threadArgs = mockStartThreadArgs as Record<string, unknown>;
-    expect(threadArgs.model).toBe('gpt-5.4');
+    expect(threadArgs.model).toBe('gpt-5.6-sol');
+    expect(threadArgs.modelReasoningEffort).toBe('medium');
     expect(threadArgs.sandboxMode).toBe('read-only');
     expect(threadArgs.workingDirectory).toBe(tmpDir);
   });

--- a/packages/codev/src/commands/consult/__tests__/default-models.test.ts
+++ b/packages/codev/src/commands/consult/__tests__/default-models.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_CLAUDE_MODEL,
+  DEFAULT_CODEX_MODEL,
+  DEFAULT_CODEX_REASONING_EFFORT,
+  computeCodexCost,
+} from '../index.js';
+
+/**
+ * Guard rail for the shipped consult lane defaults (#1288).
+ *
+ * These ids were live-probed before being adopted; a drive-by "correction"
+ * (most likely dropping the unusual `-sol` suffix, which Codex rejects on a
+ * ChatGPT account) must fail here rather than silently landing. Changing a
+ * default is legitimate — but it has to be a deliberate edit to this file too,
+ * accompanied by a fresh live probe.
+ *
+ * CI-safe: no network, no model CLIs, no API calls.
+ */
+describe('shipped consult lane defaults', () => {
+  it('pins the claude lane to claude-opus-5', () => {
+    expect(DEFAULT_CLAUDE_MODEL).toBe('claude-opus-5');
+  });
+
+  it('pins the codex lane to gpt-5.6-sol at medium reasoning effort', () => {
+    // The `-sol` suffix is load-bearing: plain `gpt-5.6` and `gpt-5.6-codex`
+    // are both rejected by Codex with a ChatGPT account.
+    expect(DEFAULT_CODEX_MODEL).toBe('gpt-5.6-sol');
+    expect(DEFAULT_CODEX_REASONING_EFFORT).toBe('medium');
+  });
+});
+
+describe('computeCodexCost', () => {
+  it('prices the default codex model at published gpt-5.6-sol rates', () => {
+    // 1M uncached input @ $5.00 + 1M cached input @ $0.50 + 1M output @ $30.00
+    const cost = computeCodexCost(DEFAULT_CODEX_MODEL, 2_000_000, 1_000_000, 1_000_000);
+    expect(cost).toBeCloseTo(35.5, 6);
+  });
+
+  it('discounts cached input tokens', () => {
+    const allUncached = computeCodexCost(DEFAULT_CODEX_MODEL, 1_000_000, 0, 0);
+    const allCached = computeCodexCost(DEFAULT_CODEX_MODEL, 1_000_000, 1_000_000, 0);
+    expect(allUncached).toBeCloseTo(5.0, 6);
+    expect(allCached).toBeCloseTo(0.5, 6);
+  });
+
+  it('returns null for a model with no published rates on file', () => {
+    // Rather than billing an unknown model at another model's rates — a
+    // confidently wrong number is worse than none.
+    expect(computeCodexCost('gpt-5.4', 100_000, 0, 10_000)).toBeNull();
+    expect(computeCodexCost('some-future-model', 100_000, 0, 10_000)).toBeNull();
+  });
+});

--- a/packages/codev/src/commands/consult/index.ts
+++ b/packages/codev/src/commands/consult/index.ts
@@ -382,8 +382,61 @@ function commandExists(cmd: string): boolean {
   }
 }
 
-// Codex pricing for cost computation (matches values from old SUBPROCESS_MODEL_PRICING)
-const CODEX_PRICING = { inputPer1M: 2.00, cachedInputPer1M: 1.00, outputPer1M: 8.00 };
+/**
+ * Shipped default model id for the codex consult lane (#1288).
+ *
+ * The `-sol` suffix is LOAD-BEARING. Both plain `gpt-5.6` and `gpt-5.6-codex`
+ * were live-probed on 2026-07-29 and rejected by Codex with a ChatGPT account
+ * ("The '<id>' model is not supported when using Codex with a ChatGPT
+ * account."). Do not "simplify" this id — `default-models.test.ts` guards it.
+ */
+export const DEFAULT_CODEX_MODEL = 'gpt-5.6-sol';
+
+/** Shipped default reasoning effort for the codex consult lane. */
+export const DEFAULT_CODEX_REASONING_EFFORT = 'medium' as const;
+
+/** Shipped default model id for the claude consult lane (#1288). */
+export const DEFAULT_CLAUDE_MODEL = 'claude-opus-5';
+
+interface CodexModelPricing {
+  inputPer1M: number;
+  cachedInputPer1M: number;
+  outputPer1M: number;
+}
+
+/**
+ * Per-1M-token codex rates, keyed by model id. Verified against
+ * https://developers.openai.com/api/docs/pricing on 2026-07-30.
+ *
+ * Only OpenAI's *standard* tier is modelled; the separate long-context tier
+ * (charged above the standard context threshold) is not, so cost is
+ * under-reported for unusually large consultations.
+ *
+ * A model id absent from this table yields `costUsd: null` rather than a cost
+ * computed from some other model's rates — a confidently wrong number is worse
+ * than none.
+ */
+const CODEX_PRICING: Record<string, CodexModelPricing> = {
+  'gpt-5.6-sol': { inputPer1M: 5.00, cachedInputPer1M: 0.50, outputPer1M: 30.00 },
+};
+
+/**
+ * Compute codex consultation cost in USD, or null when the model's published
+ * rates are unknown.
+ */
+export function computeCodexCost(
+  model: string,
+  inputTokens: number,
+  cachedInputTokens: number,
+  outputTokens: number,
+): number | null {
+  const pricing = CODEX_PRICING[model];
+  if (!pricing) return null;
+  const uncached = inputTokens - cachedInputTokens;
+  return (uncached / 1_000_000) * pricing.inputPer1M
+       + (cachedInputTokens / 1_000_000) * pricing.cachedInputPer1M
+       + (outputTokens / 1_000_000) * pricing.outputPer1M;
+}
 
 /**
  * Run Codex consultation via @openai/codex-sdk.
@@ -414,9 +467,9 @@ export async function runCodexConsultation(
     });
 
     const thread = codex.startThread({
-      model: 'gpt-5.4',
+      model: DEFAULT_CODEX_MODEL,
       sandboxMode: 'read-only',
-      modelReasoningEffort: 'medium',
+      modelReasoningEffort: DEFAULT_CODEX_REASONING_EFFORT,
       workingDirectory: workspaceRoot,
     });
 
@@ -436,10 +489,7 @@ export async function runCodexConsultation(
         // output_tokens already includes reasoning_output_tokens (OpenAI Responses-API
         // convention) — do NOT add the latter to cost or reasoning is double-billed.
         const output = event.usage.output_tokens;
-        const uncached = input - cached;
-        const cost = (uncached / 1_000_000) * CODEX_PRICING.inputPer1M
-                   + (cached / 1_000_000) * CODEX_PRICING.cachedInputPer1M
-                   + (output / 1_000_000) * CODEX_PRICING.outputPer1M;
+        const cost = computeCodexCost(DEFAULT_CODEX_MODEL, input, cached, output);
         usageData = { inputTokens: input, cachedInputTokens: cached, outputTokens: output, costUsd: cost };
       }
       if (event.type === 'turn.failed') {
@@ -555,7 +605,7 @@ async function runClaudeConsultation(
         allowedTools: ['Read', 'Glob', 'Grep'],
         permissionMode: 'bypassPermissions',
         allowDangerouslySkipPermissions: true,
-        model: 'claude-opus-4-6',
+        model: DEFAULT_CLAUDE_MODEL,
         maxTurns: CLAUDE_MAX_TURNS,
         maxBudgetUsd: 25,
         cwd: workspaceRoot,


### PR DESCRIPTION
Closes #1288.

Moves the **shipped** consult lane defaults forward — the ids every adopter gets when they haven't configured anything.

| Lane | Before | After |
|---|---|---|
| claude | `claude-opus-4-6` | **`claude-opus-5`** |
| codex | `gpt-5.4` @ medium | **`gpt-5.6-sol`** @ medium |
| gemini | agy's own default | unchanged |

## Review

### What changed and why

**The ids are now named constants, not inline literals.** `DEFAULT_CLAUDE_MODEL`, `DEFAULT_CODEX_MODEL`, and `DEFAULT_CODEX_REASONING_EFFORT` are exported from `consult/index.ts`. Two reasons: the guard test (issue item 4) needs something CI-safe to assert against, and #1286 turns these exact values into config *fallback defaults* — having them already extracted makes that a one-line change rather than a re-extraction of the same lines this PR just touched.

**Pricing is now per-model, and unknown models cost `null`.** `CODEX_PRICING` was a bare rate triple hardcoded to gpt-5.4's numbers; it's now a `Record<modelId, rates>` behind an exported `computeCodexCost(model, input, cached, output): number | null`.

gpt-5.6-sol's rates were verified against OpenAI's own pricing page ([developers.openai.com/api/docs/pricing](https://developers.openai.com/api/docs/pricing), fetched 2026-07-30), not an aggregator: **$5.00 uncached input / $0.50 cached input / $30.00 output** per 1M. So the issue's "record `cost_usd` as null if rates can't be verified" fallback didn't need to trigger — but the *mechanism* is in place anyway, which matters once #1286 lets a workspace point the lane at an arbitrary model. Without it, a configured model would silently inherit gpt-5.6-sol's rates. Now it gets `null`.

**Known gap, documented in code and docs:** OpenAI publishes a separate higher long-context tier ($10/$1/$45). We model only the standard tier, so a consultation large enough to cross into it under-reports. Modelling the tier boundary is more than this issue asked for; flagging it rather than silently rounding.

**A test was lying.** `codex-sdk.test.ts` had its own copy of the `CODEX_PRICING` constant and a local reimplementation of the cost formula. Its five "cost computation" assertions would have kept passing against gpt-5.4 rates indefinitely while the shipped rates drifted — it was testing a copy of the thing, not the thing. It now imports the real `computeCodexCost`, and the expected values were recomputed for the new rates.

### Tests

New `consult/__tests__/default-models.test.ts` pins both ids plus the reasoning effort, and covers the `null`-for-unknown-model path (using `gpt-5.4` as one of the unknowns, which doubles as an assertion that the old model's rates really are gone). CI-safe: no network, no model CLIs, no API calls.

The specific thing this guards against is a future drive-by "correction" of the `-sol` suffix. Both plain `gpt-5.6` and `gpt-5.6-codex` were live-probed on 2026-07-29 and rejected — `The '<id>' model is not supported when using Codex with a ChatGPT account.` The suffix looks like a typo and isn't one, so the test comment says so out loud.

Existing assertions updated: `consult.test.ts` (claude lane model), `codex-sdk.test.ts` (codex lane model, plus a new assertion on reasoning effort that was previously unchecked).

### Docs

- `codev/resources/commands/consult.md` — Models table gains a **Shipped default model id** column, plus a `-sol` warning callout and a "Cost reporting" section explaining the `null` semantics. Mirrored byte-identically to `codev-skeleton/`.
- `CLAUDE.md` / `AGENTS.md` — the Multi-Agent Consultation section named "GPT-5.4 Codex (gpt-5.4-codex)", an id the code never actually used. Corrected to `gpt-5.6-sol`, and the claude lane — which the section had simply omitted — is now listed. Both files remain byte-identical (verified with `diff`).

### Coordination with #1286

No PR open for #1286 as of 2026-07-30, so this lands first. Per the issue, #1286's "default preservation" test vectors must then assert the **new** ids — `default-models.test.ts` is the natural place for that to be enforced, since it will fail loudly if the fallback path resolves to anything else.

## Verification

- `pnpm build` from repo root (core → codev → dashboard → skeleton copy): green.
- Full unit suite: **3798 passed, 48 skipped, 0 failed** (197 files).
- `porch check 1288`: build ✓ (4.6s), tests ✓ (27.6s).

No flaky tests encountered; the 48 skips are pre-existing.

## Out of scope (unchanged, per the issue)

Lane composition, the gemini/agy lane's model, and the #1286 config mechanism itself.

---

## ⚠️ CI note: "Tower Integration Tests" is red, and it is not this PR

`Tower Integration Tests` failed on both runs of this branch. I diagnosed it rather than re-rolling the dice; it is a pre-existing teardown defect in a file this PR never touches.

**Problem.** `src/agent-farm/__tests__/send-integration.e2e.test.ts` fails with `Error: Hook timed out in 10000ms`. All 5 of its tests **pass** — the failure is in teardown, after the assertions are green.

**Root cause.** The suite's `afterAll` is declared with an explicit `10_000` ms budget (`send-integration.e2e.test.ts:273`), overriding the config's generous `hookTimeout: 300000`. That teardown does two `fetch(.../deactivate)` calls with **no timeout of their own** (`.catch(() => {})` swallows errors but never bounds a hang), then a `stopServer` that waits up to 2s for SIGTERM before SIGKILL, then four `rmSync` calls. On a loaded ubuntu runner that comfortably exceeds 10s; on a developer machine it doesn't. The `beforeAll` in the same suite is budgeted at `120_000` — the asymmetry looks unintentional.

**Evidence it's unrelated to this PR:**
- The suite passes locally on this branch: **5/5 in 1.76s** (`vitest run --config vitest.e2e.config.ts src/agent-farm/__tests__/send-integration.e2e.test.ts`).
- This PR's diff is confined to `commands/consult/**` and docs. It touches no Tower, websocket, or messaging code.
- The file has prior form — commit `1546ced5` is literally "Fix flaky send-integration e2e test — retry activation during Tower startup".
- `main` is green only because the margin is thin, not because the teardown is safely budgeted.

**Fix.** I did *not* apply one, and I did not skip the suite — skipping would drop 5 real integration tests to land a two-line model-id change, and either edit is outside #1288's scope. The minimal fix is to raise that `afterAll` budget (and ideally bound the two deactivate `fetch`es). Happy to do it in this PR if you'd prefer, or to file it separately — your call at the gate.
