### PR TITLE
fix(test): stop pinning live-measured totals; assert instrument correctness three ways

### DIFF
--- a/packages/codev/src/__tests__/spec-1280-measurement-instrument.test.ts
+++ b/packages/codev/src/__tests__/spec-1280-measurement-instrument.test.ts
@@ -130,7 +130,7 @@ describe('T1b — per-file four-tier resolution, not directory-level selection',
     const out = run(dir);
     // Directory-level selection would have missed the override entirely.
     expect(out).toMatch(/\| spir \| \d+ \| 8 \| \d+ \|/);
-  });
+  }, 60_000);
 
   it('prefers .codev/ over codev/ over codev-skeleton/', () => {
     const src = fs.readFileSync(script, 'utf-8');
@@ -154,7 +154,7 @@ describe('T2 — phantom-savings proof: includes are expanded', () => {
     fs.writeFileSync(path.join(dir, 'codev-skeleton/protocols/spir/templates/frag.md'), 'cc dd ee\n');
 
     expect(num(run(dir), 'ALWAYS_ON_WORDS')).toBe(before);
-  });
+  }, 60_000);
 
   it('expands non-markdown includes too — protocol.json delivery depends on it (P6)', () => {
     const dir = makeFixture();
@@ -169,7 +169,7 @@ describe('T2 — phantom-savings proof: includes are expanded', () => {
     );
     // The JSON's words must appear in the served count, not vanish.
     expect(num(run(dir), 'ALWAYS_ON_WORDS')).toBeGreaterThan(before);
-  });
+  }, 60_000);
 });
 
 describe('T3 — per-surface reporting completeness (not a ceiling)', () => {
@@ -189,11 +189,11 @@ describe('T3 — per-surface reporting completeness (not a ceiling)', () => {
         new RegExp(`^\\| ${name} \\|`, 'm'),
       );
     }
-  });
+  }, 60_000);
 
   it('includes codev-only protocols with no skeleton twin (release)', () => {
     expect(run()).toMatch(/^\| release \|/m);
-  });
+  }, 60_000);
 });
 
 describe('T11 — buckets vs audience loads are reported on different bases', () => {
@@ -202,7 +202,7 @@ describe('T11 — buckets vs audience loads are reported on different bases', ()
     expect(out).toContain('ALWAYS_ON(builder,p,I)   = SHARED + BUILDER_SPAWN[p]');
     expect(out).toMatch(/OVERLAP by design/);
     expect(out).toMatch(/these SUM/);
-  });
+  }, 60_000);
 
   it('one bucket growing while another shrinks shows BOTH movements, not a netted zero', () => {
     const dir = makeFixture();
@@ -219,7 +219,7 @@ describe('T11 — buckets vs audience loads are reported on different bases', ()
 
     expect(sharedAfter).toBeLessThan(sharedBefore);
     expect(archAfter).toBeGreaterThan(archBefore);
-  });
+  }, 60_000);
 });
 
 describe('T15 — relocation is visible, never reported as deletion (M0c)', () => {
@@ -236,7 +236,7 @@ describe('T15 — relocation is visible, never reported as deletion (M0c)', () =
     const after = run(dir);
     expect(num(after, 'ALWAYS_ON_WORDS')).toBeLessThan(num(before, 'ALWAYS_ON_WORDS'));
     expect(num(after, 'TOTAL_AUTHORED_WORDS')).toBe(num(before, 'TOTAL_AUTHORED_WORDS'));
-  });
+  }, 60_000);
 
   it('counts all four skill trees — one-tree counting would report relocation as deletion', () => {
     const src = fs.readFileSync(script, 'utf-8');
@@ -271,18 +271,18 @@ describe('portability — the count must not depend on the host', () => {
     const utf8 = num(run(repoRoot, { LC_ALL: 'en_US.UTF-8' }), 'ALWAYS_ON_WORDS');
     const c = num(run(repoRoot, { LC_ALL: 'C' }), 'ALWAYS_ON_WORDS');
     expect(c).toBe(utf8);
-  });
+  }, 60_000);
 });
 
 describe('T12 — determinism', () => {
   it('emits byte-identical output twice at the same commit', () => {
     expect(run()).toBe(run());
-  });
+  }, 60_000);
 });
 
 describe('the corrected baseline is what the spec claims', () => {
   let out: string;
-  beforeAll(() => { out = run(); });
+  beforeAll(() => { out = run(); }, 60_000);
 
   it('reproduces ALWAYS_ON_WORDS = 34,231 for a SPIR builder at I=10', () => {
     // 34,231 — not the 34,255 quoted in the spec. Two corrections, both making the
@@ -304,5 +304,5 @@ describe('the corrected baseline is what the spec claims', () => {
     const one = num(run(repoRoot, { PHASE_ITERS: '1' }), 'ALWAYS_ON_WORDS');
     const two = num(run(repoRoot, { PHASE_ITERS: '2' }), 'ALWAYS_ON_WORDS');
     expect(two - one).toBe(736 + 1396); // HOT + spir phase mean
-  });
+  }, 60_000);
 });

--- a/packages/codev/src/__tests__/spec-1280-measurement-instrument.test.ts
+++ b/packages/codev/src/__tests__/spec-1280-measurement-instrument.test.ts
@@ -280,29 +280,93 @@ describe('T12 — determinism', () => {
   });
 });
 
-describe('the corrected baseline is what the spec claims', () => {
+describe('instrument correctness — asserted without pinning the live surface', () => {
+  // WHY THERE ARE NO LIVE ABSOLUTE NUMBERS IN THIS FILE
+  //
+  // The original form asserted `ALWAYS_ON_WORDS === 34231` against the REAL repo. That fires
+  // on every always-on edit by every project — Spec 1307 hit it on day one, correctly checked
+  // causality and bumped it. But the incentive it creates for the NEXT project is
+  // bump-without-checking, which is exactly the regression this test exists to catch: the
+  // number moves for two different reasons (the instrument broke / the surface changed) and
+  // the test cannot tell them apart, so it delegates that judgement to whoever is least able
+  // to spend time on it.
+  //
+  // Three layers replace it, none of which a legitimate surface edit can disturb:
+  //   1. INVARIANTS on the live repo — the composition arithmetic, true at any surface size.
+  //   2. ABSOLUTE values on a synthetic FIXTURE — pins the instrument's correctness without
+  //      pinning the repo's content. This is what invariants alone cannot do: a component
+  //      that is silently wrong (say SHARED omitting the hot tier) still satisfies every
+  //      internal identity, because the wrong value propagates consistently.
+  //   3. BYTE-assertions on the frozen baseline artifacts — historical record, and editing
+  //      one should be a deliberate act.
+  //
+  // Live absolute numbers belong in the phase manifests and generated artifacts, where a
+  // human reads them as findings rather than maintaining them as expectations.
+
   let out: string;
-  beforeAll(() => { out = run(); });
+  beforeAll(() => { out = run(); }, 60_000);
 
-  it('reproduces ALWAYS_ON_WORDS = 34,231 for a SPIR builder at I=10', () => {
-    // 34,231 — not the 34,255 quoted in the spec. Two corrections, both making the
-    // instrument more honest and neither moving an acceptance criterion (size is
-    // reporting-only under the amended charter):
-    //   -20  the 1252 additive include model counted a `{{> path}}` directive's own
-    //        tokens AND the content substituted for them; this one substitutes.
-    //    -4  `wc -w` is not portable: BSD wc in a UTF-8 locale splits `⚠️` into two
-    //        words where GNU wc and Python's split() see one. Counting is now
-    //        defined explicitly rather than delegated to the platform's wc.
-    expect(num(out, 'ALWAYS_ON_WORDS')).toBe(34231);
+  describe('layer 1 — invariants over the live repo (hold at any surface size)', () => {
+    it('ALWAYS_ON = SHARED + BUILDER_SPAWN[spir] + I x (HOT + PHASE mean[spir])', () => {
+      const shared = Number(out.match(/\| SHARED [^|]*\| (\d+) \|/)![1]);
+      const spir = out.match(/^\| spir \| (\d+) \| (\d+) \| \d+ \|$/m)!;
+      const hot = Number(out.match(/lessons-critical\(\d+\) = (\d+)/)![1]);
+      expect(num(out, 'ALWAYS_ON_WORDS')).toBe(
+        shared + Number(spir[1]) + 10 * (hot + Number(spir[2])),
+      );
+    });
+
+    it('architect load = SHARED + ARCHITECT', () => {
+      const shared = Number(out.match(/\| SHARED [^|]*\| (\d+) \|/)![1]);
+      const architect = Number(out.match(/\| ARCHITECT [^|]*\| (\d+) \|/)![1]);
+      expect(Number(out.match(/\| Architect \(per session\) \| (\d+) \|/)![1])).toBe(
+        shared + architect,
+      );
+    });
+
+    it('PHASE_ITERS is a linear comparison constant', () => {
+      const one = num(run(repoRoot, { PHASE_ITERS: '1' }), 'ALWAYS_ON_WORDS');
+      const two = num(run(repoRoot, { PHASE_ITERS: '2' }), 'ALWAYS_ON_WORDS');
+      const spir = out.match(/^\| spir \| \d+ \| (\d+) \| \d+ \|$/m)!;
+      const hot = Number(out.match(/lessons-critical\(\d+\) = (\d+)/)![1]);
+      expect(two - one).toBe(hot + Number(spir[1]));
+    }, 60_000);
   });
 
-  it('reproduces the architect load (8,599)', () => {
-    expect(out).toMatch(/\| Architect \(per session\) \| 8599 \|/);
+  describe('layer 2 — absolute values on a fixture whose arithmetic a human can check', () => {
+    // Fixture contents (see makeFixture): CLAUDE.md 3 words, hot tier 2+2, builder role 3,
+    // spir wrapper 3, spir protocol.md 4, one spir prompt 5, consultant role 2, one
+    // consult-type 2, architect role 3.
+    //   SHARED  = 3 + 4                     =   7
+    //   SPAWN   = 3 + 3 + 4                 =  10
+    //   ALWAYS_ON = 7 + 10 + 10 x (4 + 5)   = 107
+    it('reports the hand-computed total for a known surface', () => {
+      const out2 = run(makeFixture());
+      expect(num(out2, 'ALWAYS_ON_WORDS')).toBe(107);
+    }, 60_000);
+
+    it('reports the hand-computed architect and consultant loads', () => {
+      const out2 = run(makeFixture());
+      expect(out2).toMatch(/\| Architect \(per session\) \| 10 \|/);
+      expect(out2).toMatch(/\| Consultant \(per review, spir\) \| 4 \|/);
+    }, 60_000);
+
+    it('a component silently omitted would fail here even though invariants still hold', () => {
+      // The blind spot invariants cannot see: drop the hot tier from SHARED and every
+      // internal identity still balances, because the wrong value propagates consistently.
+      // Only an externally-known expected value catches it.
+      const out2 = run(makeFixture());
+      expect(Number(out2.match(/\| SHARED [^|]*\| (\d+) \|/)![1])).toBe(7);
+    }, 60_000);
   });
 
-  it('honours PHASE_ITERS as a comparison constant', () => {
-    const one = num(run(repoRoot, { PHASE_ITERS: '1' }), 'ALWAYS_ON_WORDS');
-    const two = num(run(repoRoot, { PHASE_ITERS: '2' }), 'ALWAYS_ON_WORDS');
-    expect(two - one).toBe(736 + 1396); // HOT + spir phase mean
+  describe('layer 3 — the frozen baseline artifacts are historical records', () => {
+    it('the pre-rewrite baseline still records 34,231', () => {
+      const baseline = fs.readFileSync(
+        path.join(repoRoot, 'codev/resources/1280-word-baseline.md'),
+        'utf-8',
+      );
+      expect(baseline).toMatch(/^ALWAYS_ON_WORDS=34231$/m);
+    });
   });
 });


### PR DESCRIPTION
## Stop pinning live-measured totals in the instrument tests

Routed from the architect after **Spec 1307** hit this on day one.

### The problem with the current form

The reproduction tests assert `ALWAYS_ON_WORDS === 34231` against the **real repo**, so *every
always-on edit by every project* fires them. 1307 handled it exactly right — causal check, then
a justified bump with the derivation preserved.

But the incentive it creates for the *next* project is **bump-without-checking**, which is the
regression the test exists to catch. The number moves for two different reasons — the instrument
broke, or the surface changed — and the test cannot distinguish them, so it delegates that
judgement to whoever is least placed to spend time on it.

### Three layers replace it

None can be disturbed by a legitimate surface edit:

1. **Invariants over the live repo** — the composition arithmetic, true at any surface size:
   `ALWAYS_ON = SHARED + BUILDER_SPAWN[spir] + I × (HOT + PHASE mean)`, `architect = SHARED +
   ARCHITECT`, and `PHASE_ITERS` linearity.
2. **Absolute values on a synthetic fixture** whose arithmetic a human can check by hand —
   `SHARED 7`, `SPAWN 10`, `ALWAYS_ON 107`. This pins the **instrument's** correctness without
   pinning the **repo's** content.
3. **Byte-assertion on the frozen baseline artifact** — a historical record; editing it should
   be a deliberate act.

### Why layer 2 isn't redundant — verified by mutation, not argued

Invariants have a blind spot: a component that is silently wrong still satisfies every internal
identity, because the wrong value propagates consistently.

Mutating the script to drop `HOT` from `SHARED` — a real instrument bug:

| Layer | Result under mutation |
|---|---|
| 1 — invariants | **all three PASS** |
| 2 — fixture absolutes | **all three FAIL** |

Invariants alone would have shipped it. (The pre-existing T1 structural test also fires here,
but only because it pattern-matches the `SHARED=` source line — it would not catch a component
bug that resolves the wrong file.)

### Verified in the other direction too

Adding 44 words to `CLAUDE.md` — the exact edit shape that fired the old assertion — keeps all
**24 tests green**. No unrelated builder is asked to bump a number they don't own.

### Where live numbers go instead

Into the phase manifests and generated artifacts, where a human reads them as **findings**
rather than maintaining them as **expectations**.

### Note

Branched off `d42a061a`. 1307's interim bump (34293/8661) is **not** on `origin/main` as of this
branch point — `main` still reads `toBe(34231)` — so there is no conflict to resolve here. If
that bump lands separately it will conflict with this file; happy to rebase.
