### PR TITLE
[Bugfix #1323] Sandbox agy + metrics DB for every test suite

### DIFF
--- a/codev-skeleton/resources/commands/consult.md
+++ b/codev-skeleton/resources/commands/consult.md
@@ -208,6 +208,25 @@ through to a normal spawn.
 | `CODEV_AGY_AUTH_CACHE_DIR` | `~/.cache/codev` | Cache location (mainly for tests). |
 | `CODEV_AGY_AUTH_CACHE_DISABLE` | unset | `1` restores the always-spawn behaviour. |
 
+#### Test isolation
+
+The cache above protects *production* runs. It did not protect test runs: the
+cache disables itself under `VITEST` unless a cache directory is named, and any
+test that reached the gemini lane without pinning `CODEV_AGY_BIN` resolved the
+real binary — so a suite run could still open a login window per spawn (#1323).
+Consult now treats a test runner as a hard boundary. Under `VITEST` (or
+`CODEV_TEST`) it refuses to resolve an unpinned `agy` and refuses to open the
+user-global metrics database, failing loudly instead of reaching either. Codev's
+own suites pin a fake `agy`, a sandbox auth cache, and a sandbox metrics DB for
+every test; spawned `codev` / `consult` children inherit the pins through the
+environment.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `CODEV_AGY_BIN` | auto-resolved | Pin the agy binary. The harness sets this to a fake for every test. |
+| `CODEV_ALLOW_REAL_AGY` | unset | `1` opts a test run into the REAL agy binary — the guarded integration smoke and real-AI e2e runs. Expect a browser window if agy's login has lapsed. |
+| `CODEV_METRICS_DB` | `~/.codev/metrics.db` | Redirect the consult metrics database. Required under a test runner; the harness points it at a temp dir so suite runs stop skewing `consult stats`. |
+
 ### Claude auth: subscription vs. metered API
 
 `consult -m claude` runs on the Claude Agent SDK. When `CLAUDE_CODE_OAUTH_TOKEN`

--- a/codev-skeleton/resources/commands/consult.md
+++ b/codev-skeleton/resources/commands/consult.md
@@ -215,7 +215,7 @@ cache disables itself under `VITEST` unless a cache directory is named, and any
 test that reached the gemini lane without pinning `CODEV_AGY_BIN` resolved the
 real binary — so a suite run could still open a login window per spawn (#1323).
 Consult now treats a test runner as a hard boundary. Under `VITEST` (or
-`CODEV_TEST`) it refuses to resolve an unpinned `agy` and refuses to open the
+`CODEV_TEST_ISOLATION`) it refuses to resolve an unpinned `agy` and refuses to open the
 user-global metrics database, failing loudly instead of reaching either. Codev's
 own suites pin a fake `agy`, a sandbox auth cache, and a sandbox metrics DB for
 every test; spawned `codev` / `consult` children inherit the pins through the

--- a/codev-skeleton/resources/commands/consult.md
+++ b/codev-skeleton/resources/commands/consult.md
@@ -226,6 +226,14 @@ environment.
 | `CODEV_AGY_BIN` | auto-resolved | Pin the agy binary. The harness sets this to a fake for every test. |
 | `CODEV_ALLOW_REAL_AGY` | unset | `1` opts a test run into the REAL agy binary — the guarded integration smoke and real-AI e2e runs. Expect a browser window if agy's login has lapsed. |
 | `CODEV_METRICS_DB` | `~/.codev/metrics.db` | Redirect the consult metrics database. Required under a test runner; the harness points it at a temp dir so suite runs stop skewing `consult stats`. |
+| `CODEV_TEST_ISOLATION` | unset | `1` applies the same guards to a harness that is not vitest. |
+
+**Adopters:** `VITEST` is exported by *any* vitest run, including yours. If your
+project's own suite deliberately shells out to `consult -m gemini`, that call now
+throws until you set `CODEV_ALLOW_REAL_AGY=1` (and `CODEV_METRICS_DB` if you want
+the metrics recorded somewhere). This is intentional — a suite reaching the real
+agy is what #1323 was about — but it is a behaviour change, not a silent one: the
+error names the variable to set.
 
 ### Claude auth: subscription vs. metered API
 

--- a/codev/projects/bugfix-1323-test-suite-consult-runs-escape/status.yaml
+++ b/codev/projects/bugfix-1323-test-suite-consult-runs-escape/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1323
 title: test-suite-consult-runs-escape
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-01T13:07:26.835Z'
-updated_at: '2026-08-01T13:07:26.836Z'
+updated_at: '2026-08-01T13:10:51.247Z'

--- a/codev/projects/bugfix-1323-test-suite-consult-runs-escape/status.yaml
+++ b/codev/projects/bugfix-1323-test-suite-consult-runs-escape/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1323
 title: test-suite-consult-runs-escape
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-01T13:07:26.835Z'
-updated_at: '2026-08-01T13:10:51.247Z'
+updated_at: '2026-08-01T13:44:59.961Z'

--- a/codev/projects/bugfix-1323-test-suite-consult-runs-escape/status.yaml
+++ b/codev/projects/bugfix-1323-test-suite-consult-runs-escape/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-08-01T13:45:05.688Z'
+    approved_at: '2026-08-01T17:11:00.829Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-01T13:07:26.835Z'
-updated_at: '2026-08-01T13:45:05.689Z'
-pr_ready_for_human: true
+updated_at: '2026-08-01T17:11:00.830Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1323-test-suite-consult-runs-escape/status.yaml
+++ b/codev/projects/bugfix-1323-test-suite-consult-runs-escape/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1323
+title: test-suite-consult-runs-escape
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-01T13:07:26.835Z'
+updated_at: '2026-08-01T13:07:26.836Z'

--- a/codev/projects/bugfix-1323-test-suite-consult-runs-escape/status.yaml
+++ b/codev/projects/bugfix-1323-test-suite-consult-runs-escape/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-08-01T13:45:05.688Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-01T13:07:26.835Z'
-updated_at: '2026-08-01T13:44:59.961Z'
+updated_at: '2026-08-01T13:45:05.689Z'
+pr_ready_for_human: true

--- a/codev/resources/commands/consult.md
+++ b/codev/resources/commands/consult.md
@@ -208,6 +208,24 @@ through to a normal spawn.
 | `CODEV_AGY_AUTH_CACHE_DIR` | `~/.cache/codev` | Cache location (mainly for tests). |
 | `CODEV_AGY_AUTH_CACHE_DISABLE` | unset | `1` restores the always-spawn behaviour. |
 
+#### Test isolation
+
+The cache above protects *production* runs. It did not protect the test suites:
+`agyAuthCacheDisabled()` turns itself off under `VITEST` unless a cache directory
+is named, and any test that reached the gemini lane without pinning
+`CODEV_AGY_BIN` resolved the real binary — so a suite run could still open a
+window per spawn (#1323). Codev's vitest harness (`packages/codev/vitest-setup.ts`)
+now pins a fake `agy`, a sandbox auth cache, and a sandbox metrics DB for every
+suite; spawned `codev` / `consult` children inherit the pins. Guards in
+`src/lib/test-env.ts` make a test that escapes the harness fail loudly instead of
+reaching the real binary or the user-global database.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `CODEV_AGY_BIN` | auto-resolved | Pin the agy binary. The harness sets this to a fake for every test. |
+| `CODEV_ALLOW_REAL_AGY` | unset | `1` opts a test run into the REAL agy binary — the guarded integration smoke and real-AI e2e runs. Expect a browser window if agy's login has lapsed. |
+| `CODEV_METRICS_DB` | `~/.codev/metrics.db` | Redirect the consult metrics database. Required under a test runner; the harness points it at a temp dir so suite runs stop skewing `consult stats`. |
+
 ### Claude auth: subscription vs. metered API
 
 `consult -m claude` runs on the Claude Agent SDK. When `CLAUDE_CODE_OAUTH_TOKEN`

--- a/codev/resources/commands/consult.md
+++ b/codev/resources/commands/consult.md
@@ -215,7 +215,7 @@ cache disables itself under `VITEST` unless a cache directory is named, and any
 test that reached the gemini lane without pinning `CODEV_AGY_BIN` resolved the
 real binary — so a suite run could still open a login window per spawn (#1323).
 Consult now treats a test runner as a hard boundary. Under `VITEST` (or
-`CODEV_TEST`) it refuses to resolve an unpinned `agy` and refuses to open the
+`CODEV_TEST_ISOLATION`) it refuses to resolve an unpinned `agy` and refuses to open the
 user-global metrics database, failing loudly instead of reaching either. Codev's
 own suites pin a fake `agy`, a sandbox auth cache, and a sandbox metrics DB for
 every test; spawned `codev` / `consult` children inherit the pins through the

--- a/codev/resources/commands/consult.md
+++ b/codev/resources/commands/consult.md
@@ -226,6 +226,14 @@ environment.
 | `CODEV_AGY_BIN` | auto-resolved | Pin the agy binary. The harness sets this to a fake for every test. |
 | `CODEV_ALLOW_REAL_AGY` | unset | `1` opts a test run into the REAL agy binary — the guarded integration smoke and real-AI e2e runs. Expect a browser window if agy's login has lapsed. |
 | `CODEV_METRICS_DB` | `~/.codev/metrics.db` | Redirect the consult metrics database. Required under a test runner; the harness points it at a temp dir so suite runs stop skewing `consult stats`. |
+| `CODEV_TEST_ISOLATION` | unset | `1` applies the same guards to a harness that is not vitest. |
+
+**Adopters:** `VITEST` is exported by *any* vitest run, including yours. If your
+project's own suite deliberately shells out to `consult -m gemini`, that call now
+throws until you set `CODEV_ALLOW_REAL_AGY=1` (and `CODEV_METRICS_DB` if you want
+the metrics recorded somewhere). This is intentional — a suite reaching the real
+agy is what #1323 was about — but it is a behaviour change, not a silent one: the
+error names the variable to set.
 
 ### Claude auth: subscription vs. metered API
 

--- a/codev/resources/commands/consult.md
+++ b/codev/resources/commands/consult.md
@@ -210,15 +210,16 @@ through to a normal spawn.
 
 #### Test isolation
 
-The cache above protects *production* runs. It did not protect the test suites:
-`agyAuthCacheDisabled()` turns itself off under `VITEST` unless a cache directory
-is named, and any test that reached the gemini lane without pinning
-`CODEV_AGY_BIN` resolved the real binary — so a suite run could still open a
-window per spawn (#1323). Codev's vitest harness (`packages/codev/vitest-setup.ts`)
-now pins a fake `agy`, a sandbox auth cache, and a sandbox metrics DB for every
-suite; spawned `codev` / `consult` children inherit the pins. Guards in
-`src/lib/test-env.ts` make a test that escapes the harness fail loudly instead of
-reaching the real binary or the user-global database.
+The cache above protects *production* runs. It did not protect test runs: the
+cache disables itself under `VITEST` unless a cache directory is named, and any
+test that reached the gemini lane without pinning `CODEV_AGY_BIN` resolved the
+real binary — so a suite run could still open a login window per spawn (#1323).
+Consult now treats a test runner as a hard boundary. Under `VITEST` (or
+`CODEV_TEST`) it refuses to resolve an unpinned `agy` and refuses to open the
+user-global metrics database, failing loudly instead of reaching either. Codev's
+own suites pin a fake `agy`, a sandbox auth cache, and a sandbox metrics DB for
+every test; spawned `codev` / `consult` children inherit the pins through the
+environment.
 
 | Variable | Default | Purpose |
 |---|---|---|

--- a/codev/state/bugfix-1323_thread.md
+++ b/codev/state/bugfix-1323_thread.md
@@ -144,3 +144,48 @@ suite (`describe`, not `describe.skip`), per the architect's 13:20Z instruction 
 restoring that coverage part of this fix. #1324's stated re-enable condition — "once the
 suite pins a fake agy (or an equivalent no-browser guard)" — is exactly what landed here.
 Flagging it explicitly since the merge undoes a hotfix that is only minutes old.
+
+## CMAP + architect integration review
+
+CMAP 3/3 APPROVE (gemini HIGH, codex HIGH, claude HIGH). Gemini and codex reported
+`KEY_ISSUES: None`; claude approved with five non-blocking nits. The architect's own
+integration review (codex + claude lanes) independently flagged two of the same items
+as required-before-merge, plus three optional.
+
+All addressed:
+
+1. **Guard ordering / `checkAgy`** (required). Rather than moving the assert above the
+   resolve at each call site, the guard now lives *inside* `resolveAgyBin()`, in the
+   no-override branch — the single chokepoint every route passes through. This is
+   strictly stronger than per-call-site ordering: it covers `runAgyConsultation`,
+   `verifyAgy`, **and** `checkAgy`, and it closes the hole both reviewers found
+   independently — the unpinned lookup runs `agyRespondsToVersion()`, which *executes*
+   the candidate binary, so guarding only the spawn sites still let a suite run real agy.
+   The now-redundant per-site asserts were removed.
+2. **`skipIf`** (required). `describe.skipIf(!REAL_AGY)` on `agy-integration.e2e.test.ts`,
+   with `REAL_AGY` resolved once at module scope and short-circuited on the opt-in (so
+   `resolveAgyBin()` is never called against the harness pin). Three cases that reported
+   as *passing while executing nothing* now report as skipped.
+3. **`packages/core` / `artifact-canvas` setupFiles** — **declined, with reason.** Neither
+   package references consult, agy, or MetricsDB (the single grep hit is the word
+   "consult" inside a code comment). Wiring codev's harness into them would invert the
+   workspace dependency (core is a dependency *of* codev, not the reverse), and
+   duplicating the pin logic adds maintenance surface for a hypothetical. If one ever
+   does shell into consult, the guard's error names the variable to set.
+4. **`metrics.test.ts:512`** — was passing only because the sandbox mirrors the
+   `.codev/metrics.db` layout. Now asserts against `process.env.CODEV_METRICS_DB`
+   directly, plus a second case pinning the refusal behaviour.
+5. **Map note in `test-env.ts`** — added, but with the *corrected* rationale. The
+   architect's note suggested explaining why the guard is per-call-site "because the
+   resolution tests need the unpinned path". That premise does not hold: every
+   resolution test pins `CODEV_AGY_BIN` first (they are testing override handling), and
+   `agy-integration` short-circuits on the opt-in. So the guard moved to the resolver and
+   the note documents the three routes into agy instead.
+
+Also corrected the `verifyAgy()` docblock ("Always resolves (never throws)" — it can now
+throw synchronously via the resolver) and made `vitest-setup.ts` one-shot per process via
+a `globalThis` cache, since `setupFiles` re-executes per test file and `singleFork` would
+otherwise stack ~200 `process.on('exit')` listeners on one emitter.
+
+Out of scope, filed by the architect as #1326: `~/.agent-farm/global.db` has no env
+override, so the harness cannot pin it.

--- a/codev/state/bugfix-1323_thread.md
+++ b/codev/state/bugfix-1323_thread.md
@@ -81,14 +81,25 @@ the file, so later `doctor()` calls reached `verifyAgy()` unpinned. **Not** real
 module mock, not the pin, was doing the work). Fixed by restoring the captured value
 instead of deleting; same antipattern fixed in `consult.test.ts`.
 
-### Open: intermittent metrics leak
+### Resolved: the "intermittent metrics leak" was a confounded measurement
 
-Full run #2: 0 rows added. Full run #3: **21 rows** added (hermes/claude/gemini from
-`consult.test.ts`, codex from `codex-sdk.test.ts`). Running those files alone, or paired
-with the obvious suspects (`test-isolation`, `generate-image`), adds 0 rows — so some
-other file in a full run clears `CODEV_METRICS_DB` *and* `VITEST` (the guard throws
-whenever `VITEST` survives, so both must be gone). Tripwire instrumentation is in
-`resolveDbPath` to catch the culprit; it is temporary and must come out before commit.
+Full run #2 added 0 rows; run #3 added **21** (hermes/claude/gemini shaped like
+`consult.test.ts`, codex like `codex-sdk.test.ts`), which looked like my fix failing
+intermittently. It wasn't.
+
+Row-count delta on `~/.codev/metrics.db` is **not** a valid instrument on this machine:
+the DB is user-global and shared, `ls ../` shows ~34 sibling builder worktrees, and
+`ps` showed **101 vitest processes** running concurrently. Sibling builders on
+un-fixed branches were writing exactly those rows while my suite ran. Between run #4
+and run #5 the count rose by 64 with **no test run of mine in between** — proof the
+instrument was measuring other agents.
+
+The correct instrument is "did *my* suite ever open the user-global DB", answered by
+logging every `MetricsDB` path in the constructor. Result on a full unit run: **19
+opens, all to the sandbox; zero to `~/.codev/metrics.db`.** Same run, row delta 0.
+
+Lesson worth keeping: on a shared machine, a global counter is evidence about the
+machine, not about your change. Instrument the code path, not the side effect.
 
 ## Architect instruction (2026-08-01T13:20Z)
 

--- a/codev/state/bugfix-1323_thread.md
+++ b/codev/state/bugfix-1323_thread.md
@@ -1,0 +1,97 @@
+# bugfix-1323 — Test-suite consult runs escape isolation
+
+Issue #1323: test suites spawn the real `agy` binary (login-window burst) and write
+into the user-global consult metrics DB.
+
+## Investigate — root cause
+
+Two **independent** escapes. Both are "unsafe by omission": nothing in the harness
+pins anything, so a test that simply *doesn't* set an env var reaches the real world.
+
+### 1. Real `agy` spawn (the login-window burst)
+
+- None of the three vitest configs (`vitest.config.ts`, `vitest.cli.config.ts`,
+  `vitest.e2e.config.ts`) declares `setupFiles`. **There is no global test harness at all.**
+- `resolveAgyBin()` (`commands/consult/index.ts:743`) falls back to `~/.local/bin/agy`
+  and then PATH when `CODEV_AGY_BIN` is unset. A test that reaches the gemini lane
+  without pinning therefore resolves the developer's real binary.
+- `src/__tests__/cli/agy-integration.e2e.test.ts` does exactly this **by design** — it
+  deliberately does not mock `node:child_process`, calls `resolveAgyBin()` and
+  `_runAgyConsultation()` directly (2 tests), and spawns the built `consult` CLI as a
+  subprocess (1 test). That is the CLI-integration lane the issue points at.
+- The #1250 burst protection is inert here: `agyAuthCacheDisabled()`
+  (`agy-auth-cache.ts:113`) returns true whenever `VITEST` is set and
+  `CODEV_AGY_AUTH_CACHE_DIR` is not. Child `consult` processes inherit `VITEST`
+  (`helpers.ts:setupCliEnv` spreads `process.env`), so they are inert too.
+  Pre-flight off + real binary = unconditional spawn = one browser tab per spawn.
+
+### 2. Metrics-DB pollution (a *separate* bug, same timestamp window)
+
+- `MetricsDB`'s path is hardcoded: `join(homedir(), '.codev', 'metrics.db')`
+  (`metrics.ts:14-15`), **no env override**.
+- Unit tests run in-process under the developer's real `HOME`, so every
+  `recordMetrics()` call lands in the real user-global DB.
+- The junk rows map exactly: `codev-consult-test-<ts>` → `src/__tests__/consult.test.ts`
+  (the gemini rows), `codex-test-XXXXXX` →
+  `commands/consult/__tests__/codex-sdk.test.ts` (the codex rows).
+
+**Correction to the issue's reading:** the 0.0s gemini rows — including the one carrying
+`error_message: "agy timed out producing the review"` — come from `consult.test.ts`,
+which mocks `node:child_process` at module scope. That message is emitted by the test's
+own fake process, not by a real agy spawn. So the fingerprint in `consult stats` is
+evidence of escape #2, not escape #1; escape #1 is real but lives in the CLI-integration
+lane and leaves no metrics rows (its subprocesses run under a sandboxed `HOME`). Both
+bugs are real, they just aren't the same event.
+
+`preflightAgyAuth()` itself never spawns agy — it only reads the cache and takes a lock —
+so enabling the auth cache under test (with a sandboxed dir) is safe.
+
+## Fix shape (est. well under 300 LOC)
+
+1. New shared vitest `setupFiles` harness wired into all three configs: unconditionally
+   pin `CODEV_AGY_BIN` to a generated fake, `CODEV_AGY_AUTH_CACHE_DIR`, and a new
+   `CODEV_METRICS_DB`, all inside a per-run temp dir. Subprocess helpers inherit these
+   for free via `...process.env`.
+2. Belt-and-braces guard in `runAgyConsultation`: under a test runner, with no pinned
+   `CODEV_AGY_BIN` and no explicit opt-in, **throw** instead of spawning.
+3. `CODEV_METRICS_DB` override in `metrics.ts`; refuse the user-global path under a
+   test runner.
+4. `CODEV_ALLOW_REAL_AGY=1` opt-in for deliberate real-agy runs; gate
+   `agy-integration.e2e.test.ts` behind it.
+
+Order of work follows the architect's instruction: **pin first**, verify with the canary,
+then iterate. agy is authenticated right now but that is not something to rely on.
+
+## Fix — progress
+
+Pin landed first, as instructed, before running any suite.
+
+Implemented: `vitest-setup.ts` harness wired into all three configs; `src/lib/test-env.ts`
+guards; `CODEV_METRICS_DB` in `metrics.ts`; guard at both real-spawn sites
+(`runAgyConsultation` **and** `doctor.ts:verifyAgy` — doctor is a second way into
+agy that the issue didn't mention); `agy-integration.e2e.test.ts` gated behind
+`CODEV_ALLOW_REAL_AGY=1`.
+
+### What the guard caught
+
+First guarded run failed 11 tests in `doctor.test.ts`. Cause: `delete
+process.env.CODEV_AGY_BIN` in `finally` blocks wiped the harness pin for the rest of
+the file, so later `doctor()` calls reached `verifyAgy()` unpinned. **Not** real spawns
+— that file mocks `node:child_process` wholesale — so it was safe *by accident* (the
+module mock, not the pin, was doing the work). Fixed by restoring the captured value
+instead of deleting; same antipattern fixed in `consult.test.ts`.
+
+### Open: intermittent metrics leak
+
+Full run #2: 0 rows added. Full run #3: **21 rows** added (hermes/claude/gemini from
+`consult.test.ts`, codex from `codex-sdk.test.ts`). Running those files alone, or paired
+with the obvious suspects (`test-isolation`, `generate-image`), adds 0 rows — so some
+other file in a full run clears `CODEV_METRICS_DB` *and* `VITEST` (the guard throws
+whenever `VITEST` survives, so both must be gone). Tripwire instrumentation is in
+`resolveDbPath` to catch the culprit; it is temporary and must come out before commit.
+
+## Architect instruction (2026-08-01T13:20Z)
+
+PR #1324 is a stopgap that `describe.skip`s `agy-integration.e2e.test.ts`. Once it
+merges: merge main into this branch and **re-enable that suite** under the fake-agy pin
+/ no-browser guard, so the coverage comes back. Added to acceptance criteria.

--- a/codev/state/bugfix-1323_thread.md
+++ b/codev/state/bugfix-1323_thread.md
@@ -101,8 +101,46 @@ opens, all to the sandbox; zero to `~/.codev/metrics.db`.** Same run, row delta 
 Lesson worth keeping: on a shared machine, a global counter is evidence about the
 machine, not about your change. Instrument the code path, not the side effect.
 
+## Canary result (acceptance criterion 1)
+
+Temporarily instrumented `resolveAgyBin()` to log every resolution, and the
+`MetricsDB` constructor to log every path, then ran the full unit + CLI-integration
+suites. Instrumentation removed afterwards; the permanent equivalents are the guards
+plus `test-isolation.test.ts`.
+
+- **Every** `resolveAgyBin()` call across both suites had `override=` set to a
+  temp-dir fake. Zero calls with no override — and no override is the only way to
+  reach `~/.local/bin/agy` or PATH. Three distinct pids, all `VITEST=true`.
+- **Zero** `MetricsDB` opens against `~/.codev/metrics.db`; 19 opens, all sandbox
+  or explicit test paths.
+- Unit: 205 files / 4085 tests pass. CLI-integration: 8 files / 91 tests pass.
+
+`spec-1280-measurement-instrument.test.ts` failed intermittently along the way. Not
+mine: it shells out to `measure-prompt-surface.sh` (~2.0s per call, 2-3 calls per test,
+5s default timeout) and the machine was running 100+ concurrent vitest processes. A
+back-to-back A/B against a clean clone of `main` had both trees pass with identical
+duration (23.79s vs 23.71s), and the script itself times the same in both. Left alone.
+
 ## Architect instruction (2026-08-01T13:20Z)
 
 PR #1324 is a stopgap that `describe.skip`s `agy-integration.e2e.test.ts`. Once it
 merges: merge main into this branch and **re-enable that suite** under the fake-agy pin
 / no-browser guard, so the coverage comes back. Added to acceptance criteria.
+
+## Late correction (2026-08-01T13:31Z)
+
+Architect reverted the machine-wide agy rename; agy is back on PATH. No effect on this
+work — the canary above shows every resolution goes through a pinned fake regardless of
+whether a real agy exists, and the real-agy suite needs `CODEV_ALLOW_REAL_AGY=1`.
+
+Also renamed the non-vitest detection knob `CODEV_TEST` → `CODEV_TEST_ISOLATION`. These
+guards make `consult` *throw*, so a false positive breaks a real consultation; a generic
+name an adopter might already export is not worth that blast radius.
+
+## Note on PR #1324
+
+The merge conflict in `agy-integration.e2e.test.ts` was resolved by **re-enabling** the
+suite (`describe`, not `describe.skip`), per the architect's 13:20Z instruction to make
+restoring that coverage part of this fix. #1324's stated re-enable condition — "once the
+suite pins a fake agy (or an equivalent no-browser guard)" — is exactly what landed here.
+Flagging it explicitly since the merge undoes a hotfix that is only minutes old.

--- a/packages/codev/src/__tests__/cli/agy-integration.e2e.test.ts
+++ b/packages/codev/src/__tests__/cli/agy-integration.e2e.test.ts
@@ -7,6 +7,14 @@
  * — so the test is a no-op there rather than a failure. When agy is installed
  * and signed in, it provides real acceptance evidence that `consult -m gemini`
  * (agy backend) returns a review that actually used file contents.
+ *
+ * OPT-IN ONLY (#1323). This file is the one place in the suites that means to
+ * spawn the real binary, and a real spawn against a lapsed agy login opens a
+ * browser window per invocation. Without the opt-in the vitest harness pins a
+ * fake agy, which would make these assertions meaningless anyway, so every case
+ * no-ops instead:
+ *
+ *   CODEV_ALLOW_REAL_AGY=1 pnpm --filter @cluesmith/codev test:e2e:cli
  */
 import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'node:child_process';
@@ -14,6 +22,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { resolveAgyBin, _runAgyConsultation } from '../../commands/consult/index.js';
+import { realAgyOptIn } from '../../lib/test-env.js';
 import { CONSULT_BIN } from './helpers.js';
 
 /** A review file is the non-blocking skip artifact (agy unavailable/unauthed/timeout). */
@@ -21,9 +30,14 @@ function isSkip(out: string): boolean {
   return out.includes('VERDICT: COMMENT') && /Skipped/i.test(out);
 }
 
+/** True when a real, usable agy is available AND the suite is allowed to spawn it. */
+function realAgyAvailable(): boolean {
+  return realAgyOptIn() && Boolean(resolveAgyBin());
+}
+
 describe('agy lane integration (guarded; real agy)', () => {
   it('delivers the complete inline prompt under the agy 1.0.10 argument contract', async () => {
-    if (!resolveAgyBin()) return;
+    if (!realAgyAvailable()) return;
 
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agy-print-contract-'));
     try {
@@ -45,8 +59,8 @@ describe('agy lane integration (guarded; real agy)', () => {
   }, 90_000);
 
   it('returns a review that used file contents, or skips non-blockingly', async () => {
-    if (!resolveAgyBin()) {
-      // agy CLI not installed in this environment — nothing to verify.
+    if (!realAgyAvailable()) {
+      // agy CLI not installed, or the real-agy opt-in is off — nothing to verify.
       return;
     }
 
@@ -83,8 +97,8 @@ describe('agy lane integration (guarded; real agy)', () => {
   // agy. Guarded the same way: a missing/unauthed agy yields the non-blocking
   // skip and the assertion is bypassed.
   it('`consult -m gemini --prompt` (real binary) reads files or skips non-blockingly', async () => {
-    if (!resolveAgyBin() || !fs.existsSync(CONSULT_BIN)) {
-      // agy not installed, or the CLI hasn't been built — nothing to verify.
+    if (!realAgyAvailable() || !fs.existsSync(CONSULT_BIN)) {
+      // agy not installed / opt-in off, or the CLI hasn't been built — nothing to verify.
       return;
     }
 

--- a/packages/codev/src/__tests__/cli/agy-integration.e2e.test.ts
+++ b/packages/codev/src/__tests__/cli/agy-integration.e2e.test.ts
@@ -11,8 +11,8 @@
  * OPT-IN ONLY (#1323). This file is the one place in the suites that means to
  * spawn the real binary, and a real spawn against a lapsed agy login opens a
  * browser window per invocation. Without the opt-in the vitest harness pins a
- * fake agy, which would make these assertions meaningless anyway, so every case
- * no-ops instead:
+ * fake agy, which would make these assertions meaningless anyway, so the whole
+ * describe reports as **skipped** — not as passing tests that ran nothing:
  *
  *   CODEV_ALLOW_REAL_AGY=1 pnpm --filter @cluesmith/codev test:e2e:cli
  */
@@ -31,24 +31,26 @@ function isSkip(out: string): boolean {
 }
 
 /**
- * True when a real, usable agy is available AND the suite is allowed to spawn it.
+ * The real agy binary this file is allowed to spawn, or null.
  *
  * This is the no-browser guard PR #1324's `describe.skip` was waiting on, so the
  * skip is lifted and the coverage comes back. #1324 was right that the old
  * "unavailable/unauthed → harmless skip" check only notices the problem *after*
  * the OAuth window is already open — detection can never prevent the window,
- * only not spawning can. The opt-in moves the decision before the spawn: without
- * `CODEV_ALLOW_REAL_AGY` the harness has pinned a fake agy, `realAgyOptIn()` is
- * false, and every case below no-ops without reaching the binary at all.
+ * only not spawning can. The opt-in moves the decision before the spawn.
+ *
+ * Evaluated once, at module scope, and short-circuited on the opt-in: without
+ * `CODEV_ALLOW_REAL_AGY` we never call `resolveAgyBin()` at all — which matters
+ * because resolution is itself guarded and would throw against the harness pin.
+ *
+ * Reported via `skipIf` rather than an early `return`, so the suite says
+ * "skipped" instead of showing three passing tests that executed nothing. That
+ * is what #1324 actually wanted: skipped, but for a named, machine-checked reason.
  */
-function realAgyAvailable(): boolean {
-  return realAgyOptIn() && Boolean(resolveAgyBin());
-}
+const REAL_AGY: string | null = realAgyOptIn() ? resolveAgyBin() : null;
 
-describe('agy lane integration (guarded; real agy)', () => {
+describe.skipIf(!REAL_AGY)('agy lane integration (guarded; real agy)', () => {
   it('delivers the complete inline prompt under the agy 1.0.10 argument contract', async () => {
-    if (!realAgyAvailable()) return;
-
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agy-print-contract-'));
     try {
       const marker = `PRINT_CONTRACT_${Date.now()}`;
@@ -69,10 +71,6 @@ describe('agy lane integration (guarded; real agy)', () => {
   }, 90_000);
 
   it('returns a review that used file contents, or skips non-blockingly', async () => {
-    if (!realAgyAvailable()) {
-      // agy CLI not installed, or the real-agy opt-in is off — nothing to verify.
-      return;
-    }
 
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agy-integ-'));
     try {
@@ -107,8 +105,9 @@ describe('agy lane integration (guarded; real agy)', () => {
   // agy. Guarded the same way: a missing/unauthed agy yields the non-blocking
   // skip and the assertion is bypassed.
   it('`consult -m gemini --prompt` (real binary) reads files or skips non-blockingly', async () => {
-    if (!realAgyAvailable() || !fs.existsSync(CONSULT_BIN)) {
-      // agy not installed / opt-in off, or the CLI hasn't been built — nothing to verify.
+    if (!fs.existsSync(CONSULT_BIN)) {
+      // The CLI hasn't been built — nothing to drive. (The agy opt-in is handled
+      // by the describe-level skipIf, so it reports as a skip rather than a pass.)
       return;
     }
 

--- a/packages/codev/src/__tests__/consult.test.ts
+++ b/packages/codev/src/__tests__/consult.test.ts
@@ -63,6 +63,19 @@ vi.mock('chalk', () => ({
   },
 }));
 
+/**
+ * The sandbox pins installed by the vitest harness (`vitest-setup.ts`), captured
+ * before any test overrides them. Tests restore *these* rather than deleting, so
+ * the fake-agy pin survives for the rest of the file (#1323).
+ */
+const harnessAgyBin = process.env.CODEV_AGY_BIN;
+const harnessAgyAuthCacheDir = process.env.CODEV_AGY_AUTH_CACHE_DIR;
+
+function restoreEnv(key: string, prior: string | undefined): void {
+  if (prior === undefined) delete process.env[key];
+  else process.env[key] = prior;
+}
+
 describe('consult command', () => {
   const testBaseDir = path.join(tmpdir(), `codev-consult-test-${Date.now()}`);
   let originalCwd: string;
@@ -745,8 +758,11 @@ describe('consult command', () => {
     });
 
     afterEach(() => {
-      delete process.env.CODEV_AGY_BIN;
-      delete process.env.CODEV_AGY_AUTH_CACHE_DIR;
+      // Restore, never delete: a bare delete drops the vitest harness's
+      // fake-agy pin for every later test in the file, which is how tests came
+      // to resolve — and spawn — the developer's real agy binary (#1323).
+      restoreEnv('CODEV_AGY_BIN', harnessAgyBin);
+      restoreEnv('CODEV_AGY_AUTH_CACHE_DIR', harnessAgyAuthCacheDir);
     });
 
     async function loadAgy() {
@@ -914,7 +930,7 @@ describe('consult command', () => {
   });
 
   describe('agy binary resolution (resolveAgyBin / isRealAgyCli)', () => {
-    afterEach(() => { delete process.env.CODEV_AGY_BIN; });
+    afterEach(() => { restoreEnv('CODEV_AGY_BIN', harnessAgyBin); });
 
     it('isRealAgyCli accepts a real standalone binary', async () => {
       const { isRealAgyCli } = await import('../commands/consult/index.js');

--- a/packages/codev/src/__tests__/doctor.test.ts
+++ b/packages/codev/src/__tests__/doctor.test.ts
@@ -94,6 +94,22 @@ vi.mock('chalk', () => {
   };
 });
 
+/**
+ * Restore an env var to its captured value, honouring "was unset" (#1323).
+ *
+ * A bare `delete process.env.CODEV_AGY_BIN` drops the vitest harness's fake-agy
+ * pin for the rest of the file, leaving every later `doctor()` call to reach
+ * `verifyAgy()` with nothing pinned. Nothing real spawned here — this file mocks
+ * `node:child_process` wholesale — but that made the file safe *by accident*
+ * rather than by construction: the module mock, not the pin, was doing the work.
+ * Restoring keeps the pin intact so the lane guard stays satisfied on its own
+ * terms.
+ */
+function restoreEnv(key: string, prior: string | undefined): void {
+  if (prior === undefined) delete process.env[key];
+  else process.env[key] = prior;
+}
+
 describe('doctor command', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -217,6 +233,7 @@ describe('doctor command', () => {
 
     it('should return 1 when no AI CLI is available', async () => {
       // Mock all core deps present but no AI CLIs (incl. agy unavailable).
+      const priorAgyBin = process.env.CODEV_AGY_BIN;
       process.env.CODEV_AGY_BIN = path.join(tmpdir(), `no-such-agy-${Date.now()}`);
       vi.mocked(execSync).mockImplementation((cmd: string) => {
         if (cmd.includes('which claude') || cmd.includes('which gemini') || cmd.includes('which codex')) {
@@ -261,7 +278,7 @@ describe('doctor command', () => {
       try {
         result = await doctor();
       } finally {
-        delete process.env.CODEV_AGY_BIN;
+        restoreEnv('CODEV_AGY_BIN', priorAgyBin);
       }
       expect(result).toBe(1);
     });
@@ -861,6 +878,7 @@ describe('doctor command', () => {
       // early stream (not stall for the full timeout), reporting "needs login".
       const agyBin = path.join(testBaseDir, 'agy-fake');
       fs.writeFileSync(agyBin, '#!/bin/sh\n');
+      const priorAgyBin = process.env.CODEV_AGY_BIN;
       process.env.CODEV_AGY_BIN = agyBin;
 
       vi.mocked(execSync).mockImplementation((cmd: string) => {
@@ -897,7 +915,7 @@ describe('doctor command', () => {
         );
         expect(hasNeedsLogin).toBe(true);
       } finally {
-        delete process.env.CODEV_AGY_BIN;
+        restoreEnv('CODEV_AGY_BIN', priorAgyBin);
         vi.mocked(spawn).mockReset();
       }
     });
@@ -905,6 +923,7 @@ describe('doctor command', () => {
     it('passes the probe text immediately after --print and retains the print timeout', async () => {
       const agyBin = path.join(testBaseDir, 'agy-fake');
       fs.writeFileSync(agyBin, '#!/bin/sh\n');
+      const priorAgyBin = process.env.CODEV_AGY_BIN;
       process.env.CODEV_AGY_BIN = agyBin;
 
       vi.mocked(execSync).mockImplementation((cmd: string) => {
@@ -937,7 +956,7 @@ describe('doctor command', () => {
         expect(args.slice(0, printIndex)).toContain('--print-timeout');
         expect(args[args.indexOf('--print-timeout') + 1]).toBe('20s');
       } finally {
-        delete process.env.CODEV_AGY_BIN;
+        restoreEnv('CODEV_AGY_BIN', priorAgyBin);
       }
     });
 

--- a/packages/codev/src/__tests__/test-isolation.test.ts
+++ b/packages/codev/src/__tests__/test-isolation.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Regression tests for #1323 — the test suites must not reach user-global state.
+ *
+ * Two escapes were live before this: any test that touched the gemini consult
+ * lane without pinning `CODEV_AGY_BIN` spawned the developer's real `agy`
+ * (a browser login window per spawn once agy's auth lapsed), and every
+ * in-process test recorded metrics into the real `~/.codev/metrics.db`.
+ *
+ * These tests pin down both the harness (`vitest-setup.ts` really does sandbox
+ * every suite) and the belt-and-braces guards that catch a future test which
+ * slips past it.
+ *
+ * `node:child_process.spawn` is stubbed to throw, so a regression in the guard
+ * surfaces as a failed assertion here rather than as a real agy invocation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const spawnAttempts: unknown[][] = [];
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: vi.fn((...args: unknown[]) => {
+      spawnAttempts.push(args);
+      throw new Error('spawn() must never be reached by these tests');
+    }),
+  };
+});
+
+const AGY_ENV = ['CODEV_AGY_BIN', 'CODEV_ALLOW_REAL_AGY', 'CODEV_METRICS_DB'] as const;
+
+describe('test-suite isolation (#1323)', () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = {};
+    for (const key of AGY_ENV) saved[key] = process.env[key];
+    spawnAttempts.length = 0;
+  });
+
+  afterEach(() => {
+    for (const key of AGY_ENV) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key]!;
+    }
+  });
+
+  describe('the vitest harness sandboxes every suite', () => {
+    it('pins CODEV_AGY_BIN to a fake outside the real agy install locations', () => {
+      const pinned = process.env.CODEV_AGY_BIN;
+      expect(pinned, 'vitest-setup.ts must pin a fake agy for every suite').toBeTruthy();
+      // The two places resolveAgyBin() would otherwise find the real binary.
+      expect(pinned).not.toBe(join(homedir(), '.local', 'bin', 'agy'));
+      expect(pinned!.startsWith(homedir() + '/.local')).toBe(false);
+      expect(existsSync(pinned!)).toBe(true);
+    });
+
+    it('redirects the consult metrics DB away from the user-global path', () => {
+      const pinned = process.env.CODEV_METRICS_DB;
+      expect(pinned, 'vitest-setup.ts must pin a sandbox metrics DB').toBeTruthy();
+      expect(pinned).not.toBe(join(homedir(), '.codev', 'metrics.db'));
+    });
+
+    it('names an agy auth-cache dir, so #1077 burst protection is active in tests', async () => {
+      // agyAuthCacheDisabled() switches itself off under VITEST unless a dir is
+      // named — which is precisely what left burst protection inert for tests.
+      const { agyAuthCacheDisabled, agyAuthCacheDir } = await import('../commands/consult/agy-auth-cache.js');
+      expect(agyAuthCacheDisabled()).toBe(false);
+      expect(agyAuthCacheDir()).not.toBe(join(homedir(), '.cache', 'codev'));
+    });
+  });
+
+  describe('agy lane guard', () => {
+    it('throws instead of resolving a binary when a test forgets to pin one', async () => {
+      const { assertAgyLaneAllowedUnderTest } = await import('../lib/test-env.js');
+      delete process.env.CODEV_AGY_BIN;
+      delete process.env.CODEV_ALLOW_REAL_AGY;
+
+      expect(() => assertAgyLaneAllowedUnderTest()).toThrow(/CODEV_AGY_BIN/);
+    });
+
+    it('stands down when the test pins a binary', async () => {
+      const { assertAgyLaneAllowedUnderTest } = await import('../lib/test-env.js');
+      process.env.CODEV_AGY_BIN = '/definitely/not/real/agy';
+      delete process.env.CODEV_ALLOW_REAL_AGY;
+
+      expect(() => assertAgyLaneAllowedUnderTest()).not.toThrow();
+    });
+
+    it('stands down under the explicit real-agy opt-in', async () => {
+      const { assertAgyLaneAllowedUnderTest } = await import('../lib/test-env.js');
+      delete process.env.CODEV_AGY_BIN;
+      process.env.CODEV_ALLOW_REAL_AGY = '1';
+
+      expect(() => assertAgyLaneAllowedUnderTest()).not.toThrow();
+    });
+
+    it('_runAgyConsultation fails loudly — and spawns nothing — when unpinned', async () => {
+      vi.resetModules();
+      const { _runAgyConsultation } = await import('../commands/consult/index.js');
+      delete process.env.CODEV_AGY_BIN;
+      delete process.env.CODEV_ALLOW_REAL_AGY;
+
+      const dir = mkdtempSync(join(tmpdir(), 'codev-1323-'));
+      try {
+        // The lane's contract is "never throw" — under a test runner that is
+        // deliberately inverted, so a misconfigured suite cannot degrade to a
+        // silent non-blocking skip while spawning the real CLI.
+        await expect(
+          _runAgyConsultation('review this', 'reviewer', dir, join(dir, 'out.txt')),
+        ).rejects.toThrow(/#1323/);
+        expect(spawnAttempts).toHaveLength(0);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('metrics DB isolation', () => {
+    it('opens CODEV_METRICS_DB when set, leaving the user-global DB untouched', async () => {
+      const { MetricsDB } = await import('../commands/consult/metrics.js');
+      const dir = mkdtempSync(join(tmpdir(), 'codev-1323-metrics-'));
+      const dbPath = join(dir, 'metrics.db');
+      process.env.CODEV_METRICS_DB = dbPath;
+
+      try {
+        expect(MetricsDB.defaultPath).toBe(dbPath);
+        const db = new MetricsDB();
+        try {
+          db.record({
+            timestamp: new Date().toISOString(),
+            model: 'gemini',
+            reviewType: null,
+            subcommand: 'general',
+            protocol: 'bugfix',
+            projectId: null,
+            durationSeconds: 0,
+            inputTokens: null,
+            cachedInputTokens: null,
+            outputTokens: null,
+            costUsd: null,
+            exitCode: 0,
+            workspacePath: dir,
+            errorMessage: null,
+          });
+        } finally {
+          db.close();
+        }
+        expect(existsSync(dbPath)).toBe(true);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('refuses the user-global DB under a test runner with no redirect', async () => {
+      const { MetricsDB } = await import('../commands/consult/metrics.js');
+      delete process.env.CODEV_METRICS_DB;
+
+      expect(() => new MetricsDB()).toThrow(/CODEV_METRICS_DB/);
+      expect(() => MetricsDB.defaultPath).toThrow(/CODEV_METRICS_DB/);
+    });
+
+    it('still honours an explicit path argument', async () => {
+      const { MetricsDB } = await import('../commands/consult/metrics.js');
+      delete process.env.CODEV_METRICS_DB;
+
+      const dir = mkdtempSync(join(tmpdir(), 'codev-1323-explicit-'));
+      try {
+        const db = new MetricsDB(join(dir, 'metrics.db'));
+        db.close();
+        expect(existsSync(join(dir, 'metrics.db'))).toBe(true);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/packages/codev/src/commands/consult/__tests__/metrics.test.ts
+++ b/packages/codev/src/commands/consult/__tests__/metrics.test.ts
@@ -509,10 +509,28 @@ describe('Concurrent MetricsDB writes', () => {
 
 // Test 13: Cold start (no DB)
 describe('Cold start with no database', () => {
-  it('MetricsDB.defaultPath points to ~/.codev/metrics.db', () => {
-    const path = MetricsDB.defaultPath;
-    expect(path).toContain('.codev');
-    expect(path).toContain('metrics.db');
+  it('MetricsDB.defaultPath honours CODEV_METRICS_DB', () => {
+    // Under the vitest harness the sandbox redirect is always set, so this is
+    // what defaultPath resolves to in a test run. The old assertion here checked
+    // only for the substrings `.codev` and `metrics.db`, which the sandbox layout
+    // happens to satisfy — so it passed without testing what its name claimed.
+    const redirect = process.env.CODEV_METRICS_DB;
+    expect(redirect, 'vitest-setup.ts must pin a sandbox metrics DB').toBeTruthy();
+    expect(MetricsDB.defaultPath).toBe(redirect);
+  });
+
+  it('MetricsDB.defaultPath refuses the user-global path under a test runner', () => {
+    // The documented production fallback is ~/.codev/metrics.db, but a test
+    // runner must never reach it (#1323) — clearing the redirect is a failure,
+    // not a route back to the developer's real database.
+    const prior = process.env.CODEV_METRICS_DB;
+    delete process.env.CODEV_METRICS_DB;
+    try {
+      expect(() => MetricsDB.defaultPath).toThrow(/CODEV_METRICS_DB/);
+    } finally {
+      if (prior === undefined) delete process.env.CODEV_METRICS_DB;
+      else process.env.CODEV_METRICS_DB = prior;
+    }
   });
 
   it('handleStats prints "No metrics data found" when database does not exist', async () => {

--- a/packages/codev/src/commands/consult/index.ts
+++ b/packages/codev/src/commands/consult/index.ts
@@ -22,6 +22,7 @@ import { MetricsDB } from './metrics.js';
 import { extractUsage, extractReviewText, type SDKResultLike, type UsageData } from './usage-extractor.js';
 import { executeForgeCommandSync } from '../../lib/forge.js';
 import { preflightAgyAuth, recordAgyAuthState, type AgyAuthState } from './agy-auth-cache.js';
+import { assertAgyLaneAllowedUnderTest } from '../../lib/test-env.js';
 
 // Content reference — resolved artifact content with a display label
 interface ContentRef {
@@ -835,6 +836,13 @@ async function runAgyConsultation(
   metricsCtx?: MetricsContext,
 ): Promise<void> {
   const startTime = Date.now();
+
+  // Belt and braces for the test harness (#1323): under a test runner, refuse to
+  // resolve a binary the suite never pinned. Throwing here — rather than falling
+  // through to the non-blocking skip below — is deliberate: a misconfigured test
+  // must fail loudly instead of passing on a machine that happens not to have agy
+  // installed while spawning the real CLI on one that does.
+  assertAgyLaneAllowedUnderTest();
 
   const bin = resolveAgyBin();
   if (!bin) {

--- a/packages/codev/src/commands/consult/index.ts
+++ b/packages/codev/src/commands/consult/index.ts
@@ -746,6 +746,13 @@ export function resolveAgyBin(): string | null {
   const override = process.env.CODEV_AGY_BIN;
   if (override) return isRealAgyCli(override) ? override : null;
 
+  // Past this point we go looking for the developer's real install, so this is
+  // the true chokepoint for the test-isolation guard (#1323) — not the spawn
+  // sites. Resolution is not passive: the PATH branch below runs
+  // `agyRespondsToVersion`, which *executes* the candidate binary. Guarding only
+  // the spawn would still let a suite run the real agy.
+  assertAgyLaneAllowedUnderTest();
+
   // Canonical install path — trusted location; realpath-reject the IDE only.
   const preferred = path.join(homedir(), '.local', 'bin', 'agy');
   if (isRealAgyCli(preferred)) return preferred;
@@ -837,13 +844,11 @@ async function runAgyConsultation(
 ): Promise<void> {
   const startTime = Date.now();
 
-  // Belt and braces for the test harness (#1323): under a test runner, refuse to
-  // resolve a binary the suite never pinned. Throwing here — rather than falling
-  // through to the non-blocking skip below — is deliberate: a misconfigured test
-  // must fail loudly instead of passing on a machine that happens not to have agy
-  // installed while spawning the real CLI on one that does.
-  assertAgyLaneAllowedUnderTest();
-
+  // The test-isolation guard (#1323) lives inside resolveAgyBin, at the point
+  // where an unpinned lookup would reach the real install. It throws rather than
+  // falling through to the non-blocking skip below — deliberately: a misconfigured
+  // test must fail loudly instead of passing on a machine that happens not to have
+  // agy installed while spawning the real CLI on one that does.
   const bin = resolveAgyBin();
   if (!bin) {
     const reason = 'agy CLI not found (install: https://antigravity.google/cli/install.sh)';

--- a/packages/codev/src/commands/consult/metrics.ts
+++ b/packages/codev/src/commands/consult/metrics.ts
@@ -10,9 +10,35 @@ import Database from 'better-sqlite3';
 import { existsSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, dirname } from 'node:path';
+import { isUnderTestRunner } from '../../lib/test-env.js';
 
 const CODEV_DIR = join(homedir(), '.codev');
 const DB_PATH = join(CODEV_DIR, 'metrics.db');
+
+/**
+ * Where metrics actually get written.
+ *
+ * `CODEV_METRICS_DB` redirects the database — the vitest harness points it at a
+ * sandbox so suite runs stop appending junk rows (temp-dir workspace paths, 0.0s
+ * durations) to the developer's real `~/.codev/metrics.db` and skewing
+ * `consult stats` (#1323).
+ *
+ * Under a test runner with no redirect, we refuse rather than fall back: a
+ * future suite that escapes the harness should surface as a failure, not as
+ * silent pollution nobody notices for months.
+ */
+function resolveDbPath(): string {
+  const override = process.env.CODEV_METRICS_DB;
+  if (override) return override;
+  if (isUnderTestRunner()) {
+    throw new Error(
+      'Refusing to open the user-global consult metrics database under a test ' +
+      'runner (#1323). Set CODEV_METRICS_DB to a path inside the test\'s temp ' +
+      'directory — the vitest harness in vitest-setup.ts does this for every suite.',
+    );
+  }
+  return DB_PATH;
+}
 
 const CREATE_TABLE = `
 CREATE TABLE IF NOT EXISTS consultation_metrics (
@@ -166,7 +192,7 @@ export class MetricsDB {
   private db: Database.Database;
 
   constructor(dbPath?: string) {
-    const path = dbPath ?? DB_PATH;
+    const path = dbPath ?? resolveDbPath();
     const dir = dirname(path);
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true, mode: 0o700 });
@@ -375,7 +401,11 @@ export class MetricsDB {
     this.db.close();
   }
 
+  /**
+   * The path `new MetricsDB()` opens. Honours `CODEV_METRICS_DB` so that
+   * `consult stats`' existence check and its subsequent open agree on one file.
+   */
   static get defaultPath(): string {
-    return DB_PATH;
+    return resolveDbPath();
   }
 }

--- a/packages/codev/src/commands/doctor.ts
+++ b/packages/codev/src/commands/doctor.ts
@@ -30,6 +30,7 @@ import {
 } from '../lib/migration-backup-audit.js';
 import { resolveAgyBin, AGY_OAUTH_MARKERS } from './consult/index.js';
 import { checkCachedAgyAuth, recordAgyAuthState } from './consult/agy-auth-cache.js';
+import { assertAgyLaneAllowedUnderTest } from '../lib/test-env.js';
 import { AGENT_FARM_DIR } from '@cluesmith/codev-core/constants';
 import {
   measureSessionLogs,
@@ -486,6 +487,12 @@ function verifyAgy(): Promise<CheckResult> {
   if (cached === 'auth') {
     return Promise.resolve({ status: 'ok', version: 'operational (cached)' });
   }
+
+  // About to spawn for real. The consult lane is not the only way into agy —
+  // `codev doctor` probes it too, so it needs the same test-isolation guard
+  // (#1323): under a test runner with no pinned CODEV_AGY_BIN, fail loudly
+  // rather than open an OAuth browser window from a suite run.
+  assertAgyLaneAllowedUnderTest();
 
   return new Promise<CheckResult>((resolve) => {
     const proc = spawn(bin, ['--print-timeout', '20s', '--print', 'Reply with just OK'], {

--- a/packages/codev/src/commands/doctor.ts
+++ b/packages/codev/src/commands/doctor.ts
@@ -30,7 +30,6 @@ import {
 } from '../lib/migration-backup-audit.js';
 import { resolveAgyBin, AGY_OAUTH_MARKERS } from './consult/index.js';
 import { checkCachedAgyAuth, recordAgyAuthState } from './consult/agy-auth-cache.js';
-import { assertAgyLaneAllowedUnderTest } from '../lib/test-env.js';
 import { AGENT_FARM_DIR } from '@cluesmith/codev-core/constants';
 import {
   measureSessionLogs,
@@ -469,7 +468,13 @@ function checkAgy(): CheckResult {
  * Streams output and detects the OAuth URL on the *early* stream so an
  * unauthenticated agy reports "needs login" promptly (it would otherwise print
  * the URL and wait ~30s) — rather than stalling `codev doctor` for the full
- * auth wait. Always resolves (never throws).
+ * auth wait.
+ *
+ * Resolves rather than rejecting for every agy outcome. The one exception is the
+ * test-isolation guard inside `resolveAgyBin` (#1323), which throws
+ * *synchronously* — before the promise exists — when a suite reaches this path
+ * with no pinned `CODEV_AGY_BIN`. That is intentional loudness, but it means a
+ * caller cannot catch it via `.catch()` on the returned promise.
  *
  * Shares the consult lane's auth cache (#1077): a fresh verdict is reported
  * without probing, so `codev doctor` on an unauthenticated agy does not open yet
@@ -487,12 +492,6 @@ function verifyAgy(): Promise<CheckResult> {
   if (cached === 'auth') {
     return Promise.resolve({ status: 'ok', version: 'operational (cached)' });
   }
-
-  // About to spawn for real. The consult lane is not the only way into agy —
-  // `codev doctor` probes it too, so it needs the same test-isolation guard
-  // (#1323): under a test runner with no pinned CODEV_AGY_BIN, fail loudly
-  // rather than open an OAuth browser window from a suite run.
-  assertAgyLaneAllowedUnderTest();
 
   return new Promise<CheckResult>((resolve) => {
     const proc = spawn(bin, ['--print-timeout', '20s', '--print', 'Reply with just OK'], {

--- a/packages/codev/src/lib/test-env.ts
+++ b/packages/codev/src/lib/test-env.ts
@@ -49,13 +49,34 @@ export function realAgyOptIn(): boolean {
 }
 
 /**
- * Guard the gemini (agy) lane against spawning the real binary from a test.
+ * Guard the gemini (agy) lane against reaching the real binary from a test.
  *
  * Throws when running under a test runner with neither an explicit
  * `CODEV_AGY_BIN` pin nor the real-agy opt-in. Deliberately louder than the
  * lane's usual non-blocking skip: a misconfigured test must fail the suite, not
  * quietly degrade to a COMMENT verdict (which would hide the misconfiguration
  * on a machine where agy simply isn't installed).
+ *
+ * **Where this is called, and why there.** There is exactly one call site:
+ * `resolveAgyBin()`, in the branch taken when `CODEV_AGY_BIN` is unset. That is
+ * the chokepoint — every route to the real binary passes through it, and there
+ * is more than one route:
+ *
+ *   - `runAgyConsultation()` — the consult lane (`consult -m gemini`)
+ *   - `doctor.ts:verifyAgy()` — `codev doctor`'s OAuth probe, a second spawn
+ *     site that issue #1323 did not mention
+ *   - `doctor.ts:checkAgy()` — presence check; does not spawn, but resolution
+ *     itself is not passive
+ *
+ * That last point is the reason the guard sits at resolution rather than at the
+ * spawn sites: the unpinned lookup runs `agyRespondsToVersion()`, which
+ * *executes* the candidate binary with `--version`. Guarding only the spawns
+ * would leave a suite executing the developer's real agy — no browser window
+ * from a version print, but a violation of the invariant all the same.
+ *
+ * Guarding here is safe for the resolution tests because they all pin
+ * `CODEV_AGY_BIN` before calling (they are testing override handling), and
+ * `agy-integration.e2e.test.ts` short-circuits on the opt-in before resolving.
  */
 export function assertAgyLaneAllowedUnderTest(): void {
   if (!isUnderTestRunner()) return;

--- a/packages/codev/src/lib/test-env.ts
+++ b/packages/codev/src/lib/test-env.ts
@@ -17,13 +17,18 @@
 /**
  * True when this process is running under a test runner.
  *
- * `VITEST` is set by the runner; CLI-integration and e2e tests spawn `codev` /
- * `consult` child processes with `{ ...process.env }`, so children inherit it
- * and are covered by the same guards. `CODEV_TEST` is an explicit marker for
- * harnesses that are not vitest.
+ * `VITEST` is set by the runner and covers every suite Codev actually has;
+ * CLI-integration and e2e tests spawn `codev` / `consult` children with
+ * `{ ...process.env }`, so children inherit it and fall under the same guards.
+ *
+ * `CODEV_TEST_ISOLATION` is the opt-in for a harness that is not vitest. It is
+ * deliberately a name Codev owns: these guards make `consult` *throw*, so a
+ * false positive breaks a real consultation. A generic marker like `CODEV_TEST`
+ * or `CI` could already be exported in an adopter's environment for unrelated
+ * reasons, and inheriting someone else's variable is not worth the blast radius.
  */
 export function isUnderTestRunner(): boolean {
-  return Boolean(process.env.VITEST || process.env.CODEV_TEST);
+  return Boolean(process.env.VITEST || process.env.CODEV_TEST_ISOLATION);
 }
 
 /**

--- a/packages/codev/src/lib/test-env.ts
+++ b/packages/codev/src/lib/test-env.ts
@@ -1,0 +1,67 @@
+/**
+ * Test-runner detection and the escape hatches that go with it (#1323).
+ *
+ * Two consult side effects are *user-global*: spawning the real `agy` binary
+ * (which opens a browser login window when agy is unauthenticated) and writing
+ * to `~/.codev/metrics.db`. Both used to be reachable from the test suites by
+ * simple omission — a test that never pinned `CODEV_AGY_BIN` resolved the
+ * developer's real binary, and every in-process test recorded metrics into the
+ * developer's real database.
+ *
+ * The vitest harness (`vitest-setup.ts`) now pins a sandbox for both. These
+ * helpers are the belt-and-braces half: production code consults them so that a
+ * *future* test which slips past the harness fails loudly instead of silently
+ * reaching the real world.
+ */
+
+/**
+ * True when this process is running under a test runner.
+ *
+ * `VITEST` is set by the runner; CLI-integration and e2e tests spawn `codev` /
+ * `consult` child processes with `{ ...process.env }`, so children inherit it
+ * and are covered by the same guards. `CODEV_TEST` is an explicit marker for
+ * harnesses that are not vitest.
+ */
+export function isUnderTestRunner(): boolean {
+  return Boolean(process.env.VITEST || process.env.CODEV_TEST);
+}
+
+/**
+ * Explicit opt-in for deliberately exercising the REAL `agy` binary from a test.
+ *
+ * Unset by default, so no suite can spawn the real CLI by accident. Set it to
+ * run the guarded real-agy integration smoke, or a real-AI e2e benchmark:
+ *
+ *   CODEV_ALLOW_REAL_AGY=1 pnpm --filter @cluesmith/codev test:e2e:cli
+ *
+ * When set, the vitest harness leaves `CODEV_AGY_BIN` alone and the lane guard
+ * stands down — you get the real binary, and the real browser tab if agy's
+ * login has lapsed.
+ */
+export function realAgyOptIn(): boolean {
+  const raw = process.env.CODEV_ALLOW_REAL_AGY;
+  return raw === '1' || raw === 'true';
+}
+
+/**
+ * Guard the gemini (agy) lane against spawning the real binary from a test.
+ *
+ * Throws when running under a test runner with neither an explicit
+ * `CODEV_AGY_BIN` pin nor the real-agy opt-in. Deliberately louder than the
+ * lane's usual non-blocking skip: a misconfigured test must fail the suite, not
+ * quietly degrade to a COMMENT verdict (which would hide the misconfiguration
+ * on a machine where agy simply isn't installed).
+ */
+export function assertAgyLaneAllowedUnderTest(): void {
+  if (!isUnderTestRunner()) return;
+  if (realAgyOptIn()) return;
+  if (process.env.CODEV_AGY_BIN) return;
+  throw new Error(
+    'Refusing to resolve the agy binary under a test runner without a pinned ' +
+    'CODEV_AGY_BIN (#1323). This test reached the gemini consult lane by ' +
+    'omission and would have spawned the real Antigravity CLI — one browser ' +
+    'login window per spawn when agy is unauthenticated. Pin a fake binary ' +
+    '(the vitest harness in vitest-setup.ts does this for every suite), or set ' +
+    'CODEV_ALLOW_REAL_AGY=1 if this test genuinely means to run the real CLI.',
+  );
+}

--- a/packages/codev/vitest-setup.ts
+++ b/packages/codev/vitest-setup.ts
@@ -44,7 +44,18 @@ esac
 exit 0
 `;
 
-const sandbox = mkdtempSync(join(tmpdir(), 'codev-test-sandbox-'));
+/**
+ * setupFiles re-executes for every test file, but with `singleFork` all ~200 unit
+ * files share one process. Creating a sandbox (and registering an exit hook) per
+ * file would mean ~200 temp dirs and ~200 listeners on the same emitter — enough
+ * to trip Node's MaxListenersExceededWarning. Cache on globalThis so the setup is
+ * genuinely one-shot per process.
+ */
+const SANDBOX_KEY = '__codevTestSandbox1323';
+const g = globalThis as Record<string, unknown>;
+const firstRun = typeof g[SANDBOX_KEY] !== 'string';
+if (firstRun) g[SANDBOX_KEY] = mkdtempSync(join(tmpdir(), 'codev-test-sandbox-'));
+const sandbox = g[SANDBOX_KEY] as string;
 
 // Pin the gemini lane to a fake binary. Unconditional by design: a shell that
 // already exports CODEV_AGY_BIN must not be able to feed the real CLI back into
@@ -71,10 +82,12 @@ if (!process.env.CODEV_METRICS_DB) {
   process.env.CODEV_METRICS_DB = join(metricsDir, 'metrics.db');
 }
 
-process.on('exit', () => {
-  try {
-    rmSync(sandbox, { recursive: true, force: true });
-  } catch {
-    // A sandbox we cannot remove is temp-dir litter, never a failed test run.
-  }
-});
+if (firstRun) {
+  process.on('exit', () => {
+    try {
+      rmSync(sandbox, { recursive: true, force: true });
+    } catch {
+      // A sandbox we cannot remove is temp-dir litter, never a failed test run.
+    }
+  });
+}

--- a/packages/codev/vitest-setup.ts
+++ b/packages/codev/vitest-setup.ts
@@ -1,0 +1,80 @@
+/**
+ * Global test harness — sandboxes every user-global side effect a suite can
+ * reach (#1323). Wired into all three vitest configs via `setupFiles`.
+ *
+ * Two escapes motivated this file:
+ *
+ *  1. Any test that reached the gemini consult lane without pinning
+ *     `CODEV_AGY_BIN` resolved the developer's REAL `agy` binary and spawned it.
+ *     With agy's login lapsed that is one browser window per spawn — the #1077
+ *     forkbomb, back through the test path that PR #1250 explicitly scoped out.
+ *  2. In-process tests ran under the developer's real `HOME`, so every
+ *     `recordMetrics()` call appended junk rows (with temp-dir workspace paths)
+ *     to the real `~/.codev/metrics.db`, silently skewing `consult stats`.
+ *
+ * Both are failures of *omission*: safety depended on each test remembering to
+ * opt out. This harness inverts that — the sandbox is on by default and a test
+ * must opt in, explicitly and by name, to touch the real thing.
+ *
+ * Subprocess coverage is free: the CLI helpers spawn `codev` / `consult` with
+ * `{ ...process.env }`, so children inherit these pins. The complementary guards
+ * in `src/lib/test-env.ts` catch anything that still slips past.
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { realAgyOptIn } from './src/lib/test-env.js';
+
+/**
+ * Stand-in for the Antigravity CLI: no network, no browser tab, no OAuth. It
+ * answers `--version` (so `agyRespondsToVersion` accepts it) and appends its
+ * argv to `$CODEV_TEST_AGY_LOG` when set — the hook the isolation canary uses to
+ * prove that no suite invoked the real binary.
+ */
+const FAKE_AGY = `#!/bin/sh
+# Fake agy installed by the Codev vitest harness (#1323). See vitest-setup.ts.
+if [ -n "$CODEV_TEST_AGY_LOG" ]; then
+  printf '%s\\n' "fake-agy $*" >> "$CODEV_TEST_AGY_LOG"
+fi
+case "$1" in
+  --version) echo "codev-fake-agy 0.0.0" ;;
+  *) echo "VERDICT: COMMENT" ;;
+esac
+exit 0
+`;
+
+const sandbox = mkdtempSync(join(tmpdir(), 'codev-test-sandbox-'));
+
+// Pin the gemini lane to a fake binary. Unconditional by design: a shell that
+// already exports CODEV_AGY_BIN must not be able to feed the real CLI back into
+// the suites. CODEV_ALLOW_REAL_AGY is the single, named way through.
+if (!realAgyOptIn()) {
+  const fakeAgy = join(sandbox, 'agy');
+  writeFileSync(fakeAgy, FAKE_AGY, { mode: 0o755 });
+  process.env.CODEV_AGY_BIN = fakeAgy;
+}
+
+// Keep the #1077 auth cache ACTIVE but sandboxed. `agyAuthCacheDisabled()` turns
+// itself off under VITEST unless a directory is named, which is what left burst
+// protection inert for tests; naming one here restores it without writing into
+// the developer's real ~/.cache/codev.
+if (!process.env.CODEV_AGY_AUTH_CACHE_DIR) {
+  process.env.CODEV_AGY_AUTH_CACHE_DIR = join(sandbox, 'agy-auth-cache');
+}
+
+// Mirror the real `~/.codev/metrics.db` layout inside the sandbox so metrics
+// writes land here instead of the user-global database.
+if (!process.env.CODEV_METRICS_DB) {
+  const metricsDir = join(sandbox, '.codev');
+  mkdirSync(metricsDir, { recursive: true, mode: 0o700 });
+  process.env.CODEV_METRICS_DB = join(metricsDir, 'metrics.db');
+}
+
+process.on('exit', () => {
+  try {
+    rmSync(sandbox, { recursive: true, force: true });
+  } catch {
+    // A sandbox we cannot remove is temp-dir litter, never a failed test run.
+  }
+});

--- a/packages/codev/vitest.cli.config.ts
+++ b/packages/codev/vitest.cli.config.ts
@@ -13,6 +13,9 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    // Sandboxes the real agy binary and the user-global metrics DB (#1323).
+    // Spawned CLI children inherit the pins via `{ ...process.env }`.
+    setupFiles: ['./vitest-setup.ts'],
     include: [
       'src/__tests__/cli/*.e2e.test.ts',
     ],

--- a/packages/codev/vitest.config.ts
+++ b/packages/codev/vitest.config.ts
@@ -9,6 +9,8 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    // Sandboxes the real agy binary and the user-global metrics DB (#1323).
+    setupFiles: ['./vitest-setup.ts'],
     pool: 'forks',
     poolOptions: {
       forks: {

--- a/packages/codev/vitest.e2e.config.ts
+++ b/packages/codev/vitest.e2e.config.ts
@@ -7,12 +7,18 @@
  *
  * Run with: npm run test:e2e
  * Prerequisites: npm run build (creates skeleton/ and dist/)
+ *
+ * The porch benchmark drives a real agent that shells out to `consult`. Its
+ * gemini lane runs against the harness's fake agy unless you opt in:
+ *   CODEV_ALLOW_REAL_AGY=1 pnpm --filter @cluesmith/codev test:e2e
  */
 
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    // Sandboxes the real agy binary and the user-global metrics DB (#1323).
+    setupFiles: ['./vitest-setup.ts'],
     include: [
       'src/commands/porch/__tests__/e2e/**/*.test.ts',
       'src/**/*.e2e.test.ts',  // All server-spawning / integration tests


### PR DESCRIPTION
## Summary

Test suites could reach two pieces of user-global state by simple omission: the real `agy` binary (one OAuth browser window per spawn once agy's login lapsed) and `~/.codev/metrics.db`. Both are now sandboxed by default, with loud guards for anything that escapes the sandbox.

Fixes #1323.

## Root Cause

Two independent escapes, both failures of *omission* — safety depended on each test remembering to opt out.

**1. Real agy spawn.** None of the three vitest configs declared `setupFiles` — there was no global test harness at all. `resolveAgyBin()` falls back to `~/.local/bin/agy` and then PATH when `CODEV_AGY_BIN` is unset, so any test reaching the gemini lane without pinning resolved the developer's real binary. `agy-integration.e2e.test.ts` did exactly this by design (it deliberately does not mock `node:child_process`). The #1250 burst protection could not help: `agyAuthCacheDisabled()` turns itself off under `VITEST` unless a cache dir is named, and spawned `consult` children inherit `VITEST` via `setupCliEnv`'s `{ ...process.env }`.

**2. Metrics pollution.** `MetricsDB`'s path was hardcoded to `join(homedir(), '.codev', 'metrics.db')` with no override, so in-process tests running under the real `HOME` appended junk rows with temp-dir workspace paths.

Two corrections to the issue's reading, both verified against the code:

- The 0.0s gemini rows in `consult stats` — including the one carrying `agy timed out producing the review` — come from `consult.test.ts`, which mocks `node:child_process` at module scope. That message is emitted by the test's own fake process, **not** a real agy spawn. So that fingerprint is evidence of escape #2; escape #1 is real but lives in the CLI-integration lane and leaves no metrics rows (its subprocesses run under a sandboxed `HOME`). Both bugs are real, they just aren't the same event.
- `codev doctor`'s `verifyAgy()` is a **second** real-spawn path into agy that the issue didn't mention. It's guarded too.

## Fix

- **`packages/codev/vitest-setup.ts`** (new), wired into all three vitest configs. Pins a fake `agy`, a sandbox auth cache, and a sandbox metrics DB for every suite. CLI children inherit the pins through the environment. Pinning the auth cache also restores #1077 burst protection under test, which was previously inert.
- **`packages/codev/src/lib/test-env.ts`** (new) — belt-and-braces guards applied at both real-spawn sites (`runAgyConsultation` and `doctor.ts:verifyAgy`). Under a test runner with no pinned `CODEV_AGY_BIN` and no opt-in, they **throw** rather than fall through to the lane's usual non-blocking skip: a misconfigured test must fail the suite, not quietly degrade to a COMMENT verdict (which would hide the misconfiguration on a machine where agy simply isn't installed).
- **`CODEV_METRICS_DB`** redirects the metrics database; under a test runner with no redirect, `MetricsDB` refuses rather than falling back. `MetricsDB.defaultPath` honours it too, so `consult stats`' existence check and its subsequent open agree on one file.
- **`CODEV_ALLOW_REAL_AGY=1`** is the single named way to opt back into the real binary.
- Fixed a `delete`-instead-of-restore antipattern in `doctor.test.ts` and `consult.test.ts` that dropped the harness pin for the rest of each file.

## Test Plan

New `test-isolation.test.ts` asserts the harness is really wired, that the lane guard throws when a test forgets to pin, and that `MetricsDB` refuses the user-global path. `spawn()` is stubbed to throw, so a regression fails an assertion instead of invoking the real binary.

**Canary** (acceptance criterion 1) — temporarily instrumented `resolveAgyBin()` to log every resolution and the `MetricsDB` constructor to log every path, then ran both suites. Instrumentation removed before commit.

- **Every** `resolveAgyBin()` call across both suites had `override=` set to a temp-dir fake. Zero calls with no override — and no override is the only path to `~/.local/bin/agy` or PATH.
- **Zero** `MetricsDB` opens against `~/.codev/metrics.db` (19 opens, all sandbox or explicit test paths).
- Unit: 205 files / 4085 tests pass. CLI-integration: 8 files / 91 tests pass.
- #1250 burst/regression tests pass unchanged.

⚠️ **Row-count delta on `~/.codev/metrics.db` is not a valid instrument on a shared machine** and I initially mis-read it as my fix failing intermittently. The DB is user-global; ~34 sibling builder worktrees and 100+ concurrent vitest processes were writing to it. The count rose by 64 between two of my runs with no test run of mine in between. Instrumenting the code path is what actually answers the question.

## Note for the reviewer: this re-enables PR #1324

The merge conflict in `agy-integration.e2e.test.ts` was resolved by **re-enabling** the suite (`describe`, not `describe.skip`), per the architect's instruction to make restoring that coverage part of this fix. #1324's stated re-enable condition — "once the suite pins a fake agy (or an equivalent no-browser guard)" — is what landed here. Flagging it explicitly since this undoes a hotfix that is only minutes old.

## Scope

618 insertions / 18 deletions, but production code is ~116 LOC across four files (`test-env.ts` +67, `metrics.ts` +34, `consult/index.ts` +8, `doctor.ts` +7). The remainder is the regression test (182), the harness (80), the builder thread (108), and docs. Single-concern and contained, so I did not escalate — flagging the raw number since it exceeds the 300-LOC guideline.

`spec-1280-measurement-instrument.test.ts` failed intermittently during this work. Not related: it shells out to `measure-prompt-surface.sh` (~2.0s per call, 2-3 calls per test, 5s default timeout) under heavy machine load. A back-to-back A/B against a clean clone of `main` had both trees pass with identical duration (23.79s vs 23.71s). Left untouched.

## Behavior change worth knowing about

**Porch benchmark (e2e).** The benchmark drives a real agent that shells out to `consult`. Its gemini lane now runs against the harness's fake agy by default, so that lane returns an instant COMMENT instead of a real review. This is a step change in benchmark trends — if you're comparing runs across this commit, that's why. Restore the old behavior with `CODEV_ALLOW_REAL_AGY=1 pnpm --filter @cluesmith/codev test:e2e`.

**Adopters.** `VITEST` is exported by *any* vitest run, including a downstream project's. A suite that deliberately shells out to `consult -m gemini` now throws until it sets `CODEV_ALLOW_REAL_AGY=1`. Intentional — a suite reaching the real agy is what this issue was about — but it's a behavior change, and the error names the variable to set. Documented in `consult.md` in both trees.

## Review response

CMAP: gemini APPROVE / codex APPROVE / claude APPROVE (all HIGH). Architect integration review requested two changes, both landed:

- The test-isolation guard moved **inside `resolveAgyBin()`**'s no-override branch — the single chokepoint covering `runAgyConsultation`, `verifyAgy`, and `checkAgy`. Guarding only the spawn sites was insufficient because the unpinned lookup runs `agyRespondsToVersion()`, which *executes* the candidate binary.
- `describe.skipIf` on `agy-integration.e2e.test.ts`, so the three opt-in cases report as **skipped** rather than as passing tests that ran nothing (CLI suite: 91 passed → 88 passed / 3 skipped).

Declined one optional item — `setupFiles` for `packages/core` and `packages/artifact-canvas` — because neither references consult, agy, or `MetricsDB`, and wiring codev's harness into them would invert the workspace dependency. Reasoning in the PR comment.

Out of scope, filed separately as #1326: `~/.agent-farm/global.db` has no env override, so the harness cannot pin it.

## Carried fix: pre-existing CI flake in `spec-1280-measurement-instrument.test.ts`

Not caused by this PR, but it blocks CI on this branch, so the fix is carried here via a merge of `origin/hotfix/1280-test-timeouts` (commit `216b7932`) rather than a duplicate change.

That file shells out to `scripts/measure-prompt-surface.sh`, which I measured at ~2.0-2.5s per invocation. Cases that call it two or three times run 4-9s against vitest's 5s default timeout — deterministically over budget on a loaded runner. The hotfix gives the 12 script-shelling cases explicit 60s budgets, including `honours PHASE_ITERS as a comparison constant` (line 303), which invokes the script twice.

Verified on this branch after the merge: 20/20 pass in 26.65s with 106 concurrent vitest processes on the machine.
