### PR TITLE
test: skip real-agy e2e smoke pending #1323

### DIFF
--- a/packages/codev/src/__tests__/cli/agy-integration.e2e.test.ts
+++ b/packages/codev/src/__tests__/cli/agy-integration.e2e.test.ts
@@ -21,7 +21,11 @@ function isSkip(out: string): boolean {
   return out.includes('VERDICT: COMMENT') && /Skipped/i.test(out);
 }
 
-describe('agy lane integration (guarded; real agy)', () => {
+// Disabled pending #1323: when agy is unauthenticated, every real spawn opens an
+// OAuth browser window on the developer's machine — the "unavailable/unauthed →
+// harmless skip" guard below detects that state only AFTER the window is open.
+// Re-enable once the suite pins a fake agy (or an equivalent no-browser guard).
+describe.skip('agy lane integration (guarded; real agy)', () => {
   it('delivers the complete inline prompt under the agy 1.0.10 argument contract', async () => {
     if (!resolveAgyBin()) return;
 


### PR DESCRIPTION
## Problem

`agy-integration.e2e.test.ts` deliberately spawns the **real** Antigravity CLI. When agy is unauthenticated, each spawn opens an OAuth browser window before the test's own skip-guard can detect the state — the guard reads the OAuth marker from output that arrives only after the window is open. With ~10 active builders running `test:e2e:cli` at phase checks, yesterday's agy 1.1.9 update (which forced re-auth) turned local suite runs into the login-window burst reported this morning.

## Fix

`describe.skip` on the one real-agy suite (3 tests), with a comment pointing at #1323. No other test in the CLI lane reaches a real agy (`consult.e2e.test.ts` only exercises `--help`; the unit consult suite mocks `child_process`).

## Testing

Skip-only change to a single test file; CI runs the same suites and will show the 3 tests as skipped.

Stopgap explicitly requested by the human. #1323 (builder in flight) delivers the real fix — fake-agy pin across all suites — and should re-enable this coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)