### PR TITLE
Fix send-integration e2e flake: teardown budget asymmetry (10s afterAll vs 120s beforeAll)

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/send-integration.e2e.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/send-integration.e2e.test.ts
@@ -254,12 +254,12 @@ describe('send integration (POST /api/send → /ws/messages)', () => {
     // Guard against setup failure — variables may be undefined
     if (workspaceA) {
       const encA = encodeWorkspacePath(workspaceA);
-      await fetch(`http://localhost:${TEST_TOWER_PORT}/api/workspaces/${encA}/deactivate`, { method: 'POST' }).catch(() => {});
+      await fetch(`http://localhost:${TEST_TOWER_PORT}/api/workspaces/${encA}/deactivate`, { method: 'POST', signal: AbortSignal.timeout(10_000) }).catch(() => {});
       cleanupWorkspace(workspaceA);
     }
     if (workspaceB) {
       const encB = encodeWorkspacePath(workspaceB);
-      await fetch(`http://localhost:${TEST_TOWER_PORT}/api/workspaces/${encB}/deactivate`, { method: 'POST' }).catch(() => {});
+      await fetch(`http://localhost:${TEST_TOWER_PORT}/api/workspaces/${encB}/deactivate`, { method: 'POST', signal: AbortSignal.timeout(10_000) }).catch(() => {});
       cleanupWorkspace(workspaceB);
     }
 
@@ -270,7 +270,10 @@ describe('send integration (POST /api/send → /ws/messages)', () => {
     try { rmSync(`${dbBase}.db`, { force: true }); } catch { /* ignore */ }
     try { rmSync(`${dbBase}.db-wal`, { force: true }); } catch { /* ignore */ }
     try { rmSync(`${dbBase}.db-shm`, { force: true }); } catch { /* ignore */ }
-  }, 10_000);
+    // 120s to match beforeAll — the old explicit 10s override was tighter than
+    // the two deactivate calls + stopServer's SIGTERM wait can guarantee on a
+    // loaded CI runner, and a slow teardown failed the whole green suite.
+  }, 120_000);
 
   // ---- Single-workspace send tests ----
 


### PR DESCRIPTION
## Problem

`send-integration.e2e.test.ts` fails intermittently in the Tower Integration Tests CI job with `Error: Hook timed out in 10000ms` — **after all 5 tests pass**. It has hit three PRs in two days (#1283, #1290, #1301) plus multiple earlier branches, each time requiring a manual rerun.

## Root cause

(Credit: the air-1288 builder's diagnosis on PR #1301.) The suite's `afterAll` declares an explicit `10_000`ms budget, overriding the config's 300s `hookTimeout`, while `beforeAll` in the same suite gets `120_000` — an unintentional asymmetry. The teardown performs two unbounded deactivate fetches, `stopServer`'s 2s SIGTERM wait, and three `rmSync` calls; on a loaded ubuntu runner that exceeds 10s.

## Fix

- Raise the `afterAll` budget to `120_000`, matching `beforeAll`.
- Bound the two deactivate fetches with `AbortSignal.timeout(10_000)` so a hung Tower can't consume the enlarged budget either — the teardown still completes and the existing `.catch(() => {})` handles the abort.

## Testing

Suite passes locally under the e2e config: 5/5 in 1.8s. No production code touched — one test file, +6/−3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)