### PR TITLE
Fix #759: pr-search includes all PR states so merged PRs are found

### DIFF
--- a/.claude/skills/codev/SKILL.md
+++ b/.claude/skills/codev/SKILL.md
@@ -57,3 +57,34 @@ codev doctor
 - `codev init` creates a new directory — use `codev adopt` for existing projects
 - Always run `codev adopt` and `codev update` from the project root
 - `codev update` only updates framework files — it never touches specs/plans/reviews
+
+## Local build and install (this repository)
+
+Test changes locally before publishing. Run from the repository root:
+
+```bash
+pnpm build                  # builds core first, then codev (including dashboard)
+pnpm -w run local-install   # packs both packages, installs globally, restarts Tower
+```
+
+`local-install` (`scripts/local-install.sh`) packs `@cluesmith/codev-core` and
+`@cluesmith/codev`, installs both in a single `npm install -g` (separate installs fail —
+`codev-core` is not on the public registry), restores the executable bit on
+`scripts/forge/**/*.sh` that `pnpm pack` strips, and restarts Tower last. Install runs while
+Tower is up; only the final restart causes downtime. **Do not stop Tower first**, and do not use
+`npm link` / `pnpm link` — it breaks global installs.
+
+`pnpm build` also runs `copy-skeleton`, which copies `codev-skeleton/` into
+`packages/codev/skeleton`. **Tests read that copy**, so after editing anything under
+`codev-skeleton/` you must rebuild before the suite reflects your change.
+
+### Where to run things
+
+- `pnpm install` — repository root (installs all workspace packages)
+- `pnpm build` / `pnpm test` — `packages/codev/`, or `pnpm --filter @cluesmith/codev build`
+- Unit tests `packages/codev/tests/unit/` · E2E `packages/codev/tests/e2e/`
+- Never run npm commands from the repository root unless told to
+
+### Measuring code size
+
+`tokei -e "tests/lib" -e "node_modules" -e ".git" -e ".builders" -e "dist" .`

--- a/.claude/skills/runnable-worktrees/SKILL.md
+++ b/.claude/skills/runnable-worktrees/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: runnable-worktrees
+description: Make builder worktrees runnable — the `.codev/config.json` `worktree` block (symlinks, postSpawn, devCommand), the `afx dev` CLI, VSCode dev controls, and per-stack config recipes. Use when configuring a repo so reviewers can run a builder's branch, when `afx dev` fails to bind or start, when a dev process is orphaned holding a port, or when asked why worktree dev uses the same ports as main.
+---
+
+# Runnable worktrees
+
+When configured, each builder worktree (`.builders/<id>/`) becomes runnable: reviewers can run
+whatever your dev command starts — a dev server, `cargo run`, `expo start`, a test watcher, a
+build script — against the builder's branch without `cd`'ing, installing, or hunting for the
+command. Opt-in via `.codev/config.json`; unconfigured repos see zero behavior change.
+
+## Config: the `worktree` block
+
+```jsonc
+{
+  "worktree": {
+    "symlinks":   ["..."],   // globs symlinked from the workspace root into each new worktree
+    "postSpawn":  ["..."],   // shell commands run inside each new worktree after createWorktree
+    "devCommand": "..."      // consumed by `afx dev <builder-id|main>`
+  }
+}
+```
+
+- **`symlinks`** — globs resolve from the workspace root and link into the worktree at the same
+  relative path. Root `.env` and `.codev/config.json` are *always* symlinked regardless.
+  **Symlinks, not copies**, so edits to main's env files reflect instantly in a running dev
+  session. A directory match is silently skipped (a glob cannot mask the worktree's own source)
+  **unless** the entry ends in a slash: `".local-user-data/"` is treated as a literal path and
+  links the directory whole — shared with the parent, not branch-isolated. A dangling link is
+  fine if the source does not exist yet.
+- **`postSpawn`** — commands run sequentially with `cwd` = worktree path. A non-zero exit aborts
+  the spawn loudly; the half-built worktree stays for inspection.
+- **`devCommand`** — the foreground command that starts your dev process. Required for
+  `afx dev`.
+
+**Codev does not auto-detect your stack.** Pick a recipe below.
+
+## CLI
+
+```bash
+afx dev <builder-id>     # start dev in that builder's worktree
+afx dev main             # start dev in the MAIN workspace (Codev-managed)
+afx dev --stop           # stop the running dev PTY (builder or main)
+afx setup <builder-id>   # re-apply symlinks + postSpawn to an existing worktree (idempotent)
+```
+
+**One dev PTY at a time**, across {main + all builders} — deliberate; see *URLs are
+load-bearing*. `main` is a reserved target running `worktree.devCommand` in the main checkout as
+a Codev-managed, swappable PTY, symmetric with builders. Starting a second target prompts to
+swap; a same-target request prints the existing terminal URL and exits. Dev PTYs are
+**non-persistent** — a Tower restart or crash kills them; re-run to restart.
+
+**Start main's dev with `afx dev main`, not a bare `pnpm dev`.** A hand-run `pnpm dev` is
+invisible to Codev (which never kills what it did not spawn), so a builder dev started while it
+holds the ports either fails to bind or — worse — serves main's code under the worktree URL.
+`afx dev main` makes it a managed PTY that swap-detection can stop cleanly. This only helps if
+used consistently.
+
+## VSCode
+
+Right-click a builder row in the Codev sidebar (Builders or Needs Attention):
+
+- **Open Builder Terminal** — that builder's AI terminal in a tab (same as left-click).
+- **Open Worktree Folder** — `.builders/<id>/` in the OS file manager.
+- **Run Worktree Setup** — re-applies `worktree.symlinks` and `worktree.postSpawn` to an
+  existing worktree (the git steps are skipped). Idempotent. Use when the lockfile changed, when
+  `symlinks`/`postSpawn` grew after the builder spawned, when a link was deleted, or when the
+  original setup aborted. Streams install output in a fresh terminal. CLI: `afx setup <id>`.
+- **View Diff** — unified `main...HEAD` diff for that worktree with a file-list pane.
+- **Run Dev** / **Stop Dev** — spawn or kill the dev PTY as a `Codev: <name> (dev)` tab;
+  prompts to swap if another dev is running.
+
+The sidebar's **Workspace** view carries a dev control for whatever folder the window is rooted
+at — the main checkout resolves to `main`, a `.builders/<id>/` window resolves to that builder.
+The row tooltip names the resolved target. Commands are also in the palette (Cmd+Shift+P); no
+default keybindings.
+
+## URLs are load-bearing
+
+The dev PTY intentionally uses **the same ports and URLs as main**. OAuth callbacks, CORS
+allowlists, cookie scoping, CSP `connect-src` and webhook URLs are all keyed off origin, so
+running a worktree on a different port would break them.
+
+Consequence: stop main's dev before starting a builder's, or the spawned dev fails at bind time
+with `EADDRINUSE`.
+
+## Cleanup and orphan recovery
+
+`afx dev --stop` and the swap path kill the entire PTY **process group** (SIGTERM, then SIGKILL
+after 5s), which signals every grandchild of a monorepo orchestrator (`pnpm dev`, `turbo dev`,
+`pnpm -r --parallel run dev`) at once. Ports are reclaimed by the OS as a consequence — Codev
+never manipulates ports directly.
+
+If Tower hard-crashes mid-dev and a process is left holding a port outside Codev's records:
+
+```bash
+lsof -ti :<port> | xargs kill
+lsof -ti :3000,:3001,:4000 | xargs kill
+```
+
+## Recipes
+
+**pnpm monorepo (Next.js / Turbo)**
+```json
+{"worktree": {"symlinks": [".env.local", ".env.development.local", "packages/*/.env", "packages/*/.env.local", "turbo.json"], "postSpawn": ["pnpm install --frozen-lockfile"], "devCommand": "pnpm dev"}}
+```
+
+**npm** — `{"symlinks": [".env.local", ".env.development"], "postSpawn": ["npm ci"], "devCommand": "npm run dev"}`
+
+**yarn** — `{"symlinks": [".env.local"], "postSpawn": ["yarn install --frozen-lockfile"], "devCommand": "yarn dev"}`
+
+**bun** — `{"symlinks": [".env.local"], "postSpawn": ["bun install --frozen-lockfile"], "devCommand": "bun dev"}`
+
+**cargo** — `{"symlinks": [".env"], "postSpawn": [], "devCommand": "cargo run"}`
+
+**poetry / uv** — `{"symlinks": [".env", ".env.local"], "postSpawn": ["uv sync"], "devCommand": "uv run python -m myapp"}`
+
+**go mod** — `{"symlinks": [".env"], "postSpawn": ["go mod download"], "devCommand": "go run ./cmd/server"}`

--- a/.codex/skills/codev/SKILL.md
+++ b/.codex/skills/codev/SKILL.md
@@ -57,3 +57,34 @@ codev doctor
 - `codev init` creates a new directory — use `codev adopt` for existing projects
 - Always run `codev adopt` and `codev update` from the project root
 - `codev update` only updates framework files — it never touches specs/plans/reviews
+
+## Local build and install (this repository)
+
+Test changes locally before publishing. Run from the repository root:
+
+```bash
+pnpm build                  # builds core first, then codev (including dashboard)
+pnpm -w run local-install   # packs both packages, installs globally, restarts Tower
+```
+
+`local-install` (`scripts/local-install.sh`) packs `@cluesmith/codev-core` and
+`@cluesmith/codev`, installs both in a single `npm install -g` (separate installs fail —
+`codev-core` is not on the public registry), restores the executable bit on
+`scripts/forge/**/*.sh` that `pnpm pack` strips, and restarts Tower last. Install runs while
+Tower is up; only the final restart causes downtime. **Do not stop Tower first**, and do not use
+`npm link` / `pnpm link` — it breaks global installs.
+
+`pnpm build` also runs `copy-skeleton`, which copies `codev-skeleton/` into
+`packages/codev/skeleton`. **Tests read that copy**, so after editing anything under
+`codev-skeleton/` you must rebuild before the suite reflects your change.
+
+### Where to run things
+
+- `pnpm install` — repository root (installs all workspace packages)
+- `pnpm build` / `pnpm test` — `packages/codev/`, or `pnpm --filter @cluesmith/codev build`
+- Unit tests `packages/codev/tests/unit/` · E2E `packages/codev/tests/e2e/`
+- Never run npm commands from the repository root unless told to
+
+### Measuring code size
+
+`tokei -e "tests/lib" -e "node_modules" -e ".git" -e ".builders" -e "dist" .`

--- a/.codex/skills/runnable-worktrees/SKILL.md
+++ b/.codex/skills/runnable-worktrees/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: runnable-worktrees
+description: Make builder worktrees runnable — the `.codev/config.json` `worktree` block (symlinks, postSpawn, devCommand), the `afx dev` CLI, VSCode dev controls, and per-stack config recipes. Use when configuring a repo so reviewers can run a builder's branch, when `afx dev` fails to bind or start, when a dev process is orphaned holding a port, or when asked why worktree dev uses the same ports as main.
+---
+
+# Runnable worktrees
+
+When configured, each builder worktree (`.builders/<id>/`) becomes runnable: reviewers can run
+whatever your dev command starts — a dev server, `cargo run`, `expo start`, a test watcher, a
+build script — against the builder's branch without `cd`'ing, installing, or hunting for the
+command. Opt-in via `.codev/config.json`; unconfigured repos see zero behavior change.
+
+## Config: the `worktree` block
+
+```jsonc
+{
+  "worktree": {
+    "symlinks":   ["..."],   // globs symlinked from the workspace root into each new worktree
+    "postSpawn":  ["..."],   // shell commands run inside each new worktree after createWorktree
+    "devCommand": "..."      // consumed by `afx dev <builder-id|main>`
+  }
+}
+```
+
+- **`symlinks`** — globs resolve from the workspace root and link into the worktree at the same
+  relative path. Root `.env` and `.codev/config.json` are *always* symlinked regardless.
+  **Symlinks, not copies**, so edits to main's env files reflect instantly in a running dev
+  session. A directory match is silently skipped (a glob cannot mask the worktree's own source)
+  **unless** the entry ends in a slash: `".local-user-data/"` is treated as a literal path and
+  links the directory whole — shared with the parent, not branch-isolated. A dangling link is
+  fine if the source does not exist yet.
+- **`postSpawn`** — commands run sequentially with `cwd` = worktree path. A non-zero exit aborts
+  the spawn loudly; the half-built worktree stays for inspection.
+- **`devCommand`** — the foreground command that starts your dev process. Required for
+  `afx dev`.
+
+**Codev does not auto-detect your stack.** Pick a recipe below.
+
+## CLI
+
+```bash
+afx dev <builder-id>     # start dev in that builder's worktree
+afx dev main             # start dev in the MAIN workspace (Codev-managed)
+afx dev --stop           # stop the running dev PTY (builder or main)
+afx setup <builder-id>   # re-apply symlinks + postSpawn to an existing worktree (idempotent)
+```
+
+**One dev PTY at a time**, across {main + all builders} — deliberate; see *URLs are
+load-bearing*. `main` is a reserved target running `worktree.devCommand` in the main checkout as
+a Codev-managed, swappable PTY, symmetric with builders. Starting a second target prompts to
+swap; a same-target request prints the existing terminal URL and exits. Dev PTYs are
+**non-persistent** — a Tower restart or crash kills them; re-run to restart.
+
+**Start main's dev with `afx dev main`, not a bare `pnpm dev`.** A hand-run `pnpm dev` is
+invisible to Codev (which never kills what it did not spawn), so a builder dev started while it
+holds the ports either fails to bind or — worse — serves main's code under the worktree URL.
+`afx dev main` makes it a managed PTY that swap-detection can stop cleanly. This only helps if
+used consistently.
+
+## VSCode
+
+Right-click a builder row in the Codev sidebar (Builders or Needs Attention):
+
+- **Open Builder Terminal** — that builder's AI terminal in a tab (same as left-click).
+- **Open Worktree Folder** — `.builders/<id>/` in the OS file manager.
+- **Run Worktree Setup** — re-applies `worktree.symlinks` and `worktree.postSpawn` to an
+  existing worktree (the git steps are skipped). Idempotent. Use when the lockfile changed, when
+  `symlinks`/`postSpawn` grew after the builder spawned, when a link was deleted, or when the
+  original setup aborted. Streams install output in a fresh terminal. CLI: `afx setup <id>`.
+- **View Diff** — unified `main...HEAD` diff for that worktree with a file-list pane.
+- **Run Dev** / **Stop Dev** — spawn or kill the dev PTY as a `Codev: <name> (dev)` tab;
+  prompts to swap if another dev is running.
+
+The sidebar's **Workspace** view carries a dev control for whatever folder the window is rooted
+at — the main checkout resolves to `main`, a `.builders/<id>/` window resolves to that builder.
+The row tooltip names the resolved target. Commands are also in the palette (Cmd+Shift+P); no
+default keybindings.
+
+## URLs are load-bearing
+
+The dev PTY intentionally uses **the same ports and URLs as main**. OAuth callbacks, CORS
+allowlists, cookie scoping, CSP `connect-src` and webhook URLs are all keyed off origin, so
+running a worktree on a different port would break them.
+
+Consequence: stop main's dev before starting a builder's, or the spawned dev fails at bind time
+with `EADDRINUSE`.
+
+## Cleanup and orphan recovery
+
+`afx dev --stop` and the swap path kill the entire PTY **process group** (SIGTERM, then SIGKILL
+after 5s), which signals every grandchild of a monorepo orchestrator (`pnpm dev`, `turbo dev`,
+`pnpm -r --parallel run dev`) at once. Ports are reclaimed by the OS as a consequence — Codev
+never manipulates ports directly.
+
+If Tower hard-crashes mid-dev and a process is left holding a port outside Codev's records:
+
+```bash
+lsof -ti :<port> | xargs kill
+lsof -ti :3000,:3001,:4000 | xargs kill
+```
+
+## Recipes
+
+**pnpm monorepo (Next.js / Turbo)**
+```json
+{"worktree": {"symlinks": [".env.local", ".env.development.local", "packages/*/.env", "packages/*/.env.local", "turbo.json"], "postSpawn": ["pnpm install --frozen-lockfile"], "devCommand": "pnpm dev"}}
+```
+
+**npm** — `{"symlinks": [".env.local", ".env.development"], "postSpawn": ["npm ci"], "devCommand": "npm run dev"}`
+
+**yarn** — `{"symlinks": [".env.local"], "postSpawn": ["yarn install --frozen-lockfile"], "devCommand": "yarn dev"}`
+
+**bun** — `{"symlinks": [".env.local"], "postSpawn": ["bun install --frozen-lockfile"], "devCommand": "bun dev"}`
+
+**cargo** — `{"symlinks": [".env"], "postSpawn": [], "devCommand": "cargo run"}`
+
+**poetry / uv** — `{"symlinks": [".env", ".env.local"], "postSpawn": ["uv sync"], "devCommand": "uv run python -m myapp"}`
+
+**go mod** — `{"symlinks": [".env"], "postSpawn": ["go mod download"], "devCommand": "go run ./cmd/server"}`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,170 +16,69 @@ map to open the full arch.md / lessons-learned.md when relevant.
 
 <!-- END CODEV HOT CONTEXT -->
 
-> **Always-on governance docs (Spec 987 — hot/cold tiers).** The block above is **auto-generated** from the HOT tier (`codev/resources/arch-critical.md` and `lessons-critical.md`) and refreshed by `codev init` / `codev update` — edit those source files, not the block. Each hot file is tiny, hard-capped, and injected into *every* porch phase prompt as well as here, so the most decision-relevant facts are always in context. Their full COLD counterparts (`codev/resources/arch.md` and `lessons-learned.md`) are the on-demand reference archives; the "consult when…" maps in the hot files point into them. New facts/lessons are **routed** by tier at review time and policed (cap + map accuracy) during MAINTAIN.
+> The block above is **auto-generated** from the hot tier by `codev init` / `codev update` —
+> edit those source files, not the block. Their COLD counterparts (`codev/resources/arch.md`,
+> `lessons-learned.md`) are on-demand archives; the "consult when…" maps point into them.
+> New facts are **routed** by tier at review time and policed during MAINTAIN.
 
-> **Note**: This file is specific to Claude Code. An identical [AGENTS.md](AGENTS.md) file is also maintained following the [AGENTS.md standard](https://agents.md/) for cross-tool compatibility with Cursor, GitHub Copilot, and other AI coding assistants. Both files contain the same content and should be kept synchronized.
+> **[AGENTS.md](AGENTS.md) is a byte-identical twin of this file** for tools that read the
+> [AGENTS.md standard](https://agents.md/). Any edit here must be applied there.
 
-## Project Context
+## This repository is Codev, built with Codev
 
-**THIS IS THE CODEV SOURCE REPOSITORY - WE ARE SELF-HOSTED**
+Two trees, and the distinction governs almost every change:
 
-This project IS Codev itself, and we use our own methodology for development. All new features and improvements to Codev should follow the SPIR protocol defined in `codev/protocols/spir/protocol.md`.
+| Tree | What it is | When you edit it |
+|---|---|---|
+| `codev/` | **Our** instance — our specs, plans, reviews, resources | Implementing a feature *for* Codev |
+| `codev-skeleton/` | The **template shipped to adopters** — protocols, roles, templates, agents | Changing what other projects receive |
 
-### Important: Understanding This Repository's Structure
+A framework change usually belongs in **both**. `codev-skeleton/` carries no specs or
+plans — those are created by the projects that install it.
 
-This repository has a dual nature that's important to understand:
+### How framework files resolve
 
-1. **`codev/`** - This is OUR instance of Codev
-   - This is where WE (the Codev project) keep our specs, plans, reviews, and resources
-   - When working on Codev features, you work in this directory
-   - Example: `codev/specs/1-test-infrastructure.md` is a feature spec for Codev itself
+Protocols, prompts, roles and templates resolve at **runtime** through four tiers, highest
+first: `.codev/<path>` → `codev/<path>` → runtime cache → **installed package skeleton**.
 
-2. **`codev-skeleton/`** - This is the template for OTHER projects
-   - This is what gets copied to other projects when they install Codev
-   - Contains the protocol definitions, templates, and agents
-   - Does NOT contain specs/plans/reviews (those are created by users)
-   - Think of it as "what Codev provides" vs "how Codev uses itself"
+The absence of `codev/protocols/<name>/` is normal, not a missing reference — it means the
+protocol resolves from the installed package. Only protocols you customize need a local copy.
+When `codev update` merges a template that references a protocol you don't have locally, keep
+the reference.
 
-**When to modify each**:
-- **Modify `codev/`**: When implementing features for Codev (specs, plans, reviews, our architecture docs)
-- **Modify `codev-skeleton/`**: When updating protocols, templates, or agents that other projects will use
+**Deliver framework content; don't instruct an agent to fetch it by path.** A builder-facing
+prompt or role doc must not say "read `codev/protocols/…`" — that bypasses the resolver and
+fails in fresh installs. `protocol.md` is inlined into the spawn prompt; phase prompts and
+their templates arrive via porch. Naming a `codev/...` path in prose for orientation is fine;
+the rule is about *fetching*. (`codev/resources/arch.md` and `lessons-learned.md` are
+user-evolved files, not framework files — referencing those by path is correct.)
 
-### Release Process
+Verify an unfamiliar protocol against the CLI rather than assuming: `afx spawn --protocol
+<name> --help` succeeds if it is registered, including via the skeleton fallback.
 
-To release a new version, tell the AI: `Let's release v1.6.0`. The AI follows the **RELEASE protocol** (`codev/protocols/release/protocol.md`). Release candidate workflow and local testing procedures are documented there. For local testing shortcuts, see `codev/resources/testing-guide.md`.
+## Irreversible acts — the rules that exist because something was destroyed
 
-### Local Build Testing
+These are not style preferences. Each one is here because an agent destroyed work or bypassed
+a human decision.
 
-To test changes locally before publishing to npm:
+- Never `git add -A` / `--all` / `.` — stage each file explicitly by path.
+- Never destroy builder worktrees (`git worktree remove`, `git branch -D` on builder branches, `afx cleanup` + respawn). Use `afx spawn <id> --resume`; if it fails, ask the human — what is expendable is never your call.
+- Never run `git reset --hard`, `git checkout -- .`, `git clean -fd`, or `git stash` without explicit human permission — they destroy uncommitted work.
+- Never treat a porch gate as approved without an explicit human decision — a gate message is a notification to the human, not authorization.
+- Never hand-edit `status.yaml` — only porch commands modify project state.
+- Run `afx` commands only from the main workspace root, never from inside a builder worktree — spawning from a worktree nests builders and breaks the workspace.
+- Never kill a shellper process without verifying it is an orphan (match each PID to its workspace via Tower) — an 'extra' shellper may be a live architect session.
+- Never restart or stop Tower without explicit human permission — it kills every running builder session.
 
-```bash
-# From the repository root:
+## Gates
 
-# 1. Build (Tower stays up during this)
-pnpm build
+Two human approval gates plus the PR gate. Only a human transitions
+`conceived → specified` and `committed → integrated`. Stop and wait at each; do not infer
+approval from silence.
 
-# 2. Pack, install globally, and restart Tower (one command)
-pnpm -w run local-install
-```
+**Approved specs and plans need frontmatter and must be committed to `main` before spawning.**
+Porch runs the full protocol from `specify`, but treats an artifact carrying this as done:
 
-- `pnpm build` builds core first, then codev (including dashboard)
-- `pnpm -w run local-install` runs `scripts/local-install.sh`, which:
-  - Packs both `@cluesmith/codev-core` and `@cluesmith/codev` tarballs into their package directories
-  - Globally installs both in one `npm install -g` (separate installs fail because `@cluesmith/codev-core` isn't on the public npm registry)
-  - Restores the executable bit on `scripts/forge/**/*.sh` (pnpm pack strips it, causing "GitHub CLI unavailable" errors otherwise)
-  - Restarts Tower so it picks up the new code
-- Install runs while Tower is up — only the final restart causes downtime
-- Do NOT stop Tower yourself before running the script — the script handles restart at the end
-- Do NOT use `npm link` or `pnpm link` — it breaks global installs
-
-### Testing
-
-When making changes to UI code (tower, dashboard, terminal), you MUST test using Playwright before claiming the fix works. See `codev/resources/testing-guide.md` for Playwright patterns and Tower regression prevention.
-
-## Quick Start
-
-> **New to Codev?** See the [Cheatsheet](codev/resources/cheatsheet.md) for philosophies, concepts, and tool reference.
-
-You are working in the Codev project itself, with multiple development protocols available:
-
-**Available Protocols**:
-- **SPIR**: Multi-phase development with consultation - `codev/protocols/spir/protocol.md`
-- **ASPIR**: Autonomous SPIR (no human gates on spec/plan) - `codev/protocols/aspir/protocol.md`
-- **AIR**: Autonomous Implement & Review for small features - `codev/protocols/air/protocol.md`
-- **BUGFIX**: Bug fixes from GitHub issues - `codev/protocols/bugfix/protocol.md`
-- **PIR**: Plan / Implement / Review — issue-driven with two pre-PR human gates (plan-approval, dev-approval) plus a post-PR `pr` gate. Lighter than SPIR; stronger than BUGFIX/AIR. Useful when a change needs design review before coding OR pre-PR testing of running code (e.g., mobile / UI / cross-platform). See `codev/protocols/pir/protocol.md`.
-- **EXPERIMENT**: Disciplined experimentation - `codev/protocols/experiment/protocol.md`
-- **MAINTAIN**: Codebase maintenance (code hygiene + documentation sync) - `codev/protocols/maintain/protocol.md`
-- **RESEARCH**: Multi-agent research with 3-way investigation, synthesis, and critique - `codev/protocols/research/protocol.md`
-
-### File Resolution (How Codev Finds Protocols and Templates)
-
-Codev resolves protocol files, prompts, agent definitions, and roles through a four-tier lookup (highest priority first):
-
-1. `.codev/<path>` — user override (project-local customization)
-2. `codev/<path>` — project-local copy (customized and checked in)
-3. Runtime cache
-4. **Installed package skeleton** — ships with `@cluesmith/codev` (the default for every standard protocol)
-
-**The absence of `codev/protocols/<name>/` on disk is not a missing reference** — it's the normal case for any protocol you haven't customized. The protocol resolves from the installed package's skeleton at runtime. Only protocols you want to customize need to live in your repo's `codev/protocols/`.
-
-**Implication for `codev update` and CLAUDE.md / AGENTS.md merges:** when an updated template references a protocol (e.g., PIR), do NOT drop the reference because `codev/protocols/<name>/` is absent locally. The protocol resolves via the package skeleton, and dropping the reference removes the protocol from the user's available-protocol list while it's still callable from the CLI.
-
-### Framework files in prompts: deliver them, don't make the builder read them by path
-
-Framework files (protocol/role docs, the shipped `codev/resources/` reference docs) default to the package skeleton (see File Resolution above) and aren't guaranteed on disk in a fresh project. So when authoring any builder-facing prompt, role doc, or instruction, don't tell the builder to read a framework file by literal `codev/...` path — that bypasses the resolver and fails in fresh installs. Deliver the content instead (`protocol.md` is inlined into the spawn prompt; per-phase prompts and their templates arrive via porch). Mentioning a `codev/...` path in prose for orientation is fine — the rule is about *fetching*, not *referencing*. (`codev/resources/arch.md` and `codev/resources/lessons-learned.md` are user-evolved files, not framework files, so referencing those by path is correct.)
-
-### Protocol Verification (When You Don't Recognize a Protocol Name)
-
-If the user mentions a protocol name you don't immediately recognize, verify against the CLI before responding:
-
-```bash
-afx spawn --protocol <name> --help
-```
-
-This succeeds if the protocol is registered (including via the skeleton fallback in tier 4 of the resolution chain) and errors helpfully otherwise. The CLI is the source of truth — defer to it when in doubt.
-
-Key locations:
-- Protocol details: `codev/protocols/` (Choose appropriate protocol)
-- **Project tracking**: GitHub Issues (source of truth for all projects)
-- Specifications go in: `codev/specs/`
-- Plans go in: `codev/plans/`
-- Reviews go in: `codev/reviews/`
-
-### Project Tracking
-
-**GitHub Issues are the source of truth for project tracking.**
-
-- Issues with the `spec` label have approved specifications
-- Issues with the `plan` label have approved plans
-- Active builders are tracked via `codev/projects/<id>/status.yaml` (managed by porch)
-- The workspace overview Work view shows builders, PRs, and backlog derived from GitHub + filesystem state
-
-**When to use which:**
-- **Starting work**: Check GitHub Issues for priorities and backlog
-- **During implementation**: Use `porch status <id>` for detailed phase status
-- **After completion**: Close the GitHub Issue when PR is merged
-
-### Area Labels — the organizing axis for issues
-
-`area/*` is the **primary axis** for organizing GitHub Issues in this repo. When users ask to group, edit, audit, or bulk-move issues, treat `area/*` as the grouping dimension first — not `type:*` (we don't use them), not milestones, not assignees.
-
-**Labels**:
-
-| Label | Scope |
-|---|---|
-| `area/docs` | Documentation — this repo, CLAUDE/AGENTS, role files, `codev/resources/` |
-| `area/vscode` | VSCode extension — sidebar views, panel-area views, commands, keybindings |
-| `area/dashboard` | Tower web dashboard — the `@cluesmith/codev-web` React/Vite package, served by Tower and opened in a browser (distinct from any VSCode UI) |
-| `area/consult` | `consult` CLI and consultation tooling |
-| `area/tower` | Tower server + `afx` / agent-farm CLI. **No separate `area/agent-farm`** — afx work goes here. |
-| `area/cross-cutting` | Multi-area work — used **alone**, never alongside another `area/*` |
-| `area/porch` | Porch state machine / protocol orchestration |
-| `area/protocols` | Protocol definitions (`codev/protocols/`, `codev-skeleton/protocols/`) — distinct from `area/porch` (orchestration) |
-| `area/config` | `.codev/config.json` and workspace setup |
-| `area/terminal` | Terminal-specific — PTY, VSCode terminal pane |
-| `area/scaffold` | Install path — `codev init` / `adopt` / `update` / `doctor`, `codev-skeleton/`, the four-tier resolver |
-| `area/release` | Release tooling — version bumps, release protocol artifacts, release scripts |
-| `area/web` | Marketing site / web content — the `marketing/` directory |
-| `area/core` | Shared core library / forge abstraction (`packages/core`, `packages/codev/src/lib`, `packages/types`) |
-
-**Policy:**
-
-- **Exactly one** `area/*` per issue. Multi-area work uses `area/cross-cutting` *alone* — never two `area/*` labels.
-- **No `type:*` labels.** Codev classifies issues by area only.
-- `area/` uses **slash**. Other label families (if ever introduced) would keep colons.
-
-**🚨 CRITICAL: Two human approval gates exist:**
-- **conceived → specified**: AI creates spec, but ONLY the human can approve it
-- **committed → integrated**: AI can merge PRs, but ONLY the human can validate production
-
-AI agents must stop at `conceived` after writing a spec, and stop at `committed` after merging.
-
-**🚨 CRITICAL: Approved specs/plans need YAML frontmatter and must be committed to `main`.**
-When the architect creates and approves a spec or plan before spawning a builder, it must have YAML frontmatter marking it as approved and validated, and be committed to `main`. Porch always runs the full protocol from `specify` — but when it finds an existing artifact with this metadata, it skips that phase as a no-op. If no spec/plan exists, porch drives the builder to create one.
-
-Frontmatter format:
 ```yaml
 ---
 approved: 2026-01-29
@@ -187,555 +86,118 @@ validated: [gemini, codex, claude]
 ---
 ```
 
-## Agent Responsiveness
+## Protocols
 
-**Responsiveness is paramount.** The user should never wait for you. Use `run_in_background: true` for any operation that takes more than ~5 seconds.
+Pick by the nature of the work, not its size. Full definitions in `codev/protocols/<name>/`
+(or the package skeleton).
 
-| Task Type | Expected Duration | Action |
-|-----------|------------------|--------|
-| Running tests | 10-300s | `run_in_background: true` |
-| Consultations (consult) | 60-250s | `run_in_background: true` |
-| E2E test suites | 60-600s | `run_in_background: true` |
-| pnpm install/build | 5-60s | `run_in_background: true` |
-| Quick file reads/edits | <5s | Run normally |
+| Protocol | Use when |
+|---|---|
+| **BUGFIX** | A bug in a GitHub issue; isolated fix; no spec/plan needed |
+| **AIR** | Small feature fully described in an issue; no architectural decisions |
+| **PIR** | The approach needs review before coding, **or** the change must be tested running (mobile, UI, hardware, OAuth) before a PR exists |
+| **SPIR** | New feature from scratch, new protocol, architecture change |
+| **ASPIR** | SPIR without the spec/plan human gates — trusted, low-risk work |
+| **EXPERIMENT** | Proof of concept, model/library evaluation, research spike |
+| **MAINTAIN** | Dead code, dependency cleanup, doc sync (arch/lessons, CLAUDE↔AGENTS) |
+| **RESEARCH** | Competitive/technology analysis; output to `codev/research/` |
 
-**Critical**: Using `&` at the end of the command does NOT work - you MUST set the `run_in_background` parameter.
+Skip protocol ceremony for README typos, template one-liners, and dependency bumps.
 
-## Protocol Selection Guide
+**Issues are the source of truth for tracking.** `spec` and `plan` labels mark approved
+artifacts; `porch status <id>` gives live phase detail; close the issue when the PR merges.
 
-### Use BUGFIX for (GitHub issue fixes):
-- Bug reported as a **GitHub Issue**
-- Fix is isolated (< 300 LOC net diff)
-- No spec/plan artifacts needed
-- Single builder can fix independently
+### Artifacts
 
-**BUGFIX uses GitHub Issues as source of truth.** See `codev/protocols/bugfix/protocol.md`.
+Three documents per feature, same filename in three directories — spec defines **what**, plan
+defines **how**, review captures **what was learned**:
 
-### Use AIR for (small features from GitHub issues):
-- Small features (< 300 LOC) fully described in a **GitHub Issue**
-- No architectural decisions needed
-- No spec/plan artifacts — review goes in the PR body
-- Would be overkill for full SPIR/ASPIR ceremony
-
-**AIR uses GitHub Issues as source of truth.** Two phases: Implement → Review. See `codev/protocols/air/protocol.md`.
-
-### Use PIR for (engineer-judged — based on the nature of the work, not its size):
-
-Pick PIR when ONE or BOTH of the following apply to a GitHub-issue-driven change:
-
-**1. The approach needs review before coding starts**:
-- Root cause is ambiguous; multiple valid fixes exist
-- Area is unfamiliar or high-blast-radius (shared utilities, auth, migrations, public APIs)
-- Design-sensitive (affects conventions, patterns, architecture)
-- Cheaper to redirect at plan time than at PR time
-
-**2. The implementation needs to be TESTED before a PR is created** (PR diff alone is insufficient):
-- Mobile app changes (needs device testing on Android, iOS, possibly web)
-- UI / UX changes (visual inspection, interaction flow, accessibility)
-- Hardware-adjacent behavior (sensors, camera, permissions, notifications)
-- Integration with external services that don't mock cleanly (OAuth, payments, analytics)
-- User-journey changes that need a full-flow exercise
-- Performance-sensitive changes that need profiling on the running app
-
-**PIR uses GitHub Issues as source of truth.** Three phases: Plan (gated by `plan-approval`) → Implement (gated by `dev-approval`) → Review (PR + CMAP-2 at PR, then gated by `pr` for merge synchronization — matching SPIR's pr-gate pattern but with no post-merge verify phase). Plan and review artifacts live in `codev/plans/` and `codev/reviews/` on the builder branch, ship to main with the merge. Review file is shaped identically to SPIR's (Summary + Architecture Updates + Lessons Learned + supporting sections) so `codev/reviews/` stays semantically consistent across protocols. Lighter than SPIR (no spec phase — the issue body is the implicit spec; consult footprint matches BUGFIX/AIR's "one consult at PR" pattern). Stronger than BUGFIX/AIR (two human gates pre-PR — the human reviews the running worktree at the `dev-approval` gate, not the PR diff post-creation). CMAP at the PR is a **single advisory pass** (`max_iterations: 1`) — no iterate-until-APPROVE loop; a `REQUEST_CHANGES` is escalated to the human at the `pr` gate, not auto-re-reviewed. The CMAP-2 footprint is a design invariant: porch's model precedence is *config > protocol*, so a project-wide `porch.consultation.models` (e.g. a SPIR-tuned 3-model list) silently inflates PIR — leave it unset or scope it per-protocol to preserve the BUGFIX/AIR-parity cost. See `codev/protocols/pir/protocol.md`.
-
-### Use SPIR for (new features):
-- Creating a **new feature from scratch** (no existing spec to amend)
-- New protocols or protocol variants
-- Major changes to existing protocols
-- Complex features requiring multiple phases
-- Architecture changes
-
-### Use ASPIR for (autonomous SPIR):
-- Same as SPIR but **without human approval gates** on spec and plan
-- Trusted, low-risk work where spec/plan review can be deferred to PR
-- Builder runs autonomously through Specify → Plan → Implement → Review (→ Verify)
-- Human approval still required at the PR gate before merge
-
-**ASPIR is identical to SPIR** except `spec-approval` and `plan-approval` gates are removed. Both include an optional verify phase after review. See `codev/protocols/aspir/protocol.md`.
-
-### Use EXPERIMENT for:
-- Testing new approaches or techniques
-- Evaluating models or libraries
-- Proof-of-concept work
-- Research spikes
-
-### Use MAINTAIN for:
-- Removing dead code and unused dependencies
-- Quarterly codebase maintenance
-- Before releases (clean slate for shipping)
-- Syncing documentation (arch.md/arch-critical.md, lessons-learned.md/lessons-critical.md, CLAUDE.md/AGENTS.md)
-
-### Use RESEARCH for:
-- Competitive analysis and technology evaluation
-- Market research and "state of X" questions
-- Architectural decision support when unfamiliar with the domain
-- Triangulating across 3 AI models to get a high-confidence answer
-- Output goes to `codev/research/<topic>.md`
-
-### Skip formal protocols for:
-- README typos or minor documentation fixes
-- Small bug fixes in templates
-- Dependency updates
-
-## Core Workflow
-
-1. **When asked to build NEW FEATURES FOR CODEV**: Start with the Specification phase
-2. **Create exactly THREE documents per feature**: spec, plan, and review (all with same filename)
-3. **Follow the SPIR phases**: Specify → Plan → Implement → Review (→ Verify)
-4. **Use multi-agent consultation by default** unless user says "without consultation"
-
-## Directory Structure
 ```
-project-root/
-├── codev/
-│   ├── protocols/           # Development protocols
-│   │   ├── spir/          # Multi-phase development with consultation
-│   │   ├── experiment/     # Disciplined experimentation
-│   │   └── maintain/       # Codebase maintenance (code + docs)
-│   ├── maintain/            # MAINTAIN protocol runtime artifacts
-│   │   └── .trash/         # Soft-deleted files (gitignored, 30-day retention)
-│   ├── projects/           # Active project state (managed by porch)
-│   ├── specs/              # Feature specifications (WHAT to build)
-│   ├── plans/              # Implementation plans (HOW to build)
-│   ├── reviews/            # Reviews and lessons learned from each feature
-│   └── resources/          # Reference materials
-│       ├── arch.md         # Architecture (COLD reference; maintained during MAINTAIN)
-│       ├── arch-critical.md # Architecture HOT tier — capped, always-injected (Spec 987)
-│       ├── testing-guide.md # Local testing, Playwright, regression prevention
-│       ├── lessons-learned.md   # Engineering wisdom (COLD reference; maintained during MAINTAIN)
-│       └── lessons-critical.md  # Engineering wisdom HOT tier — capped, always-injected (Spec 987)
-├── .claude/
-│   ├── agents/             # AI agent definitions (custom project agents)
-│   └── skills/             # Claude-native Codev skills
-├── .codex/
-│   └── skills/             # Codex-native Codev skills
-├── AGENTS.md              # Universal AI agent instructions (AGENTS.md standard)
-├── CLAUDE.md              # This file (Claude Code-specific, identical to AGENTS.md)
-└── [project code]
+codev/specs/42-feature-name.md
+codev/plans/42-feature-name.md
+codev/reviews/42-feature-name.md
 ```
 
-## Directory Map
-- pnpm install → always run from the repository root (installs all workspace packages)
-- pnpm build / pnpm test → run from `packages/codev/` or use `pnpm --filter @cluesmith/codev build`
-- E2E tests → `packages/codev/tests/e2e/`
-- Unit tests → `packages/codev/tests/unit/`
-- Never run npm commands from the repository root unless explicitly told to.
+Sequential numbering, no leading zeros. Keep specs and plans separate; they answer different
+questions.
 
-## File Naming Convention
+## Issue labels
 
-Use sequential numbering with descriptive names (no leading zeros):
-- Specification: `codev/specs/42-feature-name.md`
-- Plan: `codev/plans/42-feature-name.md`
-- Review: `codev/reviews/42-feature-name.md`
+`area/*` is the **primary organizing axis** — group, audit and bulk-move issues by area first.
 
-**CRITICAL: Keep Specs and Plans Separate**
-- Specs define WHAT to build (requirements, acceptance criteria)
-- Plans define HOW to build (phases, files to modify, implementation details)
-- Each document serves a distinct purpose and must remain separate
+**Exactly one `area/*` per issue.** Multi-area work uses `area/cross-cutting` *alone*. There
+are no `type:*` labels.
 
-## Multi-Agent Consultation
+`area/`: docs · vscode · dashboard · consult · tower (includes afx; there is no
+`area/agent-farm`) · porch · protocols (definitions, distinct from porch orchestration) ·
+config · terminal · scaffold · release · web · core · cross-cutting
 
-**DEFAULT BEHAVIOR**: Consultation is ENABLED by default with:
-- **Gemini** via the **Antigravity CLI (`agy`)** for deep analysis (the retired Gemini CLI's
-  replacement; OAuth/subscription, agy's default model — no pinned model id). Skips non-blockingly
-  if `agy` is missing/unauthenticated. An unauthenticated `agy` is spawned **at most once per TTL
-  window** rather than once per consult: the verdict is cached across processes in
-  `~/.cache/codev/agy-auth.json`, because each spawn opens an OAuth browser tab before Codev can
-  detect the missing login (#1077). Sign in with `agy` in any terminal and the lane recovers on its
-  own; see `codev/resources/commands/consult.md` for the TTL/opt-out env vars.
-- **GPT-5.6 Sol** (`gpt-5.6-sol`, medium reasoning effort) via the Codex SDK for coding and
-  architecture perspective. The `-sol` suffix is load-bearing — plain `gpt-5.6` and
-  `gpt-5.6-codex` are both rejected by Codex on a ChatGPT account.
-- **Claude Opus 5** (`claude-opus-5`) via the Claude Agent SDK for balanced analysis with tool use
+## Multi-agent consultation
 
-To disable: User must explicitly say "without multi-agent consultation"
+**Enabled by default.** Three reviewers: **Gemini** via the Antigravity CLI (`agy`, skips
+non-blockingly if unauthenticated), **GPT-5.6 Sol** (`gpt-5.6-sol` — the `-sol` suffix is
+load-bearing) via the Codex SDK, and **Claude Opus 5** via the Agent SDK. Disable only when
+the user says "without consultation".
 
-**CRITICAL CONSULTATION CHECKPOINTS (DO NOT SKIP):**
-- After writing implementation code → STOP → Consult GPT-5 and Gemini (via agy)
-- After writing tests → STOP → Consult GPT-5 and Gemini (via agy)
-- ONLY THEN present results to user for evaluation
+Consult after writing implementation code and after writing tests, before presenting results.
+**"cmap"** means run all three in parallel *in the background* and return control immediately.
 
-### cmap (Consult Multiple Agents in Parallel)
+## Git
 
-**cmap** is shorthand for "consult multiple agents in parallel in the background."
+Commit messages:
 
-When the user says **"cmap the PR"** or **"cmap spec 42"**, this means:
-1. Run a 3-way parallel review (Gemini, Codex, Claude)
-2. Run all three in the **background** (`run_in_background: true`)
-3. Return control to the user **immediately**
-4. Retrieve results later with `TaskOutput` when needed
-
-**Always run consultations in parallel** using separate Bash tool calls in the same message, not sequentially.
-
-## CLI Command Reference
-
-**IMPORTANT: Never guess CLI commands.** Use the `/afx` skill to check the quick reference before running agent farm commands. Common mistakes to avoid:
-- There is NO `codev tower` command — use `afx tower start` / `afx tower stop`
-- There is NO `restart` subcommand — stop then start
-- When unsure about syntax, check the docs below first
-
-Codev provides five CLI tools. For complete reference documentation, see:
-
-- **[Overview](codev/resources/commands/overview.md)** - Quick start and summary of all tools
-- **[codev](codev/resources/commands/codev.md)** - Project management (init, adopt, doctor, update, tower)
-- **[afx](codev/resources/commands/agent-farm.md)** - Agent Farm orchestration (start, spawn, status, cleanup, send, etc.)
-- **[porch](codev/resources/commands/overview.md#porch---protocol-orchestrator)** - Protocol orchestrator (status, run, approve, pending)
-- **[consult](codev/resources/commands/consult.md)** - AI consultation (general, protocol, stats)
-- **[team](codev/resources/commands/team.md)** - Team coordination (list, message, update, add)
-
-## Runnable Worktrees
-
-When configured, each builder worktree (`.builders/<id>/`) becomes runnable — reviewers can run whatever your dev command starts against the builder's branch — a dev server, `cargo run`, `expo start`, a test watcher, a build script, whatever iterates on your project — without `cd`'ing, manually installing, or finding the right command. Opt-in via `.codev/config.json`; unconfigured repos see zero behavior change.
-
-### Config: the `worktree` block
-
-```jsonc
-{
-  "worktree": {
-    "symlinks":   ["..."],        // glob patterns of files to symlink from root into each new worktree
-    "postSpawn":  ["..."],        // shell commands run inside each new worktree after createWorktree
-    "devCommand": "..."           // consumed by `afx dev <builder-id|main>`
-  }
-}
-```
-
-- `symlinks`: globs resolve from the workspace root; matches symlink into the worktree at the same relative path. Root `.env` and `.codev/config.json` are *always* symlinked regardless. **Symlinks, not copies** — edits to main's env files reflect instantly in any running dev session. A directory match is silently skipped (so a glob can't mask the worktree's own source) **unless** the entry ends with a trailing slash: `".local-user-data/"` is treated as a literal path and symlinks the directory whole (shared with the parent, not branch-isolated; a dangling link is fine if the source doesn't exist yet).
-- `postSpawn`: each command runs sequentially with `cwd` = worktree path. Non-zero exit aborts the spawn loud (half-built worktree stays for inspection).
-- `devCommand`: the foreground command that starts your dev process (a server, a watcher, `cargo run`, `expo start`, a build script — whatever iterates on your project). Required for `afx dev` to work.
-
-**Codev does not auto-detect your stack.** Pick the recipe below that matches your toolchain.
-
-### CLI
-
-```bash
-afx dev <builder-id>     # start dev in <builder-id>'s worktree
-afx dev main             # start dev in the MAIN workspace (Codev-managed)
-afx dev --stop           # stop the currently running dev PTY (builder or main)
-```
-
-Only one dev PTY runs at a time (by design — see "URLs are load-bearing" below), across **{main + all builders}**. `main` is a reserved target: it runs `worktree.devCommand` in the main checkout as a Codev-managed, swappable PTY, symmetric with builders. Starting any target while another is up prompts for swap (`afx dev <builder>` while `main` runs, or vice-versa); same-target requests print the existing terminal URL and exit. Like builder dev, main dev is a **non-persistent** PTY — a Tower restart (`pnpm -w run local-install`, crash) kills it; re-run to restart.
-
-**Launch main dev via `afx dev main`, not a bare `pnpm dev`.** A manually-run `pnpm dev` at the repo root is invisible to Codev (the deliberate "never kill what it didn't spawn" policy) — start a builder dev while it holds the ports and the builder dev silently fails to bind, or worse serves main's code under the worktree URL. `afx dev main` makes it a managed PTY that swap-detection can cleanly stop first. This only helps if you use it *consistently*; a hand-started `pnpm dev` stays unmanaged.
-
-### VSCode
-
-The same actions are available via right-click on any builder row in the Codev sidebar (Builders or Needs Attention view):
-
-- **Codev: Open Builder Terminal** — opens that builder's AI terminal in a VSCode tab (same as left-clicking the row).
-- **Codev: Open Worktree Folder** — opens `.builders/<id>/` in the OS file manager (Finder on macOS, Explorer on Windows, xdg-open on Linux).
-- **Codev: Run Worktree Setup** — applies the configured `worktree.symlinks` and runs the `worktree.postSpawn` commands against the existing worktree (mirrors what spawn does, minus the git steps). Idempotent: existing symlinks are skipped, missing ones added. Useful when the lockfile changed (reinstall deps), `symlinks` or `postSpawn` was extended after the builder spawned, a symlink was accidentally deleted, or the original setup aborted mid-run. Opens a fresh VSCode terminal so install output streams live. Available via CLI too: `afx setup <builder-id>`.
-- **Codev: View Diff** — opens a single unified diff editor for `main...HEAD` of that builder's worktree, with a file-list pane on the left (matches VSCode's built-in Source Control "Working Tree" view). Status icons indicate added / modified / deleted. Empty diff → friendly toast.
-- **Codev: Run Dev** — reads `worktree.devCommand` from `.codev/config.json`, asks Tower to spawn a dev PTY in the builder's worktree, and opens it as a VSCode terminal tab named `Codev: <name> (dev)`. If another builder's dev is already running, you get a modal asking whether to swap.
-- **Codev: Stop Dev** — kills the running dev PTY and closes its tab.
-
-The Codev sidebar's **Workspace** view also carries a dev control for *whatever folder this VSCode window is rooted at* (it is not "main"-specific):
-
-- **Start Dev** — runs `worktree.devCommand` for the current workspace. Target is resolved from the open folder: the main checkout → `main`; a `.builders/<id>/` worktree opened as its own window (e.g. via *Open Worktree as Workspace*) → that builder. Same single-slot swap model as builder dev (prompts if another dev is running). The row tooltip names the resolved target.
-- **Stop Dev** — stops this workspace's dev; the row appears only while it is running. Scoped to the resolved target — it does not touch other devs.
-
-The three commands are also available from the command palette (Cmd+Shift+P). No default keybindings; bind via `keybindings.json` if you use them often.
-
-### URLs are load-bearing
-
-The dev PTY uses **the same ports and URLs as main** intentionally. OAuth callbacks, CORS allowlists, cookie scoping, CSP `connect-src`, webhook URLs are all keyed off origin — running the worktree on a different port would break them. Consequence: stop main's `pnpm dev` before `afx dev`. If you don't, the spawned dev fails at bind time with its own `EADDRINUSE`. Prefer `afx dev main` (or the Workspace view's *Start Dev* row) over a hand-run `pnpm dev` so Codev owns the PTY and swap-detection can stop it for you automatically.
-
-### Cleanup semantics
-
-`afx dev --stop` and the swap path kill the entire PTY process group (SIGTERM, escalating to SIGKILL after 5s via `PtySession.kill`). That signals every grandchild of a monorepo dev orchestrator (`pnpm dev`, `turbo dev`, `pnpm -r --parallel run dev`, etc.) simultaneously. The OS reclaims ports as a consequence — Codev never touches ports directly.
-
-**Orphan recovery** — if Tower itself hard-crashes mid-dev and a process is left holding a port outside Codev's records:
-
-```bash
-lsof -ti :<port> | xargs kill                       # one port
-lsof -ti :3000,:3001,:4000 | xargs kill             # several at once
-```
-
-### Runnable Worktree Recipes
-
-Ready-to-paste blocks per stack. Adjust ports / paths to your project.
-
-**pnpm monorepo (Next.js + Turbo style):**
-```json
-{
-  "worktree": {
-    "symlinks": [".env.local", ".env.development.local", "packages/*/.env", "packages/*/.env.local", "turbo.json"],
-    "postSpawn": ["pnpm install --frozen-lockfile"],
-    "devCommand": "pnpm dev"
-  }
-}
-```
-
-**npm (single package):**
-```json
-{
-  "worktree": {
-    "symlinks": [".env.local", ".env.development"],
-    "postSpawn": ["npm ci"],
-    "devCommand": "npm run dev"
-  }
-}
-```
-
-**yarn:**
-```json
-{
-  "worktree": {
-    "symlinks": [".env.local"],
-    "postSpawn": ["yarn install --frozen-lockfile"],
-    "devCommand": "yarn dev"
-  }
-}
-```
-
-**bun:**
-```json
-{
-  "worktree": {
-    "symlinks": [".env.local"],
-    "postSpawn": ["bun install --frozen-lockfile"],
-    "devCommand": "bun dev"
-  }
-}
-```
-
-**cargo (Rust):**
-```json
-{
-  "worktree": {
-    "symlinks": [".env"],
-    "postSpawn": [],
-    "devCommand": "cargo run"
-  }
-}
-```
-
-**poetry / uv (Python):**
-```json
-{
-  "worktree": {
-    "symlinks": [".env", ".env.local"],
-    "postSpawn": ["uv sync"],
-    "devCommand": "uv run python -m myapp"
-  }
-}
-```
-
-**go mod:**
-```json
-{
-  "worktree": {
-    "symlinks": [".env"],
-    "postSpawn": ["go mod download"],
-    "devCommand": "go run ./cmd/server"
-  }
-}
-```
-
-## Architect-Builder Pattern
-
-The Architect-Builder pattern enables parallel AI-assisted development:
-- **Architect** (human + primary AI): Creates specs and plans, reviews work
-- **Builders** (autonomous AI agents): Implement specs in isolated git worktrees
-
-For detailed commands, configuration, and architecture, see:
-- `codev/resources/commands/agent-farm.md` - Full CLI reference
-- `codev/resources/arch.md` - Terminal architecture, state management
-- `codev/resources/workflow-reference.md` - Stage-by-stage workflow
-
-### 🚨 NEVER DESTROY BUILDER WORKTREES 🚨
-
-**When a worktree already exists for a project:**
-1. Use `afx spawn XXXX --resume`
-2. If `--resume` fails → **ASK THE USER**
-3. Only destroy if the user explicitly says to
-
-**NEVER run without EXPLICIT user request:**
-- `git worktree remove` (with or without --force)
-- `git branch -D` on builder branches
-- `afx cleanup` followed by fresh spawn
-
-**You are NOT qualified to judge what's expendable.** It is NEVER your call to delete a worktree.
-
-### 🚨 ALWAYS Operate From the Main Workspace Root 🚨
-
-**ALL `afx` commands (`afx spawn`, `afx send`, `afx status`, `afx workspace`, `afx cleanup`) MUST be run from the repository root on the `main` branch.**
-
-- **NEVER** run `afx spawn` from inside a builder worktree — builders will get nested inside that worktree, breaking everything
-- **NEVER** run `afx workspace start` from a worktree — there is no separate workspace per worktree
-- **NEVER** `cd` into a worktree to run afx commands
-- The **only exception** is `porch` commands that need worktree context (e.g. `porch approve` from a builder's worktree)
-
-**What happened**: On 2026-02-21, `afx spawn` was run from inside a builder's worktree. All new builders were nested inside that worktree, `afx send` couldn't find them, and `afx status` showed "not active in tower". Multiple builders had to be killed and respawned.
-
-### Pre-Spawn Rule
-
-**Commit all local changes before `afx spawn`.** Builders work in git worktrees branched from HEAD — uncommitted specs, plans, and codev updates are invisible to the builder. The spawn command enforces this (override with `--force`).
-
-### Key Commands
-
-```bash
-afx workspace start                   # Start the workspace
-afx spawn 42 --protocol spir          # Spawn builder for SPIR project
-afx spawn 42 --protocol spir --soft   # Spawn builder (soft mode)
-afx spawn 42 --protocol bugfix        # Spawn builder for a bugfix
-afx status                            # Check all builders
-afx cleanup --project 0042            # Clean up (architect-driven, not automatic)
-afx open file.ts            # Open file in annotation viewer (NOT system open)
-```
-
-**IMPORTANT:** When the user says `afx open`, always run the `afx open` command — do NOT substitute the system `open` command.
-
-### Configuration
-
-Agent Farm is configured via `.codev/config.json` at the project root. Created during `codev init` or `codev adopt`. Override via CLI: `--architect-cmd`, `--builder-cmd`, `--shell-cmd`.
-
-## Inter-agent messaging
-
-Agents within a workspace communicate through `afx send`. Four addressing forms are supported:
-
-### Addressing forms
-
-| Form | Meaning | Allowed from |
-|---|---|---|
-| `afx send <builder-id> "msg"` | Send to a specific builder (e.g. `afx send 0823 "..."`). | Any sender. |
-| `afx send architect "msg"` | From a builder: routes to the spawning architect via affinity (per #774). From an architect (or any non-builder sender): routes to the architect named `main` if present, else the first registered architect. | Any sender. |
-| `afx send architect:<name> "msg"` | Explicit per-architect addressing. **Architects (including `main`)**: open address grammar — any architect can address any other architect. This is the sibling-architect messaging form. **Builders**: allowed ONLY when `<name>` matches the builder's own `spawnedByArchitect`. Mismatches are rejected by the spoofing check at `tower-messages.ts:213-218`. From a builder, this is an explicit form of the affinity routing, NOT an override. | Any sender (with the spoofing constraint above for builders). |
-| `afx send <workspace>:architect "msg"` | Cross-workspace addressing (e.g. `afx send marketmaker:architect "..."`). | Any sender. |
-
-### Sibling-architect messaging
-
-When a workspace hosts more than one architect (added via `afx workspace add-architect --name <name>`), sibling architects message each other via the `architect:<name>` form. Example:
-
-```bash
-# From main's terminal to a sibling architect named ob-refine
-afx send architect:ob-refine "PR-iter-2 feedback ready"
-```
-
-This works because sender = architect bypasses the spoofing check.
-
-### Builder spoofing-check (verified at `tower-messages.ts:213-218`)
-
-Builder `spir-823` running `afx send architect:ob-refine "..."` is rejected unless its `spawnedByArchitect == 'ob-refine'`. A builder cannot use `architect:<name>` to address an architect other than its spawning architect — that's an attempted spoof.
-
-### Discovering active agents
-
-- `afx status` lists all architects (post-#786) alongside builders, with names, terminal IDs, and PIDs where available.
-- Each active builder maintains a free-text narrative log at `codev/state/<builder-id>_thread.md` (relative to its worktree, so `.builders/<id>/codev/state/<id>_thread.md` from the main workspace root). **In-flight discovery**: `ls .builders/*/codev/state/*.md` and `cat .builders/<id>/codev/state/<id>_thread.md`. **Post-merge discovery**: after a builder's PR merges, its thread lands in `codev/state/` on `main`, alongside `codev/reviews/` — list with `ls codev/state/` and read with `cat codev/state/<builder-id>_thread.md` from the main checkout.
-
-## Porch - Protocol Orchestrator
-
-Porch drives SPIR, ASPIR, AIR, and BUGFIX protocols via a state machine with phase transitions, gates, and multi-agent consultations.
-
-### Key Commands
-
-```bash
-porch init spir 0073 "feature-name" --worktree .builders/0073
-porch status 0073
-porch run 0073
-porch approve 0073 spec-approval    # Human only
-porch pending                        # List pending gates
-```
-
-### Project State
-
-State is stored in `codev/projects/<id>-<name>/status.yaml`, managed automatically by porch. See `codev/resources/protocol-format.md` for protocol definition format.
-
-## Git Workflow
-
-### 🚨 ABSOLUTE PROHIBITION: NEVER USE `git add -A` or `git add .` 🚨
-
-**THIS IS A CRITICAL SECURITY REQUIREMENT - NO EXCEPTIONS**
-
-```bash
-git add -A        # ABSOLUTELY FORBIDDEN
-git add .         # ABSOLUTELY FORBIDDEN
-git add --all     # ABSOLUTELY FORBIDDEN
-```
-
-**MANDATORY APPROACH - ALWAYS ADD FILES EXPLICITLY**:
-```bash
-git add codev/specs/42-feature.md
-git add src/components/TodoList.tsx
-```
-
-**BEFORE EVERY COMMIT**: Run `git status`, add each file explicitly by name.
-
-### Commit Messages
 ```
 [Spec 42] Initial specification draft
 [Spec 42][Phase: user-auth] feat: Add password hashing
 [Bugfix #42] Fix: URL-encode username before API call
 ```
 
-### Branch Naming
-```
-spir/42-feature-name/phase-name
-builder/bugfix-42-description
-```
+Branches: `spir/42-feature-name/phase-name`, `builder/bugfix-42-description`.
 
-### Pull Request Merging
+**Merge PRs with `gh pr merge <n> --merge` — never squash.** Individual commits document the
+development process; squashing destroys it.
 
-**DO NOT SQUASH MERGE** - Always use regular merge commits:
-```bash
-gh pr merge <number> --merge    # CORRECT
-```
+## Working with builders
 
-Individual commits document the development process. Squashing loses this valuable history.
+Architects create specs and plans and review work; builders implement in isolated worktrees
+under `.builders/<id>/`. Commit everything before `afx spawn` — builders branch from HEAD, so
+uncommitted work is invisible to them.
 
-## Code Metrics
+Agents message each other with `afx send`:
 
-Use **tokei** for measuring codebase size: `tokei -e "tests/lib" -e "node_modules" -e ".git" -e ".builders" -e "dist" .`
+| Form | Meaning |
+|---|---|
+| `afx send <builder-id> "…"` | A specific builder |
+| `afx send architect "…"` | From a builder: its spawning architect. From anyone else: the architect named `main`, else the first registered |
+| `afx send architect:<name> "…"` | A named architect. Architects may address any architect; a **builder may only use this for its own spawning architect** — mismatches are rejected as spoofing |
+| `afx send <workspace>:architect "…"` | Cross-workspace |
 
-## Before Starting ANY Task
+`afx send` requires the workspace active in Tower (`afx workspace start`).
 
-### ALWAYS Check for Existing Work First
+Each builder keeps a narrative log at `codev/state/<builder-id>_thread.md` — in-flight at
+`.builders/<id>/codev/state/`, and on `main` after the PR merges.
 
-**BEFORE writing ANY code, run these checks:**
+## Tooling
 
-```bash
-# Check if there's already a PR for this
-gh pr list --search "XXXX"
+Each CLI has a skill carrying its commands and flags — **check the skill before running the
+command rather than guessing**: `afx` (spawn, status, send, dev, cleanup, Tower),
+`codev` (init, adopt, update, doctor, local build/test), `porch` (status, run, approve),
+`consult` (reviews, cmap, stats), `team`, `forge`, `runnable-worktrees` (making builder
+worktrees runnable), `update-arch-docs`.
 
-# Check GitHub Issues for status
-gh issue list --search "XXXX"
+`afx open <file>` opens the annotation viewer — it is not the system `open`.
 
-# Check if implementation already exists
-git log --oneline --all | grep -i "feature-name"
-```
+**Run anything slower than ~5s in the background** (`run_in_background: true`, not a trailing
+`&`): tests, consultations, installs, e2e suites.
 
-**If existing work exists**: READ it first, TEST if it works, IDENTIFY specific bugs, FIX minimally.
+Configuration lives in `.codev/config.json`.
 
-### When Stuck: STOP After 15 Minutes
+## Testing
 
-**If you've been debugging the same issue for 15+ minutes:**
-1. **STOP coding immediately**
-2. **Consult external models** (GPT-5, Gemini) with specific questions
-3. **Ask the user** if you're on the right path
-4. **Consider simpler approaches** - you're probably overcomplicating it
+UI changes (tower, dashboard, terminal) must be verified in a browser via Playwright before
+being called done — see `codev/resources/testing-guide.md`.
 
-**Warning signs you're in a rathole:**
-- Making incremental fixes that don't work
-- User telling you you're overcomplicating it (LISTEN TO THEM)
-- Trying multiple approaches without understanding why none work
-- Not understanding the underlying technology
+## Releasing
 
-### Understand Before Coding
-
-**Before implementing, you MUST understand:**
-1. **The protocol/API** - Read docs, don't guess
-2. **The module system** - ESM vs CommonJS vs UMD vs globals
-3. **What already exists** - Check the codebase and git history
-4. **The spec's assumptions** - Verify they're actually true
-
-## Important Notes
-
-1. **ALWAYS check `codev/protocols/spir/protocol.md`** for detailed phase instructions
-2. **Use provided templates** from `codev/protocols/spir/templates/`
-3. **Document all deviations** from the plan with reasoning
-4. **Create atomic commits** for each phase completion
-5. **Maintain >90% test coverage** where possible
-
----
-
-*Remember: Context drives code. When in doubt, write more documentation rather than less.*
+Say "Let's release v1.6.0"; the RELEASE protocol (`codev/protocols/release/protocol.md`)
+carries the procedure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,170 +16,69 @@ map to open the full arch.md / lessons-learned.md when relevant.
 
 <!-- END CODEV HOT CONTEXT -->
 
-> **Always-on governance docs (Spec 987 — hot/cold tiers).** The block above is **auto-generated** from the HOT tier (`codev/resources/arch-critical.md` and `lessons-critical.md`) and refreshed by `codev init` / `codev update` — edit those source files, not the block. Each hot file is tiny, hard-capped, and injected into *every* porch phase prompt as well as here, so the most decision-relevant facts are always in context. Their full COLD counterparts (`codev/resources/arch.md` and `lessons-learned.md`) are the on-demand reference archives; the "consult when…" maps in the hot files point into them. New facts/lessons are **routed** by tier at review time and policed (cap + map accuracy) during MAINTAIN.
+> The block above is **auto-generated** from the hot tier by `codev init` / `codev update` —
+> edit those source files, not the block. Their COLD counterparts (`codev/resources/arch.md`,
+> `lessons-learned.md`) are on-demand archives; the "consult when…" maps point into them.
+> New facts are **routed** by tier at review time and policed during MAINTAIN.
 
-> **Note**: This file is specific to Claude Code. An identical [AGENTS.md](AGENTS.md) file is also maintained following the [AGENTS.md standard](https://agents.md/) for cross-tool compatibility with Cursor, GitHub Copilot, and other AI coding assistants. Both files contain the same content and should be kept synchronized.
+> **[AGENTS.md](AGENTS.md) is a byte-identical twin of this file** for tools that read the
+> [AGENTS.md standard](https://agents.md/). Any edit here must be applied there.
 
-## Project Context
+## This repository is Codev, built with Codev
 
-**THIS IS THE CODEV SOURCE REPOSITORY - WE ARE SELF-HOSTED**
+Two trees, and the distinction governs almost every change:
 
-This project IS Codev itself, and we use our own methodology for development. All new features and improvements to Codev should follow the SPIR protocol defined in `codev/protocols/spir/protocol.md`.
+| Tree | What it is | When you edit it |
+|---|---|---|
+| `codev/` | **Our** instance — our specs, plans, reviews, resources | Implementing a feature *for* Codev |
+| `codev-skeleton/` | The **template shipped to adopters** — protocols, roles, templates, agents | Changing what other projects receive |
 
-### Important: Understanding This Repository's Structure
+A framework change usually belongs in **both**. `codev-skeleton/` carries no specs or
+plans — those are created by the projects that install it.
 
-This repository has a dual nature that's important to understand:
+### How framework files resolve
 
-1. **`codev/`** - This is OUR instance of Codev
-   - This is where WE (the Codev project) keep our specs, plans, reviews, and resources
-   - When working on Codev features, you work in this directory
-   - Example: `codev/specs/1-test-infrastructure.md` is a feature spec for Codev itself
+Protocols, prompts, roles and templates resolve at **runtime** through four tiers, highest
+first: `.codev/<path>` → `codev/<path>` → runtime cache → **installed package skeleton**.
 
-2. **`codev-skeleton/`** - This is the template for OTHER projects
-   - This is what gets copied to other projects when they install Codev
-   - Contains the protocol definitions, templates, and agents
-   - Does NOT contain specs/plans/reviews (those are created by users)
-   - Think of it as "what Codev provides" vs "how Codev uses itself"
+The absence of `codev/protocols/<name>/` is normal, not a missing reference — it means the
+protocol resolves from the installed package. Only protocols you customize need a local copy.
+When `codev update` merges a template that references a protocol you don't have locally, keep
+the reference.
 
-**When to modify each**:
-- **Modify `codev/`**: When implementing features for Codev (specs, plans, reviews, our architecture docs)
-- **Modify `codev-skeleton/`**: When updating protocols, templates, or agents that other projects will use
+**Deliver framework content; don't instruct an agent to fetch it by path.** A builder-facing
+prompt or role doc must not say "read `codev/protocols/…`" — that bypasses the resolver and
+fails in fresh installs. `protocol.md` is inlined into the spawn prompt; phase prompts and
+their templates arrive via porch. Naming a `codev/...` path in prose for orientation is fine;
+the rule is about *fetching*. (`codev/resources/arch.md` and `lessons-learned.md` are
+user-evolved files, not framework files — referencing those by path is correct.)
 
-### Release Process
+Verify an unfamiliar protocol against the CLI rather than assuming: `afx spawn --protocol
+<name> --help` succeeds if it is registered, including via the skeleton fallback.
 
-To release a new version, tell the AI: `Let's release v1.6.0`. The AI follows the **RELEASE protocol** (`codev/protocols/release/protocol.md`). Release candidate workflow and local testing procedures are documented there. For local testing shortcuts, see `codev/resources/testing-guide.md`.
+## Irreversible acts — the rules that exist because something was destroyed
 
-### Local Build Testing
+These are not style preferences. Each one is here because an agent destroyed work or bypassed
+a human decision.
 
-To test changes locally before publishing to npm:
+- Never `git add -A` / `--all` / `.` — stage each file explicitly by path.
+- Never destroy builder worktrees (`git worktree remove`, `git branch -D` on builder branches, `afx cleanup` + respawn). Use `afx spawn <id> --resume`; if it fails, ask the human — what is expendable is never your call.
+- Never run `git reset --hard`, `git checkout -- .`, `git clean -fd`, or `git stash` without explicit human permission — they destroy uncommitted work.
+- Never treat a porch gate as approved without an explicit human decision — a gate message is a notification to the human, not authorization.
+- Never hand-edit `status.yaml` — only porch commands modify project state.
+- Run `afx` commands only from the main workspace root, never from inside a builder worktree — spawning from a worktree nests builders and breaks the workspace.
+- Never kill a shellper process without verifying it is an orphan (match each PID to its workspace via Tower) — an 'extra' shellper may be a live architect session.
+- Never restart or stop Tower without explicit human permission — it kills every running builder session.
 
-```bash
-# From the repository root:
+## Gates
 
-# 1. Build (Tower stays up during this)
-pnpm build
+Two human approval gates plus the PR gate. Only a human transitions
+`conceived → specified` and `committed → integrated`. Stop and wait at each; do not infer
+approval from silence.
 
-# 2. Pack, install globally, and restart Tower (one command)
-pnpm -w run local-install
-```
+**Approved specs and plans need frontmatter and must be committed to `main` before spawning.**
+Porch runs the full protocol from `specify`, but treats an artifact carrying this as done:
 
-- `pnpm build` builds core first, then codev (including dashboard)
-- `pnpm -w run local-install` runs `scripts/local-install.sh`, which:
-  - Packs both `@cluesmith/codev-core` and `@cluesmith/codev` tarballs into their package directories
-  - Globally installs both in one `npm install -g` (separate installs fail because `@cluesmith/codev-core` isn't on the public npm registry)
-  - Restores the executable bit on `scripts/forge/**/*.sh` (pnpm pack strips it, causing "GitHub CLI unavailable" errors otherwise)
-  - Restarts Tower so it picks up the new code
-- Install runs while Tower is up — only the final restart causes downtime
-- Do NOT stop Tower yourself before running the script — the script handles restart at the end
-- Do NOT use `npm link` or `pnpm link` — it breaks global installs
-
-### Testing
-
-When making changes to UI code (tower, dashboard, terminal), you MUST test using Playwright before claiming the fix works. See `codev/resources/testing-guide.md` for Playwright patterns and Tower regression prevention.
-
-## Quick Start
-
-> **New to Codev?** See the [Cheatsheet](codev/resources/cheatsheet.md) for philosophies, concepts, and tool reference.
-
-You are working in the Codev project itself, with multiple development protocols available:
-
-**Available Protocols**:
-- **SPIR**: Multi-phase development with consultation - `codev/protocols/spir/protocol.md`
-- **ASPIR**: Autonomous SPIR (no human gates on spec/plan) - `codev/protocols/aspir/protocol.md`
-- **AIR**: Autonomous Implement & Review for small features - `codev/protocols/air/protocol.md`
-- **BUGFIX**: Bug fixes from GitHub issues - `codev/protocols/bugfix/protocol.md`
-- **PIR**: Plan / Implement / Review — issue-driven with two pre-PR human gates (plan-approval, dev-approval) plus a post-PR `pr` gate. Lighter than SPIR; stronger than BUGFIX/AIR. Useful when a change needs design review before coding OR pre-PR testing of running code (e.g., mobile / UI / cross-platform). See `codev/protocols/pir/protocol.md`.
-- **EXPERIMENT**: Disciplined experimentation - `codev/protocols/experiment/protocol.md`
-- **MAINTAIN**: Codebase maintenance (code hygiene + documentation sync) - `codev/protocols/maintain/protocol.md`
-- **RESEARCH**: Multi-agent research with 3-way investigation, synthesis, and critique - `codev/protocols/research/protocol.md`
-
-### File Resolution (How Codev Finds Protocols and Templates)
-
-Codev resolves protocol files, prompts, agent definitions, and roles through a four-tier lookup (highest priority first):
-
-1. `.codev/<path>` — user override (project-local customization)
-2. `codev/<path>` — project-local copy (customized and checked in)
-3. Runtime cache
-4. **Installed package skeleton** — ships with `@cluesmith/codev` (the default for every standard protocol)
-
-**The absence of `codev/protocols/<name>/` on disk is not a missing reference** — it's the normal case for any protocol you haven't customized. The protocol resolves from the installed package's skeleton at runtime. Only protocols you want to customize need to live in your repo's `codev/protocols/`.
-
-**Implication for `codev update` and CLAUDE.md / AGENTS.md merges:** when an updated template references a protocol (e.g., PIR), do NOT drop the reference because `codev/protocols/<name>/` is absent locally. The protocol resolves via the package skeleton, and dropping the reference removes the protocol from the user's available-protocol list while it's still callable from the CLI.
-
-### Framework files in prompts: deliver them, don't make the builder read them by path
-
-Framework files (protocol/role docs, the shipped `codev/resources/` reference docs) default to the package skeleton (see File Resolution above) and aren't guaranteed on disk in a fresh project. So when authoring any builder-facing prompt, role doc, or instruction, don't tell the builder to read a framework file by literal `codev/...` path — that bypasses the resolver and fails in fresh installs. Deliver the content instead (`protocol.md` is inlined into the spawn prompt; per-phase prompts and their templates arrive via porch). Mentioning a `codev/...` path in prose for orientation is fine — the rule is about *fetching*, not *referencing*. (`codev/resources/arch.md` and `codev/resources/lessons-learned.md` are user-evolved files, not framework files, so referencing those by path is correct.)
-
-### Protocol Verification (When You Don't Recognize a Protocol Name)
-
-If the user mentions a protocol name you don't immediately recognize, verify against the CLI before responding:
-
-```bash
-afx spawn --protocol <name> --help
-```
-
-This succeeds if the protocol is registered (including via the skeleton fallback in tier 4 of the resolution chain) and errors helpfully otherwise. The CLI is the source of truth — defer to it when in doubt.
-
-Key locations:
-- Protocol details: `codev/protocols/` (Choose appropriate protocol)
-- **Project tracking**: GitHub Issues (source of truth for all projects)
-- Specifications go in: `codev/specs/`
-- Plans go in: `codev/plans/`
-- Reviews go in: `codev/reviews/`
-
-### Project Tracking
-
-**GitHub Issues are the source of truth for project tracking.**
-
-- Issues with the `spec` label have approved specifications
-- Issues with the `plan` label have approved plans
-- Active builders are tracked via `codev/projects/<id>/status.yaml` (managed by porch)
-- The workspace overview Work view shows builders, PRs, and backlog derived from GitHub + filesystem state
-
-**When to use which:**
-- **Starting work**: Check GitHub Issues for priorities and backlog
-- **During implementation**: Use `porch status <id>` for detailed phase status
-- **After completion**: Close the GitHub Issue when PR is merged
-
-### Area Labels — the organizing axis for issues
-
-`area/*` is the **primary axis** for organizing GitHub Issues in this repo. When users ask to group, edit, audit, or bulk-move issues, treat `area/*` as the grouping dimension first — not `type:*` (we don't use them), not milestones, not assignees.
-
-**Labels**:
-
-| Label | Scope |
-|---|---|
-| `area/docs` | Documentation — this repo, CLAUDE/AGENTS, role files, `codev/resources/` |
-| `area/vscode` | VSCode extension — sidebar views, panel-area views, commands, keybindings |
-| `area/dashboard` | Tower web dashboard — the `@cluesmith/codev-web` React/Vite package, served by Tower and opened in a browser (distinct from any VSCode UI) |
-| `area/consult` | `consult` CLI and consultation tooling |
-| `area/tower` | Tower server + `afx` / agent-farm CLI. **No separate `area/agent-farm`** — afx work goes here. |
-| `area/cross-cutting` | Multi-area work — used **alone**, never alongside another `area/*` |
-| `area/porch` | Porch state machine / protocol orchestration |
-| `area/protocols` | Protocol definitions (`codev/protocols/`, `codev-skeleton/protocols/`) — distinct from `area/porch` (orchestration) |
-| `area/config` | `.codev/config.json` and workspace setup |
-| `area/terminal` | Terminal-specific — PTY, VSCode terminal pane |
-| `area/scaffold` | Install path — `codev init` / `adopt` / `update` / `doctor`, `codev-skeleton/`, the four-tier resolver |
-| `area/release` | Release tooling — version bumps, release protocol artifacts, release scripts |
-| `area/web` | Marketing site / web content — the `marketing/` directory |
-| `area/core` | Shared core library / forge abstraction (`packages/core`, `packages/codev/src/lib`, `packages/types`) |
-
-**Policy:**
-
-- **Exactly one** `area/*` per issue. Multi-area work uses `area/cross-cutting` *alone* — never two `area/*` labels.
-- **No `type:*` labels.** Codev classifies issues by area only.
-- `area/` uses **slash**. Other label families (if ever introduced) would keep colons.
-
-**🚨 CRITICAL: Two human approval gates exist:**
-- **conceived → specified**: AI creates spec, but ONLY the human can approve it
-- **committed → integrated**: AI can merge PRs, but ONLY the human can validate production
-
-AI agents must stop at `conceived` after writing a spec, and stop at `committed` after merging.
-
-**🚨 CRITICAL: Approved specs/plans need YAML frontmatter and must be committed to `main`.**
-When the architect creates and approves a spec or plan before spawning a builder, it must have YAML frontmatter marking it as approved and validated, and be committed to `main`. Porch always runs the full protocol from `specify` — but when it finds an existing artifact with this metadata, it skips that phase as a no-op. If no spec/plan exists, porch drives the builder to create one.
-
-Frontmatter format:
 ```yaml
 ---
 approved: 2026-01-29
@@ -187,555 +86,118 @@ validated: [gemini, codex, claude]
 ---
 ```
 
-## Agent Responsiveness
+## Protocols
 
-**Responsiveness is paramount.** The user should never wait for you. Use `run_in_background: true` for any operation that takes more than ~5 seconds.
+Pick by the nature of the work, not its size. Full definitions in `codev/protocols/<name>/`
+(or the package skeleton).
 
-| Task Type | Expected Duration | Action |
-|-----------|------------------|--------|
-| Running tests | 10-300s | `run_in_background: true` |
-| Consultations (consult) | 60-250s | `run_in_background: true` |
-| E2E test suites | 60-600s | `run_in_background: true` |
-| pnpm install/build | 5-60s | `run_in_background: true` |
-| Quick file reads/edits | <5s | Run normally |
+| Protocol | Use when |
+|---|---|
+| **BUGFIX** | A bug in a GitHub issue; isolated fix; no spec/plan needed |
+| **AIR** | Small feature fully described in an issue; no architectural decisions |
+| **PIR** | The approach needs review before coding, **or** the change must be tested running (mobile, UI, hardware, OAuth) before a PR exists |
+| **SPIR** | New feature from scratch, new protocol, architecture change |
+| **ASPIR** | SPIR without the spec/plan human gates — trusted, low-risk work |
+| **EXPERIMENT** | Proof of concept, model/library evaluation, research spike |
+| **MAINTAIN** | Dead code, dependency cleanup, doc sync (arch/lessons, CLAUDE↔AGENTS) |
+| **RESEARCH** | Competitive/technology analysis; output to `codev/research/` |
 
-**Critical**: Using `&` at the end of the command does NOT work - you MUST set the `run_in_background` parameter.
+Skip protocol ceremony for README typos, template one-liners, and dependency bumps.
 
-## Protocol Selection Guide
+**Issues are the source of truth for tracking.** `spec` and `plan` labels mark approved
+artifacts; `porch status <id>` gives live phase detail; close the issue when the PR merges.
 
-### Use BUGFIX for (GitHub issue fixes):
-- Bug reported as a **GitHub Issue**
-- Fix is isolated (< 300 LOC net diff)
-- No spec/plan artifacts needed
-- Single builder can fix independently
+### Artifacts
 
-**BUGFIX uses GitHub Issues as source of truth.** See `codev/protocols/bugfix/protocol.md`.
+Three documents per feature, same filename in three directories — spec defines **what**, plan
+defines **how**, review captures **what was learned**:
 
-### Use AIR for (small features from GitHub issues):
-- Small features (< 300 LOC) fully described in a **GitHub Issue**
-- No architectural decisions needed
-- No spec/plan artifacts — review goes in the PR body
-- Would be overkill for full SPIR/ASPIR ceremony
-
-**AIR uses GitHub Issues as source of truth.** Two phases: Implement → Review. See `codev/protocols/air/protocol.md`.
-
-### Use PIR for (engineer-judged — based on the nature of the work, not its size):
-
-Pick PIR when ONE or BOTH of the following apply to a GitHub-issue-driven change:
-
-**1. The approach needs review before coding starts**:
-- Root cause is ambiguous; multiple valid fixes exist
-- Area is unfamiliar or high-blast-radius (shared utilities, auth, migrations, public APIs)
-- Design-sensitive (affects conventions, patterns, architecture)
-- Cheaper to redirect at plan time than at PR time
-
-**2. The implementation needs to be TESTED before a PR is created** (PR diff alone is insufficient):
-- Mobile app changes (needs device testing on Android, iOS, possibly web)
-- UI / UX changes (visual inspection, interaction flow, accessibility)
-- Hardware-adjacent behavior (sensors, camera, permissions, notifications)
-- Integration with external services that don't mock cleanly (OAuth, payments, analytics)
-- User-journey changes that need a full-flow exercise
-- Performance-sensitive changes that need profiling on the running app
-
-**PIR uses GitHub Issues as source of truth.** Three phases: Plan (gated by `plan-approval`) → Implement (gated by `dev-approval`) → Review (PR + CMAP-2 at PR, then gated by `pr` for merge synchronization — matching SPIR's pr-gate pattern but with no post-merge verify phase). Plan and review artifacts live in `codev/plans/` and `codev/reviews/` on the builder branch, ship to main with the merge. Review file is shaped identically to SPIR's (Summary + Architecture Updates + Lessons Learned + supporting sections) so `codev/reviews/` stays semantically consistent across protocols. Lighter than SPIR (no spec phase — the issue body is the implicit spec; consult footprint matches BUGFIX/AIR's "one consult at PR" pattern). Stronger than BUGFIX/AIR (two human gates pre-PR — the human reviews the running worktree at the `dev-approval` gate, not the PR diff post-creation). CMAP at the PR is a **single advisory pass** (`max_iterations: 1`) — no iterate-until-APPROVE loop; a `REQUEST_CHANGES` is escalated to the human at the `pr` gate, not auto-re-reviewed. The CMAP-2 footprint is a design invariant: porch's model precedence is *config > protocol*, so a project-wide `porch.consultation.models` (e.g. a SPIR-tuned 3-model list) silently inflates PIR — leave it unset or scope it per-protocol to preserve the BUGFIX/AIR-parity cost. See `codev/protocols/pir/protocol.md`.
-
-### Use SPIR for (new features):
-- Creating a **new feature from scratch** (no existing spec to amend)
-- New protocols or protocol variants
-- Major changes to existing protocols
-- Complex features requiring multiple phases
-- Architecture changes
-
-### Use ASPIR for (autonomous SPIR):
-- Same as SPIR but **without human approval gates** on spec and plan
-- Trusted, low-risk work where spec/plan review can be deferred to PR
-- Builder runs autonomously through Specify → Plan → Implement → Review (→ Verify)
-- Human approval still required at the PR gate before merge
-
-**ASPIR is identical to SPIR** except `spec-approval` and `plan-approval` gates are removed. Both include an optional verify phase after review. See `codev/protocols/aspir/protocol.md`.
-
-### Use EXPERIMENT for:
-- Testing new approaches or techniques
-- Evaluating models or libraries
-- Proof-of-concept work
-- Research spikes
-
-### Use MAINTAIN for:
-- Removing dead code and unused dependencies
-- Quarterly codebase maintenance
-- Before releases (clean slate for shipping)
-- Syncing documentation (arch.md/arch-critical.md, lessons-learned.md/lessons-critical.md, CLAUDE.md/AGENTS.md)
-
-### Use RESEARCH for:
-- Competitive analysis and technology evaluation
-- Market research and "state of X" questions
-- Architectural decision support when unfamiliar with the domain
-- Triangulating across 3 AI models to get a high-confidence answer
-- Output goes to `codev/research/<topic>.md`
-
-### Skip formal protocols for:
-- README typos or minor documentation fixes
-- Small bug fixes in templates
-- Dependency updates
-
-## Core Workflow
-
-1. **When asked to build NEW FEATURES FOR CODEV**: Start with the Specification phase
-2. **Create exactly THREE documents per feature**: spec, plan, and review (all with same filename)
-3. **Follow the SPIR phases**: Specify → Plan → Implement → Review (→ Verify)
-4. **Use multi-agent consultation by default** unless user says "without consultation"
-
-## Directory Structure
 ```
-project-root/
-├── codev/
-│   ├── protocols/           # Development protocols
-│   │   ├── spir/          # Multi-phase development with consultation
-│   │   ├── experiment/     # Disciplined experimentation
-│   │   └── maintain/       # Codebase maintenance (code + docs)
-│   ├── maintain/            # MAINTAIN protocol runtime artifacts
-│   │   └── .trash/         # Soft-deleted files (gitignored, 30-day retention)
-│   ├── projects/           # Active project state (managed by porch)
-│   ├── specs/              # Feature specifications (WHAT to build)
-│   ├── plans/              # Implementation plans (HOW to build)
-│   ├── reviews/            # Reviews and lessons learned from each feature
-│   └── resources/          # Reference materials
-│       ├── arch.md         # Architecture (COLD reference; maintained during MAINTAIN)
-│       ├── arch-critical.md # Architecture HOT tier — capped, always-injected (Spec 987)
-│       ├── testing-guide.md # Local testing, Playwright, regression prevention
-│       ├── lessons-learned.md   # Engineering wisdom (COLD reference; maintained during MAINTAIN)
-│       └── lessons-critical.md  # Engineering wisdom HOT tier — capped, always-injected (Spec 987)
-├── .claude/
-│   ├── agents/             # AI agent definitions (custom project agents)
-│   └── skills/             # Claude-native Codev skills
-├── .codex/
-│   └── skills/             # Codex-native Codev skills
-├── AGENTS.md              # Universal AI agent instructions (AGENTS.md standard)
-├── CLAUDE.md              # This file (Claude Code-specific, identical to AGENTS.md)
-└── [project code]
+codev/specs/42-feature-name.md
+codev/plans/42-feature-name.md
+codev/reviews/42-feature-name.md
 ```
 
-## Directory Map
-- pnpm install → always run from the repository root (installs all workspace packages)
-- pnpm build / pnpm test → run from `packages/codev/` or use `pnpm --filter @cluesmith/codev build`
-- E2E tests → `packages/codev/tests/e2e/`
-- Unit tests → `packages/codev/tests/unit/`
-- Never run npm commands from the repository root unless explicitly told to.
+Sequential numbering, no leading zeros. Keep specs and plans separate; they answer different
+questions.
 
-## File Naming Convention
+## Issue labels
 
-Use sequential numbering with descriptive names (no leading zeros):
-- Specification: `codev/specs/42-feature-name.md`
-- Plan: `codev/plans/42-feature-name.md`
-- Review: `codev/reviews/42-feature-name.md`
+`area/*` is the **primary organizing axis** — group, audit and bulk-move issues by area first.
 
-**CRITICAL: Keep Specs and Plans Separate**
-- Specs define WHAT to build (requirements, acceptance criteria)
-- Plans define HOW to build (phases, files to modify, implementation details)
-- Each document serves a distinct purpose and must remain separate
+**Exactly one `area/*` per issue.** Multi-area work uses `area/cross-cutting` *alone*. There
+are no `type:*` labels.
 
-## Multi-Agent Consultation
+`area/`: docs · vscode · dashboard · consult · tower (includes afx; there is no
+`area/agent-farm`) · porch · protocols (definitions, distinct from porch orchestration) ·
+config · terminal · scaffold · release · web · core · cross-cutting
 
-**DEFAULT BEHAVIOR**: Consultation is ENABLED by default with:
-- **Gemini** via the **Antigravity CLI (`agy`)** for deep analysis (the retired Gemini CLI's
-  replacement; OAuth/subscription, agy's default model — no pinned model id). Skips non-blockingly
-  if `agy` is missing/unauthenticated. An unauthenticated `agy` is spawned **at most once per TTL
-  window** rather than once per consult: the verdict is cached across processes in
-  `~/.cache/codev/agy-auth.json`, because each spawn opens an OAuth browser tab before Codev can
-  detect the missing login (#1077). Sign in with `agy` in any terminal and the lane recovers on its
-  own; see `codev/resources/commands/consult.md` for the TTL/opt-out env vars.
-- **GPT-5.6 Sol** (`gpt-5.6-sol`, medium reasoning effort) via the Codex SDK for coding and
-  architecture perspective. The `-sol` suffix is load-bearing — plain `gpt-5.6` and
-  `gpt-5.6-codex` are both rejected by Codex on a ChatGPT account.
-- **Claude Opus 5** (`claude-opus-5`) via the Claude Agent SDK for balanced analysis with tool use
+## Multi-agent consultation
 
-To disable: User must explicitly say "without multi-agent consultation"
+**Enabled by default.** Three reviewers: **Gemini** via the Antigravity CLI (`agy`, skips
+non-blockingly if unauthenticated), **GPT-5.6 Sol** (`gpt-5.6-sol` — the `-sol` suffix is
+load-bearing) via the Codex SDK, and **Claude Opus 5** via the Agent SDK. Disable only when
+the user says "without consultation".
 
-**CRITICAL CONSULTATION CHECKPOINTS (DO NOT SKIP):**
-- After writing implementation code → STOP → Consult GPT-5 and Gemini (via agy)
-- After writing tests → STOP → Consult GPT-5 and Gemini (via agy)
-- ONLY THEN present results to user for evaluation
+Consult after writing implementation code and after writing tests, before presenting results.
+**"cmap"** means run all three in parallel *in the background* and return control immediately.
 
-### cmap (Consult Multiple Agents in Parallel)
+## Git
 
-**cmap** is shorthand for "consult multiple agents in parallel in the background."
+Commit messages:
 
-When the user says **"cmap the PR"** or **"cmap spec 42"**, this means:
-1. Run a 3-way parallel review (Gemini, Codex, Claude)
-2. Run all three in the **background** (`run_in_background: true`)
-3. Return control to the user **immediately**
-4. Retrieve results later with `TaskOutput` when needed
-
-**Always run consultations in parallel** using separate Bash tool calls in the same message, not sequentially.
-
-## CLI Command Reference
-
-**IMPORTANT: Never guess CLI commands.** Use the `/afx` skill to check the quick reference before running agent farm commands. Common mistakes to avoid:
-- There is NO `codev tower` command — use `afx tower start` / `afx tower stop`
-- There is NO `restart` subcommand — stop then start
-- When unsure about syntax, check the docs below first
-
-Codev provides five CLI tools. For complete reference documentation, see:
-
-- **[Overview](codev/resources/commands/overview.md)** - Quick start and summary of all tools
-- **[codev](codev/resources/commands/codev.md)** - Project management (init, adopt, doctor, update, tower)
-- **[afx](codev/resources/commands/agent-farm.md)** - Agent Farm orchestration (start, spawn, status, cleanup, send, etc.)
-- **[porch](codev/resources/commands/overview.md#porch---protocol-orchestrator)** - Protocol orchestrator (status, run, approve, pending)
-- **[consult](codev/resources/commands/consult.md)** - AI consultation (general, protocol, stats)
-- **[team](codev/resources/commands/team.md)** - Team coordination (list, message, update, add)
-
-## Runnable Worktrees
-
-When configured, each builder worktree (`.builders/<id>/`) becomes runnable — reviewers can run whatever your dev command starts against the builder's branch — a dev server, `cargo run`, `expo start`, a test watcher, a build script, whatever iterates on your project — without `cd`'ing, manually installing, or finding the right command. Opt-in via `.codev/config.json`; unconfigured repos see zero behavior change.
-
-### Config: the `worktree` block
-
-```jsonc
-{
-  "worktree": {
-    "symlinks":   ["..."],        // glob patterns of files to symlink from root into each new worktree
-    "postSpawn":  ["..."],        // shell commands run inside each new worktree after createWorktree
-    "devCommand": "..."           // consumed by `afx dev <builder-id|main>`
-  }
-}
-```
-
-- `symlinks`: globs resolve from the workspace root; matches symlink into the worktree at the same relative path. Root `.env` and `.codev/config.json` are *always* symlinked regardless. **Symlinks, not copies** — edits to main's env files reflect instantly in any running dev session. A directory match is silently skipped (so a glob can't mask the worktree's own source) **unless** the entry ends with a trailing slash: `".local-user-data/"` is treated as a literal path and symlinks the directory whole (shared with the parent, not branch-isolated; a dangling link is fine if the source doesn't exist yet).
-- `postSpawn`: each command runs sequentially with `cwd` = worktree path. Non-zero exit aborts the spawn loud (half-built worktree stays for inspection).
-- `devCommand`: the foreground command that starts your dev process (a server, a watcher, `cargo run`, `expo start`, a build script — whatever iterates on your project). Required for `afx dev` to work.
-
-**Codev does not auto-detect your stack.** Pick the recipe below that matches your toolchain.
-
-### CLI
-
-```bash
-afx dev <builder-id>     # start dev in <builder-id>'s worktree
-afx dev main             # start dev in the MAIN workspace (Codev-managed)
-afx dev --stop           # stop the currently running dev PTY (builder or main)
-```
-
-Only one dev PTY runs at a time (by design — see "URLs are load-bearing" below), across **{main + all builders}**. `main` is a reserved target: it runs `worktree.devCommand` in the main checkout as a Codev-managed, swappable PTY, symmetric with builders. Starting any target while another is up prompts for swap (`afx dev <builder>` while `main` runs, or vice-versa); same-target requests print the existing terminal URL and exit. Like builder dev, main dev is a **non-persistent** PTY — a Tower restart (`pnpm -w run local-install`, crash) kills it; re-run to restart.
-
-**Launch main dev via `afx dev main`, not a bare `pnpm dev`.** A manually-run `pnpm dev` at the repo root is invisible to Codev (the deliberate "never kill what it didn't spawn" policy) — start a builder dev while it holds the ports and the builder dev silently fails to bind, or worse serves main's code under the worktree URL. `afx dev main` makes it a managed PTY that swap-detection can cleanly stop first. This only helps if you use it *consistently*; a hand-started `pnpm dev` stays unmanaged.
-
-### VSCode
-
-The same actions are available via right-click on any builder row in the Codev sidebar (Builders or Needs Attention view):
-
-- **Codev: Open Builder Terminal** — opens that builder's AI terminal in a VSCode tab (same as left-clicking the row).
-- **Codev: Open Worktree Folder** — opens `.builders/<id>/` in the OS file manager (Finder on macOS, Explorer on Windows, xdg-open on Linux).
-- **Codev: Run Worktree Setup** — applies the configured `worktree.symlinks` and runs the `worktree.postSpawn` commands against the existing worktree (mirrors what spawn does, minus the git steps). Idempotent: existing symlinks are skipped, missing ones added. Useful when the lockfile changed (reinstall deps), `symlinks` or `postSpawn` was extended after the builder spawned, a symlink was accidentally deleted, or the original setup aborted mid-run. Opens a fresh VSCode terminal so install output streams live. Available via CLI too: `afx setup <builder-id>`.
-- **Codev: View Diff** — opens a single unified diff editor for `main...HEAD` of that builder's worktree, with a file-list pane on the left (matches VSCode's built-in Source Control "Working Tree" view). Status icons indicate added / modified / deleted. Empty diff → friendly toast.
-- **Codev: Run Dev** — reads `worktree.devCommand` from `.codev/config.json`, asks Tower to spawn a dev PTY in the builder's worktree, and opens it as a VSCode terminal tab named `Codev: <name> (dev)`. If another builder's dev is already running, you get a modal asking whether to swap.
-- **Codev: Stop Dev** — kills the running dev PTY and closes its tab.
-
-The Codev sidebar's **Workspace** view also carries a dev control for *whatever folder this VSCode window is rooted at* (it is not "main"-specific):
-
-- **Start Dev** — runs `worktree.devCommand` for the current workspace. Target is resolved from the open folder: the main checkout → `main`; a `.builders/<id>/` worktree opened as its own window (e.g. via *Open Worktree as Workspace*) → that builder. Same single-slot swap model as builder dev (prompts if another dev is running). The row tooltip names the resolved target.
-- **Stop Dev** — stops this workspace's dev; the row appears only while it is running. Scoped to the resolved target — it does not touch other devs.
-
-The three commands are also available from the command palette (Cmd+Shift+P). No default keybindings; bind via `keybindings.json` if you use them often.
-
-### URLs are load-bearing
-
-The dev PTY uses **the same ports and URLs as main** intentionally. OAuth callbacks, CORS allowlists, cookie scoping, CSP `connect-src`, webhook URLs are all keyed off origin — running the worktree on a different port would break them. Consequence: stop main's `pnpm dev` before `afx dev`. If you don't, the spawned dev fails at bind time with its own `EADDRINUSE`. Prefer `afx dev main` (or the Workspace view's *Start Dev* row) over a hand-run `pnpm dev` so Codev owns the PTY and swap-detection can stop it for you automatically.
-
-### Cleanup semantics
-
-`afx dev --stop` and the swap path kill the entire PTY process group (SIGTERM, escalating to SIGKILL after 5s via `PtySession.kill`). That signals every grandchild of a monorepo dev orchestrator (`pnpm dev`, `turbo dev`, `pnpm -r --parallel run dev`, etc.) simultaneously. The OS reclaims ports as a consequence — Codev never touches ports directly.
-
-**Orphan recovery** — if Tower itself hard-crashes mid-dev and a process is left holding a port outside Codev's records:
-
-```bash
-lsof -ti :<port> | xargs kill                       # one port
-lsof -ti :3000,:3001,:4000 | xargs kill             # several at once
-```
-
-### Runnable Worktree Recipes
-
-Ready-to-paste blocks per stack. Adjust ports / paths to your project.
-
-**pnpm monorepo (Next.js + Turbo style):**
-```json
-{
-  "worktree": {
-    "symlinks": [".env.local", ".env.development.local", "packages/*/.env", "packages/*/.env.local", "turbo.json"],
-    "postSpawn": ["pnpm install --frozen-lockfile"],
-    "devCommand": "pnpm dev"
-  }
-}
-```
-
-**npm (single package):**
-```json
-{
-  "worktree": {
-    "symlinks": [".env.local", ".env.development"],
-    "postSpawn": ["npm ci"],
-    "devCommand": "npm run dev"
-  }
-}
-```
-
-**yarn:**
-```json
-{
-  "worktree": {
-    "symlinks": [".env.local"],
-    "postSpawn": ["yarn install --frozen-lockfile"],
-    "devCommand": "yarn dev"
-  }
-}
-```
-
-**bun:**
-```json
-{
-  "worktree": {
-    "symlinks": [".env.local"],
-    "postSpawn": ["bun install --frozen-lockfile"],
-    "devCommand": "bun dev"
-  }
-}
-```
-
-**cargo (Rust):**
-```json
-{
-  "worktree": {
-    "symlinks": [".env"],
-    "postSpawn": [],
-    "devCommand": "cargo run"
-  }
-}
-```
-
-**poetry / uv (Python):**
-```json
-{
-  "worktree": {
-    "symlinks": [".env", ".env.local"],
-    "postSpawn": ["uv sync"],
-    "devCommand": "uv run python -m myapp"
-  }
-}
-```
-
-**go mod:**
-```json
-{
-  "worktree": {
-    "symlinks": [".env"],
-    "postSpawn": ["go mod download"],
-    "devCommand": "go run ./cmd/server"
-  }
-}
-```
-
-## Architect-Builder Pattern
-
-The Architect-Builder pattern enables parallel AI-assisted development:
-- **Architect** (human + primary AI): Creates specs and plans, reviews work
-- **Builders** (autonomous AI agents): Implement specs in isolated git worktrees
-
-For detailed commands, configuration, and architecture, see:
-- `codev/resources/commands/agent-farm.md` - Full CLI reference
-- `codev/resources/arch.md` - Terminal architecture, state management
-- `codev/resources/workflow-reference.md` - Stage-by-stage workflow
-
-### 🚨 NEVER DESTROY BUILDER WORKTREES 🚨
-
-**When a worktree already exists for a project:**
-1. Use `afx spawn XXXX --resume`
-2. If `--resume` fails → **ASK THE USER**
-3. Only destroy if the user explicitly says to
-
-**NEVER run without EXPLICIT user request:**
-- `git worktree remove` (with or without --force)
-- `git branch -D` on builder branches
-- `afx cleanup` followed by fresh spawn
-
-**You are NOT qualified to judge what's expendable.** It is NEVER your call to delete a worktree.
-
-### 🚨 ALWAYS Operate From the Main Workspace Root 🚨
-
-**ALL `afx` commands (`afx spawn`, `afx send`, `afx status`, `afx workspace`, `afx cleanup`) MUST be run from the repository root on the `main` branch.**
-
-- **NEVER** run `afx spawn` from inside a builder worktree — builders will get nested inside that worktree, breaking everything
-- **NEVER** run `afx workspace start` from a worktree — there is no separate workspace per worktree
-- **NEVER** `cd` into a worktree to run afx commands
-- The **only exception** is `porch` commands that need worktree context (e.g. `porch approve` from a builder's worktree)
-
-**What happened**: On 2026-02-21, `afx spawn` was run from inside a builder's worktree. All new builders were nested inside that worktree, `afx send` couldn't find them, and `afx status` showed "not active in tower". Multiple builders had to be killed and respawned.
-
-### Pre-Spawn Rule
-
-**Commit all local changes before `afx spawn`.** Builders work in git worktrees branched from HEAD — uncommitted specs, plans, and codev updates are invisible to the builder. The spawn command enforces this (override with `--force`).
-
-### Key Commands
-
-```bash
-afx workspace start                   # Start the workspace
-afx spawn 42 --protocol spir          # Spawn builder for SPIR project
-afx spawn 42 --protocol spir --soft   # Spawn builder (soft mode)
-afx spawn 42 --protocol bugfix        # Spawn builder for a bugfix
-afx status                            # Check all builders
-afx cleanup --project 0042            # Clean up (architect-driven, not automatic)
-afx open file.ts            # Open file in annotation viewer (NOT system open)
-```
-
-**IMPORTANT:** When the user says `afx open`, always run the `afx open` command — do NOT substitute the system `open` command.
-
-### Configuration
-
-Agent Farm is configured via `.codev/config.json` at the project root. Created during `codev init` or `codev adopt`. Override via CLI: `--architect-cmd`, `--builder-cmd`, `--shell-cmd`.
-
-## Inter-agent messaging
-
-Agents within a workspace communicate through `afx send`. Four addressing forms are supported:
-
-### Addressing forms
-
-| Form | Meaning | Allowed from |
-|---|---|---|
-| `afx send <builder-id> "msg"` | Send to a specific builder (e.g. `afx send 0823 "..."`). | Any sender. |
-| `afx send architect "msg"` | From a builder: routes to the spawning architect via affinity (per #774). From an architect (or any non-builder sender): routes to the architect named `main` if present, else the first registered architect. | Any sender. |
-| `afx send architect:<name> "msg"` | Explicit per-architect addressing. **Architects (including `main`)**: open address grammar — any architect can address any other architect. This is the sibling-architect messaging form. **Builders**: allowed ONLY when `<name>` matches the builder's own `spawnedByArchitect`. Mismatches are rejected by the spoofing check at `tower-messages.ts:213-218`. From a builder, this is an explicit form of the affinity routing, NOT an override. | Any sender (with the spoofing constraint above for builders). |
-| `afx send <workspace>:architect "msg"` | Cross-workspace addressing (e.g. `afx send marketmaker:architect "..."`). | Any sender. |
-
-### Sibling-architect messaging
-
-When a workspace hosts more than one architect (added via `afx workspace add-architect --name <name>`), sibling architects message each other via the `architect:<name>` form. Example:
-
-```bash
-# From main's terminal to a sibling architect named ob-refine
-afx send architect:ob-refine "PR-iter-2 feedback ready"
-```
-
-This works because sender = architect bypasses the spoofing check.
-
-### Builder spoofing-check (verified at `tower-messages.ts:213-218`)
-
-Builder `spir-823` running `afx send architect:ob-refine "..."` is rejected unless its `spawnedByArchitect == 'ob-refine'`. A builder cannot use `architect:<name>` to address an architect other than its spawning architect — that's an attempted spoof.
-
-### Discovering active agents
-
-- `afx status` lists all architects (post-#786) alongside builders, with names, terminal IDs, and PIDs where available.
-- Each active builder maintains a free-text narrative log at `codev/state/<builder-id>_thread.md` (relative to its worktree, so `.builders/<id>/codev/state/<id>_thread.md` from the main workspace root). **In-flight discovery**: `ls .builders/*/codev/state/*.md` and `cat .builders/<id>/codev/state/<id>_thread.md`. **Post-merge discovery**: after a builder's PR merges, its thread lands in `codev/state/` on `main`, alongside `codev/reviews/` — list with `ls codev/state/` and read with `cat codev/state/<builder-id>_thread.md` from the main checkout.
-
-## Porch - Protocol Orchestrator
-
-Porch drives SPIR, ASPIR, AIR, and BUGFIX protocols via a state machine with phase transitions, gates, and multi-agent consultations.
-
-### Key Commands
-
-```bash
-porch init spir 0073 "feature-name" --worktree .builders/0073
-porch status 0073
-porch run 0073
-porch approve 0073 spec-approval    # Human only
-porch pending                        # List pending gates
-```
-
-### Project State
-
-State is stored in `codev/projects/<id>-<name>/status.yaml`, managed automatically by porch. See `codev/resources/protocol-format.md` for protocol definition format.
-
-## Git Workflow
-
-### 🚨 ABSOLUTE PROHIBITION: NEVER USE `git add -A` or `git add .` 🚨
-
-**THIS IS A CRITICAL SECURITY REQUIREMENT - NO EXCEPTIONS**
-
-```bash
-git add -A        # ABSOLUTELY FORBIDDEN
-git add .         # ABSOLUTELY FORBIDDEN
-git add --all     # ABSOLUTELY FORBIDDEN
-```
-
-**MANDATORY APPROACH - ALWAYS ADD FILES EXPLICITLY**:
-```bash
-git add codev/specs/42-feature.md
-git add src/components/TodoList.tsx
-```
-
-**BEFORE EVERY COMMIT**: Run `git status`, add each file explicitly by name.
-
-### Commit Messages
 ```
 [Spec 42] Initial specification draft
 [Spec 42][Phase: user-auth] feat: Add password hashing
 [Bugfix #42] Fix: URL-encode username before API call
 ```
 
-### Branch Naming
-```
-spir/42-feature-name/phase-name
-builder/bugfix-42-description
-```
+Branches: `spir/42-feature-name/phase-name`, `builder/bugfix-42-description`.
 
-### Pull Request Merging
+**Merge PRs with `gh pr merge <n> --merge` — never squash.** Individual commits document the
+development process; squashing destroys it.
 
-**DO NOT SQUASH MERGE** - Always use regular merge commits:
-```bash
-gh pr merge <number> --merge    # CORRECT
-```
+## Working with builders
 
-Individual commits document the development process. Squashing loses this valuable history.
+Architects create specs and plans and review work; builders implement in isolated worktrees
+under `.builders/<id>/`. Commit everything before `afx spawn` — builders branch from HEAD, so
+uncommitted work is invisible to them.
 
-## Code Metrics
+Agents message each other with `afx send`:
 
-Use **tokei** for measuring codebase size: `tokei -e "tests/lib" -e "node_modules" -e ".git" -e ".builders" -e "dist" .`
+| Form | Meaning |
+|---|---|
+| `afx send <builder-id> "…"` | A specific builder |
+| `afx send architect "…"` | From a builder: its spawning architect. From anyone else: the architect named `main`, else the first registered |
+| `afx send architect:<name> "…"` | A named architect. Architects may address any architect; a **builder may only use this for its own spawning architect** — mismatches are rejected as spoofing |
+| `afx send <workspace>:architect "…"` | Cross-workspace |
 
-## Before Starting ANY Task
+`afx send` requires the workspace active in Tower (`afx workspace start`).
 
-### ALWAYS Check for Existing Work First
+Each builder keeps a narrative log at `codev/state/<builder-id>_thread.md` — in-flight at
+`.builders/<id>/codev/state/`, and on `main` after the PR merges.
 
-**BEFORE writing ANY code, run these checks:**
+## Tooling
 
-```bash
-# Check if there's already a PR for this
-gh pr list --search "XXXX"
+Each CLI has a skill carrying its commands and flags — **check the skill before running the
+command rather than guessing**: `afx` (spawn, status, send, dev, cleanup, Tower),
+`codev` (init, adopt, update, doctor, local build/test), `porch` (status, run, approve),
+`consult` (reviews, cmap, stats), `team`, `forge`, `runnable-worktrees` (making builder
+worktrees runnable), `update-arch-docs`.
 
-# Check GitHub Issues for status
-gh issue list --search "XXXX"
+`afx open <file>` opens the annotation viewer — it is not the system `open`.
 
-# Check if implementation already exists
-git log --oneline --all | grep -i "feature-name"
-```
+**Run anything slower than ~5s in the background** (`run_in_background: true`, not a trailing
+`&`): tests, consultations, installs, e2e suites.
 
-**If existing work exists**: READ it first, TEST if it works, IDENTIFY specific bugs, FIX minimally.
+Configuration lives in `.codev/config.json`.
 
-### When Stuck: STOP After 15 Minutes
+## Testing
 
-**If you've been debugging the same issue for 15+ minutes:**
-1. **STOP coding immediately**
-2. **Consult external models** (GPT-5, Gemini) with specific questions
-3. **Ask the user** if you're on the right path
-4. **Consider simpler approaches** - you're probably overcomplicating it
+UI changes (tower, dashboard, terminal) must be verified in a browser via Playwright before
+being called done — see `codev/resources/testing-guide.md`.
 
-**Warning signs you're in a rathole:**
-- Making incremental fixes that don't work
-- User telling you you're overcomplicating it (LISTEN TO THEM)
-- Trying multiple approaches without understanding why none work
-- Not understanding the underlying technology
+## Releasing
 
-### Understand Before Coding
-
-**Before implementing, you MUST understand:**
-1. **The protocol/API** - Read docs, don't guess
-2. **The module system** - ESM vs CommonJS vs UMD vs globals
-3. **What already exists** - Check the codebase and git history
-4. **The spec's assumptions** - Verify they're actually true
-
-## Important Notes
-
-1. **ALWAYS check `codev/protocols/spir/protocol.md`** for detailed phase instructions
-2. **Use provided templates** from `codev/protocols/spir/templates/`
-3. **Document all deviations** from the plan with reasoning
-4. **Create atomic commits** for each phase completion
-5. **Maintain >90% test coverage** where possible
-
----
-
-*Remember: Context drives code. When in doubt, write more documentation rather than less.*
+Say "Let's release v1.6.0"; the RELEASE protocol (`codev/protocols/release/protocol.md`)
+carries the procedure.

--- a/codev-skeleton/.claude/skills/codev/SKILL.md
+++ b/codev-skeleton/.claude/skills/codev/SKILL.md
@@ -57,3 +57,34 @@ codev doctor
 - `codev init` creates a new directory — use `codev adopt` for existing projects
 - Always run `codev adopt` and `codev update` from the project root
 - `codev update` only updates framework files — it never touches specs/plans/reviews
+
+## Local build and install (this repository)
+
+Test changes locally before publishing. Run from the repository root:
+
+```bash
+pnpm build                  # builds core first, then codev (including dashboard)
+pnpm -w run local-install   # packs both packages, installs globally, restarts Tower
+```
+
+`local-install` (`scripts/local-install.sh`) packs `@cluesmith/codev-core` and
+`@cluesmith/codev`, installs both in a single `npm install -g` (separate installs fail —
+`codev-core` is not on the public registry), restores the executable bit on
+`scripts/forge/**/*.sh` that `pnpm pack` strips, and restarts Tower last. Install runs while
+Tower is up; only the final restart causes downtime. **Do not stop Tower first**, and do not use
+`npm link` / `pnpm link` — it breaks global installs.
+
+`pnpm build` also runs `copy-skeleton`, which copies `codev-skeleton/` into
+`packages/codev/skeleton`. **Tests read that copy**, so after editing anything under
+`codev-skeleton/` you must rebuild before the suite reflects your change.
+
+### Where to run things
+
+- `pnpm install` — repository root (installs all workspace packages)
+- `pnpm build` / `pnpm test` — `packages/codev/`, or `pnpm --filter @cluesmith/codev build`
+- Unit tests `packages/codev/tests/unit/` · E2E `packages/codev/tests/e2e/`
+- Never run npm commands from the repository root unless told to
+
+### Measuring code size
+
+`tokei -e "tests/lib" -e "node_modules" -e ".git" -e ".builders" -e "dist" .`

--- a/codev-skeleton/.claude/skills/runnable-worktrees/SKILL.md
+++ b/codev-skeleton/.claude/skills/runnable-worktrees/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: runnable-worktrees
+description: Make builder worktrees runnable — the `.codev/config.json` `worktree` block (symlinks, postSpawn, devCommand), the `afx dev` CLI, VSCode dev controls, and per-stack config recipes. Use when configuring a repo so reviewers can run a builder's branch, when `afx dev` fails to bind or start, when a dev process is orphaned holding a port, or when asked why worktree dev uses the same ports as main.
+---
+
+# Runnable worktrees
+
+When configured, each builder worktree (`.builders/<id>/`) becomes runnable: reviewers can run
+whatever your dev command starts — a dev server, `cargo run`, `expo start`, a test watcher, a
+build script — against the builder's branch without `cd`'ing, installing, or hunting for the
+command. Opt-in via `.codev/config.json`; unconfigured repos see zero behavior change.
+
+## Config: the `worktree` block
+
+```jsonc
+{
+  "worktree": {
+    "symlinks":   ["..."],   // globs symlinked from the workspace root into each new worktree
+    "postSpawn":  ["..."],   // shell commands run inside each new worktree after createWorktree
+    "devCommand": "..."      // consumed by `afx dev <builder-id|main>`
+  }
+}
+```
+
+- **`symlinks`** — globs resolve from the workspace root and link into the worktree at the same
+  relative path. Root `.env` and `.codev/config.json` are *always* symlinked regardless.
+  **Symlinks, not copies**, so edits to main's env files reflect instantly in a running dev
+  session. A directory match is silently skipped (a glob cannot mask the worktree's own source)
+  **unless** the entry ends in a slash: `".local-user-data/"` is treated as a literal path and
+  links the directory whole — shared with the parent, not branch-isolated. A dangling link is
+  fine if the source does not exist yet.
+- **`postSpawn`** — commands run sequentially with `cwd` = worktree path. A non-zero exit aborts
+  the spawn loudly; the half-built worktree stays for inspection.
+- **`devCommand`** — the foreground command that starts your dev process. Required for
+  `afx dev`.
+
+**Codev does not auto-detect your stack.** Pick a recipe below.
+
+## CLI
+
+```bash
+afx dev <builder-id>     # start dev in that builder's worktree
+afx dev main             # start dev in the MAIN workspace (Codev-managed)
+afx dev --stop           # stop the running dev PTY (builder or main)
+afx setup <builder-id>   # re-apply symlinks + postSpawn to an existing worktree (idempotent)
+```
+
+**One dev PTY at a time**, across {main + all builders} — deliberate; see *URLs are
+load-bearing*. `main` is a reserved target running `worktree.devCommand` in the main checkout as
+a Codev-managed, swappable PTY, symmetric with builders. Starting a second target prompts to
+swap; a same-target request prints the existing terminal URL and exits. Dev PTYs are
+**non-persistent** — a Tower restart or crash kills them; re-run to restart.
+
+**Start main's dev with `afx dev main`, not a bare `pnpm dev`.** A hand-run `pnpm dev` is
+invisible to Codev (which never kills what it did not spawn), so a builder dev started while it
+holds the ports either fails to bind or — worse — serves main's code under the worktree URL.
+`afx dev main` makes it a managed PTY that swap-detection can stop cleanly. This only helps if
+used consistently.
+
+## VSCode
+
+Right-click a builder row in the Codev sidebar (Builders or Needs Attention):
+
+- **Open Builder Terminal** — that builder's AI terminal in a tab (same as left-click).
+- **Open Worktree Folder** — `.builders/<id>/` in the OS file manager.
+- **Run Worktree Setup** — re-applies `worktree.symlinks` and `worktree.postSpawn` to an
+  existing worktree (the git steps are skipped). Idempotent. Use when the lockfile changed, when
+  `symlinks`/`postSpawn` grew after the builder spawned, when a link was deleted, or when the
+  original setup aborted. Streams install output in a fresh terminal. CLI: `afx setup <id>`.
+- **View Diff** — unified `main...HEAD` diff for that worktree with a file-list pane.
+- **Run Dev** / **Stop Dev** — spawn or kill the dev PTY as a `Codev: <name> (dev)` tab;
+  prompts to swap if another dev is running.
+
+The sidebar's **Workspace** view carries a dev control for whatever folder the window is rooted
+at — the main checkout resolves to `main`, a `.builders/<id>/` window resolves to that builder.
+The row tooltip names the resolved target. Commands are also in the palette (Cmd+Shift+P); no
+default keybindings.
+
+## URLs are load-bearing
+
+The dev PTY intentionally uses **the same ports and URLs as main**. OAuth callbacks, CORS
+allowlists, cookie scoping, CSP `connect-src` and webhook URLs are all keyed off origin, so
+running a worktree on a different port would break them.
+
+Consequence: stop main's dev before starting a builder's, or the spawned dev fails at bind time
+with `EADDRINUSE`.
+
+## Cleanup and orphan recovery
+
+`afx dev --stop` and the swap path kill the entire PTY **process group** (SIGTERM, then SIGKILL
+after 5s), which signals every grandchild of a monorepo orchestrator (`pnpm dev`, `turbo dev`,
+`pnpm -r --parallel run dev`) at once. Ports are reclaimed by the OS as a consequence — Codev
+never manipulates ports directly.
+
+If Tower hard-crashes mid-dev and a process is left holding a port outside Codev's records:
+
+```bash
+lsof -ti :<port> | xargs kill
+lsof -ti :3000,:3001,:4000 | xargs kill
+```
+
+## Recipes
+
+**pnpm monorepo (Next.js / Turbo)**
+```json
+{"worktree": {"symlinks": [".env.local", ".env.development.local", "packages/*/.env", "packages/*/.env.local", "turbo.json"], "postSpawn": ["pnpm install --frozen-lockfile"], "devCommand": "pnpm dev"}}
+```
+
+**npm** — `{"symlinks": [".env.local", ".env.development"], "postSpawn": ["npm ci"], "devCommand": "npm run dev"}`
+
+**yarn** — `{"symlinks": [".env.local"], "postSpawn": ["yarn install --frozen-lockfile"], "devCommand": "yarn dev"}`
+
+**bun** — `{"symlinks": [".env.local"], "postSpawn": ["bun install --frozen-lockfile"], "devCommand": "bun dev"}`
+
+**cargo** — `{"symlinks": [".env"], "postSpawn": [], "devCommand": "cargo run"}`
+
+**poetry / uv** — `{"symlinks": [".env", ".env.local"], "postSpawn": ["uv sync"], "devCommand": "uv run python -m myapp"}`
+
+**go mod** — `{"symlinks": [".env"], "postSpawn": ["go mod download"], "devCommand": "go run ./cmd/server"}`

--- a/codev-skeleton/.codex/skills/codev/SKILL.md
+++ b/codev-skeleton/.codex/skills/codev/SKILL.md
@@ -57,3 +57,34 @@ codev doctor
 - `codev init` creates a new directory — use `codev adopt` for existing projects
 - Always run `codev adopt` and `codev update` from the project root
 - `codev update` only updates framework files — it never touches specs/plans/reviews
+
+## Local build and install (this repository)
+
+Test changes locally before publishing. Run from the repository root:
+
+```bash
+pnpm build                  # builds core first, then codev (including dashboard)
+pnpm -w run local-install   # packs both packages, installs globally, restarts Tower
+```
+
+`local-install` (`scripts/local-install.sh`) packs `@cluesmith/codev-core` and
+`@cluesmith/codev`, installs both in a single `npm install -g` (separate installs fail —
+`codev-core` is not on the public registry), restores the executable bit on
+`scripts/forge/**/*.sh` that `pnpm pack` strips, and restarts Tower last. Install runs while
+Tower is up; only the final restart causes downtime. **Do not stop Tower first**, and do not use
+`npm link` / `pnpm link` — it breaks global installs.
+
+`pnpm build` also runs `copy-skeleton`, which copies `codev-skeleton/` into
+`packages/codev/skeleton`. **Tests read that copy**, so after editing anything under
+`codev-skeleton/` you must rebuild before the suite reflects your change.
+
+### Where to run things
+
+- `pnpm install` — repository root (installs all workspace packages)
+- `pnpm build` / `pnpm test` — `packages/codev/`, or `pnpm --filter @cluesmith/codev build`
+- Unit tests `packages/codev/tests/unit/` · E2E `packages/codev/tests/e2e/`
+- Never run npm commands from the repository root unless told to
+
+### Measuring code size
+
+`tokei -e "tests/lib" -e "node_modules" -e ".git" -e ".builders" -e "dist" .`

--- a/codev-skeleton/.codex/skills/runnable-worktrees/SKILL.md
+++ b/codev-skeleton/.codex/skills/runnable-worktrees/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: runnable-worktrees
+description: Make builder worktrees runnable — the `.codev/config.json` `worktree` block (symlinks, postSpawn, devCommand), the `afx dev` CLI, VSCode dev controls, and per-stack config recipes. Use when configuring a repo so reviewers can run a builder's branch, when `afx dev` fails to bind or start, when a dev process is orphaned holding a port, or when asked why worktree dev uses the same ports as main.
+---
+
+# Runnable worktrees
+
+When configured, each builder worktree (`.builders/<id>/`) becomes runnable: reviewers can run
+whatever your dev command starts — a dev server, `cargo run`, `expo start`, a test watcher, a
+build script — against the builder's branch without `cd`'ing, installing, or hunting for the
+command. Opt-in via `.codev/config.json`; unconfigured repos see zero behavior change.
+
+## Config: the `worktree` block
+
+```jsonc
+{
+  "worktree": {
+    "symlinks":   ["..."],   // globs symlinked from the workspace root into each new worktree
+    "postSpawn":  ["..."],   // shell commands run inside each new worktree after createWorktree
+    "devCommand": "..."      // consumed by `afx dev <builder-id|main>`
+  }
+}
+```
+
+- **`symlinks`** — globs resolve from the workspace root and link into the worktree at the same
+  relative path. Root `.env` and `.codev/config.json` are *always* symlinked regardless.
+  **Symlinks, not copies**, so edits to main's env files reflect instantly in a running dev
+  session. A directory match is silently skipped (a glob cannot mask the worktree's own source)
+  **unless** the entry ends in a slash: `".local-user-data/"` is treated as a literal path and
+  links the directory whole — shared with the parent, not branch-isolated. A dangling link is
+  fine if the source does not exist yet.
+- **`postSpawn`** — commands run sequentially with `cwd` = worktree path. A non-zero exit aborts
+  the spawn loudly; the half-built worktree stays for inspection.
+- **`devCommand`** — the foreground command that starts your dev process. Required for
+  `afx dev`.
+
+**Codev does not auto-detect your stack.** Pick a recipe below.
+
+## CLI
+
+```bash
+afx dev <builder-id>     # start dev in that builder's worktree
+afx dev main             # start dev in the MAIN workspace (Codev-managed)
+afx dev --stop           # stop the running dev PTY (builder or main)
+afx setup <builder-id>   # re-apply symlinks + postSpawn to an existing worktree (idempotent)
+```
+
+**One dev PTY at a time**, across {main + all builders} — deliberate; see *URLs are
+load-bearing*. `main` is a reserved target running `worktree.devCommand` in the main checkout as
+a Codev-managed, swappable PTY, symmetric with builders. Starting a second target prompts to
+swap; a same-target request prints the existing terminal URL and exits. Dev PTYs are
+**non-persistent** — a Tower restart or crash kills them; re-run to restart.
+
+**Start main's dev with `afx dev main`, not a bare `pnpm dev`.** A hand-run `pnpm dev` is
+invisible to Codev (which never kills what it did not spawn), so a builder dev started while it
+holds the ports either fails to bind or — worse — serves main's code under the worktree URL.
+`afx dev main` makes it a managed PTY that swap-detection can stop cleanly. This only helps if
+used consistently.
+
+## VSCode
+
+Right-click a builder row in the Codev sidebar (Builders or Needs Attention):
+
+- **Open Builder Terminal** — that builder's AI terminal in a tab (same as left-click).
+- **Open Worktree Folder** — `.builders/<id>/` in the OS file manager.
+- **Run Worktree Setup** — re-applies `worktree.symlinks` and `worktree.postSpawn` to an
+  existing worktree (the git steps are skipped). Idempotent. Use when the lockfile changed, when
+  `symlinks`/`postSpawn` grew after the builder spawned, when a link was deleted, or when the
+  original setup aborted. Streams install output in a fresh terminal. CLI: `afx setup <id>`.
+- **View Diff** — unified `main...HEAD` diff for that worktree with a file-list pane.
+- **Run Dev** / **Stop Dev** — spawn or kill the dev PTY as a `Codev: <name> (dev)` tab;
+  prompts to swap if another dev is running.
+
+The sidebar's **Workspace** view carries a dev control for whatever folder the window is rooted
+at — the main checkout resolves to `main`, a `.builders/<id>/` window resolves to that builder.
+The row tooltip names the resolved target. Commands are also in the palette (Cmd+Shift+P); no
+default keybindings.
+
+## URLs are load-bearing
+
+The dev PTY intentionally uses **the same ports and URLs as main**. OAuth callbacks, CORS
+allowlists, cookie scoping, CSP `connect-src` and webhook URLs are all keyed off origin, so
+running a worktree on a different port would break them.
+
+Consequence: stop main's dev before starting a builder's, or the spawned dev fails at bind time
+with `EADDRINUSE`.
+
+## Cleanup and orphan recovery
+
+`afx dev --stop` and the swap path kill the entire PTY **process group** (SIGTERM, then SIGKILL
+after 5s), which signals every grandchild of a monorepo orchestrator (`pnpm dev`, `turbo dev`,
+`pnpm -r --parallel run dev`) at once. Ports are reclaimed by the OS as a consequence — Codev
+never manipulates ports directly.
+
+If Tower hard-crashes mid-dev and a process is left holding a port outside Codev's records:
+
+```bash
+lsof -ti :<port> | xargs kill
+lsof -ti :3000,:3001,:4000 | xargs kill
+```
+
+## Recipes
+
+**pnpm monorepo (Next.js / Turbo)**
+```json
+{"worktree": {"symlinks": [".env.local", ".env.development.local", "packages/*/.env", "packages/*/.env.local", "turbo.json"], "postSpawn": ["pnpm install --frozen-lockfile"], "devCommand": "pnpm dev"}}
+```
+
+**npm** — `{"symlinks": [".env.local", ".env.development"], "postSpawn": ["npm ci"], "devCommand": "npm run dev"}`
+
+**yarn** — `{"symlinks": [".env.local"], "postSpawn": ["yarn install --frozen-lockfile"], "devCommand": "yarn dev"}`
+
+**bun** — `{"symlinks": [".env.local"], "postSpawn": ["bun install --frozen-lockfile"], "devCommand": "bun dev"}`
+
+**cargo** — `{"symlinks": [".env"], "postSpawn": [], "devCommand": "cargo run"}`
+
+**poetry / uv** — `{"symlinks": [".env", ".env.local"], "postSpawn": ["uv sync"], "devCommand": "uv run python -m myapp"}`
+
+**go mod** — `{"symlinks": [".env"], "postSpawn": ["go mod download"], "devCommand": "go run ./cmd/server"}`

--- a/codev-skeleton/protocols/air/protocol.md
+++ b/codev-skeleton/protocols/air/protocol.md
@@ -1,91 +1,60 @@
 # AIR Protocol
 
-> **AIR** = **A**utonomous **I**mplement & **R**eview
->
-> A lightweight protocol for small features that are fully specified by their GitHub issue.
-> Two phases: Implement → Review. No spec/plan artifacts.
+**A**utonomous **I**mplement → **R**eview. The lightest protocol that still produces a reviewed
+PR: no spec, no plan, no artifact files. The GitHub issue *is* the specification, and the review
+lives in the PR body.
 
-## What is AIR?
+Use AIR when a small feature (roughly <300 LOC) is fully described by its issue and needs no
+architectural decision, no new abstraction, and no significant refactor. If the issue leaves the
+approach genuinely open, the cost of a spec is lower than the cost of building the wrong thing —
+use SPIR or ASPIR. For a defect rather than a feature, use BUGFIX.
 
-AIR is a minimal protocol for implementing small features (< 300 LOC) where the GitHub issue provides all the requirements. It skips the Specify and Plan phases entirely — the builder implements directly from the issue and creates a PR with the review embedded in the PR body.
+## The state machine
 
-### How AIR Compares
-
-| Aspect | BUGFIX | AIR | ASPIR/SPIR |
-|--------|--------|-----|------------|
-| **Use case** | Bug fixes | Small features | New features |
-| **Input** | GitHub Issue | GitHub Issue | GitHub Issue → Spec |
-| **Phases** | Investigate → Fix → PR | Implement → PR | Specify → Plan → Implement → Review |
-| **Artifacts** | None | None | Spec, plan, review files |
-| **Review location** | PR body | PR body | `codev/reviews/` file |
-| **Consultation** | PR phase only | Optional (builder decides) | Every phase (3-way) |
-| **Human gates** | None (PR gate) | None (PR gate) | Spec + Plan + PR gates (SPIR) |
-| **LOC limit** | < 300 | < 300 | No limit |
-
-### When to Use AIR
-
-- Small features (< 300 LOC)
-- Requirements are clear from the GitHub issue
-- No architectural decisions needed
-- No new abstractions or significant refactoring required
-- Would be overkill for full SPIR/ASPIR ceremony
-
-### When NOT to Use AIR
-
-- Bug fixes → use **BUGFIX**
-- Features needing spec discussion → use **SPIR** or **ASPIR**
-- Architectural changes → use **SPIR**
-- Complex features with multiple phases → use **SPIR** or **ASPIR**
-
-## Baked Decisions (Optional)
-
-When filing an issue for AIR, you can pin architectural decisions you don't want the builder or CMAP reviewers to re-litigate. Include a `## Baked Decisions` section (any heading level is fine) anywhere in the issue body. Useful categories: language, framework, deployment shape, key dependencies, decisions deferred to a later spec. The builder will treat each listed item as fixed during implementation; CMAP reviewers will not propose alternatives unless the implementation itself fails to honor a stated decision. Leave the section out for issues where you want the builder to explore freely — absence is the no-op default. You can amend or rescind a baked decision at any time by updating the issue and respawning, or by sending the builder a direct instruction via `afx send`.
-
-## Protocol Phases
-
-### I - Implement
-
-The builder reads the GitHub issue and implements the feature:
-
-1. Read and understand the issue requirements
-2. Implement the feature (< 300 LOC)
-3. Write tests
-4. Verify build and tests pass
-5. Commit with descriptive message
-
-If the feature grows beyond 300 LOC or requires architectural decisions, the builder signals `TOO_COMPLEX` to escalate to ASPIR.
-
-### R - Review (PR)
-
-The builder creates a PR with the review embedded in the PR body:
-
-1. Create PR linking to the issue
-2. Include a review section in the PR body (summary, key decisions, test plan)
-3. Optionally run CMAP consultation if the builder judges the complexity warrants it
-4. Notify the architect
-
-The **PR gate** is preserved — a human reviews all code before merge.
-
-## Usage
-
-```bash
-# Spawn a builder using AIR
-afx spawn 42 --protocol air
-
-# The builder implements autonomously and stops at the PR gate
+```json
+{{> protocols/air/protocol.json}}
 ```
 
-## File Structure
+## Artifacts
 
-```
-codev-skeleton/protocols/air/
-├── protocol.json          # Protocol definition
-├── protocol.md            # This file
-├── builder-prompt.md      # Builder instructions (Handlebars template)
-├── prompts/
-│   ├── implement.md       # Implement phase prompt
-│   └── pr.md              # PR phase prompt
-└── consult-types/
-    ├── impl-review.md     # Implementation consultation guide
-    └── pr-review.md       # PR consultation guide
-```
+**None on disk.** The issue carries the requirements; the review goes in the PR body. That is
+the whole economy of AIR — a `codev/reviews/` file for a 200-line change costs more to maintain
+than it ever repays.
+
+## Consultation
+
+At the builder's discretion, unlike SPIR's mandatory 3-way at every phase. Reach for it when the
+change touches shared code or you are unsure the approach is right; skip it when the issue is
+unambiguous and the diff is small.
+
+## Gate
+
+The `pr` gate is human. There are no pre-implementation gates — which is precisely why AIR is
+only appropriate when the issue has already settled the questions a spec would ask.
+
+## Baked Decisions
+
+An issue may carry a `## Baked Decisions` section pinning architectural choices the architect
+does not want re-litigated — typically **language**, **framework**, deployment shape, key
+**dependencies**, or decisions deferred to a later spec.
+
+Every item in it is fixed. Copy the section verbatim into the spec's Constraints and do not
+re-open it in the spec, plan, or review; CMAP reviewers will not propose alternatives unless the
+spec fails to honour one. If two items contradict each other, do not choose — surface the
+contradiction and wait.
+
+**Absence is the no-op default**: an issue with no such section is an invitation to explore
+freely, not an omission to be filled in.
+
+The architect can **amend or rescind** a baked decision at any time by updating the issue and
+respawning, or by sending the builder a direct instruction via `afx send`.
+
+## Escalation
+
+If implementation reveals that the change is not small, or that it needs a decision the issue
+does not make, **stop and say so** rather than growing an AIR project into an unplanned SPIR.
+Escalating early is cheap; discovering it at PR review is not.
+
+## Branch naming
+
+`builder/air-<issue>-<short-description>`

--- a/codev-skeleton/protocols/aspir/protocol.md
+++ b/codev-skeleton/protocols/aspir/protocol.md
@@ -1,100 +1,52 @@
 # ASPIR Protocol
 
-> **ASPIR** = **A**utonomous **S**pecify → **P**lan → **I**mplement → **R**eview
->
-> Identical to SPIR but without human approval gates on spec and plan phases.
-> Each phase has one build-verify cycle with 3-way consultation.
+Autonomous SPIR: the same phases, artifacts, consultations and checks, with the **spec and plan
+human gates absent**. The builder runs Specify → Plan → Implement without stopping, and a human
+still reviews everything at the `pr` gate before merge.
 
-## What is ASPIR?
+Use ASPIR for trusted, low-risk work where reviewing the approach up front would cost more than
+it saves, and deferring that review to the PR is acceptable. When getting the shape wrong would
+be expensive to unwind, use SPIR and take the gates.
 
-ASPIR is an autonomous variant of the SPIR protocol. It follows the exact same phases (Specify → Plan → Implement → Review) with the same 3-way consultations, checks, and PR flow — but removes the `spec-approval` and `plan-approval` human gates.
+## The state machine
 
-This means the builder proceeds automatically from Specify → Plan → Implement without waiting for human approval at each gate. The `pr` gate in the Review phase is preserved — a human still reviews all code before merge.
+Phases, gates and checks — note that `specify` and `plan` carry **no gate at all**; they are not
+auto-approved, they are ungated:
 
-### Differences from SPIR
-
-| Aspect | SPIR | ASPIR |
-|--------|------|-------|
-| Spec gate (`spec-approval`) | Human must approve | Auto-approved |
-| Plan gate (`plan-approval`) | Human must approve | Auto-approved |
-| PR gate (`pr`) | Human must approve | Human must approve |
-| Phases | Specify → Plan → Implement → Review | Same |
-| 3-way consultations | Yes, every phase | Same |
-| Checks (build, tests, PR) | Yes | Same |
-| Prompts / templates | Full set | Same prompts; templates included from SPIR (no copies) |
-
-### When to Use ASPIR
-
-Use ASPIR instead of SPIR when:
-
-- The work is **trusted and low-risk** — internal tooling, protocol additions, well-understood features
-- The architect has **pre-written and approved** the spec before spawning
-- The scope is **self-contained** with low blast radius
-- You want **full SPIR discipline** (consultations, phased implementation, review) without waiting at gates
-
-### When NOT to Use ASPIR
-
-Use SPIR instead when:
-
-- The feature involves **novel architecture** or unclear requirements
-- The spec needs **iterative human feedback** during drafting
-- The work is **high-risk** — security-sensitive, user-facing, or broadly impactful
-- You want to **review and adjust** the plan before implementation starts
-
-## Baked Decisions (Optional)
-
-When filing an issue for ASPIR, you can pin architectural decisions you don't want the builder or CMAP reviewers to re-litigate. Include a `## Baked Decisions` section (any heading level is fine) anywhere in the issue body. Useful categories: language, framework, deployment shape, key dependencies, decisions deferred to a later spec. The builder will copy the section verbatim into the spec's Constraints and treat each item as fixed; CMAP reviewers will not propose alternatives unless the spec itself fails to honor a stated decision. Leave the section out for issues where you want the builder to explore freely — absence is the no-op default. You can amend or rescind a baked decision at any time by updating the issue and respawning, or by sending the builder a direct instruction via `afx send`.
-
-## Protocol Phases
-
-ASPIR follows the same four phases as SPIR. For full phase documentation, see the [SPIR protocol](../spir/protocol.md).
-
-### S - Specify
-Write specification with 3-way review (Gemini, Codex, Claude). **No human gate** — proceeds directly to Plan after verification.
-
-### P - Plan
-Write implementation plan with 3-way review. **No human gate** — proceeds directly to Implement after verification and checks pass.
-
-### I - Implement
-Execute each plan phase with build-verify cycle. Same as SPIR — no gate between phases (SPIR also has no gate here).
-
-### R - Review
-Final review, PR preparation, and 3-way review. **PR gate preserved** — builder stops and waits for human approval before merge.
-
-## Usage
-
-```bash
-# Spawn a builder using ASPIR
-afx spawn 42 --protocol aspir
-
-# The builder runs autonomously through Specify → Plan → Implement
-# and stops only at the PR gate in the Review phase
+```json
+{{> protocols/aspir/protocol.json}}
 ```
 
-## File Structure
+## Everything else is SPIR
 
-```
-codev/protocols/aspir/
-├── protocol.json          # Protocol definition (SPIR minus gates)
-├── protocol.md            # This file
-├── builder-prompt.md      # Builder instructions (same as SPIR)
-├── prompts/
-│   ├── specify.md         # Specify phase prompt (same as SPIR)
-│   ├── plan.md            # Plan phase prompt (same as SPIR)
-│   ├── implement.md       # Implement phase prompt (same as SPIR)
-│   └── review.md          # Review phase prompt (same as SPIR)
-└── consult-types/
-    ├── spec-review.md     # Spec consultation guide (same as SPIR)
-    ├── plan-review.md     # Plan consultation guide (same as SPIR)
-    ├── impl-review.md     # Impl consultation guide (same as SPIR)
-    ├── phase-review.md    # Phase consultation guide (same as SPIR)
-    └── pr-review.md       # PR consultation guide (same as SPIR)
-```
+Artifacts (`codev/specs/`, `codev/plans/`, `codev/reviews/`, same base filename), the
+build-verify cycle per plan phase, mandatory 3-way consultation at each verify step, the
+machine-readable `phases` block in the plan, commit and branch conventions, and Baked Decisions
+handling are all identical to SPIR. ASPIR includes SPIR's templates rather than copying them, so
+there is one set to keep correct.
 
-ASPIR ships **no `templates/` directory**. Its phase prompts deliver SPIR's canonical
-templates directly, via an include directive pointing at `protocols/spir/templates/`, so
-there is exactly one copy of each template and it cannot drift between the two protocols.
-(Written as a path, not as a literal include: an include directive in prose would be
-expanded — and silently emptied — when this file is delivered to a builder.)
+See `protocols/spir/protocol.md` for that shared substance.
 
-All files except `protocol.json` and `protocol.md` are identical to their SPIR counterparts.
+## Baked Decisions
+
+An issue may carry a `## Baked Decisions` section pinning architectural choices the architect
+does not want re-litigated — typically **language**, **framework**, deployment shape, key
+**dependencies**, or decisions deferred to a later spec.
+
+Every item in it is fixed. Copy the section verbatim into the spec's Constraints and do not
+re-open it in the spec, plan, or review; CMAP reviewers will not propose alternatives unless the
+spec fails to honour one. If two items contradict each other, do not choose — surface the
+contradiction and wait.
+
+**Absence is the no-op default**: an issue with no such section is an invitation to explore
+freely, not an omission to be filled in.
+
+The architect can **amend or rescind** a baked decision at any time by updating the issue and
+respawning, or by sending the builder a direct instruction via `afx send`.
+
+## The one thing to be careful about
+
+Without the spec and plan gates, nothing external catches a misread of the issue until the PR.
+If the spec you write surprises you — if it turns out larger, or more architectural, than the
+issue implied — that is the signal ASPIR was the wrong choice. Say so early rather than
+carrying the misfit through to review.

--- a/codev-skeleton/protocols/bugfix/protocol.md
+++ b/codev-skeleton/protocols/bugfix/protocol.md
@@ -1,78 +1,72 @@
 # BUGFIX Protocol
 
-> Lightweight, issue-driven protocol for minor bug fixes. **Investigate → Fix → PR**, with a single `pr` gate before merge. No spec or plan artifacts: the GitHub issue is the spec, and the review goes in the PR body.
+Investigate → Fix → PR, driven by a GitHub issue. No spec, no plan, no artifact files: the issue
+is the specification and the PR body carries the reasoning.
 
-## When to Use
+Use it for a defect whose fix is isolated. For a small *feature* use AIR; for anything needing a
+design decision use SPIR.
 
-Use BUGFIX when a bug is reported as a GitHub Issue and:
+## The state machine
 
-- The reproduction is clear (or inferable) and the root cause is isolated
-- The fix is small (guideline: < 300 LOC net diff) and contained to one area
-- No architectural changes or new design decisions are needed
-
-Escalate to **SPIR** (or another heavier protocol) instead when:
-
-- It is actually a feature request, not a bug
-- The root cause reveals a deeper architectural issue
-- The fix needs design review, spans multiple components, or clearly exceeds ~300 LOC
+```json
+{{> protocols/bugfix/protocol.json}}
+```
 
 ## Phases
 
-```
-investigate → fix → pr
-```
+**Investigate** — reproduce the bug and identify the root cause. **No code in this phase.**
+Confirm the fix fits BUGFIX scope; if it does not, signal `BLOCKED` and recommend escalation
+rather than growing the project quietly.
 
-### Investigate
-
-Read the issue, reproduce the bug, and identify the root cause. Confirm the fix fits BUGFIX scope. If it does not, signal `BLOCKED` and recommend escalation to the architect (`afx send architect "..."`). No code in this phase.
-
-### Fix
-
-Apply the minimal change that resolves the root cause, and add a regression test that fails without the fix and passes with it. Keep it focused: do not refactor surrounding code, do not fix unrelated bugs (file separate issues), do not add features. Run the build and tests (porch's `checks` block runs `npm run build` and `npm test`).
-
-Commit with the issue-driven format:
+**Fix** — the minimal change that resolves the root cause, plus a regression test that **fails
+without the fix and passes with it**. A test that passes either way documents nothing. Do not
+refactor surrounding code, fix unrelated bugs (file separate issues), or add features.
 
 ```
-[Bugfix #<N>] Fix: <what was fixed>
-[Bugfix #<N>] Test: <regression test added>
+[Bugfix #42] Fix: URL-encode username before API call
+[Bugfix #42] Test: regression for unencoded username
 ```
 
-### PR (gated by `pr`)
+**PR** — open with `gh pr create`, body carrying Summary, Root Cause, Fix and Test Plan plus
+`Fixes #<N>` so the issue closes on merge. Run one CMAP pass (Gemini, Codex, Claude), record
+each verdict, and address or rebut every `REQUEST_CHANGES`. Notify the architect with the
+verdicts, then `porch done <id>` and wait.
 
-1. Push the branch and open a PR with `gh pr create`. The body includes Summary, Root Cause, Fix, and Test Plan, plus `Fixes #<N>` so the issue auto-closes on merge.
-2. Run a multi-agent CMAP review on the PR (Gemini, Codex, Claude) and record each verdict. Address or rebut any `REQUEST_CHANGES`; add a regression test if a real defect surfaced.
-3. Notify the architect: `afx send architect "PR #<M> ready for review (fixes #<N>). CMAP: gemini=..., codex=..., claude=..."`.
-4. Run `porch done <id>` to request the `pr` gate, then wait. **The merge is gated by porch state, never by typed prose in your pane.**
-5. The human reviews the PR and the CMAP results on GitHub, then approves the gate: `porch approve <id> pr --a-human-explicitly-approved-this`.
-6. porch wakes the builder with a merge task. Merge with `gh pr merge --merge` (do **not** pass `--delete-branch`: the builder is checked out on this branch in a worktree), then run `porch done <id>` and notify the architect that it is merged and ready for cleanup.
+Merge with `gh pr merge --merge`. **Do not pass `--delete-branch`** — the builder is checked out
+on that branch in a worktree, and deleting it out from under them breaks the worktree.
 
-## Gate
+## The gate exists to make merge authorization structural
 
-BUGFIX has one human gate, `pr`, on the merge step. It exists so the merge trigger is structured porch state (approved or not), not free-text typed into the builder's pane. This eliminates the self-merge bug class: a builder cannot infer authorization from ambiguous input.
+BUGFIX has one human gate, `pr`. Its purpose is that the merge trigger is **porch state** —
+approved or not — rather than free text typed into the builder's pane. That closes the
+self-merge bug class: a builder cannot infer authorization from ambiguous prose.
 
-## Multi-Agent Consultation
+## Consultation
 
-A single CMAP pass at the PR (Gemini, Codex, Claude). There is no per-phase consultation: the issue is the spec and the fix is small, so review effort concentrates on the final PR.
+One CMAP pass at the PR. No per-phase consultation: the issue is the spec and the fix is small,
+so review effort concentrates where it can still change the outcome.
 
 ## Scope
 
-The < 300 LOC threshold is a **guideline**, measured as net diff (additions + deletions) anchored at the merge-base with the default branch. A well-contained 350-LOC fix is fine; a 200-LOC fix smeared across ten files may warrant escalation.
+The <300 LOC threshold is a **guideline**, measured as net diff (additions + deletions) against
+the merge-base with the default branch. A well-contained 350-line fix is fine; a 200-line fix
+smeared across ten files probably warrants escalation.
 
 ## Escalation
 
-If, mid-fix, the change outgrows BUGFIX (architectural impact, multiple components, unclear root cause after investigation, or more than ~300 LOC), notify the architect with specifics and recommend escalating to SPIR. Do not silently expand scope.
+If the change outgrows BUGFIX mid-flight — architectural impact, multiple components, unclear
+root cause after investigation — notify the architect with specifics and recommend SPIR. **Do
+not silently expand scope.**
 
-## Branch Naming
-
-```
-builder/bugfix-<issue-number>-<slug>
-```
-
-## Edge Cases
+## Edge cases
 
 | Scenario | Action |
 |---|---|
-| Cannot reproduce | Document the attempts in an issue comment, ask the reporter for detail, notify the architect |
-| Fix outgrows scope (architectural / multi-component / > ~300 LOC) | Notify the architect, recommend escalation; do not proceed |
-| Unrelated test failures | Out of scope: note them for the architect, do not fix them here |
-| Multiple bugs in one issue | Fix only the primary bug; file separate issues for the rest |
+| Cannot reproduce | Document the attempts on the issue, ask the reporter for detail, notify the architect |
+| Fix outgrows scope | Notify the architect and recommend escalation; do not proceed |
+| Unrelated test failures | Out of scope — note them for the architect, do not fix here |
+| Multiple bugs in one issue | Fix the primary one; file separate issues for the rest |
+
+## Branch naming
+
+`builder/bugfix-<issue>-<slug>`

--- a/codev-skeleton/protocols/experiment/protocol.md
+++ b/codev-skeleton/protocols/experiment/protocol.md
@@ -1,203 +1,37 @@
 # EXPERIMENT Protocol
 
-## Overview
+A disciplined experiment: state the hypothesis before running it, record what actually happened,
+and keep the result whichever way it goes.
 
-Disciplined experimentation: Each experiment gets its own directory with `notes.md` tracking goals, code, and results.
+Use it for evaluating models or libraries, proof-of-concept work, and technique comparisons —
+questions that should be settled by evidence rather than by argument.
 
-**Core Principle**: Document what you're trying, what you did, and what you learned.
+## The state machine
 
-## When to Use
-
-**Use for**: Testing approaches, evaluating models, prototyping, proof-of-concept work, research spikes
-
-**Skip for**: Production code (use SPIR), simple one-off scripts
+```json
+{{> protocols/experiment/protocol.json}}
+```
 
 ## Structure
 
-```
-experiments/
-├── 1_descriptive_name/
-│   ├── notes.md           # Goal, code, results
-│   ├── experiment.py      # Your experiment code
-│   └── data/
-│       ├── input/         # Input data
-│       └── output/        # Results, plots, etc.
-└── 2_another_experiment/
-    ├── notes.md
-    └── ...
-```
+Each experiment gets a numbered directory under `codev/experiments/` with a `notes.md` recording
+the hypothesis, method, results and conclusion.
 
-## Workflow
+## Notes structure
 
-### 1. Create Experiment Directory
-
-```bash
-# Create numbered directory
-mkdir -p experiments/1_experiment_name
-cd experiments/1_experiment_name
-
-# Initialize notes.md from template
-touch notes.md   # then fill it from the embedded template at the end of this protocol
-```
-
-Or ask your AI assistant: "Create a new experiment for [goal]"
-
-### 2. Document the Goal
-
-Before writing code, clearly state what you're trying to learn in `notes.md`:
-
-```markdown
-## Goal
-
-What specific question are you trying to answer?
-What hypothesis are you testing?
-```
-
-### 3. Write Experiment Code
-
-- Keep it simple - experiments don't need production polish
-- Reuse existing project modules where possible
-- Any structure is fine - focus on learning, not architecture
-
-**Dependencies**: If your experiment requires libraries not in the main project:
-1. Do NOT add them to the main project's `requirements.txt` or `pyproject.toml`
-2. Create a `requirements.txt` inside your experiment folder
-3. Document installation in `notes.md`
-
-### 4. Run and Observe
-
-Execute your experiment and capture results:
-- Save output files to `data/output/`
-- Take screenshots of visualizations
-- Log key metrics
-
-### 5. Document Results
-
-Update `notes.md` with:
-- What happened (actual results)
-- What you learned (insights)
-- What's next (follow-up actions)
-
-### 6. Commit
-
-```bash
-git add experiments/1_experiment_name/
-git commit -m "[Experiment 1] Brief description of findings"
-```
-
-## Best Practices
-
-### Keep It Simple
-- Experiments don't need production polish
-- Skip comprehensive error handling
-- Focus on answering the question
-
-### Document Honestly
-- Include failures - they're valuable learnings
-- Note dead ends and why they didn't work
-- Be specific about what surprised you
-
-### Track Time Investment
-- Wall clock time: Total elapsed time
-- Developer time: Active working time (excluding waiting)
-- Helps estimate future similar work
-
-### Use Project Modules
-- Don't duplicate existing code
-- Import from your `src/` directory
-- Experiments validate approaches, not reimplement them
-
-### Commit Progress
-- Use `[Experiment ####]` commit prefix
-- Commit intermediate results
-- Include output files when reasonable
-
-## Integration with Other Protocols
-
-### Experiment → SPIR
-When an experiment validates an approach for production use:
-
-1. Create a specification referencing the experiment
-2. Link to experiment results as evidence
-3. Use experiment code as reference implementation
-
-Example spec reference:
-```markdown
-## Background
-
-Experiment 5 validated that [approach] achieves [results].
-See: experiments/5_validation_test/notes.md
-```
-
-## Numbering Convention
-
-Use four-digit sequential numbering (consistent with project list):
-- `1_`, `2_`, `3_`...
-- Shared sequence across all experiments
-- Descriptive name after the number (snake_case)
-
-Examples:
-- `1_api_response_caching`
-- `2_model_comparison`
-- `3_performance_baseline`
-
-## Git Workflow
-
-### Commits
-```
-[Experiment 1] Initial setup and goal
-[Experiment 1] Add baseline measurements
-[Experiment 1] Complete - caching improves latency 40%
-```
-
-### When to Commit
-- After setting up the experiment
-- After significant findings
-- When completing the experiment
-
-**Data Management**:
-- Include `data/output/` ONLY if files are small (summary metrics, small plots)
-- Do NOT commit large datasets, binary model checkpoints, or heavy artifacts
-- Add appropriate entries to `.gitignore` for large files
-- Consider storing large outputs externally and linking in notes
-
-## Example Experiment
-
-```
-experiments/1_caching_strategy/
-├── notes.md
-├── benchmark.py
-├── cache_test.py
-└── data/
-    ├── input/
-    │   └── sample_requests.json
-    └── output/
-        ├── results.csv
-        └── latency_chart.png
-```
-
-**notes.md excerpt:**
-```markdown
-# Experiment 1: Caching Strategy Evaluation
-
-**Status**: Complete
-
-**Date**: 2024-01-15
-
-## Goal
-Determine if Redis caching improves API response times for repeated queries.
-
-## Results
-- 40% latency reduction for cached queries
-- Cache hit rate: 73% after warm-up
-- Memory usage: 50MB for 10k cached responses
-
-## Next Steps
-Create SPIR spec for production caching implementation.
-```
-
-## Template: notes.md
-
-Create `notes.md` with the following content:
+`notes.md` uses this structure:
 
 {{> protocols/experiment/templates/notes.md}}
+
+## The discipline that makes it worth doing
+
+**Write the hypothesis and the success criteria before running anything.** An experiment scored
+after the fact always succeeds — you discover the criterion the result happens to meet.
+
+**Record negative results.** "We tried X and it did not work, here is why" is the output that
+saves the next person a week. An experiment directory containing only successes is a directory
+that has been curated rather than run.
+
+**Keep the experiment separate from production code.** Experimental code answers a question; it
+has not earned the standards production code is held to, and promoting it silently is how a
+proof of concept becomes a maintenance burden nobody chose.

--- a/codev-skeleton/protocols/maintain/protocol.md
+++ b/codev-skeleton/protocols/maintain/protocol.md
@@ -1,241 +1,50 @@
 # MAINTAIN Protocol
 
-## Overview
+Audit → Clean → Sync, in a single pass, then a PR. Two phases, one consultation during the
+maintain phase and one before the PR.
 
-MAINTAIN is a single-pass maintenance protocol for keeping codebases healthy. The builder does all maintenance work in one phase, then creates a PR with a 3-way review.
+Use it for dead code and unused dependencies, quarterly hygiene, pre-release cleanup, and
+keeping the governance docs honest — `arch.md`/`arch-critical.md`,
+`lessons-learned.md`/`lessons-critical.md`, and the `CLAUDE.md`↔`AGENTS.md` twins.
 
-**Core Principle**: Do the work in one pass. Don't over-ceremonialize housekeeping.
+## The state machine
 
-**Key Documents** MAINTAIN keeps current:
-- `codev/resources/arch.md` (COLD reference) + `codev/resources/arch-critical.md` (HOT, always-injected) — Architecture, two tiers (Spec 987)
-- `codev/resources/lessons-learned.md` (COLD reference) + `codev/resources/lessons-critical.md` (HOT, always-injected) — Engineering wisdom, two tiers
-
-The two governance docs are siblings with **different purposes**: `arch.md` owns system shape (services, transports, mental models, verified-wrong assumptions about *this* system); `lessons-learned.md` owns durable engineering wisdom that applies *across* specs. Use the routing matrix below to decide where each fact belongs.
-
-### Lives where: routing facts to the right home
-
-| Type of fact/insight | Lives in |
-|---|---|
-| Current system shape (services, transports, key mental models) | `codev/resources/arch.md` |
-| Mechanism for a unique subsystem | `codev/resources/arch.md` (subsystem section) OR a meta-spec under `codev/architecture/<domain>.md` if the mechanism is large enough to warrant its own doc |
-| A durable engineering pattern that applies across multiple specs | `codev/resources/lessons-learned.md` (COLD reference) |
-| A **behavior-changing, cross-cutting** rule (should change how the next project is built) | `codev/resources/lessons-critical.md` (HOT, capped) — demote to `lessons-learned.md` if full |
-| A **behavior-changing, cross-cutting** architecture invariant (a future builder must know up front) | `codev/resources/arch-critical.md` (HOT, capped) — demote to `arch.md` if full |
-| A spec-narrow fix recipe (reference detail) | `codev/resources/lessons-learned.md` (COLD) — kept as reference; **never** the hot file |
-| A system-shape surprise verified-wrong in production ("looks like X but isn't") | `codev/resources/arch.md` § "Verified-Wrong Assumptions" |
-| Aspirational architectural direction (where we want to go) | The relevant meta-spec or roadmap doc, NOT `arch.md` body |
-| A changelog entry ("we shipped X in spec Y on date Z") | `git log` + the spec/review document — NOT `arch.md`, NOT `lessons-learned.md` |
-| A retired or removed component | Delete the section entirely; do NOT keep a "retired components" graveyard. (`git log` retains history.) |
-
-The most commonly-misrouted entry is the system-shape surprise. If a future reader needs to know "the system *looks* like X but actually does Y," that is system shape and lives in `arch.md`. If they need to know "we learned that doing X is generally a bad idea," that is engineering wisdom and lives in `lessons-learned.md`.
-
-## When to Use
-
-- Before a release (clean slate for shipping)
-- After completing a major feature
-- Quarterly maintenance window
-- When the codebase feels "crusty"
-
-## Execution Model
-
-```
-afx spawn --protocol maintain
-    ↓
-1. MAINTAIN: Audit → Clean → Sync docs (single pass)
-    ↓ (build + test checks, 3-way review)
-2. REVIEW: Create PR
-    ↓ (3-way review)
-Architect reviews → Merge
+```json
+{{> protocols/maintain/protocol.json}}
 ```
 
-Two phases total. One consultation during the maintain phase, one before PR.
+## Before starting
 
-## Prerequisites
+Find the last run in `codev/maintain/`, note its base commit, and scope the audit to
+`git log --oneline <base>..HEAD`. Maintenance without a since-marker re-audits the whole
+repository every time and quietly stops being run.
 
-Before starting:
-1. Check `codev/maintain/` for the last run number
-2. Note the base commit: `git log --oneline -1` on the last run file
-3. Focus on changes since then: `git log --oneline <base-commit>..HEAD`
+## The maintain phase
 
----
+**Audit** — find unused exports, unused dependencies, and orphaned files. Treat every hit as a
+*candidate*, not a verdict: a detector cannot tell "vestigial" from "used by a path you did not
+search". Confirm each with a targeted grep before removing it.
 
-## The Maintain Phase (Single Pass)
+**Clean** — remove what you confirmed. Deletions go to `codev/maintain/.trash/` (gitignored,
+30-day retention) rather than straight out, so a wrong call is recoverable for a month rather
+than needing an archaeology session.
 
-The builder works through these tasks in order, committing as they go.
+**Sync documentation** — route facts by tier rather than appending: behaviour-changing and
+cross-cutting go to the capped hot files (displace a weaker entry rather than growing them),
+reference detail to the cold archives. The `update-arch-docs` skill encodes the routing matrix,
+the caps, and what does *not* belong in each tier. Keep `CLAUDE.md` and `AGENTS.md`
+byte-identical.
 
-### Step 1: Audit
+## The maintenance run file
 
-Identify what needs fixing. Don't fix yet — just catalog.
-
-**Dead code**:
-```bash
-# Find unused exports (TypeScript)
-npx ts-prune 2>/dev/null || echo "ts-prune not available"
-
-# Find unused dependencies
-npx depcheck 2>/dev/null || echo "depcheck not available"
-```
-
-**Stale documentation**:
-```bash
-# What changed since last maintenance?
-git log --oneline <base-commit>..HEAD
-
-# Check arch.md references still exist
-grep -oE '[a-zA-Z]+/[a-zA-Z/]+\.[a-z]+' codev/resources/arch.md | sort -u | while read f; do
-  [ -e "$f" ] || echo "Missing: $f"
-done
-```
-
-**Stale project tracking**:
-- GitHub Issues that should be closed
-- Labels that need updating
-
-Record findings in the maintenance run file (`codev/maintain/NNNN.md`).
-
-### Step 2: Clean
-
-For each finding from the audit:
-1. Verify it's truly unused (grep the codebase)
-2. Remove it (use `git rm` for tracked files)
-3. Verify build + tests still pass
-4. Commit with `[Maintain] Remove unused X`
-
-**Rules**:
-- One removal at a time — don't batch unrelated changes
-- Verify after each removal — build must pass
-- Use soft deletion for untracked files: `mv file codev/maintain/.trash/$(date +%Y-%m-%d)/`
-- Never use `git add -A` or `git add .`
-
-### Step 3: Sync Documentation
-
-Step 3 is split into two sub-steps: **Audit first, then update.** This split exists because `arch.md` and `lessons-learned.md` accumulate without bound when MAINTAIN does only "what's new" — the audit pass surfaces what should be cut so the update pass is not purely additive.
-
-The `update-arch-docs` skill (at `.claude/skills/update-arch-docs/SKILL.md`) is invoked by both sub-steps. Read it before starting Step 3 so the discipline is fresh.
-
-#### Step 3a: Audit documentation
-
-Invoke the `update-arch-docs` skill in **audit-mode**. The skill reads all four governance files — `codev/resources/arch.md` / `arch-critical.md` and `codev/resources/lessons-learned.md` / `lessons-critical.md` — end-to-end against the discipline below, applies the cuts via the Edit tool, and records each cut's reason in the run file (`codev/maintain/NNNN.md`) under a `## Audit Findings` section. The diff plus the recorded reasons **is** the proposal; the architect's PR review is the human-confirmation step (consistent with the skill's audit-mode).
-
-**Per-arch.md-section pruning checklist** — for each section in `arch.md`, ask:
-- Does it describe **current state**? If aspirational, the section moves to a meta-spec; `arch.md` keeps a 1-paragraph summary + pointer (or nothing, if the meta-spec stands on its own).
-- Does it duplicate a meta-spec? If yes, replace with a 1-paragraph summary + pointer.
-- Is it a per-file enumeration that's gone stale? If yes, prune to the directory shape + a few key files.
-- Is it a changelog/narrative section ("Spec 0042 added X")? If yes, absorb the architecturally-relevant facts and remove the spec-numbered framing.
-- Is the component still alive? If retired, delete the section entirely.
-
-**Per-COLD-`lessons-learned.md`-entry pruning checklist** — for each entry, ask:
-- Is it terse (1–3 sentences)? If multi-paragraph, split or compress.
-- Is the topic section the right home? If filed under "Architecture (continued)" or a spec-numbered section, move it to the right topical home.
-- Is it a duplicate of an adjacent entry? If yes, fold them.
-- (Spec-narrow recipes are **kept** as reference — do not cut them just for being spec-narrow. Anti-accretion now lives in the hot cap, not the cold archive.)
-
-**Per-HOT-file checklist** (`arch-critical.md`, `lessons-critical.md`) — audit the cap and map:
-- Within the cap (≈10 entries + a ≈12-topic map, ≤35 lines)? If over, **demote** the weakest entries into the cold doc.
-- Does every map topic name a real top-level cold-doc section, and is any new/renamed section reflected? Fix drift; keep the map top-level only.
-- Is every entry still behavior-changing? Demote reference detail into the cold archive.
-
-**Sample audit prompt** (paste into the skill invocation if you want a baseline checklist run):
-
-```
-Audit all four governance files — codev/resources/arch.md + arch-critical.md and
-lessons-learned.md + lessons-critical.md — against the discipline in the
-update-arch-docs skill. For each cold section/entry run the cold pruning checklists,
-and for each hot file check the cap, displacement, and map accuracy (Step 3a).
-Apply the cuts with one-line reasons. Bias toward fewer, higher-confidence
-cuts ("when in doubt, KEEP"). Record each cut's reason in the current run
-file's ## Audit Findings section as you go — the diff plus those reasons is the proposal.
-```
-
-**When in doubt, KEEP.** This rule is preserved from the older Step 3. A confident cut is better than three speculative ones. The audit pass is a *proposal*; the architect's PR review confirms it.
-
-#### Step 3b: Update documentation
-
-Apply the audit decisions from Step 3a, plus any additive content needed.
-
-**arch.md / arch-critical.md**: Compare documented structure with actual codebase. Route behavior-changing invariants to `arch-critical.md` (HOT — respect the cap + keep its map accurate); reference detail to `arch.md` (COLD). Update:
-- Directory structure
-- Component descriptions (explain HOW things work, not just WHAT)
-- Key files and their purposes
-- Remove references to deleted code (per Step 3a audit findings)
-- Add new components/utilities
-
-**lessons-learned.md / lessons-critical.md**: Scan `codev/reviews/` for new reviews since last run. **Route** each new lesson by tier — behavior-changing + cross-cutting → `lessons-critical.md` (HOT; respect the cap, demote a weaker entry to cold if full); reference recipe / spec-narrow → `lessons-learned.md` (COLD). Apply Step 3a's per-entry cuts and keep each hot file's cold-doc map accurate.
-
-For specific additive changes, invoke `update-arch-docs` in **diff-mode** — it applies the smallest section update needed.
-
-**CLAUDE.md / AGENTS.md**: Diff the two files. They must be identical. Update the stale one.
-
-**Documentation pruning**:
-- Remove obsolete references
-- ~400 line guideline for CLAUDE.md/README.md (not a hard limit)
-- Document every deletion with justification (OBSOLETE, DUPLICATIVE, MOVED, VERBOSE)
-- When in doubt, KEEP the content
-
-### Step 4: Final Checks
-
-```bash
-# Build and test from the package directory
-cd packages/codev && pnpm build && pnpm test
-```
-
-Both must pass before moving to the review phase.
-
----
-
-## Maintenance Run File
-
-Each run creates `codev/maintain/NNNN.md`, following the template below:
+Each run is recorded in `codev/maintain/` using this structure:
 
 {{> protocols/maintain/templates/maintenance-run.md}}
 
-Keep it factual and short. The run file documents what happened, not what might happen.
+## Scope discipline
 
----
+Maintenance is where scope creep is most tempting, because everything you touch looks
+improvable. Removing dead code is in scope; refactoring live code because you are already in the
+file is not. File an issue instead.
 
-## Commit Messages
-
-```
-[Maintain] Remove 5 unused exports
-[Maintain] Remove http-proxy dependency
-[Maintain] Update arch.md — add VS Code extension, remove dashboard-server refs
-[Maintain] Generate lessons-learned.md from reviews 653, 672
-[Maintain] Sync CLAUDE.md with AGENTS.md
-```
-
----
-
-## Governance
-
-MAINTAIN is an operational protocol, not a feature protocol:
-
-| Document | Required? |
-|----------|-----------|
-| Spec | No |
-| Plan | No |
-| Review | No (maintenance run file serves this purpose) |
-| Consultation | Yes — 3-way review before PR |
-
-If maintenance reveals need for architectural changes, those should follow SPIR.
-
----
-
-## Rules
-
-1. **Don't be aggressive** — when in doubt, KEEP the content
-2. **Check git blame** — understand why code/docs exist before removing
-3. **Run full test suite** — not just affected tests
-4. **Group related changes** — one commit per logical change
-5. **Document every deletion** — what, why, and where (if moved)
-6. **Prefer moving over deleting** — extract to another file rather than removing
-7. **Size targets are guidelines** — never sacrifice clarity to hit a line count
-
-## Anti-Patterns
-
-1. Aggressive rewriting without explanation
-2. Deleting without documenting why
-3. Hitting line count targets at all costs
-4. Removing "patterns" or "best practices" sections without explicit approval
-5. Deleting everything the audit finds — review each item individually
-6. Skipping validation — "it looked dead" is not validation
-7. Using `rm` instead of `git rm`
+Never `git add -A` / `--all` / `.` — stage each file explicitly by path.

--- a/codev-skeleton/protocols/pir/protocol.md
+++ b/codev-skeleton/protocols/pir/protocol.md
@@ -1,202 +1,76 @@
 # PIR Protocol
 
-> **Plan → Implement → Review** for GitHub-issue-driven work that needs human review of *either* the approach (before code is written) *or* the implementation (before a PR exists), or both. Lighter than SPIR/ASPIR (no `specify` phase — the GitHub issue is the implicit spec) with the human dev-approval moved earlier (pre-PR instead of post-PR). Stronger than BUGFIX/AIR (two human gates before the PR).
+Plan → Implement → Review, driven by a GitHub issue, with **two human gates before any PR
+exists**. The issue is the implicit spec; there is no specify phase.
 
-## When to Use PIR
+Choose PIR when either is true:
 
-Pick PIR when working from a GitHub Issue and ONE or BOTH of the following apply — based on the *nature* of the change, not its size:
+- **The approach needs review before coding.** Ambiguous root cause, unfamiliar or
+  high-blast-radius area, or a design-sensitive change — cheaper to redirect at plan time than
+  at PR time.
+- **The implementation must be exercised running, before a PR exists.** Mobile, UI/UX,
+  hardware-adjacent behaviour, OAuth or payment integrations, full user journeys, anything
+  performance-sensitive. A diff cannot show you these; a running worktree can.
 
-### 1. The approach needs review before coding starts
-- Root cause is ambiguous; multiple valid fixes exist
-- Area is unfamiliar or high-blast-radius (shared utilities, auth, migrations, public APIs)
-- Design-sensitive (affects conventions, patterns, architecture)
-- Cheaper to redirect at plan time than at PR time
+Lighter than SPIR (no spec phase, one consult at the PR). Stronger than BUGFIX/AIR (two human
+gates *before* a PR, where the human reviews the running code rather than the diff).
 
-### 2. The implementation needs to be tested before a PR is created
-The PR diff alone is insufficient; the reviewer must *run* the code:
-- Mobile app changes (needs device testing on Android, iOS, possibly web)
-- UI / UX changes (visual inspection, interaction flow, accessibility)
-- Hardware-adjacent behavior (sensors, camera, permissions, notifications)
-- Integration with external services that don't mock cleanly (OAuth, payments, analytics)
-- User-journey changes that need a full-flow exercise
-- Performance-sensitive changes that need profiling on the running app
+## The state machine
 
-### Use SPIR / ASPIR / BUGFIX / AIR instead when
-- **SPIR / ASPIR**: the change is complex enough to warrant careful specification, multi-agent consultation at every phase, and the full spec → plan → implement → review ceremony with file artifacts. The driving issue is incidental — what matters is that the design work deserves a formal spec and the implementation deserves consult-driven review at each phase
-- **BUGFIX**: small bug fix, no design review needed, diff-on-PR review is enough
-- **AIR**: small feature from an issue, autonomous, diff-on-PR review is enough
-
-## How PIR Differs from SPIR
-
-PIR is structurally *SPIR minus the `specify` phase*, with the human dev-approval moved earlier (pre-PR instead of post-PR).
-
-| Aspect | SPIR | PIR |
-|---|---|---|
-| Phases | specify → plan → implement → review → verify | plan → implement → review |
-| Spec artifact | `codev/specs/<id>-<slug>.md` | GitHub Issue body (implicit spec) |
-| Plan artifact | `codev/plans/<id>-<slug>.md` | Same — committed on builder branch |
-| Review artifact | `codev/reviews/<id>-<slug>.md` (Summary + Architecture Updates + Lessons Learned, becomes PR body) | **Same shape** — `codev/reviews/<id>-<slug>.md` with the same sections, also becomes PR body |
-| Human gates | spec-approval, plan-approval, pr, verify-approval | plan-approval, dev-approval, pr |
-| Where code is reviewed by the human | On the PR (post-creation) — read the diff | Pre-PR (at the `dev-approval` gate) — read the diff **and run the worktree locally** |
-
-The review file always includes Summary, Architecture Updates, and Lessons Learned sections so `codev/reviews/` stays semantically consistent across all protocols. PIR's lightness comes from skipping the `specify` phase (the issue body is the spec), not from cutting corners on the retrospective.
-
-The `dev-approval` gate is what makes PIR genuinely different: the human gates the *running implementation* via the worktree before the PR exists, instead of gating the PR after creation.
-
-## Phases
-
+```json
+{{> protocols/pir/protocol.json}}
 ```
-plan → implement → review
-```
-
-### Plan (gated by `plan-approval`)
-
-The builder:
-1. Reads the GitHub issue and investigates the codebase
-2. Writes `codev/plans/<id>-<slug>.md` with: Understanding / Proposed change / Files to change / Risks & alternatives / Test plan
-3. Commits the plan on the builder branch and pushes
-4. Runs `porch done` and `porch next` — the `plan-approval` gate becomes pending
-5. Sits at the interactive prompt waiting for review
-
-**Reviewer paths** (all equivalent):
-- Open `codev/plans/<id>-<slug>.md` in the worktree, read and / or edit directly, save
-- Type feedback into the builder's PTY pane — the builder is alive in interactive mode
-- `afx send <builder-id> "<feedback>"`
-- Comment on the GitHub issue (sidecar discussion)
-
-When satisfied, approve via VSCode's "Approve Gate" command (Cmd+K G) or:
-
-```bash
-porch approve <id> plan-approval --a-human-explicitly-approved-this
-```
-
-### Implement (gated by `dev-approval`)
-
-The builder:
-1. Reads the approved plan file
-2. Writes code and tests; runs build + tests via the `checks` block
-3. *No AI consult on this phase* — the human at the `dev-approval` gate is the sole reviewer of the running code. Matches BUGFIX / AIR's pattern of "no consult on implementation, one consult at PR creation".
-4. Pushes the branch
-5. Runs `porch done` and `porch next` — the `dev-approval` gate becomes pending
-6. Outputs a **prose** dev-approval summary in the PTY pane (Summary / Files / Test results / Things to look at / How to test locally). This is a transient message to orient the human reviewer — **not a committed file**. The retrospective file is written in the next phase, after the human approves the running code.
-7. Sits at the interactive prompt
-
-**The reviewer's killer move**: run the worktree locally.
-
-- VSCode: right-click the builder in the Codev sidebar → **Run Dev** (spawns `afx dev <builder-id>` via Tower)
-- CLI: `afx dev <builder-id>`
-
-The dev process uses **the same ports and URLs as main** intentionally (OAuth callbacks, CORS, cookie scoping all depend on consistent origins). Only one dev env runs at a time; stop main's `pnpm dev` before starting the worktree's, or use VSCode's **Stop Dev** to swap.
-
-Reviewer tests the change on real devices / browsers / simulators. When satisfied, approves via Cmd+K G or:
-
-```bash
-porch approve <id> dev-approval --a-human-explicitly-approved-this
-```
-
-### Review (gated by `pr`)
-
-The builder:
-1. Writes `codev/reviews/<id>-<slug>.md` with **Summary**, **Architecture Updates**, **Lessons Learned Updates**, plus the supporting sections (Files Changed, Commits, Test Results, Things to Look At, How to Test Locally).
-2. Routes new facts/wisdom by tier (Spec 987) — HOT `codev/resources/arch-critical.md` / `lessons-critical.md` (capped) or COLD `codev/resources/arch.md` / `lessons-learned.md` (reference) — if real changes need recording. If not, the review file's sections state "no changes needed" with a one-line explanation (the porch `checks` block enforces section presence, not content).
-3. Commits the review file (and arch / lessons updates if any) and pushes
-4. Opens a PR with `gh pr create`; PR body is the review file content + `Fixes #<N>`. Records the PR with `porch done <id> --pr <M> --branch <name>`.
-5. Runs `porch done <id>` — porch's `verify` block runs 3-way consultation (Gemini, Codex, Claude; type=impl) as a **single advisory pass** (`max_iterations: 1`); consultation outputs land in `codev/projects/<id>-*/`. There is no iterate-until-APPROVE loop: whatever the verdicts, porch records them and advances to the `pr` gate. A `REQUEST_CHANGES` is not auto-re-reviewed — the builder addresses or rebuts it, adds a regression test if it's a real defect, and escalates it in the architect notification so the human verifies it at the `pr` gate. Outcomes are not auto-appended to the PR body; reviewers with the worktree read them from the projects dir.
-6. The `pr` gate fires (pending) regardless of verdict. Builder notifies the architect once — leading with any `REQUEST_CHANGES` and its disposition (since PIR will not re-review it) rather than burying it in a flat status line.
-7. Builder waits at the `pr` gate. The human reviews the PR on GitHub, then approves the `pr` gate (Cmd+K G or `porch approve <id> pr --a-human-explicitly-approved-this`). Porch wakes the builder.
-8. Builder verifies the gate is genuinely approved via `porch next` (defensive — typed prose can't trigger this branch, only real porch state does), then runs `gh pr merge --merge`, records via `porch done --merged <M>`, and sends the cleanup-ready notification. Protocol complete (`next: null`).
 
 ## Gates
 
-PIR uses porch's existing gate machinery. Gate names are opaque strings; no porch engine changes are needed.
+Gate names are opaque strings keyed by `(project_id, gate_name)`, so sharing a name with another
+protocol is safe and needs no porch change.
 
-- **`plan-approval`** — pre-PR. Human reads the plan file (committed on the builder branch) and approves before any code is written. Gates are keyed by `(project_id, gate_name)` so the name is safe to share with other protocols.
-- **`dev-approval`** — pre-PR. The human reviews the *running* worktree (via `afx dev`) before any PR exists. This is PIR's distinctive gate.
-- **`pr`** — post-PR. Gates the merge step. The human reviews the PR on GitHub and approves this gate; porch wakes the builder, which then runs `gh pr merge`. The gate exists so the merge trigger is structured porch state (binary approved/not), not free-text prose typed into the builder's pane. Eliminates the self-merge bug class: builders can't infer authorization from ambiguous user input.
+| Gate | When | What the human does |
+|---|---|---|
+| `plan-approval` | pre-PR | Reads the plan committed on the builder branch, before any code exists |
+| `dev-approval` | pre-PR | **PIR's distinctive gate** — reviews the *running* worktree via `afx dev` |
+| `pr` | post-PR | Reviews on GitHub, then approves; porch wakes the builder to merge |
 
-When a gate becomes pending, porch broadcasts `overview-changed` via SSE. The VSCode Builders tree picks up the blocked state and renders it with a bell icon; a toast surfaces the new gate-pending event. Architect notification is *not* automatic — gates surface via the toast/sidebar (for IDE users) or by checking the builder pane / `porch pending` (for CLI users). The builder's job at any gate is to write the artifact, commit, signal completion, and wait — never to invoke `porch approve` itself (Claude refuses the `--a-human-explicitly-approved-this` flag by design).
+The `pr` gate makes the merge trigger **structured porch state** rather than free text in the
+builder's pane — closing the self-merge class where a builder infers authorization from
+ambiguous prose.
 
-## Rejection / Feedback Model
+**Gates do not notify the architect automatically.** Porch broadcasts `overview-changed` over
+SSE; the VSCode Builders tree renders the blocked state with a bell and raises a toast. CLI
+users see it via the builder pane or `porch pending`. The builder's job at any gate is: write
+the artifact, commit, signal, wait — never to invoke `porch approve` itself.
 
-There is no formal `porch reject` command. Rejection works via the feedback-iterate pattern:
+## Rejection is iteration, not a command
 
-1. Reviewer provides feedback (edit the plan file in VSCode, type in the builder pane, `afx send`, or issue comment)
-2. Builder reads the feedback on its next turn, revises the artifact, recommits
-3. The gate remains pending — porch doesn't advance until the human runs `porch approve`
+There is no `porch reject`. Feedback arrives however is convenient — editing the plan file,
+typing in the builder pane, `afx send`, an issue comment — the builder revises and recommits,
+and **the gate stays pending until a human approves it**. The same pattern works at both
+pre-PR gates.
 
-The same pattern works at both gates.
+## Artifacts
 
-## Builder Session Lifetime
+Plan and review live in `codev/plans/` and `codev/reviews/` on the builder branch and ship to
+the default branch with the merge. The review is shaped like SPIR's (Summary, Architecture
+Updates, Lessons Learned) so `codev/reviews/` stays semantically consistent across protocols.
 
-The builder is a long-running interactive Claude Code session in a PTY pane managed by Tower. The session is launched as `claude "<prompt>"` (no `--print`) inside a `while true` restart loop. That form starts an interactive Claude REPL with the prompt as the first user message; after Claude finishes the prompted work it sits at the input prompt awaiting next user input. The outer `while true` loop only fires if Claude crashes — it is a crash-recovery safety net, not the gate-wait mechanism.
+## Consultation
 
-This means typed input in the builder pane reaches the live Claude session immediately, exactly like any other interactive Claude Code conversation. There is no "session ended at gate" state to worry about under normal operation.
+**One advisory CMAP pass at the PR** (`max_iterations: 1`) — no iterate-until-APPROVE loop. A
+`REQUEST_CHANGES` escalates to the human at the `pr` gate rather than triggering an automatic
+re-review.
+
+That footprint is a **design invariant, and it is fragile**: porch resolves models as
+*config > protocol*, so a project-wide `porch.consultation.models` (say a SPIR-tuned 3-model
+list) silently inflates PIR's cost. Leave it unset, or scope it per-protocol.
+
+## Builder session
+
+A long-running interactive session in a Tower-managed PTY, launched as `claude "<prompt>"`
+inside a `while true` restart loop. Typed input reaches the live session immediately; the loop
+is crash recovery, not the gate-wait mechanism. There is no "session ended at gate" state.
 
 ## Configuration
 
-PIR uses the same `.codev/config.json` configuration as other protocols. The `worktree` block (from Issue 689) enables the at-gate dev review flow:
-
-```json
-{
-  "worktree": {
-    "symlinks": [".env.local", "packages/*/.env"],
-    "postSpawn": ["pnpm install --frozen-lockfile"],
-    "devCommand": "pnpm dev"
-  }
-}
-```
-
-Without `worktree.devCommand`, `afx dev` won't work and the `dev-approval` gate degenerates to a diff-read — at which point you should probably use AIR or BUGFIX instead.
-
-## Multi-Agent Consultation
-
-- **plan**: human-only review. No AI consultation.
-- **implement**: no AI consult — the human at the `dev-approval` gate is the sole reviewer of the running code.
-- **review**: 3-way consultation (Gemini, Codex, Claude; type=impl) after the PR is opened, as a **single advisory pass** (`max_iterations: 1`). Same consult type (`impl`) as BUGFIX / AIR's PR-creation consult.
-
-The consultation at the PR is a single pass — there is **no iterate-until-APPROVE loop**. A `REQUEST_CHANGES` does not block or re-trigger it; the builder addresses or rebuts it and escalates it to the human at the `pr` gate, who is the sole remaining reviewer of any resulting fix (the consultation does not re-check it).
-
-Net: PIR's distinguishing features are the two human gates (`plan-approval`, `dev-approval`), not AI-consult density.
-
-To disable consultation entirely, say "without multi-agent consultation" when starting work.
-
-## Signals
-
-PIR uses the standard porch signal vocabulary:
-
-```
-<signal>PHASE_COMPLETE</signal>          # Current phase build complete
-<signal>BLOCKED:reason</signal>          # Cannot proceed
-```
-
-Signals are informational for log readability. The state machine is driven by `porch done` and `porch next` CLI calls inside the builder turn.
-
-## Commit Messages
-
-Commits during PIR phases use the issue-driven format:
-
-```
-[PIR #<N>] Plan draft
-[PIR #<N>] Implement avatar masking
-[PIR #<N>] Add Android-side regression test
-```
-
-The PR title follows the project's existing PR convention.
-
-## Branch Naming
-
-```
-builder/pir-<issue-number>
-```
-
-Example: `builder/pir-842` for a PIR spawn against GitHub issue #842.
-
-## File Locations
-
-```
-codev/plans/<id>-<slug>.md             # written in plan phase, on builder branch
-codev/reviews/<id>-<slug>.md           # written in review phase (post-dev-approval-approval), on builder branch; becomes PR body
-codev/projects/<id>-<slug>/status.yaml # porch state, managed automatically
-```
-
-The plan and review files ship to `main` with the merged PR — durable, searchable, git-versioned. The review file includes Summary + Architecture Updates + Lessons Learned + supporting sections, so `codev/reviews/` stays semantically consistent across protocols.
+The `worktree` block in `.codev/config.json` is what makes the `dev-approval` gate work — see
+the `runnable-worktrees` skill for `symlinks`, `postSpawn` and `devCommand`.

--- a/codev-skeleton/protocols/research/protocol.md
+++ b/codev-skeleton/protocols/research/protocol.md
@@ -1,169 +1,41 @@
 # RESEARCH Protocol
 
-## Overview
+Scope → Investigate → Synthesize → Critique. Three models investigate the same question
+independently, their findings are synthesized, and the synthesis is adversarially critiqued
+before it is trusted.
 
-Multi-agent research with 3-way investigation, synthesis, and critique. Three AI models independently investigate a question, their findings are synthesized into a single report, and then all three models critique the synthesis for gaps, errors, and bias.
+Use it for competitive and technology analysis, "state of X" questions, and architectural
+decision support in an unfamiliar domain — cases where a single model's confident answer is
+exactly the failure mode.
 
-**Core Principle**: Triangulate. No single model's knowledge is authoritative. Consensus across models is more reliable than any individual output.
+## The state machine
 
-## When to Use
-
-**Use for**: Competitive analysis, technology evaluation, market research, architectural decision support, "what's the state of X?" questions, exploring unfamiliar domains.
-
-**Skip for**: Implementation work (use SPIR/ASPIR), quick questions (just ask), experiments (use EXPERIMENT), known-answer lookups (just search).
+```json
+{{> protocols/research/protocol.json}}
+```
 
 ## Output
 
-All research artifacts go to `codev/research/`. The final deliverable is a single synthesis report at `codev/research/<topic>.md`.
+`codev/research/<topic>.md` — the report, with its sources and its disagreements preserved.
 
 ## Phases
 
-### Phase 1: Scope
+**Scope** — write the research brief: the question, why it matters, what would count as an
+answer, and what is out of scope. Gated by `scope-approval`, because a badly framed question
+wastes three models' compute and produces a confident answer to the wrong thing.
 
-**Purpose**: Make sure we're asking the right question before spending 3 models' worth of compute on answering it.
+**Investigate** — the three models work the question **independently**. Independence is the
+point: cross-contaminated investigations converge on a shared error.
 
-The builder:
-1. Reads the architect's research request
-2. Clarifies the question — what specifically are we trying to learn?
-3. Defines the scope — what's in, what's out, what depth is needed
-4. Defines acceptance criteria — what does a good answer look like?
-5. Writes a **research brief** (`codev/research/<topic>-brief.md`) with:
-   - The precise question(s)
-   - Scope boundaries
-   - **Required targets** (when applicable — not all research questions have them). When the user names specific projects, products, or systems, those are exemplars of a CLASS, not an exhaustive list. The brief should:
-     - List the named targets as required coverage (each gets a dedicated section)
-     - Identify the CLASS they represent (e.g., "open-source always-on agent frameworks")
-     - Instruct investigators to find OTHER members of that class the user didn't name — discovering what the user SHOULD be thinking about is often the most valuable part of the research
-     - If an investigator cannot find information about a required target, they must say so explicitly — not silently skip it
-   - **Optional context** — additional sources that may be useful but are not required
-   - What a useful answer looks like
-   - Suggested sources or angles for the investigators
-6. Sends the brief to the architect for approval
+**Synthesize** — merge findings and, critically, **preserve disagreement**. Where models
+diverge, say so and say why; a synthesis that smooths over conflict has destroyed the signal
+that made a 3-way investigation worth running.
 
-**Gate**: `scope-approval` — the architect confirms the question is correctly scoped before the 3-way investigation begins. This prevents wasting compute on a badly-framed question.
+**Critique** — adversarial pass over the synthesis. What is asserted without a source? What
+would change the conclusion? Reaching `research-complete` means the report survived this, not
+that it was written.
 
-### Phase 2: Investigate (3-way parallel)
+## Reporting standard
 
-**Purpose**: Get three independent perspectives on the question.
-
-The builder dispatches the research brief to three models (Gemini, Codex, Claude) via `consult`. Each model:
-1. Receives the scoped research brief
-2. Independently investigates using web search, its training knowledge, and reasoning
-3. Produces a standalone investigation report with:
-   - **A dedicated section for each required target** from the brief. Every required target gets its own heading with specific findings — not mentioned in passing, not substituted with an easier target. If a required target yields no findings, the section must say "No information found" rather than being omitted.
-   - Findings (with sources where possible)
-   - Confidence levels on key claims
-   - Gaps it couldn't fill
-   - Surprises or things that contradicted expectations
-
-The investigations run in **parallel** — each model works independently without seeing the others' output. This prevents anchoring bias.
-
-Investigation reports are saved to:
-- `codev/research/<topic>-gemini.md`
-- `codev/research/<topic>-codex.md`
-- `codev/research/<topic>-claude.md`
-
-### Phase 3: Synthesize
-
-**Purpose**: Merge three independent reports into one coherent document.
-
-The builder:
-1. Reads all three investigation reports
-2. Identifies **consensus** — what all three agree on (highest confidence)
-3. Identifies **disagreements** — where models contradict each other
-4. Resolves conflicts — picks the best-supported position, notes the disagreement
-5. Identifies **unique contributions** — things only one model found that the others missed
-6. Writes the **synthesis report** (`codev/research/<topic>.md`) with:
-   - **Scope summary** — a short section (before the executive summary) restating the research question, required targets, and scope boundaries from the brief. A reader should understand what was asked without needing to read the brief separately.
-   - Executive summary
-   - Findings (organized by topic, not by model)
-   - Confidence annotations (consensus vs. single-source)
-   - Gaps and limitations
-   - Recommendations (if the research brief asked for them)
-
-The synthesis is written as a **standalone document** — a reader should never need to reference the individual investigation reports. Those are kept as appendices for traceability.
-
-### Phase 4: Critique (3-way review)
-
-**Purpose**: Pressure-test the synthesis for gaps, errors, and bias.
-
-The builder dispatches the synthesis report back to all three models for critique. Each model:
-1. Reads the synthesis
-2. **Checks coverage against the brief** — does every required target from the research brief have dedicated coverage in the synthesis? Lists any required targets that were named in the brief but have zero or minimal coverage. This is the #1 critique check.
-3. Checks for factual errors or unsupported claims
-4. Identifies gaps — important aspects the synthesis missed
-5. Flags potential bias — did the synthesis over-weight one model's perspective?
-6. Suggests specific improvements
-
-The builder then:
-1. Incorporates valid critique
-2. Documents rejected critique with rationale
-3. Finalizes the report
-4. Commits to `codev/research/<topic>.md`
-
-## File Structure
-
-Only the brief and final report are checked in. Individual investigation reports and full critique outputs are working artifacts — useful during the process but not committed to the repo.
-
-```
-codev/research/
-├── <topic>-brief.md              # Phase 1: scoped research question (checked in)
-└── <topic>.md                    # Phase 3+4: final synthesis (the deliverable, checked in)
-```
-
-The final report includes:
-- A **"Disagreements and resolution"** section documenting where the three investigators disagreed and how the synthesis resolved each disagreement
-- A **"Changes from critique"** section summarizing what the critique phase changed (not the full critique — just what was added, removed, or corrected and why)
-
-Individual investigation reports (`<topic>-gemini.md`, `<topic>-codex.md`, `<topic>-claude.md`) and raw critique outputs are kept locally during the research process but NOT committed. The final report is the deliverable; the process artifacts are disposable.
-
-## Best Practices
-
-### Scoping
-- A good research question is specific enough to answer in 1500-3000 words per model
-- "What's the state of X?" is too broad — "What are the top 5 players in X, their strengths/weaknesses, and the structural gaps?" is better
-- Include the "so what" — why are we researching this? What decision does it inform?
-
-### Investigation
-- Tell each model to cite sources where possible
-- Tell each model to be candid about uncertainty — "I don't know" is better than confabulation
-- Tell each model to note surprises — the most valuable findings are often the unexpected ones
-
-### Synthesis
-- Organize by topic, not by model ("here's what we found about X" not "here's what Gemini said")
-- Weight consensus over single-model claims
-- Don't smooth over disagreements — note them explicitly
-- Keep the synthesis shorter than the sum of the investigations
-
-### Critique
-- Critiquers should focus on gaps and errors, not style
-- A critique that says "add more about X" is useful; "rewrite the intro" is not
-- The builder should reject critique that's outside the original scope
-
-## Integration with Other Protocols
-
-### Research → SPIR
-When research informs a feature decision:
-1. Reference the research report in the spec
-2. Link specific findings as evidence for design choices
-
-### Research → EXPERIMENT
-When research identifies something worth testing:
-1. Create an experiment to validate the research finding
-2. Reference the research report as motivation
-
-## Git Workflow
-
-### Commits
-```
-[Research: topic] Scoped research brief
-[Research: topic] 3-way investigation complete
-[Research: topic] Synthesis report
-[Research: topic] Final report (post-critique)
-```
-
-### What to Commit
-- All investigation reports (for traceability)
-- The final synthesis (the deliverable)
-- The critique rebuttals (for process transparency)
-- Do NOT commit raw web search results or intermediate notes
+Cite sources for factual claims and mark inference as inference. A research report that cannot
+be checked is an opinion with footnotes.

--- a/codev-skeleton/protocols/spike/protocol.md
+++ b/codev-skeleton/protocols/spike/protocol.md
@@ -1,128 +1,45 @@
 # SPIKE Protocol
 
-## Overview
+A time-boxed feasibility investigation that answers one question: **can this be done, and at
+what cost?** The deliverable is findings, not shipped code.
 
-Time-boxed technical feasibility exploration. Answer "Can we do X?" and "What would it take?" before committing to a full SPIR project.
+Use it before committing to a SPIR project whose feasibility is genuinely unknown — an unfamiliar
+library, an unproven integration, a performance question that argument cannot settle.
 
-**Core Principle**: Stay focused on the question. Once you can answer it, write findings and stop.
+## The state machine
 
-## When to Use
-
-**Use for**: Quick technical feasibility investigations, proof-of-concept explorations, "can we do X?" questions, evaluating approaches before committing to SPIR
-
-**Skip for**: Production code (use SPIR), formal hypothesis testing (use EXPERIMENT), bug fixes (use BUGFIX)
-
-### Spike vs Experiment
-
-| | Spike | Experiment |
-|---|---|---|
-| **Goal** | Answer a feasibility question | Test a formal hypothesis |
-| **Structure** | Lightweight guidance | Formal phases (hypothesis/design/execute/analyze) |
-| **Output** | Findings document | Experiment notes with metrics |
-| **Rigor** | Exploration-first | Measurement-first |
-| **Time** | Short (hours) | Longer (days) |
-
-## Spawning a Spike
-
-```bash
-afx spawn --task "Can we use WebSockets for real-time updates?" --protocol spike
-afx spawn --task "What would it take to support SQLite FTS?" --protocol spike
+```json
+{{> protocols/spike/protocol.json}}
 ```
 
-Spikes are always soft mode — no porch orchestration, no gates, no consultation.
+## Proof-of-concept code
 
-## Recommended Workflow
+Throwaway by design. It exists to answer the question, and it is not held to production
+standards — but it must not be quietly promoted into production later either. If the answer is
+"feasible", a SPIR project builds the real thing.
 
-The following 3-step workflow is **guidance only** — not enforced by porch. Follow it, skip steps, or reorder as the investigation demands.
+## Outcomes
 
-### Step 1: Research
+| Verdict | What the findings must contain |
+|---|---|
+| **Feasible** | Recommended approach and rough cost, enough for the architect to decide on a SPIR project |
+| **Not feasible** | Why, what was tried, and what alternatives exist — this is what stops the investigation being repeated in six months |
+| **Feasible with caveats** | The conditions, risks and trade-offs that make it conditional |
 
-- Read documentation, examine existing code, search for prior art
-- Identify constraints, dependencies, and potential blockers
-- Understand the problem space before writing any code
-- Check if someone has already investigated this (look in `codev/spikes/`)
+A negative result is a successful spike. The failure mode is an inconclusive one: time spent,
+nothing recorded, question still open.
 
-### Step 2: Iterate
+Notify the architect with the verdict when done.
 
-- Build minimal proof-of-concept code
-- Try different approaches, hit walls, pivot
-- Focus on answering the feasibility question, not building production code
-- **Skip this step** if the answer is clear from research alone
+## Findings
 
-### Step 3: Findings
-
-- Write the findings document at `codev/spikes/<id>-<name>.md`
-- Use the embedded template at the end of this protocol
-- Provide a clear feasibility verdict
-- Commit and notify the architect
-
-## Output
-
-Findings are stored in `codev/spikes/` using the pattern: `<id>-<descriptive-name>.md`
-
-Examples:
-- `codev/spikes/462-websocket-feasibility.md`
-- `codev/spikes/475-sqlite-fts-performance.md`
-
-The `<id>` is the GitHub issue number or project ID.
-
-## Proof-of-Concept Code
-
-POC code from the iterate step is committed to the spike branch alongside the findings document. It serves as evidence supporting the findings. However:
-
-- POC code does NOT need tests, polish, or production quality
-- POC code does NOT get merged to main — it stays on the spike branch
-- The findings document is the primary deliverable; the code is supporting evidence
-- If the spike leads to a SPIR project, the builder starts fresh
-
-## Outcome Handling
-
-- **Feasible**: Write findings with recommended approach and effort estimate. Architect decides whether to create a SPIR project.
-- **Not Feasible**: Write findings documenting why, what was tried, and what alternatives exist. This prevents future teams from repeating the investigation.
-- **Feasible with Caveats**: Write findings with conditions, risks, and trade-offs.
-
-In all cases, notify the architect:
-```bash
-afx send architect "Spike <id> complete. Verdict: [feasible/not feasible/caveats]"
-```
-
-## Git Workflow
-
-### Commits
-```
-[Spike 462] Research: WebSocket library comparison
-[Spike 462] Iterate: POC with ws library
-[Spike 462] Findings: WebSockets feasible for real-time updates
-```
-
-### When to Commit
-- After significant research findings
-- After each iteration attempt
-- When writing the findings document (final commit)
-
-## Integration with Other Protocols
-
-### Spike -> SPIR
-When a spike validates feasibility:
-1. Create a SPIR spec referencing the spike findings
-2. Use findings to inform the solution approach
-3. Reference effort estimate for planning
-
-Example spec reference:
-```markdown
-## Background
-Spike 462 confirmed WebSocket feasibility with the `ws` library.
-See: codev/spikes/462-websocket-feasibility.md
-```
-
-### Spike -> "Do Not Pursue"
-When a spike finds something is not feasible:
-1. Document clearly in findings
-2. Close the related GitHub issue with a link to findings
-3. The findings become institutional knowledge
-
-## Template: findings.md
-
-Write the findings document using the following template:
+Write findings using this structure:
 
 {{> protocols/spike/templates/findings.md}}
+
+## Git
+
+```
+[Spike 462] Research: WebSocket library comparison
+[Spike 462] Findings: WebSockets feasible for real-time updates
+```

--- a/codev-skeleton/protocols/spir/protocol.md
+++ b/codev-skeleton/protocols/spir/protocol.md
@@ -1,657 +1,108 @@
 # SPIR Protocol
 
-> **SPIR** = **S**pecify → **P**lan → **I**mplement → **R**eview
->
-> Each phase has one build-verify cycle with 3-way consultation.
+**S**pecify → **P**lan → **I**mplement → **R**eview. Each phase is a build-verify cycle with
+3-way consultation, and two human gates stand before implementation begins.
 
+Use SPIR for new features, new protocols, architecture changes, and complex refactors — work
+where getting the shape wrong is expensive to discover late. For an isolated bug fix or a small
+feature fully described in an issue, a lighter protocol costs less and loses nothing.
 
-## Prerequisites
+## The state machine
 
-**Clean Worktree Before Spawning Builders**:
-- All specs, plans, and local changes **MUST be committed** before `afx spawn`
-- Builders work in git worktrees branched from HEAD — uncommitted files are invisible
-- This includes `codev update` results, spec drafts, and plan approvals
-- The `afx spawn` command enforces this (use `--force` to override)
+Phases, gates, checks and their order are defined here. This is the authoritative source; the
+prose below is only what the JSON cannot express.
 
-**Required for Multi-Agent Consultation**:
-- The `consult` CLI must be available (installed with `npm install -g @cluesmith/codev`)
-- At least one consultation backend: `claude`, `gemini-cli`, or `codex`
-- Check with: `codev doctor` or `consult --help`
-
-## Protocol Configuration
-
-### Multi-Agent Consultation (ENABLED BY DEFAULT)
-
-**DEFAULT BEHAVIOR:**
-Multi-agent consultation is **ENABLED BY DEFAULT** when using SPIR protocol.
-
-**DEFAULT AGENTS:**
-- **GPT-5 Codex**: Primary reviewer for architecture, feasibility, and code quality
-- **Gemini Pro**: Secondary reviewer for completeness, edge cases, and alternative approaches
-
-**DISABLING CONSULTATION:**
-To run SPIR without consultation, say "without consultation" when starting work.
-
-**CUSTOM AGENTS:**
-The user can specify different agents by saying: "use SPIR with consultation from [agent1] and [agent2]"
-
-**CONSULTATION BEHAVIOR:**
-- DEFAULT: MANDATORY consultation with GPT-5 and Gemini Pro at EVERY checkpoint
-- When explicitly disabled: Skip all consultation steps
-- The protocol is BLOCKED until all required consultations are complete
-
-**Consultation Checkpoints**:
-- **Specification**: After initial draft, after human comments
-- **Planning**: After initial plan, after human review
-- **Implementation**: After code implementation
-- **Defending**: After test creation
-- **Evaluation**: Before marking phase complete
-- **Review**: After review document
-
-## Overview
-SPIR is a structured development protocol that emphasizes specification-driven development with iterative implementation and continuous review. It builds upon the DAPPER methodology with a focus on context-first development and multi-agent collaboration.
-
-**The SPIR Model**:
-- **S - Specify**: Write specification with 3-way review → Gate: `spec-approval`
-- **P - Plan**: Write implementation plan with 3-way review → Gate: `plan-approval`
-- **I - Implement**: Execute each plan phase with build-verify cycle (one cycle per phase)
-- **R - Review**: Final review and PR preparation with 3-way review
-
-Each phase follows a build-verify loop: build the artifact, then verify with 3-way consultation (Gemini, Codex, Claude).
-
-**Core Principle**: Each feature is tracked through exactly THREE documents - a specification, a plan, and a review with lessons learned - all sharing the same filename and sequential identifier.
-
-## When to Use SPIR
-
-### Use SPIR for:
-- New feature development
-- Architecture changes
-- Complex refactoring
-- System design decisions
-- API design and implementation
-- Performance optimization initiatives
-
-### Skip SPIR for:
-- Simple bug fixes (< 10 lines)
-- Documentation updates
-- Configuration changes
-- Dependency updates
-- Emergency hotfixes (but do a lightweight retrospective after)
-
-## Baked Decisions (Optional)
-
-When filing an issue for SPIR, you can pin architectural decisions you don't want the builder or CMAP reviewers to re-litigate. Include a `## Baked Decisions` section (any heading level is fine) anywhere in the issue body. Useful categories: language, framework, deployment shape, key dependencies, decisions deferred to a later spec. The builder will copy the section verbatim into the spec's Constraints and treat each item as fixed; CMAP reviewers will not propose alternatives unless the spec itself fails to honor a stated decision. Leave the section out for issues where you want the builder to explore freely — absence is the no-op default. You can amend or rescind a baked decision at any time by updating the issue and respawning, or by sending the builder a direct instruction via `afx send`.
-
-## Protocol Phases
-
-### S - Specify (Collaborative Design Exploration)
-
-**Purpose**: Thoroughly explore the problem space and solution options before committing to an approach.
-
-**Workflow Overview**:
-1. User provides a prompt describing what they want built
-2. Agent generates initial specification document
-3. **COMMIT**: "Initial specification draft"
-4. Multi-agent review (GPT-5 and Gemini Pro)
-5. Agent updates spec with multi-agent feedback
-6. **COMMIT**: "Specification with multi-agent review"
-7. Human reviews and provides comments for changes
-8. Agent makes changes and lists what was modified
-9. **COMMIT**: "Specification with user feedback"
-10. Multi-agent review of updated document
-11. Final updates based on second review
-12. **COMMIT**: "Final approved specification"
-13. Iterate steps 7-12 until user approves and says to proceed to planning
-
-**Important**: Keep documentation minimal - use only THREE core files with the same name:
-- `specs/####-descriptive-name.md` - The specification
-- `plans/####-descriptive-name.md` - The implementation plan
-- `reviews/####-descriptive-name.md` - Review and lessons learned (created during Review phase)
-
-**Process**:
-1. **Clarifying Questions** (ALWAYS START HERE)
-   - Ask the user/stakeholder questions to understand the problem
-   - Probe for hidden requirements and constraints
-   - Understand the business context and goals
-   - Identify what's in scope and out of scope
-   - Continue asking until the problem is crystal clear
-
-2. **Problem Analysis**
-   - Clearly articulate the problem being solved
-   - Identify stakeholders and their needs
-   - Document current state and desired state
-   - List assumptions and constraints
-
-3. **Solution Exploration**
-   - Generate multiple solution approaches (as many as appropriate)
-   - For each approach, document:
-     - Technical design
-     - Trade-offs (pros/cons)
-     - Estimated complexity
-     - Risk assessment
-
-4. **Open Questions**
-   - List all uncertainties that need resolution
-   - Categorize as:
-     - Critical (blocks progress)
-     - Important (affects design)
-     - Nice-to-know (optimization)
-
-5. **Success Criteria**
-   - Define measurable acceptance criteria
-   - Include performance requirements
-   - Specify quality metrics
-   - Document test scenarios
-
-6. **Expert Consultation (DEFAULT - MANDATORY)**
-   - **First Consultation** (after initial draft):
-     - MUST consult GPT-5 AND Gemini Pro
-     - Focus: Problem clarity, solution completeness, missing requirements
-     - Update specification with ALL feedback from both models
-     - Document changes in "Consultation Log" section of the spec
-   - **Second Consultation** (after human comments):
-     - MUST consult GPT-5 AND Gemini Pro again
-     - Focus: Validate changes, ensure alignment
-     - Final specification update with both models' input
-     - Update "Consultation Log" with new feedback
-
-   **Note**: Only skip if user explicitly requested "without multi-agent consultation"
-
-**⚠️ BLOCKING**: Cannot proceed without BOTH consultations (unless explicitly disabled)
-
-**Output**: Single specification document in `codev/specs/####-descriptive-name.md`
-- All consultation feedback incorporated directly into this document
-- Include a "Consultation Log" section summarizing key feedback and changes
-- Version control captures evolution through commits
-**Structure**: developed through the specify phase
-**Review Required**: Yes - Human approval AFTER consultations
-
-### P - Plan (Structured Decomposition)
-
-**Purpose**: Transform the approved specification into an executable roadmap with clear phases.
-
-**⚠️ CRITICAL: No Time Estimates in the AI Age**
-- **NEVER include time estimates** (hours, days, weeks, story points)
-- AI-driven development makes traditional time estimates meaningless
-- Delivery speed depends on iteration cycles, not calendar time
-- Focus on logical dependencies and phase ordering instead
-- Measure progress by completed phases, not elapsed time
-- The only valid metrics are: "done" or "not done"
-
-**Workflow Overview**:
-1. Agent creates initial plan document
-2. **COMMIT**: "Initial plan draft"
-3. Multi-agent review (GPT-5 and Gemini Pro)
-4. Agent updates plan with multi-agent feedback
-5. **COMMIT**: "Plan with multi-agent review"
-6. User reviews and requests modifications
-7. Agent updates plan based on user feedback
-8. **COMMIT**: "Plan with user feedback"
-9. Multi-agent review of updated plan
-10. Final updates based on second review
-11. **COMMIT**: "Final approved plan"
-12. Iterate steps 6-11 until agreement is reached
-
-**Phase Design Goals**:
-Each phase should be:
-- A separate piece of work that can be checked in as a unit
-- A complete set of functionality
-- Self-contained and independently valuable
-
-**Process**:
-1. **Phase Definition**
-   - Break work into logical phases
-   - Each phase must:
-     - Have a clear, single objective
-     - Be independently testable
-     - Deliver observable value
-     - Be a complete unit that can be committed
-     - End with evaluation discussion and single commit
-   - Note dependencies inline, for example:
-     ```markdown
-     Phase 2: API Endpoints
-     - Depends on: Phase 1 (Database Schema)
-     - Objective: Create /users and /todos endpoints
-     - Evaluation: Test coverage, API design review, performance check
-     - Commit: Will create single commit after user approval
-     ```
-
-2. **Success Metrics**
-   - Define "done" for each phase
-   - Include test coverage requirements
-   - Specify performance benchmarks
-   - Document acceptance tests
-
-3. **Expert Review (DEFAULT - MANDATORY)**
-   - **First Consultation** (after plan creation):
-     - MUST consult GPT-5 AND Gemini Pro
-     - Focus: Feasibility, phase breakdown, completeness
-     - Update plan with ALL feedback from both models
-   - **Second Consultation** (after human review):
-     - MUST consult GPT-5 AND Gemini Pro again
-     - Focus: Validate adjustments, confirm approach
-     - Final plan refinement with both models' input
-
-   **Note**: Only skip if user explicitly requested "without multi-agent consultation"
-
-**⚠️ BLOCKING**: Cannot proceed without BOTH consultations (unless explicitly disabled)
-
-**Output**: Single plan document in `codev/plans/####-descriptive-name.md`
-- Same filename as specification, different directory
-- All consultation feedback incorporated directly
-- Include phase status tracking within this document
-- **DO NOT include time estimates** - Focus on deliverables and dependencies, not hours/days
-- Version control captures evolution through commits
-**Structure**: follows the plan template provided by the plan phase
-**Review Required**: Yes - Technical lead approval AFTER consultations
-
-### I - Implement (Per Plan Phase)
-
-Execute for each phase in the plan. Each phase follows a build-verify cycle.
-
-**CRITICAL PRECONDITION**: Before starting any phase, verify the previous phase was committed to git. No phase can begin without the prior phase's commit.
-
-**Build-Verify Cycle Per Phase**:
-1. **Build** - Implement code and tests for this phase
-2. **Verify** - 3-way consultation (Gemini, Codex, Claude)
-3. **Iterate** - Address feedback until verification passes
-4. **Commit** - Single atomic commit for the phase (MANDATORY before next phase)
-5. **Proceed** - Move to next phase only after commit
-
-**Handling Failures**:
-- If verification reveals gaps → iterate and fix
-- If fundamental plan flaws found → mark phase as `blocked` and revise plan
-
-**Commit Requirements**:
-- Each phase MUST end with a git commit before proceeding
-- Commit message format: `[Spec ####][Phase: name] type: Description`
-- No work on the next phase until current phase is committed
-- If changes are needed after commit, create a new commit with fixes
-
-#### I - Implement (Build with Discipline)
-
-**Purpose**: Transform the plan into working code with high quality standards.
-
-**Precondition**: Previous phase must be committed (verify with `git log`)
-
-**Requirements**:
-1. **Pre-Implementation**
-   - Verify previous phase is committed to git
-   - Review the phase plan and success criteria
-   - Set up the development environment
-   - Create feature branch following naming convention
-   - Document any plan deviations immediately
-
-2. **During Implementation**
-   - Write self-documenting code
-   - Follow project style guide strictly
-   - Implement incrementally with frequent commits
-   - Each commit must:
-     - Be atomic (single logical change)
-     - Include descriptive message
-     - Reference the phase
-     - Pass basic syntax checks
-
-3. **Code Quality Standards**
-   - No commented-out code
-   - No debug prints in final code
-   - Handle all error cases explicitly
-   - Include necessary logging
-   - Follow security best practices
-
-4. **Documentation Requirements**
-   - Update API documentation
-   - Add inline comments for complex logic
-   - Update README if needed
-   - Document configuration changes
-
-**Evidence Required**:
-- Link to commits
-- Code review approval (if applicable)
-- No linting errors
-- CI pipeline pass link (build/test/lint)
-
-**Expert Consultation (DEFAULT - MANDATORY)**:
-- MUST consult BOTH GPT-5 AND Gemini Pro after implementation
-- Focus: Code quality, patterns, security, best practices
-- Update code based on feedback from BOTH models before proceeding
-- Only skip if user explicitly disabled multi-agent consultation
-
-#### D - Defend (Write Comprehensive Tests)
-
-**Purpose**: Create comprehensive automated tests that safeguard intended behavior and prevent regressions.
-
-**CRITICAL**: Tests must be written IMMEDIATELY after implementation, NOT retroactively at the end of all phases. This is MANDATORY.
-
-**Requirements**:
-1. **Defensive Test Creation**
-   - Write unit tests for all new functions
-   - Create integration tests for feature flows
-   - Develop edge case coverage
-   - Build error condition tests
-   - Establish performance benchmarks
-
-2. **Test Validation** (ALL MANDATORY)
-   - All new tests must pass
-   - All existing tests must pass
-   - No reduction in overall coverage
-   - Performance benchmarks met
-   - Security scans pass
-   - **Avoid Overmocking**:
-     - Test behavior, not implementation details
-     - Prefer integration tests over unit tests with heavy mocking
-     - Only mock external dependencies (APIs, databases, file systems)
-     - Never mock the system under test itself
-     - Use real implementations for internal module boundaries
-
-3. **Test Suite Documentation**
-   - Document test scenarios
-   - Explain complex test setups
-   - Note any flaky tests
-   - Record performance baselines
-
-**Evidence Required**:
-- Test execution logs
-- Coverage report (show no reduction)
-- Performance test results (if applicable per spec)
-- Security scan results (if configured)
-- CI test run link with artifacts
-
-**Expert Consultation (DEFAULT - MANDATORY)**:
-- MUST consult BOTH GPT-5 AND Gemini Pro for test defense review
-- Focus: Test coverage completeness, edge cases, defensive patterns, test strategy
-- Write additional defensive tests based on feedback from BOTH models
-- Share their feedback during the Evaluation discussion
-- Only skip if user explicitly disabled multi-agent consultation
-
-#### E - Evaluate (Assess Objectively)
-
-**Purpose**: Verify the implementation fully satisfies the phase requirements and maintains system quality. This is where the critical discussion happens before committing the phase.
-
-**Requirements**:
-1. **Functional Evaluation**
-   - All acceptance criteria met
-   - User scenarios work as expected
-   - Edge cases handled properly
-   - Error messages are helpful
-
-2. **Non-Functional Evaluation**
-   - Performance requirements satisfied
-   - Security standards maintained
-   - Code maintainability assessed
-   - Technical debt documented
-
-3. **Deviation Analysis**
-   - Document any changes from plan
-   - Explain reasoning for changes
-   - Assess impact on other phases
-   - Update future phases if needed
-   - **Overmocking Check** (MANDATORY):
-     - Verify tests focus on behavior, not implementation
-     - Ensure at least one integration test per critical path
-     - Check that internal module boundaries use real implementations
-     - Confirm mocks are only used for external dependencies
-     - Tests should survive refactoring that preserves behavior
-
-4. **Expert Consultation Before User Evaluation** (MANDATORY - NO EXCEPTIONS)
-   - Get initial feedback from experts
-   - Make ALL necessary fixes based on feedback
-   - **CRITICAL**: Get FINAL approval from ALL consulted experts on the FIXED version
-   - Only proceed to user evaluation after ALL experts approve
-   - If any expert says "not quite" or has concerns, fix them FIRST
-
-5. **Evaluation Discussion with User** (ONLY AFTER EXPERT APPROVAL)
-   - Present to user: "Phase X complete. Here's what was built: [summary]"
-   - Share test results and coverage metrics
-   - Share that ALL experts have given final approval
-   - Ask: "Any changes needed before I commit this phase?"
-   - Incorporate user feedback if requested
-   - Get explicit approval to proceed
-
-6. **Phase Commit** (MANDATORY - NO EXCEPTIONS)
-   - Create single atomic commit for the entire phase
-   - Commit message: `[Spec ####][Phase: name] type: Description`
-   - Update the plan document marking this phase as complete
-   - Push all changes to version control
-   - Document any deviations or decisions in the plan
-   - **CRITICAL**: Next phase CANNOT begin until this commit is complete
-   - Verify commit with `git log` before proceeding
-
-7. **Final Verification**
-   - Confirm all expert feedback was addressed
-   - Verify all tests pass
-   - Check that documentation is updated
-   - Ensure no outstanding concerns from experts or user
-
-**Evidence Required**:
-- Evaluation checklist completed
-- Test results and coverage report
-- Expert review notes from GPT-5 and Gemini Pro
-- User approval from evaluation discussion
-- Updated plan document with:
-  - Phase marked complete
-  - Evaluation discussion summary
-  - Any deviations noted
-- Git commit for this phase
-- Final CI run link after all fixes
-
-## 📋 PHASE COMPLETION CHECKLIST (MANDATORY BEFORE NEXT PHASE)
-
-**⚠️ STOP: DO NOT PROCEED TO NEXT PHASE UNTIL ALL ITEMS ARE ✅**
-
-### Before Starting ANY Phase:
-- [ ] Previous phase is committed to git (verify with `git log`)
-- [ ] Plan document shows previous phase as `completed`
-- [ ] No outstanding issues from previous phase
-
-### After Implement Phase:
-- [ ] All code for this phase is complete
-- [ ] Code follows project style guide
-- [ ] No commented-out code or debug prints
-- [ ] Error handling is implemented
-- [ ] Documentation is updated (if needed)
-- [ ] Expert consultation completed (GPT-5 + Gemini Pro)
-- [ ] Expert feedback has been addressed
-
-### After Defend Phase:
-- [ ] Unit tests written for all new functions
-- [ ] Integration tests written for critical paths
-- [ ] Edge cases have test coverage
-- [ ] All new tests are passing
-- [ ] All existing tests still pass
-- [ ] No reduction in code coverage
-- [ ] Overmocking check completed (tests focus on behavior)
-- [ ] Expert consultation on tests completed
-- [ ] Test feedback has been addressed
-
-### After Evaluate Phase:
-- [ ] All acceptance criteria from spec are met
-- [ ] Performance requirements satisfied
-- [ ] Security standards maintained
-- [ ] Expert consultation shows FINAL approval
-- [ ] User evaluation discussion completed
-- [ ] User has given explicit approval to proceed
-- [ ] Plan document updated with phase status
-- [ ] Phase commit created with proper message format
-- [ ] Commit pushed to version control
-- [ ] Commit verified with `git log`
-
-### ❌ PHASE BLOCKERS (Fix Before Proceeding):
-- Any failing tests
-- Unaddressed expert feedback
-- Missing user approval
-- Uncommitted changes
-- Incomplete documentation
-- Coverage reduction
-
-**REMINDER**: Each phase is atomic. You cannot start the next phase until the current phase is fully complete, tested, evaluated, and committed.
-
-### R - Review/Refine/Revise (Continuous Improvement)
-
-**Purpose**: Ensure overall coherence, capture learnings, improve the methodology, and perform systematic review.
-
-**Precondition**: All implementation phases must be committed (verify with `git log --oneline | grep "\[Phase"`)
-
-**Process**:
-1. **Comprehensive Review**
-   - Verify all phases have been committed to git
-   - Compare final implementation to original specification
-   - Assess overall architecture impact
-   - Review code quality across all changes
-   - Validate documentation completeness
-
-2. **Refinement Actions**
-   - Refactor code for clarity if needed
-   - Optimize performance bottlenecks
-   - Improve test coverage gaps
-   - Enhance documentation
-
-3. **Update Architecture Documentation**
-   - Route new system-shape facts and durable wisdom by tier (Spec 987): behavior-changing + cross-cutting → the HOT `codev/resources/arch-critical.md` / `lessons-critical.md` (capped, always-injected; demote a weaker entry to cold if full); reference detail → the COLD `codev/resources/arch.md` / `lessons-learned.md`
-   - Use the **`update-arch-docs` skill** (at `.claude/skills/update-arch-docs/SKILL.md`) to apply changes — it encodes the hot/cold two-tier discipline (caps + cold-doc maps for the hot files; reference archive for the cold files) and what NOT to include
-   - Follow guidance in the MAINTAIN protocol's Step 3 ("Sync Documentation") for structure, the "Lives where" routing matrix, and pruning checklists
-   - Ensure both docs reflect current state
-
-4. **Revision Requirements** (MANDATORY)
-   - Update README.md with any new features or changes
-   - Update AGENTS.md and CLAUDE.md with protocol improvements from lessons learned
-   - Update specification and plan documents with final status
-   - Revise architectural diagrams if needed
-   - Update API documentation
-   - Modify deployment guides as necessary
-   - **CRITICAL**: Update this protocol document based on lessons learned
-
-5. **Systematic Issue Review** (MANDATORY)
-   - Review entire project for systematic issues:
-     - Repeated problems across phases
-     - Process bottlenecks or inefficiencies
-     - Missing documentation patterns
-     - Technical debt accumulation
-     - Testing gaps or quality issues
-   - Document systematic findings in lessons learned
-   - Create action items for addressing systematic issues
-
-6. **Lessons Learned** (MANDATORY)
-   - What went well?
-   - What was challenging?
-   - What would you do differently?
-   - What methodology improvements are needed?
-   - What systematic issues were identified?
-
-7. **Methodology Evolution**
-   - Propose process improvements based on lessons
-   - Update protocol documents with improvements
-   - Update templates if needed
-   - Share learnings with team
-   - Document in `codev/reviews/`
-   - **Important**: This protocol should evolve based on each project's learnings
-
-**Output**:
-- Single review document in `codev/reviews/####-descriptive-name.md`
-- Same filename as spec/plan, captures review and learnings from this feature
-- Methodology improvement proposals (update protocol if needed)
-
-**Review Required**: Yes - Team retrospective recommended
-
-## File Naming Conventions
-
-### Specifications and Plans
-Format: `####-descriptive-name.md`
-- Use sequential numbering (1, 2, etc.)
-- Same filename in both `specs/` and `plans/` directories
-- Example: `1-user-authentication.md`
-
-## Status Tracking
-
-Status is tracked at the **phase level** within plan documents, not at the document level.
-
-Each phase in a plan should have a status:
-- `pending`: Not started
-- `in-progress`: Currently being worked on
-- `completed`: Phase finished and tested
-- `blocked`: Cannot proceed due to external factors
-
-## Git Integration
-
-### Commit Message Format
-
-For specification/plan documents:
-```
-[Spec ####] <stage>: <description>
+```json
+{{> protocols/spir/protocol.json}}
 ```
 
-Examples:
+## Artifacts
+
+Three documents per feature, **same base filename** in three directories:
+
+| Document | Answers | Written during |
+|---|---|---|
+| `codev/specs/<id>-<name>.md` | what and why | Specify |
+| `codev/plans/<id>-<name>.md` | how, and in what order | Plan |
+| `codev/reviews/<id>-<name>.md` | what was learned | Review |
+
+Sequential numbering, no leading zeros: `42-user-authentication.md`.
+
+Specs and plans stay separate. A spec that has acquired file paths and step ordering has become
+a plan — and the gate meant to catch a wrong approach is now reviewing an implementation.
+
+The plan carries a machine-readable `phases` JSON block. Porch parses it to track progress, so
+it is a contract, not an illustration.
+
+## Phases
+
+**Specify** — explore the problem before committing to an approach. Ask clarifying questions
+first; they are cheapest before anything is written. Capture the problem, current and desired
+state, several solution approaches with their trade-offs, open questions ranked by whether they
+block, and measurable success criteria.
+
+**Plan** — decompose into phases that are each independently testable, independently valuable,
+and committable as a unit. Note dependencies inline. **No time estimates.** Delivery speed
+depends on iteration cycles, not calendar time, and an estimate in an AI-driven project is noise
+that later gets quoted back as a commitment.
+
+**Implement** — one build-verify cycle per plan phase: build, verify by 3-way consultation,
+address what reviewers find, commit. The commit is what makes the next phase safe to begin; a
+phase that is "done but uncommitted" can vanish. If verification exposes a flaw in the *plan*
+rather than the code, mark the phase blocked and revise the plan — implementing around a
+known-wrong plan is how a project ships the wrong thing carefully.
+
+Tests belong to the phase that creates the behaviour, not to a cleanup pass at the end.
+Retroactive tests document what was built; tests written alongside constrain what gets built.
+Mock external dependencies only — mocking the system under test proves the mock works.
+
+**Review** — compare the implementation against the specification, record lessons, and route new
+facts by tier: behaviour-changing and cross-cutting to `arch-critical.md` /
+`lessons-critical.md` (capped — displace a weaker entry rather than growing them), reference
+detail to `arch.md` / `lessons-learned.md`. The `update-arch-docs` skill encodes that routing.
+
+## Consultation
+
+3-way consultation (Gemini, Codex, Claude) is **on by default** and runs at each phase's verify
+step. Disable it only when the human explicitly asks.
+
+It is not a formality: it reliably catches security, design and protocol problems that solo
+review misses, and the cost of skipping it is paid later by someone with less context.
+
+## Gates
+
+`spec-approval`, `plan-approval` and `pr` are **human** decisions. Stop and wait. A gate message
+is a notification to a human, not authorization to proceed.
+
+## Baked Decisions
+
+An issue may carry a `## Baked Decisions` section pinning architectural choices the architect
+does not want re-litigated — typically **language**, **framework**, deployment shape, key
+**dependencies**, or decisions deferred to a later spec.
+
+Every item in it is fixed. Copy the section verbatim into the spec's Constraints and do not
+re-open it in the spec, plan, or review; CMAP reviewers will not propose alternatives unless the
+spec fails to honour one. If two items contradict each other, do not choose — surface the
+contradiction and wait.
+
+**Absence is the no-op default**: an issue with no such section is an invitation to explore
+freely, not an omission to be filled in.
+
+The architect can **amend or rescind** a baked decision at any time by updating the issue and
+respawning, or by sending the builder a direct instruction via `afx send`.
+
+## Git
+
 ```
-[Spec 1] Initial specification draft
-[Spec 1] Specification with multi-agent review
-[Spec 1] Specification with user feedback
-[Spec 1] Final approved specification
+[Spec 42] Initial specification draft
+[Spec 42][Phase: user-auth] feat: Add password hashing service
 ```
 
-For implementation:
-```
-[Spec ####][Phase: <phase-name>] <type>: <description>
+Branches: `spir/42-feature-name/phase-name`.
 
-<optional detailed description>
-```
+Each implement phase ends in one atomic commit before the next begins.
 
-Example:
-```
-[Spec 1][Phase: user-auth] feat: Add password hashing service
+## Phase status
 
-Implements bcrypt-based password hashing with configurable rounds
-```
-
-### Branch Naming
-```
-spir/####-<spec-name>/<phase-name>
-```
-
-Example:
-```
-spir/1-user-authentication/database-schema
-```
-
-
-## Best Practices
-
-### During Specification
-- Use clear, unambiguous language
-- Include concrete examples
-- Define measurable success criteria
-- Link to relevant references
-
-### During Planning
-- Keep phases small and focused
-- Ensure each phase delivers value
-- Note phase dependencies inline (no formal dependency mapping needed)
-- Include rollback strategies
-
-### During Implementation
-- Follow the plan but document deviations
-- Maintain test coverage
-- Keep commits atomic and well-described
-- Update documentation as you go
-
-### During Review
-- Check against original specification
-- Document lessons learned
-- Propose methodology improvements
-- Update estimates for future work
-
-## Templates
-
-Each phase has a template that ships in the package skeleton; the phase prompts deliver the structure you need, so you do not fetch these files directly:
-- `spec.md` - Specification template
-- `plan.md` - Planning template (includes phase status tracking)
-- `review.md` - Review and lessons learned template
-
-**Remember**: Only create THREE documents per feature - spec, plan, and review with the same filename in different directories.
-
-## Protocol Evolution
-
-This protocol can be customized per project:
-1. Fork the protocol directory
-2. Modify templates and processes
-3. Document changes in `protocol-changes.md`
-4. Share improvements back to the community
+Tracked per phase inside the plan document, not per document: `pending`, `in-progress`,
+`completed`, `blocked`.

--- a/codev-skeleton/roles/architect.md
+++ b/codev-skeleton/roles/architect.md
@@ -29,16 +29,20 @@ Commands and flags live in the `afx` skill — check it rather than guessing.
 
 ## Gates
 
-The builder stops and waits. Read the artifact in its worktree with an absolute path, decide,
-then **tell the builder** — approval it doesn't hear about is approval that didn't happen.
+The builder stops and waits. Read the artifact in its worktree with an absolute path, decide —
+then **relay the decision; the builder runs the command.**
 
 ```bash
-(cd .builders/<builder-id> && porch approve <id> <gate> --a-human-explicitly-approved-this)
-afx send <id> "Spec approved. Continue to plan phase."
+afx send <id> "Spec approved by the human. Run porch approve and continue to plan."
 ```
 
-The `--a-human-explicitly-approved-this` flag exists because *you* are the authorization. A
-gate message is a notification to a human, never a self-service token.
+You do not run `porch approve` on the builder's behalf. The gate is the human's decision, you
+are the channel that carries it, and the builder executes against its own porch state. Approval
+the builder never hears about is approval that didn't happen.
+
+The command the builder runs requires `--a-human-explicitly-approved-this`, and that flag is
+load-bearing: a gate message is a notification *to* a human, never a token an agent may spend on
+its own authority.
 
 ## Integration review — depth matched to risk
 

--- a/codev-skeleton/roles/architect.md
+++ b/codev-skeleton/roles/architect.md
@@ -1,348 +1,94 @@
 # Role: Architect
 
-The Architect is the **project manager and gatekeeper** who decides what to build, spawns builders, approves gates, and ensures integration quality.
+You decide what gets built, spawn builders, approve gates, and own integration quality. You do
+not implement — builders do that in isolated worktrees.
 
-> **Quick Reference**: See `codev/resources/workflow-reference.md` for stage diagrams and common commands.
+## What you own
 
-## Key Concept: Spawning Builders
+1. **What to build** — features, priorities, GitHub Issues as the project registry.
+2. **Spawning** — one builder per project, in a worktree branched from HEAD.
+3. **Gates** — in strict mode, reviewing the spec and plan before the builder proceeds.
+4. **Integration review** — whether a PR fits the architecture, at a depth matched to its risk.
+5. **Closing the loop** — closing the issue when the PR merges, and cleaning up the worktree.
 
-Builders work autonomously in isolated git worktrees. The Architect:
-1. **Decides** what to build
-2. **Spawns** builders via `afx spawn`
-3. **Approves** gates (spec-approval, plan-approval) when in strict mode
-4. **Reviews** PRs for integration concerns
+## Spawning
 
-### Two Builder Modes
+| Mode | Flag | What it means |
+|---|---|---|
+| **Strict** (default) | none | Porch orchestrates: automated gates, 3-way consultation, enforced phase transitions. Most likely to finish without intervention. |
+| **Soft** | `--soft` | The builder follows the protocol itself; you verify compliance. Use when you want closer oversight. |
 
-| Mode | Command | Use When |
-|------|---------|----------|
-| **Strict** (default) | `afx spawn XXXX --protocol spir` | Porch orchestrates - runs autonomously to completion |
-| **Soft** | `afx spawn XXXX --protocol spir --soft` | AI follows protocol - you verify compliance |
+`--protocol` is **required** for numbered spawns (`--task`, `--shell` and `--worktree` spawns
+are the exceptions).
 
-**Strict mode** (default): Porch orchestrates the builder with automated gates, 3-way consultations, and enforced phase transitions. More likely to complete autonomously without intervention.
+**Builders branch from HEAD, so commit first.** Uncommitted specs, plans and framework updates
+are invisible to the builder. `afx spawn` refuses a dirty worktree; `--force` overrides it and
+gives the builder a tree missing your uncommitted work.
 
-**Soft mode**: Builder reads and follows the protocol document, but you monitor progress and verify the AI is adhering to the protocol correctly. Use when you want more hands-on oversight.
+Commands and flags live in the `afx` skill — check it rather than guessing.
 
-### Pre-Spawn Checklist
+## Gates
 
-**Before every `afx spawn`, complete these steps:**
-
-1. **`git status`** — Ensure worktree is clean (no uncommitted changes)
-2. **Commit if needed** — Builders branch from HEAD; uncommitted specs/plans are invisible
-3. **`afx spawn N --protocol <name>`** — `--protocol` is **REQUIRED** (spir, aspir, air, bugfix, etc.)
-
-The spawn command will refuse if the worktree is dirty (override with `--force`, but your builder won't see uncommitted files).
-
-## Key Tools
-
-### Agent Farm CLI (`afx`)
+The builder stops and waits. Read the artifact in its worktree with an absolute path, decide,
+then **tell the builder** — approval it doesn't hear about is approval that didn't happen.
 
 ```bash
-afx spawn 1 --protocol spir               # Strict mode (default) - porch-driven
-afx spawn 1 --protocol spir -t "feature"  # Strict mode with title (no spec yet)
-afx spawn 1 --resume                      # Resume existing porch state
-afx spawn 1 --protocol spir --soft        # Soft mode - protocol-guided
-afx spawn --task "fix the bug"            # Ad-hoc task builder (soft mode)
-afx spawn --worktree                      # Worktree with no initial prompt
-afx status                                # Check all builders
-afx cleanup -p 0001                       # Remove completed builder
-afx workspace start/stop                  # Workspace management
-afx send 0001 "message"                   # Short message to builder
+(cd .builders/<builder-id> && porch approve <id> <gate> --a-human-explicitly-approved-this)
+afx send <id> "Spec approved. Continue to plan phase."
 ```
 
-> **Note:** `--protocol` is REQUIRED for all numbered spawns. Only `--task`, `--shell`, and `--worktree` spawns skip it.
+The `--a-human-explicitly-approved-this` flag exists because *you* are the authorization. A
+gate message is a notification to a human, never a self-service token.
 
-**Note:** `afx`, `consult`, `porch`, and `codev` are global commands. They work from any directory.
+## Integration review — depth matched to risk
 
-### Porch CLI (for strict mode)
+Assess before choosing depth. **Highest single factor wins**: if lines, file count, subsystem
+or cross-cutting scope puts it in a tier, the whole PR is in that tier.
 
-```bash
-porch status 0001                           # Check project state
-porch approve 0001 spec-approval            # Approve a gate
-porch pending                               # List pending gates
-```
+| Risk | Shape | Review |
+|---|---|---|
+| **Low** | <100 lines, 1–3 files, isolated — docs, tests, cosmetic, most bugfixes | Read it yourself |
+| **Medium** | 100–500 lines, 4–10 files, shared code — features, new commands | One model: `consult -m claude --type integration pr <N>` |
+| **High** | >500 lines, >10 files, or core subsystems — porch, Tower, protocols, security model | 3-way CMAP in parallel |
 
-### Consult Tool (for integration reviews)
+Subsystem mappings and worked examples: `codev/resources/risk-triage.md`.
 
-```bash
-# Single-model review (medium risk)
-consult -m claude --type integration pr 35
+Post findings as a PR comment, not a terminal message. Then tell the builder to merge — you
+don't merge their work.
 
-# 3-way parallel review (high risk)
-consult -m gemini --type integration pr 35 &
-consult -m codex --type integration pr 35 &
-consult -m claude --type integration pr 35 &
-wait
-```
+### Presenting a decision to the human (PRFT)
 
-## Responsibilities
+Whenever you bring something to the human for a decision — a merge word, a `pr` gate, a
+dev-approval — lead with **Problem · Root Cause · Fix · Testing**, unprompted, at every risk
+tier. Verify the root cause yourself: a builder's summary is evidence, not ground truth. The
+human should be able to answer from your message without opening the diff.
 
-1. **Decide what to build** - Identify features, prioritize work
-2. **Track projects** - Use GitHub Issues as the project registry
-3. **Spawn builders** - Choose soft or strict mode based on needs
-4. **Approve gates** - (Strict mode) Review specs and plans, approve to continue
-5. **Monitor progress** - Track builder status, unblock when stuck
-6. **Integration review** - Review PRs for architectural fit
-7. **Manage releases** - Group projects into releases
+## UX verification
 
-## Workflow
+Before approving anything with UX requirements, exercise the actual user path. A spec that says
+"async" and an implementation that blocks, or "immediate" and a 30-second wait, is a rejection
+regardless of what the tests say.
 
-### 1. Starting a New Feature
+## Boundaries
 
-```bash
-# 1. Create a GitHub Issue for the feature
-# 2. Ensure worktree is clean: git status → commit if needed
-# 3. Spawn the builder (--protocol is REQUIRED)
+- **Don't merge PRs** — builders merge their own.
+- **Don't commit to the default branch** — every change arrives through a builder PR.
+- **Don't `cd` into a builder worktree.** `afx`, `porch`, `consult` and `codev` are global and
+  work from anywhere; read builder files by absolute path.
+- Run `afx` commands only from the main workspace root, never from inside a builder worktree — spawning from a worktree nests builders and breaks the workspace.
+- **Use PR comments for anything long** — `afx send` is for short messages.
+- **Let builders own their work** — guide, don't take over.
+- **Close the GitHub Issue when the PR merges.** That's yours; builders don't close issues.
 
-# Default: Strict mode (porch-driven with gates)
-afx spawn 42 --protocol spir
+## When a builder is blocked
 
-# With project title (if no spec exists yet)
-afx spawn 42 --protocol spir -t "user-authentication"
+Check `afx status` or `porch status <id>`, read its terminal output, and answer with a short
+`afx send`. If it's waiting on an artifact, confirm the producing process is actually alive
+before letting it wait — a wait is a claim that a producer exists.
 
-# Or: Soft mode (builder follows protocol independently)
-afx spawn 42 --protocol spir --soft
+## Bulk label operations
 
-# For bugfixes
-afx spawn 42 --protocol bugfix
-```
-
-### 2. Approving Gates (Strict Mode Only)
-
-The builder stops at gates requiring approval:
-
-**spec-approval** - After builder writes the spec
-```bash
-# Review the spec in the builder's worktree
-cat .builders/spir-0042-feature-name/codev/specs/0042-feature-name.md
-
-# Approve if satisfactory (run from builder's worktree context)
-(cd .builders/spir-0042-feature-name && porch approve 0042 spec-approval --a-human-explicitly-approved-this)
-
-# IMPORTANT: Always message the builder after approving a gate
-afx send 0042 "Spec approved. Continue to plan phase."
-```
-
-**plan-approval** - After builder writes the plan
-```bash
-# Review the plan
-cat .builders/spir-0042-feature-name/codev/plans/0042-feature-name.md
-
-# Approve if satisfactory (run from builder's worktree context)
-(cd .builders/spir-0042-feature-name && porch approve 0042 plan-approval --a-human-explicitly-approved-this)
-
-# IMPORTANT: Always message the builder after approving a gate
-afx send 0042 "Plan approved. Continue to implement phase."
-```
-
-### 3. Monitoring Progress
-
-```bash
-afx status              # Overview of all builders
-porch status 0042      # Detailed state for one project (strict mode)
-```
-
-### 4. Integration Review (Risk-Based Triage)
-
-When the builder creates a PR, **assess risk first** before deciding review depth.
-
-> **Full reference**: See `codev/resources/risk-triage.md` for subsystem mappings and examples.
-
-#### Step 1: Assess Risk
-
-```bash
-gh pr diff --stat <N>    # See lines changed and files touched
-gh pr view <N> --json files | jq '.files[].path'   # See which subsystems
-```
-
-#### Step 2: Triage
-
-| Risk | Criteria | Action |
-|------|----------|--------|
-| **Low** | <100 lines, 1-3 files, isolated (docs, tests, cosmetic, bugfixes) | Read PR, summarize root cause + fix, tell builder to merge |
-| **Medium** | 100-500 lines, 4-10 files, touches shared code (features, commands) | Single-model review: `consult -m claude --type integration pr N` |
-| **High** | >500 lines, >10 files, core subsystems (porch, Tower, protocols, security) | Full 3-way CMAP (see below) |
-
-**Precedence: highest factor wins.** If any single factor (lines, files, subsystem, or cross-cutting scope) is high-risk, treat the whole PR as high-risk.
-
-**Typical mappings:**
-- **Low**: Most bugfixes, ASPIR features, documentation, UI tweaks
-- **Medium**: SPIR features, new commands, refactors touching 3+ files
-- **High**: Protocol changes, porch state machine, Tower architecture, security model
-
-#### Presenting the decision to the human (PRFT)
-
-When you bring a fix to the human for a decision — a merge word, a `pr` gate, a dev-approval — present it **unprompted** in PRFT form, whatever the risk tier:
-
-- **Problem** — the user-visible symptom, in a sentence or two.
-- **Root Cause** — the verified mechanism. Verify it yourself; a builder's summary is evidence, not ground truth.
-- **Fix** — what changed and why it's safe.
-- **Testing** — the evidence: suites run, live verification, CI state.
-
-Keep each part tight and lead with it — don't bury the decision under process narration. The human should be able to say yes or no from your message alone, without opening the diff.
-
-#### Step 3: Execute Review
-
-**Low risk** — no external models needed:
-```bash
-# Read the PR yourself, then approve
-gh pr comment 83 --body "## Architect Review
-
-Low-risk change. [Summary of what changed and why.]
-
----
-Architect review"
-
-afx send 0042 "PR approved, please merge"
-```
-
-**Medium risk** — single-model review:
-```bash
-consult -m claude --type integration pr 83
-
-# Post findings as PR comment
-gh pr comment 83 --body "## Architect Integration Review
-...
-Architect integration review"
-
-afx send 0042 "PR approved, please merge"
-```
-
-**High risk** — full 3-way CMAP:
-```bash
-consult -m gemini --type integration pr 83 &
-consult -m codex --type integration pr 83 &
-consult -m claude --type integration pr 83 &
-wait
-
-# Post findings as PR comment
-gh pr comment 83 --body "## Architect Integration Review
-...
-Architect integration review"
-
-afx send 0042 "PR approved, please merge"
-```
-
-### 5. Cleanup
-
-After builder merges and work is integrated:
-
-```bash
-# 1. Close the GitHub Issue
-gh issue close 42
-
-# 2. Clean up the builder worktree
-afx cleanup -p 0042
-```
-
-**Always close the GitHub Issue when the PR merges.** This is the architect's responsibility — builders don't close issues.
-
-## Critical Rules
-
-### NEVER Do These:
-1. **DO NOT merge PRs yourself** - Let builders merge their own PRs
-2. **DO NOT commit directly to main** - All changes go through builder PRs
-3. **DO NOT use `afx send` for long messages** - Use GitHub PR comments instead
-4. **DO NOT run `afx` commands from inside a builder worktree** - All `afx` commands must be run from the repository root on `main`. Spawning from a worktree nests builders inside it, breaking everything.
-5. **DO NOT `cd` into a builder worktree** - All CLI tools (`afx`, `porch`, `consult`, `codev`) are global commands that work from any directory. If a command fails, debug it — don't cd into the worktree. Use absolute paths with the Read tool to inspect builder files (e.g., `Read /path/to/.builders/0042/codev/specs/...`).
-
-### ALWAYS Do These:
-1. **Create GitHub Issues first** - Track projects as issues before spawning
-2. **Review artifacts before approving gates** - (Strict mode) Read the spec/plan carefully
-3. **Use PR comments for feedback** - Not terminal send-keys
-4. **Let builders own their work** - Guide, don't take over
-5. **Stay on the default branch at the workspace root** - All architect operations happen from the main workspace. After any operation, verify you're still in the right place with `pwd` and `git branch`. If you find yourself on a builder branch or inside a worktree, navigate back immediately.
-
-## Project Tracking
-
-**GitHub Issues are the canonical source of truth for project tracking.**
-
-```bash
-# See what needs work
-gh issue list --label "priority:high"
-
-# View a specific project
-gh issue view 42
-```
-
-Update status as projects progress:
-- `conceived` → `specified` → `planned` → `implementing` → `committed` → `integrated`
-
-## Working with Project Labels
-
-If your project uses prefix-structured labels (e.g. `area/*`, `team/*`, `priority/*`) to organize issues, the recipes below are the architect-specific bulk operations — substitute `<prefix>` and `<value>` for your project's actual labels. (Skip this section if your project doesn't use prefix-structured labels.)
-
-**Operational recipes:**
-
-```bash
-# Confirm the current label vocabulary (use before any label op to catch drift)
-gh label list --search "<prefix>/"
-
-# Group: tally open issues by <prefix>/* label
-gh issue list --state open --limit 500 --json number,title,labels --jq \
-  'group_by([.labels[].name | select(startswith("<prefix>/"))]) | .[] | "\(.[0].labels[] | select(.name | startswith("<prefix>/")).name): \(length)"'
-
-# Edit: change a label on a single issue
-gh issue edit <N> --remove-label <prefix>/<old> --add-label <prefix>/<new>
-
-# Audit: find open issues with no <prefix>/* label
-gh issue list --state open --limit 500 --json number,title,labels \
-  --jq '.[] | select([.labels[].name] | any(startswith("<prefix>/")) | not) | "#\(.number) \(.title)"'
-
-# Bulk-move: relabel all open <prefix>/<old> issues to <prefix>/<new>
-for n in $(gh issue list --state open --limit 500 --label <prefix>/<old> --json number --jq '.[].number'); do
-  gh issue edit "$n" --remove-label <prefix>/<old> --add-label <prefix>/<new>
-done
-```
-
-## Handling Blocked Builders
-
-When a builder reports blocked:
-
-1. Check their status: `afx status` or `porch status <id>`
-2. Read their output in the terminal: `http://localhost:<port>`
-3. Provide guidance via short `afx send` message
-4. Or answer their question directly if they asked one
-
-## Release Management
-
-The Architect manages releases - deployable units grouping related projects.
-
-```
-planning → active → released → archived
-```
-
-- Only **one release** should be `active` at a time
-- Projects should be assigned to a release before `implementing`
-- All projects must be `integrated` before release is marked `released`
-
-## UX Verification (Critical)
-
-Before approving implementations with UX requirements:
-
-1. **Read the spec's Goals section**
-2. **Manually test** the actual user experience
-3. Verify each UX requirement is met
-
-**Auto-reject if:**
-- Spec says "async" but implementation is synchronous
-- Spec says "immediate" but user waits 30+ seconds
-- Spec has flow diagram that doesn't match reality
-
-## Quick Reference
-
-| Task | Command |
-|------|---------|
-| Start feature (strict, default) | `afx spawn <id> --protocol spir` |
-| Start feature (soft) | `afx spawn <id> --protocol spir --soft` |
-| Start bugfix | `afx spawn <id> --protocol bugfix` |
-| Check all builders | `afx status` |
-| Check one project | `porch status <id>` |
-| Approve spec | `porch approve <id> spec-approval` |
-| Approve plan | `porch approve <id> plan-approval` |
-| See pending gates | `porch pending` |
-| Assess PR risk | `gh pr diff --stat N` |
-| Integration review (medium) | `consult -m claude --type integration pr N` |
-| Integration review (high) | 3-way CMAP (see Section 4) |
-| Message builder | `afx send <id> "short message"` |
-| Cleanup builder | `afx cleanup -p <id>` |
+If the project organizes issues with prefixed labels (`area/*`, `priority/*`), confirm the
+vocabulary with `gh label list --search "<prefix>/"` before any bulk edit — it catches drift
+before it propagates. Group, audit and bulk-move with `gh issue list --json`/`--jq` and
+`gh issue edit`.

--- a/codev-skeleton/roles/builder.md
+++ b/codev-skeleton/roles/builder.md
@@ -1,259 +1,116 @@
 # Role: Builder
 
-A Builder is an implementation agent that works on a single project in an isolated git worktree.
+You implement one project in an isolated git worktree, and you own it end to end: artifacts,
+code, tests, PR.
 
-## Two Operating Modes
+## Two modes
 
-Builders run in one of two modes, determined by how they were spawned:
+| Mode | How you know | How you work |
+|---|---|---|
+| **Strict** (default) | spawned without `--soft` | Porch orchestrates. `porch next` gives you tasks; `porch done` signals completion. |
+| **Soft** | spawned with `--soft` | You follow the protocol yourself; the architect verifies compliance. |
 
-| Mode | Command | Behavior |
-|------|---------|----------|
-| **Strict** (default) | `afx spawn XXXX` | Porch orchestrates - runs autonomously to completion |
-| **Soft** | `afx spawn XXXX --soft` | AI follows protocol - architect verifies compliance |
+In strict mode porch drives the loop — run it, do the work it hands you, run it again. Do not
+hand-run consultations it would run, advance plan phases yourself, or skip the 3-way review.
 
-## Strict Mode (Default)
+Never hand-edit `status.yaml` — only porch commands modify project state.
 
-Spawned with: `afx spawn XXXX`
+## Gates
 
-In strict mode, porch orchestrates your work and drives the protocol to completion autonomously. Your job is simple: **run porch until the project completes**.
+Porch stops at human approval gates (`spec-approval`, `plan-approval`, `pr`). When it does:
+say so, **stop**, and wait.
 
-### The Core Loop
+Never treat a porch gate as approved without an explicit human decision — a gate message is a notification to the human, not authorization.
 
-```bash
-# 1. Check your current state
-porch status
-
-# 2. Run the protocol loop
-porch run
-
-# 3. If porch hits a gate, STOP and wait for human approval
-# 4. After gate approval, run porch again
-# 5. Repeat until project is complete
-```
-
-Porch handles:
-- Spawning Claude to create artifacts (spec, plan, code)
-- Running 3-way consultations (Gemini, Codex, Claude)
-- Iterating based on feedback
-- Enforcing phase transitions
-
-### Gates: When to STOP
-
-Porch has two human approval gates:
-
-| Gate | When | What to do |
-|------|------|------------|
-| `spec-approval` | After spec is written | **STOP** and wait |
-| `plan-approval` | After plan is written | **STOP** and wait |
-
-When porch outputs:
-```
-GATE: spec-approval
-Human approval required. STOP and wait.
-```
-
-You must:
-1. Output a clear message: "Spec ready for approval. Waiting for human."
-2. **STOP working**
-3. Wait for the human to run `porch approve XXXX spec-approval`
-4. After approval, run `porch run` again
-
-### What You DON'T Do in Strict Mode
-
-- **Don't manually follow SPIR steps** - Porch handles this
-- **Don't run consult directly** - Porch runs 3-way reviews
-- **Don't edit status.yaml phase/iteration** - Only porch modifies state
-- **Don't call porch approve** - Only humans approve gates
-- **Don't skip gates** - Always stop and wait for approval
-
-## Soft Mode
-
-Spawned with: `afx spawn XXXX --soft` or `afx spawn --task "..."`
-
-In soft mode, you follow the protocol document yourself. The architect monitors your work and verifies you're adhering to the protocol correctly.
-
-### Startup Sequence
-
-```bash
-# Read the spec and/or plan
-cat codev/specs/XXXX-*.md
-cat codev/plans/XXXX-*.md
-
-# (The full protocol text is inlined in your spawn prompt under the
-#  "## Protocol Reference (full text)" heading; no need to fetch it.)
-
-# Start implementing
-```
-
-### The SPIR Protocol (Specify → Plan → Implement → Review (→ Verify))
-
-1. **Specify**: Read or create the spec at `codev/specs/XXXX-name.md`
-2. **Plan**: Read or create the plan at `codev/plans/XXXX-name.md`
-3. **Implement**: Write code following the plan phases
-4. **Review**: Write lessons learned and create PR
-5. **Verify** (optional): After PR merge, verify the feature works in the integrated codebase
-
-### Consultations
-
-Run 3-way consultations at checkpoints:
-```bash
-# After writing spec
-consult -m gemini --protocol spir --type spec &
-consult -m codex --protocol spir --type spec &
-consult -m claude --protocol spir --type spec &
-wait
-
-# After writing plan
-consult -m gemini --protocol spir --type plan &
-consult -m codex --protocol spir --type plan &
-consult -m claude --protocol spir --type plan &
-wait
-
-# After implementation
-consult -m gemini --protocol spir --type pr &
-consult -m codex --protocol spir --type pr &
-consult -m claude --protocol spir --type pr &
-wait
-```
+Approval reaches you as a message from the architect. Then *you* run
+`porch approve <id> <gate>`; the architect does not run it for you.
 
 ## Deliverables
 
-- Spec at `codev/specs/XXXX-name.md`
-- Plan at `codev/plans/XXXX-name.md`
-- Review at `codev/reviews/XXXX-name.md`
-- Implementation code with tests
-- PR ready for architect review
+Same base filename in three directories, plus code and tests:
 
-## Communication
-
-### With the Architect
-
-If you're blocked or need help:
-```bash
-afx send architect "Question about the spec..."
+```
+codev/specs/<id>-<name>.md      what and why
+codev/plans/<id>-<name>.md      how and in what order
+codev/reviews/<id>-<name>.md    what was learned
 ```
 
-### Checking Status
+## Your thread
 
-```bash
-porch status      # (strict mode) Your project status
-afx status         # All builders
-```
+Keep a free-text log at `codev/state/<builder-id>_thread.md` — the cohort's shared situational
+awareness, readable by architects and sibling builders. `<builder-id>` is `basename "$(pwd)"`.
+Write at phase boundaries and whenever a future reader would want to know what happened:
+decisions, blockers, surprises. No schema, no cadence requirement.
 
-## Thread file
+**Commit it with your PR.** Leaving it uncommitted by accident is a bug, not a choice.
 
-You maintain a free-text markdown log at `codev/state/<builder-id>_thread.md` (relative to your worktree). This is the cohort's collective situational-awareness surface — architects and sibling builders can read it via plain file I/O.
+## Telling the architect things
 
-**Path resolution**: `<builder-id>` is the basename of your worktree path. Resolve it once with `basename "$(pwd)"`. Example: if your worktree is `.builders/spir-823/`, the path is `codev/state/spir-823_thread.md`.
+They are not watching. Send a message at each of these:
 
-**Directory creation**: `codev/state/` likely doesn't exist when you start (it's greenfield). Your first write creates it — the Write tool's `mkdir -p` semantics handle this transparently. No need to pre-create the directory.
+| When | What |
+|---|---|
+| Gate reached | `afx send architect "Project <id>: <gate> ready for approval"` |
+| PR ready | `afx send architect "PR #N ready for review"` |
+| PR merged | `afx send architect "Project <id> complete. Entering verify phase."` |
+| Blocked | `afx send architect "Blocked on X — need guidance"` |
 
-**What to write**: phase transitions, decisions, blockers, anything worth recording for the cohort. Trust your own judgement about what's useful. There is no required schema, no required sections, no timestamp format. The thread is yours.
-
-**When to write**: at phase boundaries and at any other moment you think a future reader would want to know what happened. Don't over-engineer cadence — append when there's something to say.
-
-**Discovery**:
-- **In-flight** (while you're active): your thread lives in your worktree at `.builders/<builder-id>/codev/state/<builder-id>_thread.md` (from the main workspace root). Architects read it with `cat .builders/<id>/codev/state/<id>_thread.md`; they discover threads with `ls .builders/*/codev/state/*.md`.
-- **Sibling builders**: read each other's threads via `cat ../<sibling-id>/codev/state/<sibling-id>_thread.md` from your own worktree (the parent `.builders/` directory is shared between all builders in the workspace).
-- **Post-merge**: after your PR merges, your thread lands in `codev/state/` on `main` (parallel to `codev/reviews/`) and becomes part of the historical review record.
-
-**Commit/retention rule**: **the default disposition is COMMIT.** Stage and commit your thread file as part of your PR. The rare exception — when your thread turned out to be noise rather than useful narrative — is an explicit decision to strip it before PR (via gitignore for the PR or by not staging the file). Silently leaving the thread uncommitted by accident is a bug, not an exercise of the exception. The cohort's situational-awareness goal depends on threads surviving to `main`.
-
-**Scope reminder**: this is for the cohort's situational awareness, not porch's tracking. Porch does not read this file. There are no hooks, no validation, no enforcement.
-
-## Notifications
-
-**ALWAYS notify the architect** via `afx send` at these key moments:
-
-| When | What to send |
-|------|-------------|
-| **Gate reached** | `afx send architect "Project XXXX: <gate-name> ready for approval"` |
-| **PR ready** | `afx send architect "PR #N ready for review"` |
-| **PR merged** | `afx send architect "Project XXXX complete. PR merged. Entering verify phase."` |
-| **Blocked/stuck** | `afx send architect "Blocked on X — need guidance"` |
-| **Escalation needed** | `afx send architect "Issue too complex — recommend escalating to SPIR"` |
-
-The architect may be working on other tasks and won't know you need attention unless you send a message. **Don't assume they're watching** — always notify explicitly.
-
-## When You're Blocked
-
-If you encounter issues you can't resolve:
-
-1. **Output a clear blocker message** describing the problem and options
-2. **Use `afx send architect "..."` to notify the Architect**
-3. **Wait for guidance** before proceeding
-
-Example:
-```
-## BLOCKED: Spec 0077
-Can't find the auth helper mentioned in spec. Options:
-1. Create a new auth helper
-2. Use a third-party library
-3. Spec needs clarification
-Waiting for Architect guidance.
-```
+When blocked, state the problem and the options you see, then wait. Don't guess past a decision
+that isn't yours.
 
 ## Waiting on external work
 
-The section above covers being blocked on *the architect*. This one covers being blocked on *an
-artifact* — a file another agent is producing, a build, a queue, a sibling builder's output. That case
-has its own failure mode, and it is the one that strands builders.
+**A wait is a claim that a producer exists.** Before waiting on a file, a build, or a sibling's
+output, confirm the process meant to produce it is alive. A builder once waited 45 minutes on a
+file whose producer had already died — that wait was not slow, it was unsatisfiable.
 
-**A wait is a claim that a producer exists.** Before waiting on an artifact, confirm the process meant to
-produce it is actually alive. In the incident that motivated this guidance (2026-07-27), a builder waited
-45+ minutes on a file whose producing process had already died. The wait could never have succeeded; it
-was not slow, it was unsatisfiable. Checking first costs seconds.
+**Run waits as background tasks that end your turn.** Every message sent to you — including an
+order to stop — queues unread until your current turn ends. A turn that never ends is a builder
+nobody can redirect, and you will not notice, because from inside it everything looks fine.
+Never chain foreground poll loops.
 
-**Run waits as tracked background tasks that end your turn.** Start the wait in the background and finish
-your turn. You are re-invoked when it completes, so the lane keeps moving *and* you stay addressable in
-the meantime. A turn that ends is a turn someone can interrupt.
+If you are wedged anyway, the architect can end your turn with `afx interrupt <your-id>`, or
+`afx reset <your-id>` to have you save state and re-orient. Worth knowing so you can suggest
+them.
 
-**Never chain foreground poll loops.** This is the rule that matters most, and the reason is not
-efficiency. Every `afx send` to you — including the architect's order to stop, including a reset
-request — **queues unread until your current turn ends**. A turn that never ends is a builder that cannot
-be reached by anyone, doing work nobody can redirect. You will not notice, because from inside the turn
-everything looks fine.
+## PRs
 
-**If you are wedged anyway, you are not unreachable.** The architect can send you an ESC keystroke with
-`afx interrupt <your-id>`, which ends the running turn so your queued messages process. They can also run
-`afx reset <your-id>` to have you save your working state, clear your context, and be re-oriented — the
-supported recovery when your context window is exhausted rather than merely stuck. Neither requires you
-to do anything; both are worth knowing exist, so you can suggest them when you notice you are in trouble.
+Plan phases are **git commits inside one PR**, not a PR each. Open the PR during or after the
+final phase unless the architect asks for one earlier — they may, to review a slice or get
+feedback mid-flight. Record them with `porch done <id> --pr <N> --branch <name>` and
+`porch done <id> --merged <N>`.
 
-## Multi-PR Workflow
+For sequential PRs, branch from the integration branch without checking it out — a worktree
+cannot check out a branch that is checked out elsewhere:
 
-Builders may submit multiple sequential PRs within a single worktree session. The worktree persists across PRs -- it is not cleaned up automatically after merge. This allows builders to do follow-up work (e.g., addressing review feedback in a second PR, or splitting large features across checkpoint PRs).
+```bash
+git fetch origin main && git checkout -b <next-branch> origin/main
+```
 
-- **Worktree cleanup is architect-driven** -- the architect decides when to run `afx cleanup`, not the builder
-- If a builder session is interrupted, use `afx spawn XXXX --resume` to reconnect to the existing worktree
+## Worktree discipline
 
-## Worktree isolation: filesystem path discipline
+Your worktree is nested inside the main checkout and, at the branch base, byte-identical to it.
+So a path that drops the `.builders/<id>/` segment silently reads and writes **main's** copy —
+reads succeed, writes succeed, and nothing corrects you until a later `git add` fails.
 
-Your worktree (`.builders/<id>/`) is **nested inside the main checkout**, and at the
-branch base the two trees are **byte-identical**. This creates a silent failure mode:
+- Absolute paths for file writes must be rooted at your worktree. A guard blocks writes outside
+  it; if you see that denial, re-root the path.
+- In Bash, prefer relative paths — `cwd` is your worktree, so a relative path cannot be anchored
+  to the wrong root.
 
-- The `Write`/`Edit` tools require **absolute** paths. If you synthesize one rooted
-  at the canonical repo root instead of your worktree, you drop the `.builders/<id>/`
-  segment and write into the **main checkout** — a real, writable directory. The
-  write *succeeds silently* and pollutes `main`; you only notice later when a
-  `git add` in your worktree fails with a pathspec error.
-- Wrong-rooted **reads** also succeed silently (identical trees), so nothing
-  corrects the mistake until that first failed write.
+## Scope
 
-Rules:
-- **Absolute paths for Write/Edit must be rooted at your worktree.** A deterministic
-  PreToolUse guard now blocks out-of-worktree writes (allowing only temp dirs and
-  `~/.claude`); if you see that denial, re-root the path under your worktree.
-- **Bash `cwd` is your worktree — prefer relative paths there.** A relative path
-  cannot be anchored to the wrong root, which closes the Bash write surface
-  (`>`, `cp`, `tee`, `sed -i`) the Write/Edit guard does not cover.
+Build what the spec says. If part of it is blocked, finish everything else and say plainly what
+you left out and why — scaling the work down is the architect's call.
 
-## Constraints
+Never `git add -A` / `--all` / `.` — stage each file explicitly by path.
 
-- **Stay in scope** - Only implement what's in the spec
-- **Merge your own PRs** - After architect approves
-- **Keep worktree clean** - No untracked files, no debug code
-- **(Strict mode)** Run porch, don't bypass it
-- **(Strict mode)** Stop at gates - Human approval is required
-- **(Strict mode)** NEVER edit status.yaml directly
-- **(Strict mode)** NEVER call porch approve
+If the issue carries a **Baked Decisions** section, those are fixed. Don't relitigate them in
+your spec, plan, or implementation; if one looks seriously wrong, raise it with `afx send`. If
+two contradict each other, don't pick — flag the contradiction and wait.
+
+## Flaky tests
+
+If a pre-existing test fails intermittently and unrelated to your change: skip it with an
+annotation naming it flaky, document it under `## Flaky Tests` in your review, and continue.
+Never edit `status.yaml` or bypass a porch check to route around it.

--- a/codev/projects/1280-prompt-surface-judgment-not-ru/manifests/phase-1-shared-skills.md
+++ b/codev/projects/1280-prompt-surface-judgment-not-ru/manifests/phase-1-shared-skills.md
@@ -1,0 +1,81 @@
+# Phase 1 — CLAUDE.md/AGENTS.md + four-tree skill relocation (G2)
+
+**Decisions**: 1 (CLAUDE.md/AGENTS.md are one decision, two byte-identical files)
+**Rollback group**: G2 · commit-pure
+**Suite**: green · **Build**: rerun (`copy-skeleton` — skeleton edits are otherwise invisible to tests)
+
+## Batch 1 — 10 files
+
+| File | Old | New | Principles | Rationale |
+|---|---:|---:|---|---|
+| `CLAUDE.md` | 5815 | 1417 | P1, P3, P4, P7 | Contracts kept, procedure deleted. See breakdown below. |
+| `AGENTS.md` | 5815 | 1417 | P1, P3, P4, P7 | Byte-identical twin of the above (T7). |
+| `.claude/skills/runnable-worktrees/SKILL.md` | 0 | 926 | P3, P4 | **New destination.** Receives the entire Runnable Worktrees section — config block, `afx dev` CLI, VSCode controls, URL/cleanup semantics, 7 stack recipes. Needed rarely, was loaded always. |
+| `.codex/skills/runnable-worktrees/SKILL.md` | 0 | 926 | P3, P4 | Four-tree copy (T17). |
+| `codev-skeleton/.claude/skills/runnable-worktrees/SKILL.md` | 0 | 926 | P3, P4 | Four-tree copy — adopters receive it via `codev update`. |
+| `codev-skeleton/.codex/skills/runnable-worktrees/SKILL.md` | 0 | 926 | P3, P4 | Four-tree copy. |
+| `.claude/skills/codev/SKILL.md` | 326 | 529 | P4 | Receives Local Build Testing, the directory map, and the tokei metrics line — tool how-tos belong with the tool. |
+| `.codex/skills/codev/SKILL.md` | 326 | 529 | P4 | Four-tree copy (T17). |
+| `codev-skeleton/.claude/skills/codev/SKILL.md` | 326 | 529 | P4 | Four-tree copy. |
+| `codev-skeleton/.codex/skills/codev/SKILL.md` | 326 | 529 | P4 | Four-tree copy. |
+
+Supporting (new test, not a prompt surface):
+`packages/codev/src/__tests__/spec-1280-skills-parity.test.ts` — **T17**.
+
+## What was deleted vs relocated (M0c)
+
+| | Words |
+|---|---:|
+| CLAUDE.md before | 5,815 |
+| CLAUDE.md after | 1,417 |
+| **Removed from always-on** | **4,398** |
+| ↳ **relocated** to skills (`runnable-worktrees` 926 + `codev` +203) | 1,129 |
+| ↳ **deleted** outright | 3,269 |
+
+Relocation is written to **four** trees, so authored total falls by less than always-on —
+which is the honest picture and exactly what T15 exists to expose.
+
+- `ALWAYS_ON_WORDS`: 34,231 → **29,833** (−4,398)
+- `TOTAL_AUTHORED_WORDS`: 153,219 → **148,925** (−4,294)
+
+## What was deleted, and why it was safe
+
+| Cut | Principle | Reasoning |
+|---|---|---|
+| "Before Starting ANY Task" (check for existing PRs/issues/git log, with bash) | P1 | A frontier model checks for prior art without being told; the hot tier already carries "check for existing work" as a lesson. |
+| "When Stuck: STOP After 15 Minutes" + rathole warning signs | P1 | Judgment, and duplicated by the hot-tier lesson "when stuck, get an outside model's perspective". |
+| "Understand Before Coding" | P1 | Restates what a competent agent does. |
+| Duplicated 🚨 blocks (worktree destruction ×2, `afx` from root ×2, `git add -A` ×3) | P7 | Each survives **once**, verbatim, under *Irreversible acts*. Repetition was worst-case padding for weaker models. |
+| CLI Command Reference — six doc links | P4 | Each CLI has a skill; the pointer list was a table of contents for content that is already addressable by name. |
+| Agent Responsiveness table (4 rows of examples) | P1, P2 | Reduced to the rule: run anything over ~5s in the background. |
+| cmap walkthrough (4 numbered steps) | P4 | One sentence + the `consult` skill. |
+| Porch command list, Architect-Builder prose, messaging examples | P4 | Contract kept (addressing table, spoofing rule); walkthroughs dropped. |
+| "Important Notes", "Core Workflow" numbered restatements | P1, P7 | Restated the protocol table immediately above them. |
+
+## What was deliberately kept
+
+- **All eight scar canonicals, verbatim and unwrapped** — verified byte-for-byte against
+  `builder/spir-1252:codev/resources/scar-rules.yaml`. My first draft reflowed them across
+  lines, which broke exact-match; canonicals must stay on one line.
+- The generated hot-context block, byte-for-byte (`codev init`/`update` owns it).
+- Repository dual nature, four-tier resolution, deliver-don't-fetch — the facts a wrong
+  assumption about which would corrupt a whole change.
+- Gate semantics and the approval frontmatter contract.
+- `area/*` policy (compressed to the rule + the label list).
+- Consultation defaults, including the load-bearing `-sol` model-id suffix.
+- Commit/branch formats and the never-squash rule.
+
+## M10 — assertions retired: **none**
+
+`spec-1273-wait-discipline-docs`, `governance-sweep`, `framework-ref-audit` and
+`template-delivery` all pass **unmodified**. The `afx` skill was deliberately **not** touched:
+relocating messaging content into it would have obliged me to resolve its pre-existing
+repo-vs-skeleton drift (and propagate its stale `tick` references to adopters), which is the
+architect's separate issue. The addressing *contract* stayed in CLAUDE.md instead — it is a
+policy, not a how-to, so P4 does not apply. **Flagged as a judgment call rather than made
+silently.**
+
+## Scope note
+
+`roles/*.md` are **Phase 2** (groups G6/G3/G5), not this phase — Phase 1 is G2 only, so the
+commit stays group-pure and a G2 revert cannot pull role work out with it.

--- a/codev/projects/1280-prompt-surface-judgment-not-ru/manifests/phase-2-roles.md
+++ b/codev/projects/1280-prompt-surface-judgment-not-ru/manifests/phase-2-roles.md
@@ -1,0 +1,76 @@
+# Phase 2 — Three role files (G6, G3, G5)
+
+**Decisions**: 3 · **Rollback groups**: G6 (architect), G3 (builder), G5 (consultant) —
+**three group-pure commits**, so a G3 revert cannot pull architect work out with it.
+**Suite**: green · **Build**: rerun before testing (`copy-skeleton`).
+
+## Batch 1 — 6 files
+
+| File | Old | New | Principles | Rationale |
+|---|---:|---:|---|---|
+| `codev/roles/architect.md` | 2048 | 761 | P1, P4, P7 | Command walkthroughs → the `afx`/`porch`/`consult` skills that already own them. Risk-triage table, PRFT contract, UX-verification rule and boundaries kept. |
+| `codev-skeleton/roles/architect.md` | 2048 | 761 | P1, P4, P7 | Byte-identical twin. |
+| `codev/roles/builder.md` | 1837 | 849 | P1, P7 | Mode contract, gates, deliverables, thread, notifications, wait discipline, worktree path discipline, scope, flaky-test rule all kept. Numbered "core loop" walkthroughs and repeated ALL-CAPS prohibitions deleted. |
+| `codev-skeleton/roles/builder.md` | 1837 | 849 | P1, P7 | Byte-identical twin. |
+| `codev/roles/consultant.md` | 252 | 252 | none | **Inspected, unchanged.** Already conformant — states a contract, not a procedure. Under the acceptance model a conformant file passes *as-is*; shrinking it further would be size-chasing, which the charter amendment explicitly rejects. |
+| `codev-skeleton/roles/consultant.md` | 252 | 252 | none | Unchanged. |
+
+- `ALWAYS_ON_WORDS`: 29,833 → **28,844** (−989; SPIR spawn 6,364 → 5,371)
+- `ALWAYS_ON(architect)`: 8,599 → **2,914**
+- `TOTAL_AUTHORED_WORDS`: 148,925 → **144,373**
+
+**Deleted vs relocated (M0c): all deletion, no relocation.** The command walkthroughs were not
+moved — the `afx`, `porch` and `consult` skills already carry that material, so copying it would
+have created a second owner for content that has one. Authored total falls by 4,552 (both trees
+× two files), more than always-on, which is what pure deletion looks like.
+
+## Verified before cutting, not assumed
+
+The plan flagged an open question: *is anything in `architect.md` load-bearing for
+multi-architect coordination (Specs 755/786/823)?* **Answer: no.** Grepped the file for
+`architect:<name>`, sibling/multi-architect language, `spawnedByArchitect`, and `whoami` —
+**zero matches**. The multi-architect addressing contract lives in CLAUDE.md (kept there in
+Phase 1). Recording it as checked rather than leaving the question open.
+
+## What was deleted, and why it was safe
+
+| Cut | Principle | Reasoning |
+|---|---|---|
+| Architect: `afx`/`porch`/`consult` command blocks and the 14-row Quick Reference | P4 | Each CLI has a skill that is the single owner of its flags; the role doc was a stale second copy (it still advertised `porch approve` without the `--a-human-explicitly-approved-this` flag the command now requires). |
+| Architect: step-by-step "Starting a New Feature", "Monitoring Progress", "Cleanup" walkthroughs | P1 | Sequenced narration of three commands. The obligations (close the issue; clean up the worktree) survive as contract lines. |
+| Architect: "Release Management" state diagram | P1, P7 | Aspirational process with no mechanism behind it in this repo. |
+| Builder: the numbered "Core Loop" and "What You DON'T Do in Strict Mode" | P1, P7 | The mode table plus one sentence carries it. |
+| Builder: "Getting Started" 3-step list, duplicated protocol summary | P1 | The protocol is inlined into the spawn prompt; restating it in the role doc is a second, drift-prone copy. |
+| Both: ALL-CAPS repetition of prohibitions already stated once | P7 | Each prohibition survives exactly once. |
+
+## Kept verbatim
+
+Required scar canonicals verified byte-for-byte against
+`builder/spir-1252:codev/resources/scar-rules.yaml`:
+
+- `roles/builder.md` → `no-hand-edit-status` ✓ (and `human-gates` carried in the Gates section)
+- `roles/architect.md` → `afx-from-root` ✓
+- `roles/consultant.md` → none required
+
+## M10 — assertions retired: **none**
+
+`spec-1273-wait-discipline-docs.test.ts` (18 assertions over both role-doc copies) passes
+**unmodified**. Three of its assertions initially failed against my rewrite:
+
+| Failure | Cause | Resolution |
+|---|---|---|
+| `## Waiting on external work` heading missing | I had renamed it to "Waiting on work you don't control" | **Reverted my heading.** The rename bought nothing; the assertion protects that the section exists. |
+| "never chain foreground poll loops" not found | **Line wrap split the phrase** across two lines | Unwrapped. |
+| "queues unread until your current turn ends" not found | I had dropped the word "current" | Restored. |
+
+In all three the *behaviour* survived the rewrite — only the strings moved. **The right response
+was to adjust my prose, not Spec 1273's assertions**: the strings encode a wait-discipline
+incident, preserving them cost nothing in conformance, and editing a prior spec's protection to
+fit new prose is precisely the silent-erosion M10 exists to prevent.
+
+## Hazard worth naming (third occurrence)
+
+Reflowing prose silently breaks any string match that spans a line wrap — it has now broken
+scar canonicals (Phase 1) and a prior spec's test assertions (here). **Any exact-match string in
+a rewritten file must be verified after the rewrite, not assumed**, and canonicals must stay on
+one line however long.

--- a/codev/projects/1280-prompt-surface-judgment-not-ru/manifests/phase-2-roles.md
+++ b/codev/projects/1280-prompt-surface-judgment-not-ru/manifests/phase-2-roles.md
@@ -8,8 +8,8 @@
 
 | File | Old | New | Principles | Rationale |
 |---|---:|---:|---|---|
-| `codev/roles/architect.md` | 2048 | 761 | P1, P4, P7 | Command walkthroughs → the `afx`/`porch`/`consult` skills that already own them. Risk-triage table, PRFT contract, UX-verification rule and boundaries kept. |
-| `codev-skeleton/roles/architect.md` | 2048 | 761 | P1, P4, P7 | Byte-identical twin. |
+| `codev/roles/architect.md` | 2048 | 807 | P1, P4, P7 | Command walkthroughs → the `afx`/`porch`/`consult` skills that already own them. Risk-triage table, PRFT contract, UX-verification rule and boundaries kept. |
+| `codev-skeleton/roles/architect.md` | 2048 | 807 | P1, P4, P7 | Byte-identical twin. |
 | `codev/roles/builder.md` | 1837 | 849 | P1, P7 | Mode contract, gates, deliverables, thread, notifications, wait discipline, worktree path discipline, scope, flaky-test rule all kept. Numbered "core loop" walkthroughs and repeated ALL-CAPS prohibitions deleted. |
 | `codev-skeleton/roles/builder.md` | 1837 | 849 | P1, P7 | Byte-identical twin. |
 | `codev/roles/consultant.md` | 252 | 252 | none | **Inspected, unchanged.** Already conformant — states a contract, not a procedure. Under the acceptance model a conformant file passes *as-is*; shrinking it further would be size-chasing, which the charter amendment explicitly rejects. |
@@ -74,3 +74,27 @@ Reflowing prose silently breaks any string match that spans a line wrap — it h
 scar canonicals (Phase 1) and a prior spec's test assertions (here). **Any exact-match string in
 a rewritten file must be verified after the rewrite, not assumed**, and canonicals must stay on
 one line however long.
+
+## Post-inspection fix (architect-required, same phase, G6-pure)
+
+**Finding**: my rewrite created a cross-file contradiction. `builder.md` correctly encoded the
+relay convention — *"Approval reaches you as a message from the architect. Then you run
+`porch approve`; the architect does not run it for you"* — while `architect.md` kept the **old**
+worked example showing the architect running
+`(cd .builders/<id> && porch approve ...)`. The two roles disagreed on who the approval actor is.
+
+`builder.md` was correct: it matches the owner's standing convention, and it is what actually
+happened at both of this project's own gates — so `architect.md`'s example contradicted observed
+behaviour.
+
+**Fix** (`21ac428c`): the Gates section is now relay-shaped — read, decide, `afx send` the
+approval; the builder executes against its own porch state. The
+`--a-human-explicitly-approved-this` explanation is kept because the *why* is load-bearing.
+architect.md 761 → 807 words: **the fix made the file longer, which is fine** — conformance is
+the criterion, not size.
+
+**Worth recording plainly**: this is the same stale-second-owner class I had just caught on the
+porch-approve flag syntax, one level up — and I introduced it, by fixing one owner and leaving
+the other. Catching a class of defect is not the same as being immune to it. The general form:
+*when a rewrite changes a convention, every file that documents that convention is in scope,
+not just the one being edited.*

--- a/codev/projects/1280-prompt-surface-judgment-not-ru/manifests/phase-3-protocol-md.md
+++ b/codev/projects/1280-prompt-surface-judgment-not-ru/manifests/phase-3-protocol-md.md
@@ -1,0 +1,119 @@
+# Phase 3 — `protocol.md` ×10 with the P6 include mechanism (G3)
+
+**Decisions**: 10 · **Rollback group**: G3, commit-pure
+**Suite**: green · **Build**: rerun (`copy-skeleton`) before testing
+
+## Batch 1 — 10 decisions (19 files; twins are byte-identical, so inspection is per DECISION and T7 verifies the sync)
+
+| File (both trees unless noted) | Old | New | Principles | Rationale |
+|---|---:|---:|---|---|
+| `{codev,codev-skeleton}/protocols/spir/protocol.md` | 3699 | 671 | **P6**, P1, P7 | Largest cut in the project. State machine delivered as JSON; deleted the 40-line MANDATORY checklist, four BLOCKING banners, the 13-step workflow, When-to-Use, Best Practices, Protocol Evolution. Kept artifact contract, spec-vs-plan boundary, no-time-estimates, consultation, gates, commit/branch formats. |
+| `{codev,codev-skeleton}/protocols/pir/protocol.md` | 2066 | 551 | **P6**, P1, P7 | Kept the three gates with `dev-approval` named as PIR's distinctive one, the merge-trigger-is-structured-state rationale, the no-`porch reject` iteration model, PTY session semantics, and the CMAP-2 config-precedence trap. |
+| `{codev,codev-skeleton}/protocols/maintain/protocol.md` | 1765 | 285 | **P6**, P1 | Kept since-marker discipline, `.trash/` 30-day recovery, tier routing, the explicit-`git add` canonical, and the maintenance-run template include. |
+| `{codev,codev-skeleton}/protocols/research/protocol.md` | 1278 | 238 | **P6**, P1 | Kept independence-of-investigation and preserve-disagreement — the two properties that make a 3-way pass worth its cost. |
+| `{codev,codev-skeleton}/protocols/aspir/protocol.md` | 810 | 248 | **P6**, P1 | Now says spec/plan are **ungated**, not 'auto-approved' — the JSON defines no gate there. Defers shared substance to SPIR. |
+| `{codev,codev-skeleton}/protocols/bugfix/protocol.md` | 699 | 488 | **P6**, P1 | Kept the `--delete-branch` worktree warning, net-diff-at-merge-base scope, the self-merge-class gate rationale, and the edge-case table. |
+| `{codev,codev-skeleton}/protocols/experiment/protocol.md` | 711 | 191 | **P6**, P1, P7 | Kept hypothesis-before-running, record-negative-results, and the notes template include. |
+| `{codev,codev-skeleton}/protocols/spike/protocol.md` | 655 | 223 | **P6**, P1 | Kept the three-verdict table, 'a negative result is a successful spike', and the findings template include. |
+| `{codev,codev-skeleton}/protocols/air/protocol.md` | 643 | 275 | **P6**, P1 | Kept the no-artifacts economy and the escalate-early rule. |
+| `codev/protocols/release/protocol.md` *(codev-only)* | 1626 | 1626 | none | **Inspected, unchanged** — no `protocol.json` so P6 does not apply, and 36% of it is exact commands where the sequence *is* the contract. |
+
+### Served words (P6 expands the JSON back in)
+
+Authored → served, per protocol: spir 671→1239 · pir 551→926 · aspir 248→816 · bugfix 488→742 ·
+research 238→494 · maintain 285→477 · air 275→557 · experiment 191→380 · spike 223→300.
+
+*(Deliberately prose, not a table: a second table of the same shape parses as manifest rows and
+inflates the batch count — T16 caught exactly that on this file.)*
+
+- `ALWAYS_ON_WORDS`: 28,844 → **26,384**
+- `TOTAL_AUTHORED_WORDS`: 144,465 → **126,155**
+
+**Deleted vs relocated (M0c): all deletion, no relocation.** Nothing moved to a skill; the
+structured source was already on disk and is now *delivered* rather than *narrated*. Authored
+total falls 18,310 against always-on's 2,460, which is what deletion across both trees looks
+like when the deleted prose was not always-on for every protocol.
+
+## `release` — inspected, deliberately unchanged
+
+`release/protocol.md` is **36% code blocks** (594 of 1,626 words) carrying exact `git add` file
+lists, the root-`package.json` version-anchor pattern, the pre-release auto-skip for the VS Code
+Marketplace, and the backport path. **Here the sequence *is* the contract**: P1 says delete the
+procedure and keep the contract, and for a release the procedure is what the agent must not
+improvise.
+
+It is also the one protocol with **no `protocol.json`**, so P6 does not apply.
+
+Under the acceptance model a conformant file passes as-is, and a file that is conformant at more
+words passes. Cutting it to hit a number would be size-chasing — which the charter amendment
+explicitly rejects. Recorded as a decision, not an omission.
+
+## P6 mechanism — delivered, not fetched
+
+`protocol.md` carries a fenced ` ```json ` block containing `{{> protocols/<p>/protocol.json}}`.
+Verified rather than assumed:
+
+- `resolveCodevIncludes` is **extension-agnostic** (`skeleton.ts:108-119`), so the JSON expands
+  in place.
+- The **spawn path** uses the same resolver — `spawn-roles.ts:127` passes `protocol.md` through
+  `resolveCodevIncludes` before inlining it as `{{protocol_reference}}`. Both modes benefit.
+- **T18** asserts delivery in **both modes**, which are not symmetric: strict-mode builders also
+  get gates/checks as porch task JSON, but **soft-mode builders have only this document**. A
+  silent expansion failure would leave a soft-mode builder with a protocol doc describing
+  nothing.
+
+**A correction to my model of the resolver, found by T18 and worth recording**: tier 4 is
+`getSkeletonDir()` — the **installed npm package** — *not* `<root>/codev-skeleton/`. The
+repo-local `codev-skeleton/` is a build *source* (`copy-skeleton` copies it into
+`packages/codev/skeleton`); the resolver never reads it. My first fresh-install test planted
+files in a temp `codev-skeleton/` and "passed" against the real installed package. Rewritten to
+assert the actual adopter guarantee: `skeleton` is in the npm `files` allowlist and every P6
+protocol's `protocol.json` is in the built skeleton.
+
+## Cross-batch convention diff (the Phase 2 lesson, generalised)
+
+Ten files describing the same gates is ten chances for one stale owner. Diffed conventions
+*across* the batch before declaring it:
+
+- **Gates**: every gate defined in `protocol.json` is present in the **served** text of its
+  `protocol.md`. The pre-existing gap — five protocols whose prose described *less* than their
+  JSON — is **dissolved by construction**, not fixed by hand.
+- **Approval actor**: no file claims the architect runs `porch approve`.
+- **Merge command**: `--delete-branch` warning preserved where it appears.
+
+Two apparent contradictions surfaced and **both were my diff's crudeness, not the files'**: it
+checked *raw* text where T18 checks *served*, and its actor regex matched the **negation**
+("You do **not** run `porch approve`"). Verified against the real artifacts before reporting.
+
+## M10 — assertions retired: **none**, but only after repair
+
+**I wrote "none retired / suite green" in this manifest before the suite finished.** It was not
+green: 37 failures across three files, all of them real capability loss I had introduced.
+Correcting the record rather than the claim:
+
+| Broke | Originating spec | Behaviour survived? | Resolution |
+|---|---|---|---|
+| `template-delivery` (12) — `maintain/maintenance-run.md`, `spike/findings.md`, `experiment/notes.md` orphaned | **#1279** | **No** — I replaced each protocol's template include with the `protocol.json` include instead of carrying both. Builders would have stopped receiving those artifact structures | Restored all three includes alongside the JSON |
+| `baked-decisions` (24) — category hints, amend/rescind hatch, "no-op default" missing from spir/aspir/air | **Spec 746** | **No** — I shortened it in SPIR and dropped it from ASPIR and AIR. Losing "absence is the no-op default" invites a builder to invent constraints where the architect deliberately left them open | Restored to full Spec 746 completeness in all three |
+| `framework-ref-audit` (1) | — | consequence of the above | Resolved by the same repair |
+
+**Zero assertions were retired — but by repair, not because nothing broke.** Every failure was
+the tests catching capability I had deleted, which is the machinery working exactly as M5/M10
+intend.
+
+The process lesson is mine, not the code's: I applied "read the raw thing, don't trust the
+summary" to every instrument this project touched, then skipped it on my own completion claim.
+
+## T16 caught three defects in this manifest itself
+
+Worth recording, because the guard was written before any manifest existed and has now earned it:
+
+1. A fifth column (`Served`) I added silently — the parser read `1239` as the principles field.
+   **The format is the contract; I conformed the manifest rather than loosening the test.**
+2. Listing 19 file-rows instead of 10 decision-rows, which broke the ≤12 batch cap. The plan's
+   model is inspection *per decision* with twins verified mechanically by T7 — my "fix" had
+   silently abandoned that model.
+3. A supplementary table of the same shape parsing as manifest rows and inflating the count.
+   Served figures are now prose.
+
+All three were my deviations from a format I defined myself.

--- a/codev/projects/bugfix-759-forge-github-pr-search-sh-defa/status.yaml
+++ b/codev/projects/bugfix-759-forge-github-pr-search-sh-defa/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-759
 title: forge-github-pr-search-sh-defa
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-01T20:42:19.622Z'
-updated_at: '2026-08-01T20:44:19.667Z'
+updated_at: '2026-08-01T20:48:18.555Z'

--- a/codev/projects/bugfix-759-forge-github-pr-search-sh-defa/status.yaml
+++ b/codev/projects/bugfix-759-forge-github-pr-search-sh-defa/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-759
 title: forge-github-pr-search-sh-defa
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-01T20:42:19.622Z'
-updated_at: '2026-08-01T20:42:19.623Z'
+updated_at: '2026-08-01T20:44:19.667Z'

--- a/codev/projects/bugfix-759-forge-github-pr-search-sh-defa/status.yaml
+++ b/codev/projects/bugfix-759-forge-github-pr-search-sh-defa/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-759
+title: forge-github-pr-search-sh-defa
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-01T20:42:19.622Z'
+updated_at: '2026-08-01T20:42:19.623Z'

--- a/codev/protocols/air/protocol.md
+++ b/codev/protocols/air/protocol.md
@@ -1,91 +1,60 @@
 # AIR Protocol
 
-> **AIR** = **A**utonomous **I**mplement & **R**eview
->
-> A lightweight protocol for small features that are fully specified by their GitHub issue.
-> Two phases: Implement → Review. No spec/plan artifacts.
+**A**utonomous **I**mplement → **R**eview. The lightest protocol that still produces a reviewed
+PR: no spec, no plan, no artifact files. The GitHub issue *is* the specification, and the review
+lives in the PR body.
 
-## What is AIR?
+Use AIR when a small feature (roughly <300 LOC) is fully described by its issue and needs no
+architectural decision, no new abstraction, and no significant refactor. If the issue leaves the
+approach genuinely open, the cost of a spec is lower than the cost of building the wrong thing —
+use SPIR or ASPIR. For a defect rather than a feature, use BUGFIX.
 
-AIR is a minimal protocol for implementing small features (< 300 LOC) where the GitHub issue provides all the requirements. It skips the Specify and Plan phases entirely — the builder implements directly from the issue and creates a PR with the review embedded in the PR body.
+## The state machine
 
-### How AIR Compares
-
-| Aspect | BUGFIX | AIR | ASPIR/SPIR |
-|--------|--------|-----|------------|
-| **Use case** | Bug fixes | Small features | New features |
-| **Input** | GitHub Issue | GitHub Issue | GitHub Issue → Spec |
-| **Phases** | Investigate → Fix → PR | Implement → PR | Specify → Plan → Implement → Review |
-| **Artifacts** | None | None | Spec, plan, review files |
-| **Review location** | PR body | PR body | `codev/reviews/` file |
-| **Consultation** | PR phase only | Optional (builder decides) | Every phase (3-way) |
-| **Human gates** | None (PR gate) | None (PR gate) | Spec + Plan + PR gates (SPIR) |
-| **LOC limit** | < 300 | < 300 | No limit |
-
-### When to Use AIR
-
-- Small features (< 300 LOC)
-- Requirements are clear from the GitHub issue
-- No architectural decisions needed
-- No new abstractions or significant refactoring required
-- Would be overkill for full SPIR/ASPIR ceremony
-
-### When NOT to Use AIR
-
-- Bug fixes → use **BUGFIX**
-- Features needing spec discussion → use **SPIR** or **ASPIR**
-- Architectural changes → use **SPIR**
-- Complex features with multiple phases → use **SPIR** or **ASPIR**
-
-## Baked Decisions (Optional)
-
-When filing an issue for AIR, you can pin architectural decisions you don't want the builder or CMAP reviewers to re-litigate. Include a `## Baked Decisions` section (any heading level is fine) anywhere in the issue body. Useful categories: language, framework, deployment shape, key dependencies, decisions deferred to a later spec. The builder will treat each listed item as fixed during implementation; CMAP reviewers will not propose alternatives unless the implementation itself fails to honor a stated decision. Leave the section out for issues where you want the builder to explore freely — absence is the no-op default. You can amend or rescind a baked decision at any time by updating the issue and respawning, or by sending the builder a direct instruction via `afx send`.
-
-## Protocol Phases
-
-### I - Implement
-
-The builder reads the GitHub issue and implements the feature:
-
-1. Read and understand the issue requirements
-2. Implement the feature (< 300 LOC)
-3. Write tests
-4. Verify build and tests pass
-5. Commit with descriptive message
-
-If the feature grows beyond 300 LOC or requires architectural decisions, the builder signals `TOO_COMPLEX` to escalate to ASPIR.
-
-### R - Review (PR)
-
-The builder creates a PR with the review embedded in the PR body:
-
-1. Create PR linking to the issue
-2. Include a review section in the PR body (summary, key decisions, test plan)
-3. Optionally run CMAP consultation if the builder judges the complexity warrants it
-4. Notify the architect
-
-The **PR gate** is preserved — a human reviews all code before merge.
-
-## Usage
-
-```bash
-# Spawn a builder using AIR
-afx spawn 42 --protocol air
-
-# The builder implements autonomously and stops at the PR gate
+```json
+{{> protocols/air/protocol.json}}
 ```
 
-## File Structure
+## Artifacts
 
-```
-codev-skeleton/protocols/air/
-├── protocol.json          # Protocol definition
-├── protocol.md            # This file
-├── builder-prompt.md      # Builder instructions (Handlebars template)
-├── prompts/
-│   ├── implement.md       # Implement phase prompt
-│   └── pr.md              # PR phase prompt
-└── consult-types/
-    ├── impl-review.md     # Implementation consultation guide
-    └── pr-review.md       # PR consultation guide
-```
+**None on disk.** The issue carries the requirements; the review goes in the PR body. That is
+the whole economy of AIR — a `codev/reviews/` file for a 200-line change costs more to maintain
+than it ever repays.
+
+## Consultation
+
+At the builder's discretion, unlike SPIR's mandatory 3-way at every phase. Reach for it when the
+change touches shared code or you are unsure the approach is right; skip it when the issue is
+unambiguous and the diff is small.
+
+## Gate
+
+The `pr` gate is human. There are no pre-implementation gates — which is precisely why AIR is
+only appropriate when the issue has already settled the questions a spec would ask.
+
+## Baked Decisions
+
+An issue may carry a `## Baked Decisions` section pinning architectural choices the architect
+does not want re-litigated — typically **language**, **framework**, deployment shape, key
+**dependencies**, or decisions deferred to a later spec.
+
+Every item in it is fixed. Copy the section verbatim into the spec's Constraints and do not
+re-open it in the spec, plan, or review; CMAP reviewers will not propose alternatives unless the
+spec fails to honour one. If two items contradict each other, do not choose — surface the
+contradiction and wait.
+
+**Absence is the no-op default**: an issue with no such section is an invitation to explore
+freely, not an omission to be filled in.
+
+The architect can **amend or rescind** a baked decision at any time by updating the issue and
+respawning, or by sending the builder a direct instruction via `afx send`.
+
+## Escalation
+
+If implementation reveals that the change is not small, or that it needs a decision the issue
+does not make, **stop and say so** rather than growing an AIR project into an unplanned SPIR.
+Escalating early is cheap; discovering it at PR review is not.
+
+## Branch naming
+
+`builder/air-<issue>-<short-description>`

--- a/codev/protocols/aspir/protocol.md
+++ b/codev/protocols/aspir/protocol.md
@@ -1,100 +1,52 @@
 # ASPIR Protocol
 
-> **ASPIR** = **A**utonomous **S**pecify → **P**lan → **I**mplement → **R**eview
->
-> Identical to SPIR but without human approval gates on spec and plan phases.
-> Each phase has one build-verify cycle with 3-way consultation.
+Autonomous SPIR: the same phases, artifacts, consultations and checks, with the **spec and plan
+human gates absent**. The builder runs Specify → Plan → Implement without stopping, and a human
+still reviews everything at the `pr` gate before merge.
 
-## What is ASPIR?
+Use ASPIR for trusted, low-risk work where reviewing the approach up front would cost more than
+it saves, and deferring that review to the PR is acceptable. When getting the shape wrong would
+be expensive to unwind, use SPIR and take the gates.
 
-ASPIR is an autonomous variant of the SPIR protocol. It follows the exact same phases (Specify → Plan → Implement → Review) with the same 3-way consultations, checks, and PR flow — but removes the `spec-approval` and `plan-approval` human gates.
+## The state machine
 
-This means the builder proceeds automatically from Specify → Plan → Implement without waiting for human approval at each gate. The `pr` gate in the Review phase is preserved — a human still reviews all code before merge.
+Phases, gates and checks — note that `specify` and `plan` carry **no gate at all**; they are not
+auto-approved, they are ungated:
 
-### Differences from SPIR
-
-| Aspect | SPIR | ASPIR |
-|--------|------|-------|
-| Spec gate (`spec-approval`) | Human must approve | Auto-approved |
-| Plan gate (`plan-approval`) | Human must approve | Auto-approved |
-| PR gate (`pr`) | Human must approve | Human must approve |
-| Phases | Specify → Plan → Implement → Review | Same |
-| 3-way consultations | Yes, every phase | Same |
-| Checks (build, tests, PR) | Yes | Same |
-| Prompts / templates | Full set | Same prompts; templates included from SPIR (no copies) |
-
-### When to Use ASPIR
-
-Use ASPIR instead of SPIR when:
-
-- The work is **trusted and low-risk** — internal tooling, protocol additions, well-understood features
-- The architect has **pre-written and approved** the spec before spawning
-- The scope is **self-contained** with low blast radius
-- You want **full SPIR discipline** (consultations, phased implementation, review) without waiting at gates
-
-### When NOT to Use ASPIR
-
-Use SPIR instead when:
-
-- The feature involves **novel architecture** or unclear requirements
-- The spec needs **iterative human feedback** during drafting
-- The work is **high-risk** — security-sensitive, user-facing, or broadly impactful
-- You want to **review and adjust** the plan before implementation starts
-
-## Baked Decisions (Optional)
-
-When filing an issue for ASPIR, you can pin architectural decisions you don't want the builder or CMAP reviewers to re-litigate. Include a `## Baked Decisions` section (any heading level is fine) anywhere in the issue body. Useful categories: language, framework, deployment shape, key dependencies, decisions deferred to a later spec. The builder will copy the section verbatim into the spec's Constraints and treat each item as fixed; CMAP reviewers will not propose alternatives unless the spec itself fails to honor a stated decision. Leave the section out for issues where you want the builder to explore freely — absence is the no-op default. You can amend or rescind a baked decision at any time by updating the issue and respawning, or by sending the builder a direct instruction via `afx send`.
-
-## Protocol Phases
-
-ASPIR follows the same four phases as SPIR. For full phase documentation, see the [SPIR protocol](../spir/protocol.md).
-
-### S - Specify
-Write specification with 3-way review (Gemini, Codex, Claude). **No human gate** — proceeds directly to Plan after verification.
-
-### P - Plan
-Write implementation plan with 3-way review. **No human gate** — proceeds directly to Implement after verification and checks pass.
-
-### I - Implement
-Execute each plan phase with build-verify cycle. Same as SPIR — no gate between phases (SPIR also has no gate here).
-
-### R - Review
-Final review, PR preparation, and 3-way review. **PR gate preserved** — builder stops and waits for human approval before merge.
-
-## Usage
-
-```bash
-# Spawn a builder using ASPIR
-afx spawn 42 --protocol aspir
-
-# The builder runs autonomously through Specify → Plan → Implement
-# and stops only at the PR gate in the Review phase
+```json
+{{> protocols/aspir/protocol.json}}
 ```
 
-## File Structure
+## Everything else is SPIR
 
-```
-codev/protocols/aspir/
-├── protocol.json          # Protocol definition (SPIR minus gates)
-├── protocol.md            # This file
-├── builder-prompt.md      # Builder instructions (same as SPIR)
-├── prompts/
-│   ├── specify.md         # Specify phase prompt (same as SPIR)
-│   ├── plan.md            # Plan phase prompt (same as SPIR)
-│   ├── implement.md       # Implement phase prompt (same as SPIR)
-│   └── review.md          # Review phase prompt (same as SPIR)
-└── consult-types/
-    ├── spec-review.md     # Spec consultation guide (same as SPIR)
-    ├── plan-review.md     # Plan consultation guide (same as SPIR)
-    ├── impl-review.md     # Impl consultation guide (same as SPIR)
-    ├── phase-review.md    # Phase consultation guide (same as SPIR)
-    └── pr-review.md       # PR consultation guide (same as SPIR)
-```
+Artifacts (`codev/specs/`, `codev/plans/`, `codev/reviews/`, same base filename), the
+build-verify cycle per plan phase, mandatory 3-way consultation at each verify step, the
+machine-readable `phases` block in the plan, commit and branch conventions, and Baked Decisions
+handling are all identical to SPIR. ASPIR includes SPIR's templates rather than copying them, so
+there is one set to keep correct.
 
-ASPIR ships **no `templates/` directory**. Its phase prompts deliver SPIR's canonical
-templates directly, via an include directive pointing at `protocols/spir/templates/`, so
-there is exactly one copy of each template and it cannot drift between the two protocols.
-(Written as a path, not as a literal include: an include directive in prose would be
-expanded — and silently emptied — when this file is delivered to a builder.)
+See `protocols/spir/protocol.md` for that shared substance.
 
-All files except `protocol.json` and `protocol.md` are identical to their SPIR counterparts.
+## Baked Decisions
+
+An issue may carry a `## Baked Decisions` section pinning architectural choices the architect
+does not want re-litigated — typically **language**, **framework**, deployment shape, key
+**dependencies**, or decisions deferred to a later spec.
+
+Every item in it is fixed. Copy the section verbatim into the spec's Constraints and do not
+re-open it in the spec, plan, or review; CMAP reviewers will not propose alternatives unless the
+spec fails to honour one. If two items contradict each other, do not choose — surface the
+contradiction and wait.
+
+**Absence is the no-op default**: an issue with no such section is an invitation to explore
+freely, not an omission to be filled in.
+
+The architect can **amend or rescind** a baked decision at any time by updating the issue and
+respawning, or by sending the builder a direct instruction via `afx send`.
+
+## The one thing to be careful about
+
+Without the spec and plan gates, nothing external catches a misread of the issue until the PR.
+If the spec you write surprises you — if it turns out larger, or more architectural, than the
+issue implied — that is the signal ASPIR was the wrong choice. Say so early rather than
+carrying the misfit through to review.

--- a/codev/protocols/bugfix/protocol.md
+++ b/codev/protocols/bugfix/protocol.md
@@ -1,78 +1,72 @@
 # BUGFIX Protocol
 
-> Lightweight, issue-driven protocol for minor bug fixes. **Investigate → Fix → PR**, with a single `pr` gate before merge. No spec or plan artifacts: the GitHub issue is the spec, and the review goes in the PR body.
+Investigate → Fix → PR, driven by a GitHub issue. No spec, no plan, no artifact files: the issue
+is the specification and the PR body carries the reasoning.
 
-## When to Use
+Use it for a defect whose fix is isolated. For a small *feature* use AIR; for anything needing a
+design decision use SPIR.
 
-Use BUGFIX when a bug is reported as a GitHub Issue and:
+## The state machine
 
-- The reproduction is clear (or inferable) and the root cause is isolated
-- The fix is small (guideline: < 300 LOC net diff) and contained to one area
-- No architectural changes or new design decisions are needed
-
-Escalate to **SPIR** (or another heavier protocol) instead when:
-
-- It is actually a feature request, not a bug
-- The root cause reveals a deeper architectural issue
-- The fix needs design review, spans multiple components, or clearly exceeds ~300 LOC
+```json
+{{> protocols/bugfix/protocol.json}}
+```
 
 ## Phases
 
-```
-investigate → fix → pr
-```
+**Investigate** — reproduce the bug and identify the root cause. **No code in this phase.**
+Confirm the fix fits BUGFIX scope; if it does not, signal `BLOCKED` and recommend escalation
+rather than growing the project quietly.
 
-### Investigate
-
-Read the issue, reproduce the bug, and identify the root cause. Confirm the fix fits BUGFIX scope. If it does not, signal `BLOCKED` and recommend escalation to the architect (`afx send architect "..."`). No code in this phase.
-
-### Fix
-
-Apply the minimal change that resolves the root cause, and add a regression test that fails without the fix and passes with it. Keep it focused: do not refactor surrounding code, do not fix unrelated bugs (file separate issues), do not add features. Run the build and tests (porch's `checks` block runs `npm run build` and `npm test`).
-
-Commit with the issue-driven format:
+**Fix** — the minimal change that resolves the root cause, plus a regression test that **fails
+without the fix and passes with it**. A test that passes either way documents nothing. Do not
+refactor surrounding code, fix unrelated bugs (file separate issues), or add features.
 
 ```
-[Bugfix #<N>] Fix: <what was fixed>
-[Bugfix #<N>] Test: <regression test added>
+[Bugfix #42] Fix: URL-encode username before API call
+[Bugfix #42] Test: regression for unencoded username
 ```
 
-### PR (gated by `pr`)
+**PR** — open with `gh pr create`, body carrying Summary, Root Cause, Fix and Test Plan plus
+`Fixes #<N>` so the issue closes on merge. Run one CMAP pass (Gemini, Codex, Claude), record
+each verdict, and address or rebut every `REQUEST_CHANGES`. Notify the architect with the
+verdicts, then `porch done <id>` and wait.
 
-1. Push the branch and open a PR with `gh pr create`. The body includes Summary, Root Cause, Fix, and Test Plan, plus `Fixes #<N>` so the issue auto-closes on merge.
-2. Run a multi-agent CMAP review on the PR (Gemini, Codex, Claude) and record each verdict. Address or rebut any `REQUEST_CHANGES`; add a regression test if a real defect surfaced.
-3. Notify the architect: `afx send architect "PR #<M> ready for review (fixes #<N>). CMAP: gemini=..., codex=..., claude=..."`.
-4. Run `porch done <id>` to request the `pr` gate, then wait. **The merge is gated by porch state, never by typed prose in your pane.**
-5. The human reviews the PR and the CMAP results on GitHub, then approves the gate: `porch approve <id> pr --a-human-explicitly-approved-this`.
-6. porch wakes the builder with a merge task. Merge with `gh pr merge --merge` (do **not** pass `--delete-branch`: the builder is checked out on this branch in a worktree), then run `porch done <id>` and notify the architect that it is merged and ready for cleanup.
+Merge with `gh pr merge --merge`. **Do not pass `--delete-branch`** — the builder is checked out
+on that branch in a worktree, and deleting it out from under them breaks the worktree.
 
-## Gate
+## The gate exists to make merge authorization structural
 
-BUGFIX has one human gate, `pr`, on the merge step. It exists so the merge trigger is structured porch state (approved or not), not free-text typed into the builder's pane. This eliminates the self-merge bug class: a builder cannot infer authorization from ambiguous input.
+BUGFIX has one human gate, `pr`. Its purpose is that the merge trigger is **porch state** —
+approved or not — rather than free text typed into the builder's pane. That closes the
+self-merge bug class: a builder cannot infer authorization from ambiguous prose.
 
-## Multi-Agent Consultation
+## Consultation
 
-A single CMAP pass at the PR (Gemini, Codex, Claude). There is no per-phase consultation: the issue is the spec and the fix is small, so review effort concentrates on the final PR.
+One CMAP pass at the PR. No per-phase consultation: the issue is the spec and the fix is small,
+so review effort concentrates where it can still change the outcome.
 
 ## Scope
 
-The < 300 LOC threshold is a **guideline**, measured as net diff (additions + deletions) anchored at the merge-base with the default branch. A well-contained 350-LOC fix is fine; a 200-LOC fix smeared across ten files may warrant escalation.
+The <300 LOC threshold is a **guideline**, measured as net diff (additions + deletions) against
+the merge-base with the default branch. A well-contained 350-line fix is fine; a 200-line fix
+smeared across ten files probably warrants escalation.
 
 ## Escalation
 
-If, mid-fix, the change outgrows BUGFIX (architectural impact, multiple components, unclear root cause after investigation, or more than ~300 LOC), notify the architect with specifics and recommend escalating to SPIR. Do not silently expand scope.
+If the change outgrows BUGFIX mid-flight — architectural impact, multiple components, unclear
+root cause after investigation — notify the architect with specifics and recommend SPIR. **Do
+not silently expand scope.**
 
-## Branch Naming
-
-```
-builder/bugfix-<issue-number>-<slug>
-```
-
-## Edge Cases
+## Edge cases
 
 | Scenario | Action |
 |---|---|
-| Cannot reproduce | Document the attempts in an issue comment, ask the reporter for detail, notify the architect |
-| Fix outgrows scope (architectural / multi-component / > ~300 LOC) | Notify the architect, recommend escalation; do not proceed |
-| Unrelated test failures | Out of scope: note them for the architect, do not fix them here |
-| Multiple bugs in one issue | Fix only the primary bug; file separate issues for the rest |
+| Cannot reproduce | Document the attempts on the issue, ask the reporter for detail, notify the architect |
+| Fix outgrows scope | Notify the architect and recommend escalation; do not proceed |
+| Unrelated test failures | Out of scope — note them for the architect, do not fix here |
+| Multiple bugs in one issue | Fix the primary one; file separate issues for the rest |
+
+## Branch naming
+
+`builder/bugfix-<issue>-<slug>`

--- a/codev/protocols/experiment/protocol.md
+++ b/codev/protocols/experiment/protocol.md
@@ -1,203 +1,37 @@
 # EXPERIMENT Protocol
 
-## Overview
+A disciplined experiment: state the hypothesis before running it, record what actually happened,
+and keep the result whichever way it goes.
 
-Disciplined experimentation: Each experiment gets its own directory with `notes.md` tracking goals, code, and results.
+Use it for evaluating models or libraries, proof-of-concept work, and technique comparisons —
+questions that should be settled by evidence rather than by argument.
 
-**Core Principle**: Document what you're trying, what you did, and what you learned.
+## The state machine
 
-## When to Use
-
-**Use for**: Testing approaches, evaluating models, prototyping, proof-of-concept work, research spikes
-
-**Skip for**: Production code (use SPIR), simple one-off scripts
+```json
+{{> protocols/experiment/protocol.json}}
+```
 
 ## Structure
 
-```
-experiments/
-├── 1_descriptive_name/
-│   ├── notes.md           # Goal, code, results
-│   ├── experiment.py      # Your experiment code
-│   └── data/
-│       ├── input/         # Input data
-│       └── output/        # Results, plots, etc.
-└── 2_another_experiment/
-    ├── notes.md
-    └── ...
-```
+Each experiment gets a numbered directory under `codev/experiments/` with a `notes.md` recording
+the hypothesis, method, results and conclusion.
 
-## Workflow
+## Notes structure
 
-### 1. Create Experiment Directory
-
-```bash
-# Create numbered directory
-mkdir -p experiments/1_experiment_name
-cd experiments/1_experiment_name
-
-# Initialize notes.md from template
-touch notes.md   # then fill it from the embedded template at the end of this protocol
-```
-
-Or ask your AI assistant: "Create a new experiment for [goal]"
-
-### 2. Document the Goal
-
-Before writing code, clearly state what you're trying to learn in `notes.md`:
-
-```markdown
-## Goal
-
-What specific question are you trying to answer?
-What hypothesis are you testing?
-```
-
-### 3. Write Experiment Code
-
-- Keep it simple - experiments don't need production polish
-- Reuse existing project modules where possible
-- Any structure is fine - focus on learning, not architecture
-
-**Dependencies**: If your experiment requires libraries not in the main project:
-1. Do NOT add them to the main project's `requirements.txt` or `pyproject.toml`
-2. Create a `requirements.txt` inside your experiment folder
-3. Document installation in `notes.md`
-
-### 4. Run and Observe
-
-Execute your experiment and capture results:
-- Save output files to `data/output/`
-- Take screenshots of visualizations
-- Log key metrics
-
-### 5. Document Results
-
-Update `notes.md` with:
-- What happened (actual results)
-- What you learned (insights)
-- What's next (follow-up actions)
-
-### 6. Commit
-
-```bash
-git add experiments/1_experiment_name/
-git commit -m "[Experiment 1] Brief description of findings"
-```
-
-## Best Practices
-
-### Keep It Simple
-- Experiments don't need production polish
-- Skip comprehensive error handling
-- Focus on answering the question
-
-### Document Honestly
-- Include failures - they're valuable learnings
-- Note dead ends and why they didn't work
-- Be specific about what surprised you
-
-### Track Time Investment
-- Wall clock time: Total elapsed time
-- Developer time: Active working time (excluding waiting)
-- Helps estimate future similar work
-
-### Use Project Modules
-- Don't duplicate existing code
-- Import from your `src/` directory
-- Experiments validate approaches, not reimplement them
-
-### Commit Progress
-- Use `[Experiment ####]` commit prefix
-- Commit intermediate results
-- Include output files when reasonable
-
-## Integration with Other Protocols
-
-### Experiment → SPIR
-When an experiment validates an approach for production use:
-
-1. Create a specification referencing the experiment
-2. Link to experiment results as evidence
-3. Use experiment code as reference implementation
-
-Example spec reference:
-```markdown
-## Background
-
-Experiment 5 validated that [approach] achieves [results].
-See: experiments/5_validation_test/notes.md
-```
-
-## Numbering Convention
-
-Use four-digit sequential numbering (consistent with project list):
-- `1_`, `2_`, `3_`...
-- Shared sequence across all experiments
-- Descriptive name after the number (snake_case)
-
-Examples:
-- `1_api_response_caching`
-- `2_model_comparison`
-- `3_performance_baseline`
-
-## Git Workflow
-
-### Commits
-```
-[Experiment 1] Initial setup and goal
-[Experiment 1] Add baseline measurements
-[Experiment 1] Complete - caching improves latency 40%
-```
-
-### When to Commit
-- After setting up the experiment
-- After significant findings
-- When completing the experiment
-
-**Data Management**:
-- Include `data/output/` ONLY if files are small (summary metrics, small plots)
-- Do NOT commit large datasets, binary model checkpoints, or heavy artifacts
-- Add appropriate entries to `.gitignore` for large files
-- Consider storing large outputs externally and linking in notes
-
-## Example Experiment
-
-```
-experiments/1_caching_strategy/
-├── notes.md
-├── benchmark.py
-├── cache_test.py
-└── data/
-    ├── input/
-    │   └── sample_requests.json
-    └── output/
-        ├── results.csv
-        └── latency_chart.png
-```
-
-**notes.md excerpt:**
-```markdown
-# Experiment 1: Caching Strategy Evaluation
-
-**Status**: Complete
-
-**Date**: 2024-01-15
-
-## Goal
-Determine if Redis caching improves API response times for repeated queries.
-
-## Results
-- 40% latency reduction for cached queries
-- Cache hit rate: 73% after warm-up
-- Memory usage: 50MB for 10k cached responses
-
-## Next Steps
-Create SPIR spec for production caching implementation.
-```
-
-## Template: notes.md
-
-Create `notes.md` with the following content:
+`notes.md` uses this structure:
 
 {{> protocols/experiment/templates/notes.md}}
+
+## The discipline that makes it worth doing
+
+**Write the hypothesis and the success criteria before running anything.** An experiment scored
+after the fact always succeeds — you discover the criterion the result happens to meet.
+
+**Record negative results.** "We tried X and it did not work, here is why" is the output that
+saves the next person a week. An experiment directory containing only successes is a directory
+that has been curated rather than run.
+
+**Keep the experiment separate from production code.** Experimental code answers a question; it
+has not earned the standards production code is held to, and promoting it silently is how a
+proof of concept becomes a maintenance burden nobody chose.

--- a/codev/protocols/maintain/protocol.md
+++ b/codev/protocols/maintain/protocol.md
@@ -1,241 +1,50 @@
 # MAINTAIN Protocol
 
-## Overview
+Audit → Clean → Sync, in a single pass, then a PR. Two phases, one consultation during the
+maintain phase and one before the PR.
 
-MAINTAIN is a single-pass maintenance protocol for keeping codebases healthy. The builder does all maintenance work in one phase, then creates a PR with a 3-way review.
+Use it for dead code and unused dependencies, quarterly hygiene, pre-release cleanup, and
+keeping the governance docs honest — `arch.md`/`arch-critical.md`,
+`lessons-learned.md`/`lessons-critical.md`, and the `CLAUDE.md`↔`AGENTS.md` twins.
 
-**Core Principle**: Do the work in one pass. Don't over-ceremonialize housekeeping.
+## The state machine
 
-**Key Documents** MAINTAIN keeps current:
-- `codev/resources/arch.md` (COLD reference) + `codev/resources/arch-critical.md` (HOT, always-injected) — Architecture, two tiers (Spec 987)
-- `codev/resources/lessons-learned.md` (COLD reference) + `codev/resources/lessons-critical.md` (HOT, always-injected) — Engineering wisdom, two tiers
-
-The two governance docs are siblings with **different purposes**: `arch.md` owns system shape (services, transports, mental models, verified-wrong assumptions about *this* system); `lessons-learned.md` owns durable engineering wisdom that applies *across* specs. Use the routing matrix below to decide where each fact belongs.
-
-### Lives where: routing facts to the right home
-
-| Type of fact/insight | Lives in |
-|---|---|
-| Current system shape (services, transports, key mental models) | `codev/resources/arch.md` |
-| Mechanism for a unique subsystem | `codev/resources/arch.md` (subsystem section) OR a meta-spec under `codev/architecture/<domain>.md` if the mechanism is large enough to warrant its own doc |
-| A durable engineering pattern that applies across multiple specs | `codev/resources/lessons-learned.md` (COLD reference) |
-| A **behavior-changing, cross-cutting** rule (should change how the next project is built) | `codev/resources/lessons-critical.md` (HOT, capped) — demote to `lessons-learned.md` if full |
-| A **behavior-changing, cross-cutting** architecture invariant (a future builder must know up front) | `codev/resources/arch-critical.md` (HOT, capped) — demote to `arch.md` if full |
-| A spec-narrow fix recipe (reference detail) | `codev/resources/lessons-learned.md` (COLD) — kept as reference; **never** the hot file |
-| A system-shape surprise verified-wrong in production ("looks like X but isn't") | `codev/resources/arch.md` § "Verified-Wrong Assumptions" |
-| Aspirational architectural direction (where we want to go) | The relevant meta-spec or roadmap doc, NOT `arch.md` body |
-| A changelog entry ("we shipped X in spec Y on date Z") | `git log` + the spec/review document — NOT `arch.md`, NOT `lessons-learned.md` |
-| A retired or removed component | Delete the section entirely; do NOT keep a "retired components" graveyard. (`git log` retains history.) |
-
-The most commonly-misrouted entry is the system-shape surprise. If a future reader needs to know "the system *looks* like X but actually does Y," that is system shape and lives in `arch.md`. If they need to know "we learned that doing X is generally a bad idea," that is engineering wisdom and lives in `lessons-learned.md`.
-
-## When to Use
-
-- Before a release (clean slate for shipping)
-- After completing a major feature
-- Quarterly maintenance window
-- When the codebase feels "crusty"
-
-## Execution Model
-
-```
-afx spawn --protocol maintain
-    ↓
-1. MAINTAIN: Audit → Clean → Sync docs (single pass)
-    ↓ (build + test checks, 3-way review)
-2. REVIEW: Create PR
-    ↓ (3-way review)
-Architect reviews → Merge
+```json
+{{> protocols/maintain/protocol.json}}
 ```
 
-Two phases total. One consultation during the maintain phase, one before PR.
+## Before starting
 
-## Prerequisites
+Find the last run in `codev/maintain/`, note its base commit, and scope the audit to
+`git log --oneline <base>..HEAD`. Maintenance without a since-marker re-audits the whole
+repository every time and quietly stops being run.
 
-Before starting:
-1. Check `codev/maintain/` for the last run number
-2. Note the base commit: `git log --oneline -1` on the last run file
-3. Focus on changes since then: `git log --oneline <base-commit>..HEAD`
+## The maintain phase
 
----
+**Audit** — find unused exports, unused dependencies, and orphaned files. Treat every hit as a
+*candidate*, not a verdict: a detector cannot tell "vestigial" from "used by a path you did not
+search". Confirm each with a targeted grep before removing it.
 
-## The Maintain Phase (Single Pass)
+**Clean** — remove what you confirmed. Deletions go to `codev/maintain/.trash/` (gitignored,
+30-day retention) rather than straight out, so a wrong call is recoverable for a month rather
+than needing an archaeology session.
 
-The builder works through these tasks in order, committing as they go.
+**Sync documentation** — route facts by tier rather than appending: behaviour-changing and
+cross-cutting go to the capped hot files (displace a weaker entry rather than growing them),
+reference detail to the cold archives. The `update-arch-docs` skill encodes the routing matrix,
+the caps, and what does *not* belong in each tier. Keep `CLAUDE.md` and `AGENTS.md`
+byte-identical.
 
-### Step 1: Audit
+## The maintenance run file
 
-Identify what needs fixing. Don't fix yet — just catalog.
-
-**Dead code**:
-```bash
-# Find unused exports (TypeScript)
-npx ts-prune 2>/dev/null || echo "ts-prune not available"
-
-# Find unused dependencies
-npx depcheck 2>/dev/null || echo "depcheck not available"
-```
-
-**Stale documentation**:
-```bash
-# What changed since last maintenance?
-git log --oneline <base-commit>..HEAD
-
-# Check arch.md references still exist
-grep -oE '[a-zA-Z]+/[a-zA-Z/]+\.[a-z]+' codev/resources/arch.md | sort -u | while read f; do
-  [ -e "$f" ] || echo "Missing: $f"
-done
-```
-
-**Stale project tracking**:
-- GitHub Issues that should be closed
-- Labels that need updating
-
-Record findings in the maintenance run file (`codev/maintain/NNNN.md`).
-
-### Step 2: Clean
-
-For each finding from the audit:
-1. Verify it's truly unused (grep the codebase)
-2. Remove it (use `git rm` for tracked files)
-3. Verify build + tests still pass
-4. Commit with `[Maintain] Remove unused X`
-
-**Rules**:
-- One removal at a time — don't batch unrelated changes
-- Verify after each removal — build must pass
-- Use soft deletion for untracked files: `mv file codev/maintain/.trash/$(date +%Y-%m-%d)/`
-- Never use `git add -A` or `git add .`
-
-### Step 3: Sync Documentation
-
-Step 3 is split into two sub-steps: **Audit first, then update.** This split exists because `arch.md` and `lessons-learned.md` accumulate without bound when MAINTAIN does only "what's new" — the audit pass surfaces what should be cut so the update pass is not purely additive.
-
-The `update-arch-docs` skill (at `.claude/skills/update-arch-docs/SKILL.md`) is invoked by both sub-steps. Read it before starting Step 3 so the discipline is fresh.
-
-#### Step 3a: Audit documentation
-
-Invoke the `update-arch-docs` skill in **audit-mode**. The skill reads all four governance files — `codev/resources/arch.md` / `arch-critical.md` and `codev/resources/lessons-learned.md` / `lessons-critical.md` — end-to-end against the discipline below, applies the cuts via the Edit tool, and records each cut's reason in the run file (`codev/maintain/NNNN.md`) under a `## Audit Findings` section. The diff plus the recorded reasons **is** the proposal; the architect's PR review is the human-confirmation step (consistent with the skill's audit-mode).
-
-**Per-arch.md-section pruning checklist** — for each section in `arch.md`, ask:
-- Does it describe **current state**? If aspirational, the section moves to a meta-spec; `arch.md` keeps a 1-paragraph summary + pointer (or nothing, if the meta-spec stands on its own).
-- Does it duplicate a meta-spec? If yes, replace with a 1-paragraph summary + pointer.
-- Is it a per-file enumeration that's gone stale? If yes, prune to the directory shape + a few key files.
-- Is it a changelog/narrative section ("Spec 0042 added X")? If yes, absorb the architecturally-relevant facts and remove the spec-numbered framing.
-- Is the component still alive? If retired, delete the section entirely.
-
-**Per-COLD-`lessons-learned.md`-entry pruning checklist** — for each entry, ask:
-- Is it terse (1–3 sentences)? If multi-paragraph, split or compress.
-- Is the topic section the right home? If filed under "Architecture (continued)" or a spec-numbered section, move it to the right topical home.
-- Is it a duplicate of an adjacent entry? If yes, fold them.
-- (Spec-narrow recipes are **kept** as reference — do not cut them just for being spec-narrow. Anti-accretion now lives in the hot cap, not the cold archive.)
-
-**Per-HOT-file checklist** (`arch-critical.md`, `lessons-critical.md`) — audit the cap and map:
-- Within the cap (≈10 entries + a ≈12-topic map, ≤35 lines)? If over, **demote** the weakest entries into the cold doc.
-- Does every map topic name a real top-level cold-doc section, and is any new/renamed section reflected? Fix drift; keep the map top-level only.
-- Is every entry still behavior-changing? Demote reference detail into the cold archive.
-
-**Sample audit prompt** (paste into the skill invocation if you want a baseline checklist run):
-
-```
-Audit all four governance files — codev/resources/arch.md + arch-critical.md and
-lessons-learned.md + lessons-critical.md — against the discipline in the
-update-arch-docs skill. For each cold section/entry run the cold pruning checklists,
-and for each hot file check the cap, displacement, and map accuracy (Step 3a).
-Apply the cuts with one-line reasons. Bias toward fewer, higher-confidence
-cuts ("when in doubt, KEEP"). Record each cut's reason in the current run
-file's ## Audit Findings section as you go — the diff plus those reasons is the proposal.
-```
-
-**When in doubt, KEEP.** This rule is preserved from the older Step 3. A confident cut is better than three speculative ones. The audit pass is a *proposal*; the architect's PR review confirms it.
-
-#### Step 3b: Update documentation
-
-Apply the audit decisions from Step 3a, plus any additive content needed.
-
-**arch.md / arch-critical.md**: Compare documented structure with actual codebase. Route behavior-changing invariants to `arch-critical.md` (HOT — respect the cap + keep its map accurate); reference detail to `arch.md` (COLD). Update:
-- Directory structure
-- Component descriptions (explain HOW things work, not just WHAT)
-- Key files and their purposes
-- Remove references to deleted code (per Step 3a audit findings)
-- Add new components/utilities
-
-**lessons-learned.md / lessons-critical.md**: Scan `codev/reviews/` for new reviews since last run. **Route** each new lesson by tier — behavior-changing + cross-cutting → `lessons-critical.md` (HOT; respect the cap, demote a weaker entry to cold if full); reference recipe / spec-narrow → `lessons-learned.md` (COLD). Apply Step 3a's per-entry cuts and keep each hot file's cold-doc map accurate.
-
-For specific additive changes, invoke `update-arch-docs` in **diff-mode** — it applies the smallest section update needed.
-
-**CLAUDE.md / AGENTS.md**: Diff the two files. They must be identical. Update the stale one.
-
-**Documentation pruning**:
-- Remove obsolete references
-- ~400 line guideline for CLAUDE.md/README.md (not a hard limit)
-- Document every deletion with justification (OBSOLETE, DUPLICATIVE, MOVED, VERBOSE)
-- When in doubt, KEEP the content
-
-### Step 4: Final Checks
-
-```bash
-# Build and test from the package directory
-cd packages/codev && pnpm build && pnpm test
-```
-
-Both must pass before moving to the review phase.
-
----
-
-## Maintenance Run File
-
-Each run creates `codev/maintain/NNNN.md`, following the template below:
+Each run is recorded in `codev/maintain/` using this structure:
 
 {{> protocols/maintain/templates/maintenance-run.md}}
 
-Keep it factual and short. The run file documents what happened, not what might happen.
+## Scope discipline
 
----
+Maintenance is where scope creep is most tempting, because everything you touch looks
+improvable. Removing dead code is in scope; refactoring live code because you are already in the
+file is not. File an issue instead.
 
-## Commit Messages
-
-```
-[Maintain] Remove 5 unused exports
-[Maintain] Remove http-proxy dependency
-[Maintain] Update arch.md — add VS Code extension, remove dashboard-server refs
-[Maintain] Generate lessons-learned.md from reviews 653, 672
-[Maintain] Sync CLAUDE.md with AGENTS.md
-```
-
----
-
-## Governance
-
-MAINTAIN is an operational protocol, not a feature protocol:
-
-| Document | Required? |
-|----------|-----------|
-| Spec | No |
-| Plan | No |
-| Review | No (maintenance run file serves this purpose) |
-| Consultation | Yes — 3-way review before PR |
-
-If maintenance reveals need for architectural changes, those should follow SPIR.
-
----
-
-## Rules
-
-1. **Don't be aggressive** — when in doubt, KEEP the content
-2. **Check git blame** — understand why code/docs exist before removing
-3. **Run full test suite** — not just affected tests
-4. **Group related changes** — one commit per logical change
-5. **Document every deletion** — what, why, and where (if moved)
-6. **Prefer moving over deleting** — extract to another file rather than removing
-7. **Size targets are guidelines** — never sacrifice clarity to hit a line count
-
-## Anti-Patterns
-
-1. Aggressive rewriting without explanation
-2. Deleting without documenting why
-3. Hitting line count targets at all costs
-4. Removing "patterns" or "best practices" sections without explicit approval
-5. Deleting everything the audit finds — review each item individually
-6. Skipping validation — "it looked dead" is not validation
-7. Using `rm` instead of `git rm`
+Never `git add -A` / `--all` / `.` — stage each file explicitly by path.

--- a/codev/protocols/pir/protocol.md
+++ b/codev/protocols/pir/protocol.md
@@ -1,202 +1,76 @@
 # PIR Protocol
 
-> **Plan → Implement → Review** for GitHub-issue-driven work that needs human review of *either* the approach (before code is written) *or* the implementation (before a PR exists), or both. Lighter than SPIR/ASPIR (no `specify` phase — the GitHub issue is the implicit spec) with the human dev-approval moved earlier (pre-PR instead of post-PR). Stronger than BUGFIX/AIR (two human gates before the PR).
+Plan → Implement → Review, driven by a GitHub issue, with **two human gates before any PR
+exists**. The issue is the implicit spec; there is no specify phase.
 
-## When to Use PIR
+Choose PIR when either is true:
 
-Pick PIR when working from a GitHub Issue and ONE or BOTH of the following apply — based on the *nature* of the change, not its size:
+- **The approach needs review before coding.** Ambiguous root cause, unfamiliar or
+  high-blast-radius area, or a design-sensitive change — cheaper to redirect at plan time than
+  at PR time.
+- **The implementation must be exercised running, before a PR exists.** Mobile, UI/UX,
+  hardware-adjacent behaviour, OAuth or payment integrations, full user journeys, anything
+  performance-sensitive. A diff cannot show you these; a running worktree can.
 
-### 1. The approach needs review before coding starts
-- Root cause is ambiguous; multiple valid fixes exist
-- Area is unfamiliar or high-blast-radius (shared utilities, auth, migrations, public APIs)
-- Design-sensitive (affects conventions, patterns, architecture)
-- Cheaper to redirect at plan time than at PR time
+Lighter than SPIR (no spec phase, one consult at the PR). Stronger than BUGFIX/AIR (two human
+gates *before* a PR, where the human reviews the running code rather than the diff).
 
-### 2. The implementation needs to be tested before a PR is created
-The PR diff alone is insufficient; the reviewer must *run* the code:
-- Mobile app changes (needs device testing on Android, iOS, possibly web)
-- UI / UX changes (visual inspection, interaction flow, accessibility)
-- Hardware-adjacent behavior (sensors, camera, permissions, notifications)
-- Integration with external services that don't mock cleanly (OAuth, payments, analytics)
-- User-journey changes that need a full-flow exercise
-- Performance-sensitive changes that need profiling on the running app
+## The state machine
 
-### Use SPIR / ASPIR / BUGFIX / AIR instead when
-- **SPIR / ASPIR**: the change is complex enough to warrant careful specification, multi-agent consultation at every phase, and the full spec → plan → implement → review ceremony with file artifacts. The driving issue is incidental — what matters is that the design work deserves a formal spec and the implementation deserves consult-driven review at each phase
-- **BUGFIX**: small bug fix, no design review needed, diff-on-PR review is enough
-- **AIR**: small feature from an issue, autonomous, diff-on-PR review is enough
-
-## How PIR Differs from SPIR
-
-PIR is structurally *SPIR minus the `specify` phase*, with the human dev-approval moved earlier (pre-PR instead of post-PR).
-
-| Aspect | SPIR | PIR |
-|---|---|---|
-| Phases | specify → plan → implement → review → verify | plan → implement → review |
-| Spec artifact | `codev/specs/<id>-<slug>.md` | GitHub Issue body (implicit spec) |
-| Plan artifact | `codev/plans/<id>-<slug>.md` | Same — committed on builder branch |
-| Review artifact | `codev/reviews/<id>-<slug>.md` (Summary + Architecture Updates + Lessons Learned, becomes PR body) | **Same shape** — `codev/reviews/<id>-<slug>.md` with the same sections, also becomes PR body |
-| Human gates | spec-approval, plan-approval, pr, verify-approval | plan-approval, dev-approval, pr |
-| Where code is reviewed by the human | On the PR (post-creation) — read the diff | Pre-PR (at the `dev-approval` gate) — read the diff **and run the worktree locally** |
-
-The review file always includes Summary, Architecture Updates, and Lessons Learned sections so `codev/reviews/` stays semantically consistent across all protocols. PIR's lightness comes from skipping the `specify` phase (the issue body is the spec), not from cutting corners on the retrospective.
-
-The `dev-approval` gate is what makes PIR genuinely different: the human gates the *running implementation* via the worktree before the PR exists, instead of gating the PR after creation.
-
-## Phases
-
+```json
+{{> protocols/pir/protocol.json}}
 ```
-plan → implement → review
-```
-
-### Plan (gated by `plan-approval`)
-
-The builder:
-1. Reads the GitHub issue and investigates the codebase
-2. Writes `codev/plans/<id>-<slug>.md` with: Understanding / Proposed change / Files to change / Risks & alternatives / Test plan
-3. Commits the plan on the builder branch and pushes
-4. Runs `porch done` and `porch next` — the `plan-approval` gate becomes pending
-5. Sits at the interactive prompt waiting for review
-
-**Reviewer paths** (all equivalent):
-- Open `codev/plans/<id>-<slug>.md` in the worktree, read and / or edit directly, save
-- Type feedback into the builder's PTY pane — the builder is alive in interactive mode
-- `afx send <builder-id> "<feedback>"`
-- Comment on the GitHub issue (sidecar discussion)
-
-When satisfied, approve via VSCode's "Approve Gate" command (Cmd+K G) or:
-
-```bash
-porch approve <id> plan-approval --a-human-explicitly-approved-this
-```
-
-### Implement (gated by `dev-approval`)
-
-The builder:
-1. Reads the approved plan file
-2. Writes code and tests; runs build + tests via the `checks` block
-3. *No AI consult on this phase* — the human at the `dev-approval` gate is the sole reviewer of the running code. Matches BUGFIX / AIR's pattern of "no consult on implementation, one consult at PR creation".
-4. Pushes the branch
-5. Runs `porch done` and `porch next` — the `dev-approval` gate becomes pending
-6. Outputs a **prose** dev-approval summary in the PTY pane (Summary / Files / Test results / Things to look at / How to test locally). This is a transient message to orient the human reviewer — **not a committed file**. The retrospective file is written in the next phase, after the human approves the running code.
-7. Sits at the interactive prompt
-
-**The reviewer's killer move**: run the worktree locally.
-
-- VSCode: right-click the builder in the Codev sidebar → **Run Dev** (spawns `afx dev <builder-id>` via Tower)
-- CLI: `afx dev <builder-id>`
-
-The dev process uses **the same ports and URLs as main** intentionally (OAuth callbacks, CORS, cookie scoping all depend on consistent origins). Only one dev env runs at a time; stop main's `pnpm dev` before starting the worktree's, or use VSCode's **Stop Dev** to swap.
-
-Reviewer tests the change on real devices / browsers / simulators. When satisfied, approves via Cmd+K G or:
-
-```bash
-porch approve <id> dev-approval --a-human-explicitly-approved-this
-```
-
-### Review (gated by `pr`)
-
-The builder:
-1. Writes `codev/reviews/<id>-<slug>.md` with **Summary**, **Architecture Updates**, **Lessons Learned Updates**, plus the supporting sections (Files Changed, Commits, Test Results, Things to Look At, How to Test Locally).
-2. Routes new facts/wisdom by tier (Spec 987) — HOT `codev/resources/arch-critical.md` / `lessons-critical.md` (capped) or COLD `codev/resources/arch.md` / `lessons-learned.md` (reference) — if real changes need recording. If not, the review file's sections state "no changes needed" with a one-line explanation (the porch `checks` block enforces section presence, not content).
-3. Commits the review file (and arch / lessons updates if any) and pushes
-4. Opens a PR with `gh pr create`; PR body is the review file content + `Fixes #<N>`. Records the PR with `porch done <id> --pr <M> --branch <name>`.
-5. Runs `porch done <id>` — porch's `verify` block runs 3-way consultation (Gemini, Codex, Claude; type=impl) as a **single advisory pass** (`max_iterations: 1`); consultation outputs land in `codev/projects/<id>-*/`. There is no iterate-until-APPROVE loop: whatever the verdicts, porch records them and advances to the `pr` gate. A `REQUEST_CHANGES` is not auto-re-reviewed — the builder addresses or rebuts it, adds a regression test if it's a real defect, and escalates it in the architect notification so the human verifies it at the `pr` gate. Outcomes are not auto-appended to the PR body; reviewers with the worktree read them from the projects dir.
-6. The `pr` gate fires (pending) regardless of verdict. Builder notifies the architect once — leading with any `REQUEST_CHANGES` and its disposition (since PIR will not re-review it) rather than burying it in a flat status line.
-7. Builder waits at the `pr` gate. The human reviews the PR on GitHub, then approves the `pr` gate (Cmd+K G or `porch approve <id> pr --a-human-explicitly-approved-this`). Porch wakes the builder.
-8. Builder verifies the gate is genuinely approved via `porch next` (defensive — typed prose can't trigger this branch, only real porch state does), then runs `gh pr merge --merge`, records via `porch done --merged <M>`, and sends the cleanup-ready notification. Protocol complete (`next: null`).
 
 ## Gates
 
-PIR uses porch's existing gate machinery. Gate names are opaque strings; no porch engine changes are needed.
+Gate names are opaque strings keyed by `(project_id, gate_name)`, so sharing a name with another
+protocol is safe and needs no porch change.
 
-- **`plan-approval`** — pre-PR. Human reads the plan file (committed on the builder branch) and approves before any code is written. Gates are keyed by `(project_id, gate_name)` so the name is safe to share with other protocols.
-- **`dev-approval`** — pre-PR. The human reviews the *running* worktree (via `afx dev`) before any PR exists. This is PIR's distinctive gate.
-- **`pr`** — post-PR. Gates the merge step. The human reviews the PR on GitHub and approves this gate; porch wakes the builder, which then runs `gh pr merge`. The gate exists so the merge trigger is structured porch state (binary approved/not), not free-text prose typed into the builder's pane. Eliminates the self-merge bug class: builders can't infer authorization from ambiguous user input.
+| Gate | When | What the human does |
+|---|---|---|
+| `plan-approval` | pre-PR | Reads the plan committed on the builder branch, before any code exists |
+| `dev-approval` | pre-PR | **PIR's distinctive gate** — reviews the *running* worktree via `afx dev` |
+| `pr` | post-PR | Reviews on GitHub, then approves; porch wakes the builder to merge |
 
-When a gate becomes pending, porch broadcasts `overview-changed` via SSE. The VSCode Builders tree picks up the blocked state and renders it with a bell icon; a toast surfaces the new gate-pending event. Architect notification is *not* automatic — gates surface via the toast/sidebar (for IDE users) or by checking the builder pane / `porch pending` (for CLI users). The builder's job at any gate is to write the artifact, commit, signal completion, and wait — never to invoke `porch approve` itself (Claude refuses the `--a-human-explicitly-approved-this` flag by design).
+The `pr` gate makes the merge trigger **structured porch state** rather than free text in the
+builder's pane — closing the self-merge class where a builder infers authorization from
+ambiguous prose.
 
-## Rejection / Feedback Model
+**Gates do not notify the architect automatically.** Porch broadcasts `overview-changed` over
+SSE; the VSCode Builders tree renders the blocked state with a bell and raises a toast. CLI
+users see it via the builder pane or `porch pending`. The builder's job at any gate is: write
+the artifact, commit, signal, wait — never to invoke `porch approve` itself.
 
-There is no formal `porch reject` command. Rejection works via the feedback-iterate pattern:
+## Rejection is iteration, not a command
 
-1. Reviewer provides feedback (edit the plan file in VSCode, type in the builder pane, `afx send`, or issue comment)
-2. Builder reads the feedback on its next turn, revises the artifact, recommits
-3. The gate remains pending — porch doesn't advance until the human runs `porch approve`
+There is no `porch reject`. Feedback arrives however is convenient — editing the plan file,
+typing in the builder pane, `afx send`, an issue comment — the builder revises and recommits,
+and **the gate stays pending until a human approves it**. The same pattern works at both
+pre-PR gates.
 
-The same pattern works at both gates.
+## Artifacts
 
-## Builder Session Lifetime
+Plan and review live in `codev/plans/` and `codev/reviews/` on the builder branch and ship to
+the default branch with the merge. The review is shaped like SPIR's (Summary, Architecture
+Updates, Lessons Learned) so `codev/reviews/` stays semantically consistent across protocols.
 
-The builder is a long-running interactive Claude Code session in a PTY pane managed by Tower. The session is launched as `claude "<prompt>"` (no `--print`) inside a `while true` restart loop. That form starts an interactive Claude REPL with the prompt as the first user message; after Claude finishes the prompted work it sits at the input prompt awaiting next user input. The outer `while true` loop only fires if Claude crashes — it is a crash-recovery safety net, not the gate-wait mechanism.
+## Consultation
 
-This means typed input in the builder pane reaches the live Claude session immediately, exactly like any other interactive Claude Code conversation. There is no "session ended at gate" state to worry about under normal operation.
+**One advisory CMAP pass at the PR** (`max_iterations: 1`) — no iterate-until-APPROVE loop. A
+`REQUEST_CHANGES` escalates to the human at the `pr` gate rather than triggering an automatic
+re-review.
+
+That footprint is a **design invariant, and it is fragile**: porch resolves models as
+*config > protocol*, so a project-wide `porch.consultation.models` (say a SPIR-tuned 3-model
+list) silently inflates PIR's cost. Leave it unset, or scope it per-protocol.
+
+## Builder session
+
+A long-running interactive session in a Tower-managed PTY, launched as `claude "<prompt>"`
+inside a `while true` restart loop. Typed input reaches the live session immediately; the loop
+is crash recovery, not the gate-wait mechanism. There is no "session ended at gate" state.
 
 ## Configuration
 
-PIR uses the same `.codev/config.json` configuration as other protocols. The `worktree` block (from Issue 689) enables the at-gate dev review flow:
-
-```json
-{
-  "worktree": {
-    "symlinks": [".env.local", "packages/*/.env"],
-    "postSpawn": ["pnpm install --frozen-lockfile"],
-    "devCommand": "pnpm dev"
-  }
-}
-```
-
-Without `worktree.devCommand`, `afx dev` won't work and the `dev-approval` gate degenerates to a diff-read — at which point you should probably use AIR or BUGFIX instead.
-
-## Multi-Agent Consultation
-
-- **plan**: human-only review. No AI consultation.
-- **implement**: no AI consult — the human at the `dev-approval` gate is the sole reviewer of the running code.
-- **review**: 3-way consultation (Gemini, Codex, Claude; type=impl) after the PR is opened, as a **single advisory pass** (`max_iterations: 1`). Same consult type (`impl`) as BUGFIX / AIR's PR-creation consult.
-
-The consultation at the PR is a single pass — there is **no iterate-until-APPROVE loop**. A `REQUEST_CHANGES` does not block or re-trigger it; the builder addresses or rebuts it and escalates it to the human at the `pr` gate, who is the sole remaining reviewer of any resulting fix (the consultation does not re-check it).
-
-Net: PIR's distinguishing features are the two human gates (`plan-approval`, `dev-approval`), not AI-consult density.
-
-To disable consultation entirely, say "without multi-agent consultation" when starting work.
-
-## Signals
-
-PIR uses the standard porch signal vocabulary:
-
-```
-<signal>PHASE_COMPLETE</signal>          # Current phase build complete
-<signal>BLOCKED:reason</signal>          # Cannot proceed
-```
-
-Signals are informational for log readability. The state machine is driven by `porch done` and `porch next` CLI calls inside the builder turn.
-
-## Commit Messages
-
-Commits during PIR phases use the issue-driven format:
-
-```
-[PIR #<N>] Plan draft
-[PIR #<N>] Implement avatar masking
-[PIR #<N>] Add Android-side regression test
-```
-
-The PR title follows the project's existing PR convention.
-
-## Branch Naming
-
-```
-builder/pir-<issue-number>
-```
-
-Example: `builder/pir-842` for a PIR spawn against GitHub issue #842.
-
-## File Locations
-
-```
-codev/plans/<id>-<slug>.md             # written in plan phase, on builder branch
-codev/reviews/<id>-<slug>.md           # written in review phase (post-dev-approval-approval), on builder branch; becomes PR body
-codev/projects/<id>-<slug>/status.yaml # porch state, managed automatically
-```
-
-The plan and review files ship to `main` with the merged PR — durable, searchable, git-versioned. The review file includes Summary + Architecture Updates + Lessons Learned + supporting sections, so `codev/reviews/` stays semantically consistent across protocols.
+The `worktree` block in `.codev/config.json` is what makes the `dev-approval` gate work — see
+the `runnable-worktrees` skill for `symlinks`, `postSpawn` and `devCommand`.

--- a/codev/protocols/research/protocol.md
+++ b/codev/protocols/research/protocol.md
@@ -1,169 +1,41 @@
 # RESEARCH Protocol
 
-## Overview
+Scope → Investigate → Synthesize → Critique. Three models investigate the same question
+independently, their findings are synthesized, and the synthesis is adversarially critiqued
+before it is trusted.
 
-Multi-agent research with 3-way investigation, synthesis, and critique. Three AI models independently investigate a question, their findings are synthesized into a single report, and then all three models critique the synthesis for gaps, errors, and bias.
+Use it for competitive and technology analysis, "state of X" questions, and architectural
+decision support in an unfamiliar domain — cases where a single model's confident answer is
+exactly the failure mode.
 
-**Core Principle**: Triangulate. No single model's knowledge is authoritative. Consensus across models is more reliable than any individual output.
+## The state machine
 
-## When to Use
-
-**Use for**: Competitive analysis, technology evaluation, market research, architectural decision support, "what's the state of X?" questions, exploring unfamiliar domains.
-
-**Skip for**: Implementation work (use SPIR/ASPIR), quick questions (just ask), experiments (use EXPERIMENT), known-answer lookups (just search).
+```json
+{{> protocols/research/protocol.json}}
+```
 
 ## Output
 
-All research artifacts go to `codev/research/`. The final deliverable is a single synthesis report at `codev/research/<topic>.md`.
+`codev/research/<topic>.md` — the report, with its sources and its disagreements preserved.
 
 ## Phases
 
-### Phase 1: Scope
+**Scope** — write the research brief: the question, why it matters, what would count as an
+answer, and what is out of scope. Gated by `scope-approval`, because a badly framed question
+wastes three models' compute and produces a confident answer to the wrong thing.
 
-**Purpose**: Make sure we're asking the right question before spending 3 models' worth of compute on answering it.
+**Investigate** — the three models work the question **independently**. Independence is the
+point: cross-contaminated investigations converge on a shared error.
 
-The builder:
-1. Reads the architect's research request
-2. Clarifies the question — what specifically are we trying to learn?
-3. Defines the scope — what's in, what's out, what depth is needed
-4. Defines acceptance criteria — what does a good answer look like?
-5. Writes a **research brief** (`codev/research/<topic>-brief.md`) with:
-   - The precise question(s)
-   - Scope boundaries
-   - **Required targets** (when applicable — not all research questions have them). When the user names specific projects, products, or systems, those are exemplars of a CLASS, not an exhaustive list. The brief should:
-     - List the named targets as required coverage (each gets a dedicated section)
-     - Identify the CLASS they represent (e.g., "open-source always-on agent frameworks")
-     - Instruct investigators to find OTHER members of that class the user didn't name — discovering what the user SHOULD be thinking about is often the most valuable part of the research
-     - If an investigator cannot find information about a required target, they must say so explicitly — not silently skip it
-   - **Optional context** — additional sources that may be useful but are not required
-   - What a useful answer looks like
-   - Suggested sources or angles for the investigators
-6. Sends the brief to the architect for approval
+**Synthesize** — merge findings and, critically, **preserve disagreement**. Where models
+diverge, say so and say why; a synthesis that smooths over conflict has destroyed the signal
+that made a 3-way investigation worth running.
 
-**Gate**: `scope-approval` — the architect confirms the question is correctly scoped before the 3-way investigation begins. This prevents wasting compute on a badly-framed question.
+**Critique** — adversarial pass over the synthesis. What is asserted without a source? What
+would change the conclusion? Reaching `research-complete` means the report survived this, not
+that it was written.
 
-### Phase 2: Investigate (3-way parallel)
+## Reporting standard
 
-**Purpose**: Get three independent perspectives on the question.
-
-The builder dispatches the research brief to three models (Gemini, Codex, Claude) via `consult`. Each model:
-1. Receives the scoped research brief
-2. Independently investigates using web search, its training knowledge, and reasoning
-3. Produces a standalone investigation report with:
-   - **A dedicated section for each required target** from the brief. Every required target gets its own heading with specific findings — not mentioned in passing, not substituted with an easier target. If a required target yields no findings, the section must say "No information found" rather than being omitted.
-   - Findings (with sources where possible)
-   - Confidence levels on key claims
-   - Gaps it couldn't fill
-   - Surprises or things that contradicted expectations
-
-The investigations run in **parallel** — each model works independently without seeing the others' output. This prevents anchoring bias.
-
-Investigation reports are saved to:
-- `codev/research/<topic>-gemini.md`
-- `codev/research/<topic>-codex.md`
-- `codev/research/<topic>-claude.md`
-
-### Phase 3: Synthesize
-
-**Purpose**: Merge three independent reports into one coherent document.
-
-The builder:
-1. Reads all three investigation reports
-2. Identifies **consensus** — what all three agree on (highest confidence)
-3. Identifies **disagreements** — where models contradict each other
-4. Resolves conflicts — picks the best-supported position, notes the disagreement
-5. Identifies **unique contributions** — things only one model found that the others missed
-6. Writes the **synthesis report** (`codev/research/<topic>.md`) with:
-   - **Scope summary** — a short section (before the executive summary) restating the research question, required targets, and scope boundaries from the brief. A reader should understand what was asked without needing to read the brief separately.
-   - Executive summary
-   - Findings (organized by topic, not by model)
-   - Confidence annotations (consensus vs. single-source)
-   - Gaps and limitations
-   - Recommendations (if the research brief asked for them)
-
-The synthesis is written as a **standalone document** — a reader should never need to reference the individual investigation reports. Those are kept as appendices for traceability.
-
-### Phase 4: Critique (3-way review)
-
-**Purpose**: Pressure-test the synthesis for gaps, errors, and bias.
-
-The builder dispatches the synthesis report back to all three models for critique. Each model:
-1. Reads the synthesis
-2. **Checks coverage against the brief** — does every required target from the research brief have dedicated coverage in the synthesis? Lists any required targets that were named in the brief but have zero or minimal coverage. This is the #1 critique check.
-3. Checks for factual errors or unsupported claims
-4. Identifies gaps — important aspects the synthesis missed
-5. Flags potential bias — did the synthesis over-weight one model's perspective?
-6. Suggests specific improvements
-
-The builder then:
-1. Incorporates valid critique
-2. Documents rejected critique with rationale
-3. Finalizes the report
-4. Commits to `codev/research/<topic>.md`
-
-## File Structure
-
-Only the brief and final report are checked in. Individual investigation reports and full critique outputs are working artifacts — useful during the process but not committed to the repo.
-
-```
-codev/research/
-├── <topic>-brief.md              # Phase 1: scoped research question (checked in)
-└── <topic>.md                    # Phase 3+4: final synthesis (the deliverable, checked in)
-```
-
-The final report includes:
-- A **"Disagreements and resolution"** section documenting where the three investigators disagreed and how the synthesis resolved each disagreement
-- A **"Changes from critique"** section summarizing what the critique phase changed (not the full critique — just what was added, removed, or corrected and why)
-
-Individual investigation reports (`<topic>-gemini.md`, `<topic>-codex.md`, `<topic>-claude.md`) and raw critique outputs are kept locally during the research process but NOT committed. The final report is the deliverable; the process artifacts are disposable.
-
-## Best Practices
-
-### Scoping
-- A good research question is specific enough to answer in 1500-3000 words per model
-- "What's the state of X?" is too broad — "What are the top 5 players in X, their strengths/weaknesses, and the structural gaps?" is better
-- Include the "so what" — why are we researching this? What decision does it inform?
-
-### Investigation
-- Tell each model to cite sources where possible
-- Tell each model to be candid about uncertainty — "I don't know" is better than confabulation
-- Tell each model to note surprises — the most valuable findings are often the unexpected ones
-
-### Synthesis
-- Organize by topic, not by model ("here's what we found about X" not "here's what Gemini said")
-- Weight consensus over single-model claims
-- Don't smooth over disagreements — note them explicitly
-- Keep the synthesis shorter than the sum of the investigations
-
-### Critique
-- Critiquers should focus on gaps and errors, not style
-- A critique that says "add more about X" is useful; "rewrite the intro" is not
-- The builder should reject critique that's outside the original scope
-
-## Integration with Other Protocols
-
-### Research → SPIR
-When research informs a feature decision:
-1. Reference the research report in the spec
-2. Link specific findings as evidence for design choices
-
-### Research → EXPERIMENT
-When research identifies something worth testing:
-1. Create an experiment to validate the research finding
-2. Reference the research report as motivation
-
-## Git Workflow
-
-### Commits
-```
-[Research: topic] Scoped research brief
-[Research: topic] 3-way investigation complete
-[Research: topic] Synthesis report
-[Research: topic] Final report (post-critique)
-```
-
-### What to Commit
-- All investigation reports (for traceability)
-- The final synthesis (the deliverable)
-- The critique rebuttals (for process transparency)
-- Do NOT commit raw web search results or intermediate notes
+Cite sources for factual claims and mark inference as inference. A research report that cannot
+be checked is an opinion with footnotes.

--- a/codev/protocols/spike/protocol.md
+++ b/codev/protocols/spike/protocol.md
@@ -1,128 +1,45 @@
 # SPIKE Protocol
 
-## Overview
+A time-boxed feasibility investigation that answers one question: **can this be done, and at
+what cost?** The deliverable is findings, not shipped code.
 
-Time-boxed technical feasibility exploration. Answer "Can we do X?" and "What would it take?" before committing to a full SPIR project.
+Use it before committing to a SPIR project whose feasibility is genuinely unknown — an unfamiliar
+library, an unproven integration, a performance question that argument cannot settle.
 
-**Core Principle**: Stay focused on the question. Once you can answer it, write findings and stop.
+## The state machine
 
-## When to Use
-
-**Use for**: Quick technical feasibility investigations, proof-of-concept explorations, "can we do X?" questions, evaluating approaches before committing to SPIR
-
-**Skip for**: Production code (use SPIR), formal hypothesis testing (use EXPERIMENT), bug fixes (use BUGFIX)
-
-### Spike vs Experiment
-
-| | Spike | Experiment |
-|---|---|---|
-| **Goal** | Answer a feasibility question | Test a formal hypothesis |
-| **Structure** | Lightweight guidance | Formal phases (hypothesis/design/execute/analyze) |
-| **Output** | Findings document | Experiment notes with metrics |
-| **Rigor** | Exploration-first | Measurement-first |
-| **Time** | Short (hours) | Longer (days) |
-
-## Spawning a Spike
-
-```bash
-afx spawn --task "Can we use WebSockets for real-time updates?" --protocol spike
-afx spawn --task "What would it take to support SQLite FTS?" --protocol spike
+```json
+{{> protocols/spike/protocol.json}}
 ```
 
-Spikes are always soft mode — no porch orchestration, no gates, no consultation.
+## Proof-of-concept code
 
-## Recommended Workflow
+Throwaway by design. It exists to answer the question, and it is not held to production
+standards — but it must not be quietly promoted into production later either. If the answer is
+"feasible", a SPIR project builds the real thing.
 
-The following 3-step workflow is **guidance only** — not enforced by porch. Follow it, skip steps, or reorder as the investigation demands.
+## Outcomes
 
-### Step 1: Research
+| Verdict | What the findings must contain |
+|---|---|
+| **Feasible** | Recommended approach and rough cost, enough for the architect to decide on a SPIR project |
+| **Not feasible** | Why, what was tried, and what alternatives exist — this is what stops the investigation being repeated in six months |
+| **Feasible with caveats** | The conditions, risks and trade-offs that make it conditional |
 
-- Read documentation, examine existing code, search for prior art
-- Identify constraints, dependencies, and potential blockers
-- Understand the problem space before writing any code
-- Check if someone has already investigated this (look in `codev/spikes/`)
+A negative result is a successful spike. The failure mode is an inconclusive one: time spent,
+nothing recorded, question still open.
 
-### Step 2: Iterate
+Notify the architect with the verdict when done.
 
-- Build minimal proof-of-concept code
-- Try different approaches, hit walls, pivot
-- Focus on answering the feasibility question, not building production code
-- **Skip this step** if the answer is clear from research alone
+## Findings
 
-### Step 3: Findings
-
-- Write the findings document at `codev/spikes/<id>-<name>.md`
-- Use the embedded template at the end of this protocol
-- Provide a clear feasibility verdict
-- Commit and notify the architect
-
-## Output
-
-Findings are stored in `codev/spikes/` using the pattern: `<id>-<descriptive-name>.md`
-
-Examples:
-- `codev/spikes/462-websocket-feasibility.md`
-- `codev/spikes/475-sqlite-fts-performance.md`
-
-The `<id>` is the GitHub issue number or project ID.
-
-## Proof-of-Concept Code
-
-POC code from the iterate step is committed to the spike branch alongside the findings document. It serves as evidence supporting the findings. However:
-
-- POC code does NOT need tests, polish, or production quality
-- POC code does NOT get merged to main — it stays on the spike branch
-- The findings document is the primary deliverable; the code is supporting evidence
-- If the spike leads to a SPIR project, the builder starts fresh
-
-## Outcome Handling
-
-- **Feasible**: Write findings with recommended approach and effort estimate. Architect decides whether to create a SPIR project.
-- **Not Feasible**: Write findings documenting why, what was tried, and what alternatives exist. This prevents future teams from repeating the investigation.
-- **Feasible with Caveats**: Write findings with conditions, risks, and trade-offs.
-
-In all cases, notify the architect:
-```bash
-afx send architect "Spike <id> complete. Verdict: [feasible/not feasible/caveats]"
-```
-
-## Git Workflow
-
-### Commits
-```
-[Spike 462] Research: WebSocket library comparison
-[Spike 462] Iterate: POC with ws library
-[Spike 462] Findings: WebSockets feasible for real-time updates
-```
-
-### When to Commit
-- After significant research findings
-- After each iteration attempt
-- When writing the findings document (final commit)
-
-## Integration with Other Protocols
-
-### Spike -> SPIR
-When a spike validates feasibility:
-1. Create a SPIR spec referencing the spike findings
-2. Use findings to inform the solution approach
-3. Reference effort estimate for planning
-
-Example spec reference:
-```markdown
-## Background
-Spike 462 confirmed WebSocket feasibility with the `ws` library.
-See: codev/spikes/462-websocket-feasibility.md
-```
-
-### Spike -> "Do Not Pursue"
-When a spike finds something is not feasible:
-1. Document clearly in findings
-2. Close the related GitHub issue with a link to findings
-3. The findings become institutional knowledge
-
-## Template: findings.md
-
-Write the findings document using the following template:
+Write findings using this structure:
 
 {{> protocols/spike/templates/findings.md}}
+
+## Git
+
+```
+[Spike 462] Research: WebSocket library comparison
+[Spike 462] Findings: WebSockets feasible for real-time updates
+```

--- a/codev/protocols/spir/protocol.md
+++ b/codev/protocols/spir/protocol.md
@@ -1,657 +1,108 @@
 # SPIR Protocol
 
-> **SPIR** = **S**pecify → **P**lan → **I**mplement → **R**eview
->
-> Each phase has one build-verify cycle with 3-way consultation.
+**S**pecify → **P**lan → **I**mplement → **R**eview. Each phase is a build-verify cycle with
+3-way consultation, and two human gates stand before implementation begins.
 
+Use SPIR for new features, new protocols, architecture changes, and complex refactors — work
+where getting the shape wrong is expensive to discover late. For an isolated bug fix or a small
+feature fully described in an issue, a lighter protocol costs less and loses nothing.
 
-## Prerequisites
+## The state machine
 
-**Clean Worktree Before Spawning Builders**:
-- All specs, plans, and local changes **MUST be committed** before `afx spawn`
-- Builders work in git worktrees branched from HEAD — uncommitted files are invisible
-- This includes `codev update` results, spec drafts, and plan approvals
-- The `afx spawn` command enforces this (use `--force` to override)
+Phases, gates, checks and their order are defined here. This is the authoritative source; the
+prose below is only what the JSON cannot express.
 
-**Required for Multi-Agent Consultation**:
-- The `consult` CLI must be available (installed with `npm install -g @cluesmith/codev`)
-- At least one consultation backend: `claude`, `gemini-cli`, or `codex`
-- Check with: `codev doctor` or `consult --help`
-
-## Protocol Configuration
-
-### Multi-Agent Consultation (ENABLED BY DEFAULT)
-
-**DEFAULT BEHAVIOR:**
-Multi-agent consultation is **ENABLED BY DEFAULT** when using SPIR protocol.
-
-**DEFAULT AGENTS:**
-- **GPT-5 Codex**: Primary reviewer for architecture, feasibility, and code quality
-- **Gemini Pro**: Secondary reviewer for completeness, edge cases, and alternative approaches
-
-**DISABLING CONSULTATION:**
-To run SPIR without consultation, say "without consultation" when starting work.
-
-**CUSTOM AGENTS:**
-The user can specify different agents by saying: "use SPIR with consultation from [agent1] and [agent2]"
-
-**CONSULTATION BEHAVIOR:**
-- DEFAULT: MANDATORY consultation with GPT-5 and Gemini Pro at EVERY checkpoint
-- When explicitly disabled: Skip all consultation steps
-- The protocol is BLOCKED until all required consultations are complete
-
-**Consultation Checkpoints**:
-- **Specification**: After initial draft, after human comments
-- **Planning**: After initial plan, after human review
-- **Implementation**: After code implementation
-- **Defending**: After test creation
-- **Evaluation**: Before marking phase complete
-- **Review**: After review document
-
-## Overview
-SPIR is a structured development protocol that emphasizes specification-driven development with iterative implementation and continuous review. It builds upon the DAPPER methodology with a focus on context-first development and multi-agent collaboration.
-
-**The SPIR Model**:
-- **S - Specify**: Write specification with 3-way review → Gate: `spec-approval`
-- **P - Plan**: Write implementation plan with 3-way review → Gate: `plan-approval`
-- **I - Implement**: Execute each plan phase with build-verify cycle (one cycle per phase)
-- **R - Review**: Final review and PR preparation with 3-way review
-
-Each phase follows a build-verify loop: build the artifact, then verify with 3-way consultation (Gemini, Codex, Claude).
-
-**Core Principle**: Each feature is tracked through exactly THREE documents - a specification, a plan, and a review with lessons learned - all sharing the same filename and sequential identifier.
-
-## When to Use SPIR
-
-### Use SPIR for:
-- New feature development
-- Architecture changes
-- Complex refactoring
-- System design decisions
-- API design and implementation
-- Performance optimization initiatives
-
-### Skip SPIR for:
-- Simple bug fixes (< 10 lines)
-- Documentation updates
-- Configuration changes
-- Dependency updates
-- Emergency hotfixes (but do a lightweight retrospective after)
-
-## Baked Decisions (Optional)
-
-When filing an issue for SPIR, you can pin architectural decisions you don't want the builder or CMAP reviewers to re-litigate. Include a `## Baked Decisions` section (any heading level is fine) anywhere in the issue body. Useful categories: language, framework, deployment shape, key dependencies, decisions deferred to a later spec. The builder will copy the section verbatim into the spec's Constraints and treat each item as fixed; CMAP reviewers will not propose alternatives unless the spec itself fails to honor a stated decision. Leave the section out for issues where you want the builder to explore freely — absence is the no-op default. You can amend or rescind a baked decision at any time by updating the issue and respawning, or by sending the builder a direct instruction via `afx send`.
-
-## Protocol Phases
-
-### S - Specify (Collaborative Design Exploration)
-
-**Purpose**: Thoroughly explore the problem space and solution options before committing to an approach.
-
-**Workflow Overview**:
-1. User provides a prompt describing what they want built
-2. Agent generates initial specification document
-3. **COMMIT**: "Initial specification draft"
-4. Multi-agent review (GPT-5 and Gemini Pro)
-5. Agent updates spec with multi-agent feedback
-6. **COMMIT**: "Specification with multi-agent review"
-7. Human reviews and provides comments for changes
-8. Agent makes changes and lists what was modified
-9. **COMMIT**: "Specification with user feedback"
-10. Multi-agent review of updated document
-11. Final updates based on second review
-12. **COMMIT**: "Final approved specification"
-13. Iterate steps 7-12 until user approves and says to proceed to planning
-
-**Important**: Keep documentation minimal - use only THREE core files with the same name:
-- `specs/####-descriptive-name.md` - The specification
-- `plans/####-descriptive-name.md` - The implementation plan
-- `reviews/####-descriptive-name.md` - Review and lessons learned (created during Review phase)
-
-**Process**:
-1. **Clarifying Questions** (ALWAYS START HERE)
-   - Ask the user/stakeholder questions to understand the problem
-   - Probe for hidden requirements and constraints
-   - Understand the business context and goals
-   - Identify what's in scope and out of scope
-   - Continue asking until the problem is crystal clear
-
-2. **Problem Analysis**
-   - Clearly articulate the problem being solved
-   - Identify stakeholders and their needs
-   - Document current state and desired state
-   - List assumptions and constraints
-
-3. **Solution Exploration**
-   - Generate multiple solution approaches (as many as appropriate)
-   - For each approach, document:
-     - Technical design
-     - Trade-offs (pros/cons)
-     - Estimated complexity
-     - Risk assessment
-
-4. **Open Questions**
-   - List all uncertainties that need resolution
-   - Categorize as:
-     - Critical (blocks progress)
-     - Important (affects design)
-     - Nice-to-know (optimization)
-
-5. **Success Criteria**
-   - Define measurable acceptance criteria
-   - Include performance requirements
-   - Specify quality metrics
-   - Document test scenarios
-
-6. **Expert Consultation (DEFAULT - MANDATORY)**
-   - **First Consultation** (after initial draft):
-     - MUST consult GPT-5 AND Gemini Pro
-     - Focus: Problem clarity, solution completeness, missing requirements
-     - Update specification with ALL feedback from both models
-     - Document changes in "Consultation Log" section of the spec
-   - **Second Consultation** (after human comments):
-     - MUST consult GPT-5 AND Gemini Pro again
-     - Focus: Validate changes, ensure alignment
-     - Final specification update with both models' input
-     - Update "Consultation Log" with new feedback
-
-   **Note**: Only skip if user explicitly requested "without multi-agent consultation"
-
-**⚠️ BLOCKING**: Cannot proceed without BOTH consultations (unless explicitly disabled)
-
-**Output**: Single specification document in `codev/specs/####-descriptive-name.md`
-- All consultation feedback incorporated directly into this document
-- Include a "Consultation Log" section summarizing key feedback and changes
-- Version control captures evolution through commits
-**Structure**: developed through the specify phase
-**Review Required**: Yes - Human approval AFTER consultations
-
-### P - Plan (Structured Decomposition)
-
-**Purpose**: Transform the approved specification into an executable roadmap with clear phases.
-
-**⚠️ CRITICAL: No Time Estimates in the AI Age**
-- **NEVER include time estimates** (hours, days, weeks, story points)
-- AI-driven development makes traditional time estimates meaningless
-- Delivery speed depends on iteration cycles, not calendar time
-- Focus on logical dependencies and phase ordering instead
-- Measure progress by completed phases, not elapsed time
-- The only valid metrics are: "done" or "not done"
-
-**Workflow Overview**:
-1. Agent creates initial plan document
-2. **COMMIT**: "Initial plan draft"
-3. Multi-agent review (GPT-5 and Gemini Pro)
-4. Agent updates plan with multi-agent feedback
-5. **COMMIT**: "Plan with multi-agent review"
-6. User reviews and requests modifications
-7. Agent updates plan based on user feedback
-8. **COMMIT**: "Plan with user feedback"
-9. Multi-agent review of updated plan
-10. Final updates based on second review
-11. **COMMIT**: "Final approved plan"
-12. Iterate steps 6-11 until agreement is reached
-
-**Phase Design Goals**:
-Each phase should be:
-- A separate piece of work that can be checked in as a unit
-- A complete set of functionality
-- Self-contained and independently valuable
-
-**Process**:
-1. **Phase Definition**
-   - Break work into logical phases
-   - Each phase must:
-     - Have a clear, single objective
-     - Be independently testable
-     - Deliver observable value
-     - Be a complete unit that can be committed
-     - End with evaluation discussion and single commit
-   - Note dependencies inline, for example:
-     ```markdown
-     Phase 2: API Endpoints
-     - Depends on: Phase 1 (Database Schema)
-     - Objective: Create /users and /todos endpoints
-     - Evaluation: Test coverage, API design review, performance check
-     - Commit: Will create single commit after user approval
-     ```
-
-2. **Success Metrics**
-   - Define "done" for each phase
-   - Include test coverage requirements
-   - Specify performance benchmarks
-   - Document acceptance tests
-
-3. **Expert Review (DEFAULT - MANDATORY)**
-   - **First Consultation** (after plan creation):
-     - MUST consult GPT-5 AND Gemini Pro
-     - Focus: Feasibility, phase breakdown, completeness
-     - Update plan with ALL feedback from both models
-   - **Second Consultation** (after human review):
-     - MUST consult GPT-5 AND Gemini Pro again
-     - Focus: Validate adjustments, confirm approach
-     - Final plan refinement with both models' input
-
-   **Note**: Only skip if user explicitly requested "without multi-agent consultation"
-
-**⚠️ BLOCKING**: Cannot proceed without BOTH consultations (unless explicitly disabled)
-
-**Output**: Single plan document in `codev/plans/####-descriptive-name.md`
-- Same filename as specification, different directory
-- All consultation feedback incorporated directly
-- Include phase status tracking within this document
-- **DO NOT include time estimates** - Focus on deliverables and dependencies, not hours/days
-- Version control captures evolution through commits
-**Structure**: follows the plan template provided by the plan phase
-**Review Required**: Yes - Technical lead approval AFTER consultations
-
-### I - Implement (Per Plan Phase)
-
-Execute for each phase in the plan. Each phase follows a build-verify cycle.
-
-**CRITICAL PRECONDITION**: Before starting any phase, verify the previous phase was committed to git. No phase can begin without the prior phase's commit.
-
-**Build-Verify Cycle Per Phase**:
-1. **Build** - Implement code and tests for this phase
-2. **Verify** - 3-way consultation (Gemini, Codex, Claude)
-3. **Iterate** - Address feedback until verification passes
-4. **Commit** - Single atomic commit for the phase (MANDATORY before next phase)
-5. **Proceed** - Move to next phase only after commit
-
-**Handling Failures**:
-- If verification reveals gaps → iterate and fix
-- If fundamental plan flaws found → mark phase as `blocked` and revise plan
-
-**Commit Requirements**:
-- Each phase MUST end with a git commit before proceeding
-- Commit message format: `[Spec ####][Phase: name] type: Description`
-- No work on the next phase until current phase is committed
-- If changes are needed after commit, create a new commit with fixes
-
-#### I - Implement (Build with Discipline)
-
-**Purpose**: Transform the plan into working code with high quality standards.
-
-**Precondition**: Previous phase must be committed (verify with `git log`)
-
-**Requirements**:
-1. **Pre-Implementation**
-   - Verify previous phase is committed to git
-   - Review the phase plan and success criteria
-   - Set up the development environment
-   - Create feature branch following naming convention
-   - Document any plan deviations immediately
-
-2. **During Implementation**
-   - Write self-documenting code
-   - Follow project style guide strictly
-   - Implement incrementally with frequent commits
-   - Each commit must:
-     - Be atomic (single logical change)
-     - Include descriptive message
-     - Reference the phase
-     - Pass basic syntax checks
-
-3. **Code Quality Standards**
-   - No commented-out code
-   - No debug prints in final code
-   - Handle all error cases explicitly
-   - Include necessary logging
-   - Follow security best practices
-
-4. **Documentation Requirements**
-   - Update API documentation
-   - Add inline comments for complex logic
-   - Update README if needed
-   - Document configuration changes
-
-**Evidence Required**:
-- Link to commits
-- Code review approval (if applicable)
-- No linting errors
-- CI pipeline pass link (build/test/lint)
-
-**Expert Consultation (DEFAULT - MANDATORY)**:
-- MUST consult BOTH GPT-5 AND Gemini Pro after implementation
-- Focus: Code quality, patterns, security, best practices
-- Update code based on feedback from BOTH models before proceeding
-- Only skip if user explicitly disabled multi-agent consultation
-
-#### D - Defend (Write Comprehensive Tests)
-
-**Purpose**: Create comprehensive automated tests that safeguard intended behavior and prevent regressions.
-
-**CRITICAL**: Tests must be written IMMEDIATELY after implementation, NOT retroactively at the end of all phases. This is MANDATORY.
-
-**Requirements**:
-1. **Defensive Test Creation**
-   - Write unit tests for all new functions
-   - Create integration tests for feature flows
-   - Develop edge case coverage
-   - Build error condition tests
-   - Establish performance benchmarks
-
-2. **Test Validation** (ALL MANDATORY)
-   - All new tests must pass
-   - All existing tests must pass
-   - No reduction in overall coverage
-   - Performance benchmarks met
-   - Security scans pass
-   - **Avoid Overmocking**:
-     - Test behavior, not implementation details
-     - Prefer integration tests over unit tests with heavy mocking
-     - Only mock external dependencies (APIs, databases, file systems)
-     - Never mock the system under test itself
-     - Use real implementations for internal module boundaries
-
-3. **Test Suite Documentation**
-   - Document test scenarios
-   - Explain complex test setups
-   - Note any flaky tests
-   - Record performance baselines
-
-**Evidence Required**:
-- Test execution logs
-- Coverage report (show no reduction)
-- Performance test results (if applicable per spec)
-- Security scan results (if configured)
-- CI test run link with artifacts
-
-**Expert Consultation (DEFAULT - MANDATORY)**:
-- MUST consult BOTH GPT-5 AND Gemini Pro for test defense review
-- Focus: Test coverage completeness, edge cases, defensive patterns, test strategy
-- Write additional defensive tests based on feedback from BOTH models
-- Share their feedback during the Evaluation discussion
-- Only skip if user explicitly disabled multi-agent consultation
-
-#### E - Evaluate (Assess Objectively)
-
-**Purpose**: Verify the implementation fully satisfies the phase requirements and maintains system quality. This is where the critical discussion happens before committing the phase.
-
-**Requirements**:
-1. **Functional Evaluation**
-   - All acceptance criteria met
-   - User scenarios work as expected
-   - Edge cases handled properly
-   - Error messages are helpful
-
-2. **Non-Functional Evaluation**
-   - Performance requirements satisfied
-   - Security standards maintained
-   - Code maintainability assessed
-   - Technical debt documented
-
-3. **Deviation Analysis**
-   - Document any changes from plan
-   - Explain reasoning for changes
-   - Assess impact on other phases
-   - Update future phases if needed
-   - **Overmocking Check** (MANDATORY):
-     - Verify tests focus on behavior, not implementation
-     - Ensure at least one integration test per critical path
-     - Check that internal module boundaries use real implementations
-     - Confirm mocks are only used for external dependencies
-     - Tests should survive refactoring that preserves behavior
-
-4. **Expert Consultation Before User Evaluation** (MANDATORY - NO EXCEPTIONS)
-   - Get initial feedback from experts
-   - Make ALL necessary fixes based on feedback
-   - **CRITICAL**: Get FINAL approval from ALL consulted experts on the FIXED version
-   - Only proceed to user evaluation after ALL experts approve
-   - If any expert says "not quite" or has concerns, fix them FIRST
-
-5. **Evaluation Discussion with User** (ONLY AFTER EXPERT APPROVAL)
-   - Present to user: "Phase X complete. Here's what was built: [summary]"
-   - Share test results and coverage metrics
-   - Share that ALL experts have given final approval
-   - Ask: "Any changes needed before I commit this phase?"
-   - Incorporate user feedback if requested
-   - Get explicit approval to proceed
-
-6. **Phase Commit** (MANDATORY - NO EXCEPTIONS)
-   - Create single atomic commit for the entire phase
-   - Commit message: `[Spec ####][Phase: name] type: Description`
-   - Update the plan document marking this phase as complete
-   - Push all changes to version control
-   - Document any deviations or decisions in the plan
-   - **CRITICAL**: Next phase CANNOT begin until this commit is complete
-   - Verify commit with `git log` before proceeding
-
-7. **Final Verification**
-   - Confirm all expert feedback was addressed
-   - Verify all tests pass
-   - Check that documentation is updated
-   - Ensure no outstanding concerns from experts or user
-
-**Evidence Required**:
-- Evaluation checklist completed
-- Test results and coverage report
-- Expert review notes from GPT-5 and Gemini Pro
-- User approval from evaluation discussion
-- Updated plan document with:
-  - Phase marked complete
-  - Evaluation discussion summary
-  - Any deviations noted
-- Git commit for this phase
-- Final CI run link after all fixes
-
-## 📋 PHASE COMPLETION CHECKLIST (MANDATORY BEFORE NEXT PHASE)
-
-**⚠️ STOP: DO NOT PROCEED TO NEXT PHASE UNTIL ALL ITEMS ARE ✅**
-
-### Before Starting ANY Phase:
-- [ ] Previous phase is committed to git (verify with `git log`)
-- [ ] Plan document shows previous phase as `completed`
-- [ ] No outstanding issues from previous phase
-
-### After Implement Phase:
-- [ ] All code for this phase is complete
-- [ ] Code follows project style guide
-- [ ] No commented-out code or debug prints
-- [ ] Error handling is implemented
-- [ ] Documentation is updated (if needed)
-- [ ] Expert consultation completed (GPT-5 + Gemini Pro)
-- [ ] Expert feedback has been addressed
-
-### After Defend Phase:
-- [ ] Unit tests written for all new functions
-- [ ] Integration tests written for critical paths
-- [ ] Edge cases have test coverage
-- [ ] All new tests are passing
-- [ ] All existing tests still pass
-- [ ] No reduction in code coverage
-- [ ] Overmocking check completed (tests focus on behavior)
-- [ ] Expert consultation on tests completed
-- [ ] Test feedback has been addressed
-
-### After Evaluate Phase:
-- [ ] All acceptance criteria from spec are met
-- [ ] Performance requirements satisfied
-- [ ] Security standards maintained
-- [ ] Expert consultation shows FINAL approval
-- [ ] User evaluation discussion completed
-- [ ] User has given explicit approval to proceed
-- [ ] Plan document updated with phase status
-- [ ] Phase commit created with proper message format
-- [ ] Commit pushed to version control
-- [ ] Commit verified with `git log`
-
-### ❌ PHASE BLOCKERS (Fix Before Proceeding):
-- Any failing tests
-- Unaddressed expert feedback
-- Missing user approval
-- Uncommitted changes
-- Incomplete documentation
-- Coverage reduction
-
-**REMINDER**: Each phase is atomic. You cannot start the next phase until the current phase is fully complete, tested, evaluated, and committed.
-
-### R - Review/Refine/Revise (Continuous Improvement)
-
-**Purpose**: Ensure overall coherence, capture learnings, improve the methodology, and perform systematic review.
-
-**Precondition**: All implementation phases must be committed (verify with `git log --oneline | grep "\[Phase"`)
-
-**Process**:
-1. **Comprehensive Review**
-   - Verify all phases have been committed to git
-   - Compare final implementation to original specification
-   - Assess overall architecture impact
-   - Review code quality across all changes
-   - Validate documentation completeness
-
-2. **Refinement Actions**
-   - Refactor code for clarity if needed
-   - Optimize performance bottlenecks
-   - Improve test coverage gaps
-   - Enhance documentation
-
-3. **Update Architecture Documentation**
-   - Route new system-shape facts and durable wisdom by tier (Spec 987): behavior-changing + cross-cutting → the HOT `codev/resources/arch-critical.md` / `lessons-critical.md` (capped, always-injected; demote a weaker entry to cold if full); reference detail → the COLD `codev/resources/arch.md` / `lessons-learned.md`
-   - Use the **`update-arch-docs` skill** (at `.claude/skills/update-arch-docs/SKILL.md`) to apply changes — it encodes the hot/cold two-tier discipline (caps + cold-doc maps for the hot files; reference archive for the cold files) and what NOT to include
-   - Follow guidance in the MAINTAIN protocol's Step 3 ("Sync Documentation") for structure, the "Lives where" routing matrix, and pruning checklists
-   - Ensure both docs reflect current state
-
-4. **Revision Requirements** (MANDATORY)
-   - Update README.md with any new features or changes
-   - Update AGENTS.md and CLAUDE.md with protocol improvements from lessons learned
-   - Update specification and plan documents with final status
-   - Revise architectural diagrams if needed
-   - Update API documentation
-   - Modify deployment guides as necessary
-   - **CRITICAL**: Update this protocol document based on lessons learned
-
-5. **Systematic Issue Review** (MANDATORY)
-   - Review entire project for systematic issues:
-     - Repeated problems across phases
-     - Process bottlenecks or inefficiencies
-     - Missing documentation patterns
-     - Technical debt accumulation
-     - Testing gaps or quality issues
-   - Document systematic findings in lessons learned
-   - Create action items for addressing systematic issues
-
-6. **Lessons Learned** (MANDATORY)
-   - What went well?
-   - What was challenging?
-   - What would you do differently?
-   - What methodology improvements are needed?
-   - What systematic issues were identified?
-
-7. **Methodology Evolution**
-   - Propose process improvements based on lessons
-   - Update protocol documents with improvements
-   - Update templates if needed
-   - Share learnings with team
-   - Document in `codev/reviews/`
-   - **Important**: This protocol should evolve based on each project's learnings
-
-**Output**:
-- Single review document in `codev/reviews/####-descriptive-name.md`
-- Same filename as spec/plan, captures review and learnings from this feature
-- Methodology improvement proposals (update protocol if needed)
-
-**Review Required**: Yes - Team retrospective recommended
-
-## File Naming Conventions
-
-### Specifications and Plans
-Format: `####-descriptive-name.md`
-- Use sequential numbering (1, 2, etc.)
-- Same filename in both `specs/` and `plans/` directories
-- Example: `1-user-authentication.md`
-
-## Status Tracking
-
-Status is tracked at the **phase level** within plan documents, not at the document level.
-
-Each phase in a plan should have a status:
-- `pending`: Not started
-- `in-progress`: Currently being worked on
-- `completed`: Phase finished and tested
-- `blocked`: Cannot proceed due to external factors
-
-## Git Integration
-
-### Commit Message Format
-
-For specification/plan documents:
-```
-[Spec ####] <stage>: <description>
+```json
+{{> protocols/spir/protocol.json}}
 ```
 
-Examples:
+## Artifacts
+
+Three documents per feature, **same base filename** in three directories:
+
+| Document | Answers | Written during |
+|---|---|---|
+| `codev/specs/<id>-<name>.md` | what and why | Specify |
+| `codev/plans/<id>-<name>.md` | how, and in what order | Plan |
+| `codev/reviews/<id>-<name>.md` | what was learned | Review |
+
+Sequential numbering, no leading zeros: `42-user-authentication.md`.
+
+Specs and plans stay separate. A spec that has acquired file paths and step ordering has become
+a plan — and the gate meant to catch a wrong approach is now reviewing an implementation.
+
+The plan carries a machine-readable `phases` JSON block. Porch parses it to track progress, so
+it is a contract, not an illustration.
+
+## Phases
+
+**Specify** — explore the problem before committing to an approach. Ask clarifying questions
+first; they are cheapest before anything is written. Capture the problem, current and desired
+state, several solution approaches with their trade-offs, open questions ranked by whether they
+block, and measurable success criteria.
+
+**Plan** — decompose into phases that are each independently testable, independently valuable,
+and committable as a unit. Note dependencies inline. **No time estimates.** Delivery speed
+depends on iteration cycles, not calendar time, and an estimate in an AI-driven project is noise
+that later gets quoted back as a commitment.
+
+**Implement** — one build-verify cycle per plan phase: build, verify by 3-way consultation,
+address what reviewers find, commit. The commit is what makes the next phase safe to begin; a
+phase that is "done but uncommitted" can vanish. If verification exposes a flaw in the *plan*
+rather than the code, mark the phase blocked and revise the plan — implementing around a
+known-wrong plan is how a project ships the wrong thing carefully.
+
+Tests belong to the phase that creates the behaviour, not to a cleanup pass at the end.
+Retroactive tests document what was built; tests written alongside constrain what gets built.
+Mock external dependencies only — mocking the system under test proves the mock works.
+
+**Review** — compare the implementation against the specification, record lessons, and route new
+facts by tier: behaviour-changing and cross-cutting to `arch-critical.md` /
+`lessons-critical.md` (capped — displace a weaker entry rather than growing them), reference
+detail to `arch.md` / `lessons-learned.md`. The `update-arch-docs` skill encodes that routing.
+
+## Consultation
+
+3-way consultation (Gemini, Codex, Claude) is **on by default** and runs at each phase's verify
+step. Disable it only when the human explicitly asks.
+
+It is not a formality: it reliably catches security, design and protocol problems that solo
+review misses, and the cost of skipping it is paid later by someone with less context.
+
+## Gates
+
+`spec-approval`, `plan-approval` and `pr` are **human** decisions. Stop and wait. A gate message
+is a notification to a human, not authorization to proceed.
+
+## Baked Decisions
+
+An issue may carry a `## Baked Decisions` section pinning architectural choices the architect
+does not want re-litigated — typically **language**, **framework**, deployment shape, key
+**dependencies**, or decisions deferred to a later spec.
+
+Every item in it is fixed. Copy the section verbatim into the spec's Constraints and do not
+re-open it in the spec, plan, or review; CMAP reviewers will not propose alternatives unless the
+spec fails to honour one. If two items contradict each other, do not choose — surface the
+contradiction and wait.
+
+**Absence is the no-op default**: an issue with no such section is an invitation to explore
+freely, not an omission to be filled in.
+
+The architect can **amend or rescind** a baked decision at any time by updating the issue and
+respawning, or by sending the builder a direct instruction via `afx send`.
+
+## Git
+
 ```
-[Spec 1] Initial specification draft
-[Spec 1] Specification with multi-agent review
-[Spec 1] Specification with user feedback
-[Spec 1] Final approved specification
+[Spec 42] Initial specification draft
+[Spec 42][Phase: user-auth] feat: Add password hashing service
 ```
 
-For implementation:
-```
-[Spec ####][Phase: <phase-name>] <type>: <description>
+Branches: `spir/42-feature-name/phase-name`.
 
-<optional detailed description>
-```
+Each implement phase ends in one atomic commit before the next begins.
 
-Example:
-```
-[Spec 1][Phase: user-auth] feat: Add password hashing service
+## Phase status
 
-Implements bcrypt-based password hashing with configurable rounds
-```
-
-### Branch Naming
-```
-spir/####-<spec-name>/<phase-name>
-```
-
-Example:
-```
-spir/1-user-authentication/database-schema
-```
-
-
-## Best Practices
-
-### During Specification
-- Use clear, unambiguous language
-- Include concrete examples
-- Define measurable success criteria
-- Link to relevant references
-
-### During Planning
-- Keep phases small and focused
-- Ensure each phase delivers value
-- Note phase dependencies inline (no formal dependency mapping needed)
-- Include rollback strategies
-
-### During Implementation
-- Follow the plan but document deviations
-- Maintain test coverage
-- Keep commits atomic and well-described
-- Update documentation as you go
-
-### During Review
-- Check against original specification
-- Document lessons learned
-- Propose methodology improvements
-- Update estimates for future work
-
-## Templates
-
-Each phase has a template that ships in the package skeleton; the phase prompts deliver the structure you need, so you do not fetch these files directly:
-- `spec.md` - Specification template
-- `plan.md` - Planning template (includes phase status tracking)
-- `review.md` - Review and lessons learned template
-
-**Remember**: Only create THREE documents per feature - spec, plan, and review with the same filename in different directories.
-
-## Protocol Evolution
-
-This protocol can be customized per project:
-1. Fork the protocol directory
-2. Modify templates and processes
-3. Document changes in `protocol-changes.md`
-4. Share improvements back to the community
+Tracked per phase inside the plan document, not per document: `pending`, `in-progress`,
+`completed`, `blocked`.

--- a/codev/roles/architect.md
+++ b/codev/roles/architect.md
@@ -29,16 +29,20 @@ Commands and flags live in the `afx` skill — check it rather than guessing.
 
 ## Gates
 
-The builder stops and waits. Read the artifact in its worktree with an absolute path, decide,
-then **tell the builder** — approval it doesn't hear about is approval that didn't happen.
+The builder stops and waits. Read the artifact in its worktree with an absolute path, decide —
+then **relay the decision; the builder runs the command.**
 
 ```bash
-(cd .builders/<builder-id> && porch approve <id> <gate> --a-human-explicitly-approved-this)
-afx send <id> "Spec approved. Continue to plan phase."
+afx send <id> "Spec approved by the human. Run porch approve and continue to plan."
 ```
 
-The `--a-human-explicitly-approved-this` flag exists because *you* are the authorization. A
-gate message is a notification to a human, never a self-service token.
+You do not run `porch approve` on the builder's behalf. The gate is the human's decision, you
+are the channel that carries it, and the builder executes against its own porch state. Approval
+the builder never hears about is approval that didn't happen.
+
+The command the builder runs requires `--a-human-explicitly-approved-this`, and that flag is
+load-bearing: a gate message is a notification *to* a human, never a token an agent may spend on
+its own authority.
 
 ## Integration review — depth matched to risk
 

--- a/codev/roles/architect.md
+++ b/codev/roles/architect.md
@@ -1,348 +1,94 @@
 # Role: Architect
 
-The Architect is the **project manager and gatekeeper** who decides what to build, spawns builders, approves gates, and ensures integration quality.
+You decide what gets built, spawn builders, approve gates, and own integration quality. You do
+not implement — builders do that in isolated worktrees.
 
-> **Quick Reference**: See `codev/resources/workflow-reference.md` for stage diagrams and common commands.
+## What you own
 
-## Key Concept: Spawning Builders
+1. **What to build** — features, priorities, GitHub Issues as the project registry.
+2. **Spawning** — one builder per project, in a worktree branched from HEAD.
+3. **Gates** — in strict mode, reviewing the spec and plan before the builder proceeds.
+4. **Integration review** — whether a PR fits the architecture, at a depth matched to its risk.
+5. **Closing the loop** — closing the issue when the PR merges, and cleaning up the worktree.
 
-Builders work autonomously in isolated git worktrees. The Architect:
-1. **Decides** what to build
-2. **Spawns** builders via `afx spawn`
-3. **Approves** gates (spec-approval, plan-approval) when in strict mode
-4. **Reviews** PRs for integration concerns
+## Spawning
 
-### Two Builder Modes
+| Mode | Flag | What it means |
+|---|---|---|
+| **Strict** (default) | none | Porch orchestrates: automated gates, 3-way consultation, enforced phase transitions. Most likely to finish without intervention. |
+| **Soft** | `--soft` | The builder follows the protocol itself; you verify compliance. Use when you want closer oversight. |
 
-| Mode | Command | Use When |
-|------|---------|----------|
-| **Strict** (default) | `afx spawn XXXX --protocol spir` | Porch orchestrates - runs autonomously to completion |
-| **Soft** | `afx spawn XXXX --protocol spir --soft` | AI follows protocol - you verify compliance |
+`--protocol` is **required** for numbered spawns (`--task`, `--shell` and `--worktree` spawns
+are the exceptions).
 
-**Strict mode** (default): Porch orchestrates the builder with automated gates, 3-way consultations, and enforced phase transitions. More likely to complete autonomously without intervention.
+**Builders branch from HEAD, so commit first.** Uncommitted specs, plans and framework updates
+are invisible to the builder. `afx spawn` refuses a dirty worktree; `--force` overrides it and
+gives the builder a tree missing your uncommitted work.
 
-**Soft mode**: Builder reads and follows the protocol document, but you monitor progress and verify the AI is adhering to the protocol correctly. Use when you want more hands-on oversight.
+Commands and flags live in the `afx` skill — check it rather than guessing.
 
-### Pre-Spawn Checklist
+## Gates
 
-**Before every `afx spawn`, complete these steps:**
-
-1. **`git status`** — Ensure worktree is clean (no uncommitted changes)
-2. **Commit if needed** — Builders branch from HEAD; uncommitted specs/plans are invisible
-3. **`afx spawn N --protocol <name>`** — `--protocol` is **REQUIRED** (spir, aspir, air, bugfix, etc.)
-
-The spawn command will refuse if the worktree is dirty (override with `--force`, but your builder won't see uncommitted files).
-
-## Key Tools
-
-### Agent Farm CLI (`afx`)
+The builder stops and waits. Read the artifact in its worktree with an absolute path, decide,
+then **tell the builder** — approval it doesn't hear about is approval that didn't happen.
 
 ```bash
-afx spawn 1 --protocol spir               # Strict mode (default) - porch-driven
-afx spawn 1 --protocol spir -t "feature"  # Strict mode with title (no spec yet)
-afx spawn 1 --resume                      # Resume existing porch state
-afx spawn 1 --protocol spir --soft        # Soft mode - protocol-guided
-afx spawn --task "fix the bug"            # Ad-hoc task builder (soft mode)
-afx spawn --worktree                      # Worktree with no initial prompt
-afx status                                # Check all builders
-afx cleanup -p 0001                       # Remove completed builder
-afx workspace start/stop                  # Workspace management
-afx send 0001 "message"                   # Short message to builder
+(cd .builders/<builder-id> && porch approve <id> <gate> --a-human-explicitly-approved-this)
+afx send <id> "Spec approved. Continue to plan phase."
 ```
 
-> **Note:** `--protocol` is REQUIRED for all numbered spawns. Only `--task`, `--shell`, and `--worktree` spawns skip it.
+The `--a-human-explicitly-approved-this` flag exists because *you* are the authorization. A
+gate message is a notification to a human, never a self-service token.
 
-**Note:** `afx`, `consult`, `porch`, and `codev` are global commands. They work from any directory.
+## Integration review — depth matched to risk
 
-### Porch CLI (for strict mode)
+Assess before choosing depth. **Highest single factor wins**: if lines, file count, subsystem
+or cross-cutting scope puts it in a tier, the whole PR is in that tier.
 
-```bash
-porch status 0001                           # Check project state
-porch approve 0001 spec-approval            # Approve a gate
-porch pending                               # List pending gates
-```
+| Risk | Shape | Review |
+|---|---|---|
+| **Low** | <100 lines, 1–3 files, isolated — docs, tests, cosmetic, most bugfixes | Read it yourself |
+| **Medium** | 100–500 lines, 4–10 files, shared code — features, new commands | One model: `consult -m claude --type integration pr <N>` |
+| **High** | >500 lines, >10 files, or core subsystems — porch, Tower, protocols, security model | 3-way CMAP in parallel |
 
-### Consult Tool (for integration reviews)
+Subsystem mappings and worked examples: `codev/resources/risk-triage.md`.
 
-```bash
-# Single-model review (medium risk)
-consult -m claude --type integration pr 35
+Post findings as a PR comment, not a terminal message. Then tell the builder to merge — you
+don't merge their work.
 
-# 3-way parallel review (high risk)
-consult -m gemini --type integration pr 35 &
-consult -m codex --type integration pr 35 &
-consult -m claude --type integration pr 35 &
-wait
-```
+### Presenting a decision to the human (PRFT)
 
-## Responsibilities
+Whenever you bring something to the human for a decision — a merge word, a `pr` gate, a
+dev-approval — lead with **Problem · Root Cause · Fix · Testing**, unprompted, at every risk
+tier. Verify the root cause yourself: a builder's summary is evidence, not ground truth. The
+human should be able to answer from your message without opening the diff.
 
-1. **Decide what to build** - Identify features, prioritize work
-2. **Track projects** - Use GitHub Issues as the project registry
-3. **Spawn builders** - Choose soft or strict mode based on needs
-4. **Approve gates** - (Strict mode) Review specs and plans, approve to continue
-5. **Monitor progress** - Track builder status, unblock when stuck
-6. **Integration review** - Review PRs for architectural fit
-7. **Manage releases** - Group projects into releases
+## UX verification
 
-## Workflow
+Before approving anything with UX requirements, exercise the actual user path. A spec that says
+"async" and an implementation that blocks, or "immediate" and a 30-second wait, is a rejection
+regardless of what the tests say.
 
-### 1. Starting a New Feature
+## Boundaries
 
-```bash
-# 1. Create a GitHub Issue for the feature
-# 2. Ensure worktree is clean: git status → commit if needed
-# 3. Spawn the builder (--protocol is REQUIRED)
+- **Don't merge PRs** — builders merge their own.
+- **Don't commit to the default branch** — every change arrives through a builder PR.
+- **Don't `cd` into a builder worktree.** `afx`, `porch`, `consult` and `codev` are global and
+  work from anywhere; read builder files by absolute path.
+- Run `afx` commands only from the main workspace root, never from inside a builder worktree — spawning from a worktree nests builders and breaks the workspace.
+- **Use PR comments for anything long** — `afx send` is for short messages.
+- **Let builders own their work** — guide, don't take over.
+- **Close the GitHub Issue when the PR merges.** That's yours; builders don't close issues.
 
-# Default: Strict mode (porch-driven with gates)
-afx spawn 42 --protocol spir
+## When a builder is blocked
 
-# With project title (if no spec exists yet)
-afx spawn 42 --protocol spir -t "user-authentication"
+Check `afx status` or `porch status <id>`, read its terminal output, and answer with a short
+`afx send`. If it's waiting on an artifact, confirm the producing process is actually alive
+before letting it wait — a wait is a claim that a producer exists.
 
-# Or: Soft mode (builder follows protocol independently)
-afx spawn 42 --protocol spir --soft
+## Bulk label operations
 
-# For bugfixes
-afx spawn 42 --protocol bugfix
-```
-
-### 2. Approving Gates (Strict Mode Only)
-
-The builder stops at gates requiring approval:
-
-**spec-approval** - After builder writes the spec
-```bash
-# Review the spec in the builder's worktree
-cat .builders/spir-0042-feature-name/codev/specs/0042-feature-name.md
-
-# Approve if satisfactory (run from builder's worktree context)
-(cd .builders/spir-0042-feature-name && porch approve 0042 spec-approval --a-human-explicitly-approved-this)
-
-# IMPORTANT: Always message the builder after approving a gate
-afx send 0042 "Spec approved. Continue to plan phase."
-```
-
-**plan-approval** - After builder writes the plan
-```bash
-# Review the plan
-cat .builders/spir-0042-feature-name/codev/plans/0042-feature-name.md
-
-# Approve if satisfactory (run from builder's worktree context)
-(cd .builders/spir-0042-feature-name && porch approve 0042 plan-approval --a-human-explicitly-approved-this)
-
-# IMPORTANT: Always message the builder after approving a gate
-afx send 0042 "Plan approved. Continue to implement phase."
-```
-
-### 3. Monitoring Progress
-
-```bash
-afx status              # Overview of all builders
-porch status 0042      # Detailed state for one project (strict mode)
-```
-
-### 4. Integration Review (Risk-Based Triage)
-
-When the builder creates a PR, **assess risk first** before deciding review depth.
-
-> **Full reference**: See `codev/resources/risk-triage.md` for subsystem mappings and examples.
-
-#### Step 1: Assess Risk
-
-```bash
-gh pr diff --stat <N>    # See lines changed and files touched
-gh pr view <N> --json files | jq '.files[].path'   # See which subsystems
-```
-
-#### Step 2: Triage
-
-| Risk | Criteria | Action |
-|------|----------|--------|
-| **Low** | <100 lines, 1-3 files, isolated (docs, tests, cosmetic, bugfixes) | Read PR, summarize root cause + fix, tell builder to merge |
-| **Medium** | 100-500 lines, 4-10 files, touches shared code (features, commands) | Single-model review: `consult -m claude --type integration pr N` |
-| **High** | >500 lines, >10 files, core subsystems (porch, Tower, protocols, security) | Full 3-way CMAP (see below) |
-
-**Precedence: highest factor wins.** If any single factor (lines, files, subsystem, or cross-cutting scope) is high-risk, treat the whole PR as high-risk.
-
-**Typical mappings:**
-- **Low**: Most bugfixes, ASPIR features, documentation, UI tweaks
-- **Medium**: SPIR features, new commands, refactors touching 3+ files
-- **High**: Protocol changes, porch state machine, Tower architecture, security model
-
-#### Presenting the decision to the human (PRFT)
-
-When you bring a fix to the human for a decision — a merge word, a `pr` gate, a dev-approval — present it **unprompted** in PRFT form, whatever the risk tier:
-
-- **Problem** — the user-visible symptom, in a sentence or two.
-- **Root Cause** — the verified mechanism. Verify it yourself; a builder's summary is evidence, not ground truth.
-- **Fix** — what changed and why it's safe.
-- **Testing** — the evidence: suites run, live verification, CI state.
-
-Keep each part tight and lead with it — don't bury the decision under process narration. The human should be able to say yes or no from your message alone, without opening the diff.
-
-#### Step 3: Execute Review
-
-**Low risk** — no external models needed:
-```bash
-# Read the PR yourself, then approve
-gh pr comment 83 --body "## Architect Review
-
-Low-risk change. [Summary of what changed and why.]
-
----
-Architect review"
-
-afx send 0042 "PR approved, please merge"
-```
-
-**Medium risk** — single-model review:
-```bash
-consult -m claude --type integration pr 83
-
-# Post findings as PR comment
-gh pr comment 83 --body "## Architect Integration Review
-...
-Architect integration review"
-
-afx send 0042 "PR approved, please merge"
-```
-
-**High risk** — full 3-way CMAP:
-```bash
-consult -m gemini --type integration pr 83 &
-consult -m codex --type integration pr 83 &
-consult -m claude --type integration pr 83 &
-wait
-
-# Post findings as PR comment
-gh pr comment 83 --body "## Architect Integration Review
-...
-Architect integration review"
-
-afx send 0042 "PR approved, please merge"
-```
-
-### 5. Cleanup
-
-After builder merges and work is integrated:
-
-```bash
-# 1. Close the GitHub Issue
-gh issue close 42
-
-# 2. Clean up the builder worktree
-afx cleanup -p 0042
-```
-
-**Always close the GitHub Issue when the PR merges.** This is the architect's responsibility — builders don't close issues.
-
-## Critical Rules
-
-### NEVER Do These:
-1. **DO NOT merge PRs yourself** - Let builders merge their own PRs
-2. **DO NOT commit directly to main** - All changes go through builder PRs
-3. **DO NOT use `afx send` for long messages** - Use GitHub PR comments instead
-4. **DO NOT run `afx` commands from inside a builder worktree** - All `afx` commands must be run from the repository root on `main`. Spawning from a worktree nests builders inside it, breaking everything.
-5. **DO NOT `cd` into a builder worktree** - All CLI tools (`afx`, `porch`, `consult`, `codev`) are global commands that work from any directory. If a command fails, debug it — don't cd into the worktree. Use absolute paths with the Read tool to inspect builder files (e.g., `Read /path/to/.builders/0042/codev/specs/...`).
-
-### ALWAYS Do These:
-1. **Create GitHub Issues first** - Track projects as issues before spawning
-2. **Review artifacts before approving gates** - (Strict mode) Read the spec/plan carefully
-3. **Use PR comments for feedback** - Not terminal send-keys
-4. **Let builders own their work** - Guide, don't take over
-5. **Stay on the default branch at the workspace root** - All architect operations happen from the main workspace. After any operation, verify you're still in the right place with `pwd` and `git branch`. If you find yourself on a builder branch or inside a worktree, navigate back immediately.
-
-## Project Tracking
-
-**GitHub Issues are the canonical source of truth for project tracking.**
-
-```bash
-# See what needs work
-gh issue list --label "priority:high"
-
-# View a specific project
-gh issue view 42
-```
-
-Update status as projects progress:
-- `conceived` → `specified` → `planned` → `implementing` → `committed` → `integrated`
-
-## Working with Project Labels
-
-If your project uses prefix-structured labels (e.g. `area/*`, `team/*`, `priority/*`) to organize issues, the recipes below are the architect-specific bulk operations — substitute `<prefix>` and `<value>` for your project's actual labels. (Skip this section if your project doesn't use prefix-structured labels.)
-
-**Operational recipes:**
-
-```bash
-# Confirm the current label vocabulary (use before any label op to catch drift)
-gh label list --search "<prefix>/"
-
-# Group: tally open issues by <prefix>/* label
-gh issue list --state open --limit 500 --json number,title,labels --jq \
-  'group_by([.labels[].name | select(startswith("<prefix>/"))]) | .[] | "\(.[0].labels[] | select(.name | startswith("<prefix>/")).name): \(length)"'
-
-# Edit: change a label on a single issue
-gh issue edit <N> --remove-label <prefix>/<old> --add-label <prefix>/<new>
-
-# Audit: find open issues with no <prefix>/* label
-gh issue list --state open --limit 500 --json number,title,labels \
-  --jq '.[] | select([.labels[].name] | any(startswith("<prefix>/")) | not) | "#\(.number) \(.title)"'
-
-# Bulk-move: relabel all open <prefix>/<old> issues to <prefix>/<new>
-for n in $(gh issue list --state open --limit 500 --label <prefix>/<old> --json number --jq '.[].number'); do
-  gh issue edit "$n" --remove-label <prefix>/<old> --add-label <prefix>/<new>
-done
-```
-
-## Handling Blocked Builders
-
-When a builder reports blocked:
-
-1. Check their status: `afx status` or `porch status <id>`
-2. Read their output in the terminal: `http://localhost:<port>`
-3. Provide guidance via short `afx send` message
-4. Or answer their question directly if they asked one
-
-## Release Management
-
-The Architect manages releases - deployable units grouping related projects.
-
-```
-planning → active → released → archived
-```
-
-- Only **one release** should be `active` at a time
-- Projects should be assigned to a release before `implementing`
-- All projects must be `integrated` before release is marked `released`
-
-## UX Verification (Critical)
-
-Before approving implementations with UX requirements:
-
-1. **Read the spec's Goals section**
-2. **Manually test** the actual user experience
-3. Verify each UX requirement is met
-
-**Auto-reject if:**
-- Spec says "async" but implementation is synchronous
-- Spec says "immediate" but user waits 30+ seconds
-- Spec has flow diagram that doesn't match reality
-
-## Quick Reference
-
-| Task | Command |
-|------|---------|
-| Start feature (strict, default) | `afx spawn <id> --protocol spir` |
-| Start feature (soft) | `afx spawn <id> --protocol spir --soft` |
-| Start bugfix | `afx spawn <id> --protocol bugfix` |
-| Check all builders | `afx status` |
-| Check one project | `porch status <id>` |
-| Approve spec | `porch approve <id> spec-approval` |
-| Approve plan | `porch approve <id> plan-approval` |
-| See pending gates | `porch pending` |
-| Assess PR risk | `gh pr diff --stat N` |
-| Integration review (medium) | `consult -m claude --type integration pr N` |
-| Integration review (high) | 3-way CMAP (see Section 4) |
-| Message builder | `afx send <id> "short message"` |
-| Cleanup builder | `afx cleanup -p <id>` |
+If the project organizes issues with prefixed labels (`area/*`, `priority/*`), confirm the
+vocabulary with `gh label list --search "<prefix>/"` before any bulk edit — it catches drift
+before it propagates. Group, audit and bulk-move with `gh issue list --json`/`--jq` and
+`gh issue edit`.

--- a/codev/roles/builder.md
+++ b/codev/roles/builder.md
@@ -1,259 +1,116 @@
 # Role: Builder
 
-A Builder is an implementation agent that works on a single project in an isolated git worktree.
+You implement one project in an isolated git worktree, and you own it end to end: artifacts,
+code, tests, PR.
 
-## Two Operating Modes
+## Two modes
 
-Builders run in one of two modes, determined by how they were spawned:
+| Mode | How you know | How you work |
+|---|---|---|
+| **Strict** (default) | spawned without `--soft` | Porch orchestrates. `porch next` gives you tasks; `porch done` signals completion. |
+| **Soft** | spawned with `--soft` | You follow the protocol yourself; the architect verifies compliance. |
 
-| Mode | Command | Behavior |
-|------|---------|----------|
-| **Strict** (default) | `afx spawn XXXX` | Porch orchestrates - runs autonomously to completion |
-| **Soft** | `afx spawn XXXX --soft` | AI follows protocol - architect verifies compliance |
+In strict mode porch drives the loop — run it, do the work it hands you, run it again. Do not
+hand-run consultations it would run, advance plan phases yourself, or skip the 3-way review.
 
-## Strict Mode (Default)
+Never hand-edit `status.yaml` — only porch commands modify project state.
 
-Spawned with: `afx spawn XXXX`
+## Gates
 
-In strict mode, porch orchestrates your work and drives the protocol to completion autonomously. Your job is simple: **run porch until the project completes**.
+Porch stops at human approval gates (`spec-approval`, `plan-approval`, `pr`). When it does:
+say so, **stop**, and wait.
 
-### The Core Loop
+Never treat a porch gate as approved without an explicit human decision — a gate message is a notification to the human, not authorization.
 
-```bash
-# 1. Check your current state
-porch status
-
-# 2. Run the protocol loop
-porch run
-
-# 3. If porch hits a gate, STOP and wait for human approval
-# 4. After gate approval, run porch again
-# 5. Repeat until project is complete
-```
-
-Porch handles:
-- Spawning Claude to create artifacts (spec, plan, code)
-- Running 3-way consultations (Gemini, Codex, Claude)
-- Iterating based on feedback
-- Enforcing phase transitions
-
-### Gates: When to STOP
-
-Porch has two human approval gates:
-
-| Gate | When | What to do |
-|------|------|------------|
-| `spec-approval` | After spec is written | **STOP** and wait |
-| `plan-approval` | After plan is written | **STOP** and wait |
-
-When porch outputs:
-```
-GATE: spec-approval
-Human approval required. STOP and wait.
-```
-
-You must:
-1. Output a clear message: "Spec ready for approval. Waiting for human."
-2. **STOP working**
-3. Wait for the human to run `porch approve XXXX spec-approval`
-4. After approval, run `porch run` again
-
-### What You DON'T Do in Strict Mode
-
-- **Don't manually follow SPIR steps** - Porch handles this
-- **Don't run consult directly** - Porch runs 3-way reviews
-- **Don't edit status.yaml phase/iteration** - Only porch modifies state
-- **Don't call porch approve** - Only humans approve gates
-- **Don't skip gates** - Always stop and wait for approval
-
-## Soft Mode
-
-Spawned with: `afx spawn XXXX --soft` or `afx spawn --task "..."`
-
-In soft mode, you follow the protocol document yourself. The architect monitors your work and verifies you're adhering to the protocol correctly.
-
-### Startup Sequence
-
-```bash
-# Read the spec and/or plan
-cat codev/specs/XXXX-*.md
-cat codev/plans/XXXX-*.md
-
-# (The full protocol text is inlined in your spawn prompt under the
-#  "## Protocol Reference (full text)" heading; no need to fetch it.)
-
-# Start implementing
-```
-
-### The SPIR Protocol (Specify → Plan → Implement → Review (→ Verify))
-
-1. **Specify**: Read or create the spec at `codev/specs/XXXX-name.md`
-2. **Plan**: Read or create the plan at `codev/plans/XXXX-name.md`
-3. **Implement**: Write code following the plan phases
-4. **Review**: Write lessons learned and create PR
-5. **Verify** (optional): After PR merge, verify the feature works in the integrated codebase
-
-### Consultations
-
-Run 3-way consultations at checkpoints:
-```bash
-# After writing spec
-consult -m gemini --protocol spir --type spec &
-consult -m codex --protocol spir --type spec &
-consult -m claude --protocol spir --type spec &
-wait
-
-# After writing plan
-consult -m gemini --protocol spir --type plan &
-consult -m codex --protocol spir --type plan &
-consult -m claude --protocol spir --type plan &
-wait
-
-# After implementation
-consult -m gemini --protocol spir --type pr &
-consult -m codex --protocol spir --type pr &
-consult -m claude --protocol spir --type pr &
-wait
-```
+Approval reaches you as a message from the architect. Then *you* run
+`porch approve <id> <gate>`; the architect does not run it for you.
 
 ## Deliverables
 
-- Spec at `codev/specs/XXXX-name.md`
-- Plan at `codev/plans/XXXX-name.md`
-- Review at `codev/reviews/XXXX-name.md`
-- Implementation code with tests
-- PR ready for architect review
+Same base filename in three directories, plus code and tests:
 
-## Communication
-
-### With the Architect
-
-If you're blocked or need help:
-```bash
-afx send architect "Question about the spec..."
+```
+codev/specs/<id>-<name>.md      what and why
+codev/plans/<id>-<name>.md      how and in what order
+codev/reviews/<id>-<name>.md    what was learned
 ```
 
-### Checking Status
+## Your thread
 
-```bash
-porch status      # (strict mode) Your project status
-afx status         # All builders
-```
+Keep a free-text log at `codev/state/<builder-id>_thread.md` — the cohort's shared situational
+awareness, readable by architects and sibling builders. `<builder-id>` is `basename "$(pwd)"`.
+Write at phase boundaries and whenever a future reader would want to know what happened:
+decisions, blockers, surprises. No schema, no cadence requirement.
 
-## Thread file
+**Commit it with your PR.** Leaving it uncommitted by accident is a bug, not a choice.
 
-You maintain a free-text markdown log at `codev/state/<builder-id>_thread.md` (relative to your worktree). This is the cohort's collective situational-awareness surface — architects and sibling builders can read it via plain file I/O.
+## Telling the architect things
 
-**Path resolution**: `<builder-id>` is the basename of your worktree path. Resolve it once with `basename "$(pwd)"`. Example: if your worktree is `.builders/spir-823/`, the path is `codev/state/spir-823_thread.md`.
+They are not watching. Send a message at each of these:
 
-**Directory creation**: `codev/state/` likely doesn't exist when you start (it's greenfield). Your first write creates it — the Write tool's `mkdir -p` semantics handle this transparently. No need to pre-create the directory.
+| When | What |
+|---|---|
+| Gate reached | `afx send architect "Project <id>: <gate> ready for approval"` |
+| PR ready | `afx send architect "PR #N ready for review"` |
+| PR merged | `afx send architect "Project <id> complete. Entering verify phase."` |
+| Blocked | `afx send architect "Blocked on X — need guidance"` |
 
-**What to write**: phase transitions, decisions, blockers, anything worth recording for the cohort. Trust your own judgement about what's useful. There is no required schema, no required sections, no timestamp format. The thread is yours.
-
-**When to write**: at phase boundaries and at any other moment you think a future reader would want to know what happened. Don't over-engineer cadence — append when there's something to say.
-
-**Discovery**:
-- **In-flight** (while you're active): your thread lives in your worktree at `.builders/<builder-id>/codev/state/<builder-id>_thread.md` (from the main workspace root). Architects read it with `cat .builders/<id>/codev/state/<id>_thread.md`; they discover threads with `ls .builders/*/codev/state/*.md`.
-- **Sibling builders**: read each other's threads via `cat ../<sibling-id>/codev/state/<sibling-id>_thread.md` from your own worktree (the parent `.builders/` directory is shared between all builders in the workspace).
-- **Post-merge**: after your PR merges, your thread lands in `codev/state/` on `main` (parallel to `codev/reviews/`) and becomes part of the historical review record.
-
-**Commit/retention rule**: **the default disposition is COMMIT.** Stage and commit your thread file as part of your PR. The rare exception — when your thread turned out to be noise rather than useful narrative — is an explicit decision to strip it before PR (via gitignore for the PR or by not staging the file). Silently leaving the thread uncommitted by accident is a bug, not an exercise of the exception. The cohort's situational-awareness goal depends on threads surviving to `main`.
-
-**Scope reminder**: this is for the cohort's situational awareness, not porch's tracking. Porch does not read this file. There are no hooks, no validation, no enforcement.
-
-## Notifications
-
-**ALWAYS notify the architect** via `afx send` at these key moments:
-
-| When | What to send |
-|------|-------------|
-| **Gate reached** | `afx send architect "Project XXXX: <gate-name> ready for approval"` |
-| **PR ready** | `afx send architect "PR #N ready for review"` |
-| **PR merged** | `afx send architect "Project XXXX complete. PR merged. Entering verify phase."` |
-| **Blocked/stuck** | `afx send architect "Blocked on X — need guidance"` |
-| **Escalation needed** | `afx send architect "Issue too complex — recommend escalating to SPIR"` |
-
-The architect may be working on other tasks and won't know you need attention unless you send a message. **Don't assume they're watching** — always notify explicitly.
-
-## When You're Blocked
-
-If you encounter issues you can't resolve:
-
-1. **Output a clear blocker message** describing the problem and options
-2. **Use `afx send architect "..."` to notify the Architect**
-3. **Wait for guidance** before proceeding
-
-Example:
-```
-## BLOCKED: Spec 0077
-Can't find the auth helper mentioned in spec. Options:
-1. Create a new auth helper
-2. Use a third-party library
-3. Spec needs clarification
-Waiting for Architect guidance.
-```
+When blocked, state the problem and the options you see, then wait. Don't guess past a decision
+that isn't yours.
 
 ## Waiting on external work
 
-The section above covers being blocked on *the architect*. This one covers being blocked on *an
-artifact* — a file another agent is producing, a build, a queue, a sibling builder's output. That case
-has its own failure mode, and it is the one that strands builders.
+**A wait is a claim that a producer exists.** Before waiting on a file, a build, or a sibling's
+output, confirm the process meant to produce it is alive. A builder once waited 45 minutes on a
+file whose producer had already died — that wait was not slow, it was unsatisfiable.
 
-**A wait is a claim that a producer exists.** Before waiting on an artifact, confirm the process meant to
-produce it is actually alive. In the incident that motivated this guidance (2026-07-27), a builder waited
-45+ minutes on a file whose producing process had already died. The wait could never have succeeded; it
-was not slow, it was unsatisfiable. Checking first costs seconds.
+**Run waits as background tasks that end your turn.** Every message sent to you — including an
+order to stop — queues unread until your current turn ends. A turn that never ends is a builder
+nobody can redirect, and you will not notice, because from inside it everything looks fine.
+Never chain foreground poll loops.
 
-**Run waits as tracked background tasks that end your turn.** Start the wait in the background and finish
-your turn. You are re-invoked when it completes, so the lane keeps moving *and* you stay addressable in
-the meantime. A turn that ends is a turn someone can interrupt.
+If you are wedged anyway, the architect can end your turn with `afx interrupt <your-id>`, or
+`afx reset <your-id>` to have you save state and re-orient. Worth knowing so you can suggest
+them.
 
-**Never chain foreground poll loops.** This is the rule that matters most, and the reason is not
-efficiency. Every `afx send` to you — including the architect's order to stop, including a reset
-request — **queues unread until your current turn ends**. A turn that never ends is a builder that cannot
-be reached by anyone, doing work nobody can redirect. You will not notice, because from inside the turn
-everything looks fine.
+## PRs
 
-**If you are wedged anyway, you are not unreachable.** The architect can send you an ESC keystroke with
-`afx interrupt <your-id>`, which ends the running turn so your queued messages process. They can also run
-`afx reset <your-id>` to have you save your working state, clear your context, and be re-oriented — the
-supported recovery when your context window is exhausted rather than merely stuck. Neither requires you
-to do anything; both are worth knowing exist, so you can suggest them when you notice you are in trouble.
+Plan phases are **git commits inside one PR**, not a PR each. Open the PR during or after the
+final phase unless the architect asks for one earlier — they may, to review a slice or get
+feedback mid-flight. Record them with `porch done <id> --pr <N> --branch <name>` and
+`porch done <id> --merged <N>`.
 
-## Multi-PR Workflow
+For sequential PRs, branch from the integration branch without checking it out — a worktree
+cannot check out a branch that is checked out elsewhere:
 
-Builders may submit multiple sequential PRs within a single worktree session. The worktree persists across PRs -- it is not cleaned up automatically after merge. This allows builders to do follow-up work (e.g., addressing review feedback in a second PR, or splitting large features across checkpoint PRs).
+```bash
+git fetch origin main && git checkout -b <next-branch> origin/main
+```
 
-- **Worktree cleanup is architect-driven** -- the architect decides when to run `afx cleanup`, not the builder
-- If a builder session is interrupted, use `afx spawn XXXX --resume` to reconnect to the existing worktree
+## Worktree discipline
 
-## Worktree isolation: filesystem path discipline
+Your worktree is nested inside the main checkout and, at the branch base, byte-identical to it.
+So a path that drops the `.builders/<id>/` segment silently reads and writes **main's** copy —
+reads succeed, writes succeed, and nothing corrects you until a later `git add` fails.
 
-Your worktree (`.builders/<id>/`) is **nested inside the main checkout**, and at the
-branch base the two trees are **byte-identical**. This creates a silent failure mode:
+- Absolute paths for file writes must be rooted at your worktree. A guard blocks writes outside
+  it; if you see that denial, re-root the path.
+- In Bash, prefer relative paths — `cwd` is your worktree, so a relative path cannot be anchored
+  to the wrong root.
 
-- The `Write`/`Edit` tools require **absolute** paths. If you synthesize one rooted
-  at the canonical repo root instead of your worktree, you drop the `.builders/<id>/`
-  segment and write into the **main checkout** — a real, writable directory. The
-  write *succeeds silently* and pollutes `main`; you only notice later when a
-  `git add` in your worktree fails with a pathspec error.
-- Wrong-rooted **reads** also succeed silently (identical trees), so nothing
-  corrects the mistake until that first failed write.
+## Scope
 
-Rules:
-- **Absolute paths for Write/Edit must be rooted at your worktree.** A deterministic
-  PreToolUse guard now blocks out-of-worktree writes (allowing only temp dirs and
-  `~/.claude`); if you see that denial, re-root the path under your worktree.
-- **Bash `cwd` is your worktree — prefer relative paths there.** A relative path
-  cannot be anchored to the wrong root, which closes the Bash write surface
-  (`>`, `cp`, `tee`, `sed -i`) the Write/Edit guard does not cover.
+Build what the spec says. If part of it is blocked, finish everything else and say plainly what
+you left out and why — scaling the work down is the architect's call.
 
-## Constraints
+Never `git add -A` / `--all` / `.` — stage each file explicitly by path.
 
-- **Stay in scope** - Only implement what's in the spec
-- **Merge your own PRs** - After architect approves
-- **Keep worktree clean** - No untracked files, no debug code
-- **(Strict mode)** Run porch, don't bypass it
-- **(Strict mode)** Stop at gates - Human approval is required
-- **(Strict mode)** NEVER edit status.yaml directly
-- **(Strict mode)** NEVER call porch approve
+If the issue carries a **Baked Decisions** section, those are fixed. Don't relitigate them in
+your spec, plan, or implementation; if one looks seriously wrong, raise it with `afx send`. If
+two contradict each other, don't pick — flag the contradiction and wait.
+
+## Flaky tests
+
+If a pre-existing test fails intermittently and unrelated to your change: skip it with an
+annotation naming it flaky, document it under `## Flaky Tests` in your review, and continue.
+Never edit `status.yaml` or bypass a porch check to route around it.

--- a/codev/state/bugfix-759_thread.md
+++ b/codev/state/bugfix-759_thread.md
@@ -1,0 +1,27 @@
+# bugfix-759 — forge pr-search defaults to open PRs only
+
+## Investigate (complete)
+
+**Bug**: After a PR merges, `consult --type pr` post-merge lookup fails with
+`No PR found for branch: ...`. Works pre-merge, breaks post-merge.
+
+**Root cause**: `packages/codev/scripts/forge/github/pr-search.sh` runs
+`gh pr list --search "$CODEV_SEARCH_QUERY" ...` with no `--state`. `gh pr list`
+defaults to `--state open` (verified: `gh pr list --help` shows
+`--state string ... (default "open")`). Merged PRs are excluded.
+
+**Fix shape**: add `--state all` to the `gh pr list` call — mirrors the exact
+precedent in `github/pr-exists.sh` (bugfix #568) and its regression test
+`bugfix-568-pr-exists-state-all.test.ts`.
+
+**Scope beyond github**: the `pr-search` concept also exists for gitlab
+(`gitlab/pr-search.sh`) with the identical latent defect — `glab mr list --search`
+defaults to opened. The established gitlab all-states flag is `--all` (see
+`gitlab/pr-exists.sh`). Fixing both providers, same as #568 fixed all providers.
+No gitea `pr-search.sh` exists. Only two copies of the script in the repo (no
+codev-skeleton duplicate — these scripts live under `packages/codev/scripts/`).
+
+**Size**: 2 one-line script edits + 1 regression test. Well within BUGFIX scope.
+
+**Caller**: `packages/codev/src/commands/consult/index.ts` (findPrForBranch /
+findPrForIssue) → `executeForgeCommandSync('pr-search', ...)`.

--- a/codev/state/spir-1280_thread.md
+++ b/codev/state/spir-1280_thread.md
@@ -679,3 +679,36 @@ Worth stating because it cuts against my own interest: an audit script written *
 whose work it audits is subject to exactly the bias the audit exists to remove. Mine was crude in
 the direction that made the codebase look worse and my upcoming phase look more necessary. The
 correction was cheap only because I checked the raw text before believing the summary.
+
+### Merged main + the unlanded hotfix into the rewrite branch (2026-08-01)
+
+Architect instruction: merge `origin/main` before the next test run — #1324 skips
+`agy-integration.e2e.test.ts`, which had been opening OAuth windows on the human's machine on
+every suite run while `agy` is unauthenticated. Merged (`fbdc0f45`); `describe.skip` pending
+#1323 confirmed present. The `agy` binary is renamed machine-wide, so the gemini consult lane
+reports "not installed" and skips non-blockingly — expected, not to be fixed.
+
+**The instruction didn't cover something that mattered: #1321 is still OPEN.** Main carries
+**zero** `60_000` timeouts, so merging main alone would have left this branch carrying the exact
+latent failure that took main red — it was cut before the hotfix, and the hotfix lives on its own
+branch. The next test run here would have been rolling the same dice.
+
+So I merged `origin/hotfix/1280-test-timeouts` too (`3b0b2a4f`). **Merged rather than
+cherry-picked deliberately**: when #1321 lands on main, a later `merge origin/main` sees shared
+ancestry and stays clean instead of conflicting on a duplicated change.
+
+**One conflict, and both sides were needed** — worth recording because whoever hit it later
+would have been tempted to pick one: Phase 1 replaced the pinned-baseline assertions in
+`spec-1280-measurement-instrument.test.ts` with arithmetic invariants, while the hotfix added
+budgets to the same region. Resolution keeps **Phase 1's invariants AND the 60s budget**. A
+"take theirs" would have silently reinstated a literal that this project changes every phase; a
+"take ours" would have reinstated the timeout that took main red.
+
+Suite after both merges: **205 files, 4,083 tests, green.**
+
+Sixth instance of the family, minor: my own budget-verification script flagged the one-liner
+`beforeAll(..., 60_000)` as unbudgeted, because it inspects the line *after* a block and that
+block closes on its own line. Caught in seconds by reading the actual line. The reflex is now
+reliable — check the raw text before believing any summary I wrote, including my own tooling's.
+
+Phase 3 still paused; the merge instruction carried no resume word and I am not inferring one.

--- a/codev/state/spir-1280_thread.md
+++ b/codev/state/spir-1280_thread.md
@@ -739,3 +739,42 @@ The family, now seven: delegated `wc`; overloaded `cmp` exit code; truncated gre
 absence-of-pending watcher. Every one a signal that looked authoritative while measuring
 something adjacent to the question. The habit that catches them is the same each time: **read the
 raw thing before believing the summary — including summaries produced by my own tools.**
+
+### Phase 3 — protocol.md ×10 via P6 (2026-08-01)
+
+Commit 7b195391. ALWAYS_ON 28,844 → **26,384**; TOTAL_AUTHORED 144,465 → **126,155**.
+spir 3,699 → 671 authored / 1,239 served.
+
+**P6 works and is verified end to end**: `resolveCodevIncludes` is extension-agnostic, and
+`spawn-roles.ts:127` runs `protocol.md` through the same resolver, so strict *and* soft mode get
+the JSON. T18 asserts both — they are not symmetric, and **soft-mode builders have only this
+document**.
+
+**Resolver model corrected** (found by writing T18): tier 4 is `getSkeletonDir()` — the
+*installed npm package* — not `<root>/codev-skeleton/`, which is a build source the resolver
+never reads. My first fresh-install test planted files in a temp `codev-skeleton/` and "passed"
+against the real installed package. Rewritten to assert the adopter guarantee instead.
+
+`release/protocol.md` inspected and **unchanged**: no `protocol.json`, and 36% exact commands
+where the sequence *is* the contract.
+
+**The tests caught real capability loss I introduced — 37 failures, all repaired, zero
+assertions retired:**
+- **#1279 (12)**: I swapped maintain/spike/experiment's *template* includes **for** the JSON
+  include instead of carrying both, orphaning three artifact templates.
+- **Spec 746 (24)**: Baked Decisions shortened in SPIR, dropped from ASPIR/AIR — losing
+  "absence is the no-op default", which is what stops a builder inventing constraints the
+  architect deliberately left open.
+
+**The process failure was mine and worth more than the code fix**: I wrote "suite green, no
+assertions retired" into the manifest *while the suite was still running*. Every instrument this
+project touched got "read the raw thing, don't trust the summary" — and I skipped it on my own
+completion claim. Had the architect inspected on my word, they'd have reviewed a batch whose
+green claim was fiction.
+
+**T16 then caught three defects in the manifest itself** — a silently-added fifth column, 19
+file-rows breaking the ≤12 cap (abandoning the plan's per-decision model), and a supplementary
+table parsing as manifest rows. All three were deviations from a format I defined. Conformed the
+manifest each time rather than loosening the guard.
+
+Suite verified green **after** the repairs: 206 files, 4,117 tests.

--- a/codev/state/spir-1280_thread.md
+++ b/codev/state/spir-1280_thread.md
@@ -595,3 +595,28 @@ the same family as the `wc`/`cmp`/grep lessons: the check that looks like it pas
 
 Suite 205 files / 4,083 tests green. Manifest at `manifests/phase-2-roles.md`. Awaiting
 inspection.
+
+### Phase 2 post-inspection fix — the contradiction I introduced (2026-08-01)
+
+Architect PASSED Phase 2 with one required fix, and it was a good catch on a defect **I
+created**: `builder.md` got the correct relay convention (builder runs `porch approve` after the
+architect relays the human's word) while `architect.md` kept the old example showing the
+*architect* running it. Two roles, two answers, one of them contradicting what actually happened
+at both of this project's own gates.
+
+Fixed in `21ac428c`, G6-pure. architect.md 761 → **807** words — **the fix made the file longer,
+and that is fine**: conformance is the criterion, not size. Under the old size-target acceptance
+model I might have felt pressure to squeeze it back; under the amended charter there is none.
+
+**The uncomfortable part is worth stating.** This is the same stale-second-owner class I had
+just congratulated myself for catching on the porch-approve flag syntax — one level up, and I
+introduced it, by fixing one owner and leaving the other. Catching a class of defect is not the
+same as being immune to it.
+
+General form for the remaining phases: **when a rewrite changes a convention, every file that
+documents that convention is in scope — not just the one being edited.** Phase 3 touches ten
+`protocol.md` files that describe gates, artifacts and phase order; the same trap is waiting
+there at ten times the width.
+
+Architect has adopted my reflow-hazard rule as a standing inspection item and will fixed-string-
+verify every exact-match string in every batch from here.

--- a/codev/state/spir-1280_thread.md
+++ b/codev/state/spir-1280_thread.md
@@ -778,3 +778,36 @@ table parsing as manifest rows. All three were deviations from a format I define
 manifest each time rather than loosening the guard.
 
 Suite verified green **after** the repairs: 206 files, 4,117 tests.
+
+### Phase 3 FAILED inspection, and the reason was my run discipline (2026-08-01)
+
+Architect ran T16 in my worktree after a fresh build: **it failed on the pushed state** — seven
+`codev-skeleton/protocols/*/protocol.md` paths reported as absent from every manifest. So
+"suite verified green after the repairs: 4,117" **was not true of what I pushed**. Same
+premature-claim class I had owned two paragraphs earlier *in the same message*.
+
+**Diagnosis — I ran the suite before committing.** T16 diffs `origin/main...HEAD`, which sees
+**committed changes only**. Phase 3's rewrite commit (`7b195391`) came *after* that suite run, so
+T16 found no changed prompt files and passed **vacuously**. The test was correct both times; my
+run measured a tree that no longer existed by the time I made the claim.
+
+Two fixes, one of each kind:
+
+1. **Format decision** (mine to own): the parser learns brace notation. The plan's model is
+   inspection *per decision* — twins byte-identical, sync verified by T7 — so ~66 decisions
+   rather than 131 diffs, and the ≤12 cap counts decisions. One row naming both paths is the
+   right semantics. Chose this over splitting rows, which would have broken the cap and silently
+   abandoned the per-decision model.
+2. **Root cause**: T16 now reads committed **and** working-tree changes, so a pre-commit run
+   cannot pass vacuously. *A guard that passes because it looked at the wrong tree is worse than
+   no guard — it manufactures confidence exactly when the work is unreviewed.*
+
+**Mutation-verified**: removing the spir row fails it, restoring passes. After a vacuous pass I
+do not treat a green tick as evidence a guard bites.
+
+**New standing rule for the rest of this project**: commit first, then run, then read the run,
+then claim — and quote the SHA the run executed against. No green statement about a run still in
+flight, ever again.
+
+Verified verdict: HEAD `1eac5c35`, **206 files / 4,117 tests, exit 0**, working tree clean, all
+four T16 assertions passing individually.

--- a/codev/state/spir-1280_thread.md
+++ b/codev/state/spir-1280_thread.md
@@ -556,3 +556,42 @@ relocated table and a per-cut justification column. Suite 205 files / 4,083 test
 (rebuilt first — skeleton edits are invisible until `copy-skeleton` reruns).
 
 Awaiting architect per-file inspection before Phase 2.
+
+### Phase 2 built — three role files, three group-pure commits (2026-08-01)
+
+architect 2,048 → 761 (G6, cc2398c2) · builder 1,837 → 849 (G3, 20567714) · consultant 252 →
+**unchanged** (G5, no commit). ALWAYS_ON 29,833 → **28,844**.
+
+**Consultant left alone deliberately.** It is already conformant — a contract, not a procedure.
+Under the acceptance model a conformant file passes *as-is*, and trimming it anyway would be
+size-chasing, which the charter amendment explicitly rejects. Recording the non-change as a
+decision rather than an omission.
+
+**Resolved the plan's open question by checking, not assuming**: `architect.md` carries nothing
+load-bearing for multi-architect coordination (Specs 755/786/823) — grepped for
+`architect:<name>`, sibling language, `spawnedByArchitect`, `whoami`: zero matches. That
+contract lives in CLAUDE.md, kept there in Phase 1.
+
+**Found while cutting**: the architect role's command block was a *stale second owner* — it
+still showed `porch approve <id> spec-approval` without the
+`--a-human-explicitly-approved-this` flag the command now requires. Exactly the drift P4 exists
+to prevent: two owners of the same syntax, one of them quietly wrong. Deleting the copy fixes
+the drift as a side effect.
+
+**M10: zero assertions retired**, but three initially failed and the resolution is the
+interesting part. `spec-1273-wait-discipline-docs` (18 assertions) broke on: a heading I had
+renamed, a phrase **split by a line wrap**, and a dropped word ("current"). In all three the
+*behaviour* survived — only the strings moved. **I adjusted my prose rather than the
+assertions.** Those strings encode a real wait-discipline incident; preserving them cost nothing
+in conformance terms, and editing a prior spec's protection to fit new prose is precisely the
+silent erosion M10 exists to prevent. Writing to the test would have been the easy call and the
+wrong one.
+
+**Hazard named, third occurrence**: reflowing prose silently breaks any exact-match string that
+spans a line wrap — scar canonicals in Phase 1, a prior spec's assertions here, and I repeated
+it *within* Phase 2 on `afx-from-root` before catching it. Any exact-match string in a rewritten
+file must be re-verified after the rewrite; canonicals stay on one line however long. This is
+the same family as the `wc`/`cmp`/grep lessons: the check that looks like it passed, and didn't.
+
+Suite 205 files / 4,083 tests green. Manifest at `manifests/phase-2-roles.md`. Awaiting
+inspection.

--- a/codev/state/spir-1280_thread.md
+++ b/codev/state/spir-1280_thread.md
@@ -712,3 +712,30 @@ block closes on its own line. Caught in seconds by reading the actual line. The 
 reliable — check the raw text before believing any summary I wrote, including my own tooling's.
 
 Phase 3 still paused; the merge instruction carried no resume word and I am not inferring one.
+
+### Two instrument PRs queued; a seventh family instance (2026-08-01)
+
+`#1321` (test budgets) and `#1327` (invariant-form reproduction tests) both green, queued in that
+order. Phase 3 held on #1321's merge word.
+
+**#1327 nearly went into the queue red, from a cause I had warned about an hour earlier.** It
+branched from `d42a061a`, predating #1321, so it inherited 10 unbudgeted script-shelling tests —
+the same latent 5s failure that took main red. My three new tests carried budgets; the ten I did
+not touch did not. Merged the hotfix branch in rather than duplicating the change, so the
+eventual #1321-on-main merge stays clean.
+
+The conflict there was the instructive kind: the hotfix carried a *budgeted copy* of a test
+`#1327` **replaces**. A mechanical "prefer theirs" would have left the PR **green and wrong** —
+silently reinstating the live-measured literal the PR exists to remove. Resolved for the
+replacement; verified zero unbudgeted tests and zero markers after.
+
+**Seventh family instance, and this one was my own tooling again**: my CI watcher polled for
+*absence of pending checks*, but my push had started a new run — the gap between runs read as
+"settled". Re-watched pinned to the head SHA, and confirmed local == remote before believing the
+result. The architect reports their own watchers share the flaw and is pinning theirs too.
+
+The family, now seven: delegated `wc`; overloaded `cmp` exit code; truncated grep;
+`pipefail`+`grep -q`; naive regex + type-blind JSON walk; one-liner-blind budget checker;
+absence-of-pending watcher. Every one a signal that looked authoritative while measuring
+something adjacent to the question. The habit that catches them is the same each time: **read the
+raw thing before believing the summary — including summaries produced by my own tools.**

--- a/codev/state/spir-1280_thread.md
+++ b/codev/state/spir-1280_thread.md
@@ -518,3 +518,41 @@ principle P7 exists to delete.** Recorded rather than smoothed over.
 build.* The delegated tool — like the overloaded exit code, the truncated grep, the
 skeleton-only enumeration, and the stale script comment before it — looked authoritative and
 wasn't. CI was the authoritative signal here, and it existed all along.
+
+### Phase 1 built — CLAUDE.md/AGENTS.md + four-tree relocation (2026-08-01)
+
+PR #1319 merged; re-branched `builder/1280-rewrite` from `origin/main` (no duplicate Phase-0
+commits — verified). Commit f9cd93c6.
+
+CLAUDE.md 5,815 → **1,417**. ALWAYS_ON 34,231 → **29,833**.
+
+**The M0c split is the number that matters**, and it is why M0c exists: of 4,398 words removed
+from always-on, **1,129 were relocated** and **3,269 deleted**. Authored total fell only 4,294
+because relocation writes to four trees. An always-on-only metric would have reported the whole
+4,398 as deletion — a 26% overstatement of what actually went away.
+
+Deliberate judgment call, flagged rather than made silently: **I did not touch the `afx` skill.**
+Relocating inter-agent messaging into it would have obliged me to resolve its pre-existing
+repo-vs-skeleton drift *and* propagate its stale `tick` references (a protocol that does not
+exist in either tree) to adopters — squarely the architect's separate issue. The addressing
+*contract* stayed in CLAUDE.md instead: it is policy, not a how-to, so P4 does not apply.
+
+**M10: zero assertions retired.** All four collision candidates pass unmodified.
+
+**Two of my own mistakes, both caught by verification rather than review:**
+
+1. **Reflowing broke the scar canonicals.** My first draft wrapped them across lines for
+   readability; five of eight then failed exact-match against the ratified YAML. Canonicals must
+   be single-line. Caught because I checked byte-for-byte against
+   `builder/spir-1252:scar-rules.yaml` rather than eyeballing that they "looked present".
+2. **My Phase 0 test pinned a moving number.** It asserted ALWAYS_ON == 34,231 — a literal this
+   project changes *every phase*. It failed on Phase 1 exactly as designed to, but the design was
+   wrong: a test edited every phase is a test edited carelessly, which is M10's own argument
+   turned on my suite. Replaced with arithmetic invariants that hold at any surface size, plus an
+   immutable assertion that the FROZEN baseline artifact still records 34,231.
+
+Manifest at `manifests/phase-1-shared-skills.md`: 10 files in one batch, with the deleted-vs-
+relocated table and a per-cut justification column. Suite 205 files / 4,083 tests green
+(rebuilt first — skeleton edits are invisible until `copy-skeleton` reruns).
+
+Awaiting architect per-file inspection before Phase 2.

--- a/codev/state/spir-1280_thread.md
+++ b/codev/state/spir-1280_thread.md
@@ -620,3 +620,30 @@ there at ten times the width.
 
 Architect has adopted my reflow-hazard rule as a standing inspection item and will fixed-string-
 verify every exact-match string in every batch from here.
+
+### Hotfix #1321 — main went red on my test (2026-08-01)
+
+`honours PHASE_ITERS` timed out at vitest's 5000ms default on a loaded CI runner (5,690ms),
+blocking green CI for every open PR. Fixed with explicit 60s budgets on the 12 blocks that shell
+out to the measurement script (11 tests + the `beforeAll`), per the #1302 precedent. One file,
+12 lines.
+
+**Scope determined by parsing, not eyeballing**: I parsed the file for blocks whose body calls
+`run()`. The 9 non-shelling tests keep the default budget deliberately — a timeout on a test that
+*cannot* be slow is noise, and would mask a future regression in exactly the tests that can be.
+
+**The honest diagnosis is worse than "flake".** On an *unloaded* machine those tests take
+3.9–4.0s against a 5s default — ~80% of budget before any contention. The sibling test hit
+4,576ms in the same CI run; it was next regardless of load. **I shipped a test file where a third
+of the tests sat at 80% of budget and never looked at the timings.** The failure was latent in
+PR #1319 and a fast runner flattered it. Architect accepted the correction on the record.
+
+**Approved follow-up, scheduled AFTER Phase 3** (architect ruling): `measure-prompt-surface.sh`
+spawns `python3` once per file for include expansion — that is the whole ~4s. A single-pass
+expansion takes these tests under a second and speeds up every measurement the remaining phases
+run. Own small PR. Unblocking main and resuming the rewrite outranks it.
+
+Standing lesson, and it generalises past this project: **a test that passes at 80% of its budget
+is a failure that has not happened yet.** Check timings, not just the green tick — the same
+family as the delegated `wc`, the overloaded `cmp` exit code, and the truncated grep: a signal
+that looks like success and is measuring the wrong thing.

--- a/codev/state/spir-1280_thread.md
+++ b/codev/state/spir-1280_thread.md
@@ -647,3 +647,35 @@ Standing lesson, and it generalises past this project: **a test that passes at 8
 is a failure that has not happened yet.** Check timings, not just the green tick — the same
 family as the delegated `wc`, the overloaded `cmp` exit code, and the truncated grep: a signal
 that looks like success and is measuring the wrong thing.
+
+### Pre-Phase-3 convention audit — and my own instrument was the defect (2026-08-01)
+
+Ran the cross-batch convention diff I committed to after Phase 2, read-only, while waiting on the
+#1321 merge word. It produced an alarming first result: **seven of nine protocols appeared to
+have `protocol.md` contradicting `protocol.json` about gates**, including `aspir` apparently
+claiming the very `spec-approval`/`plan-approval` gates ASPIR exists to remove — which would have
+meant a builder stopping forever at a gate porch never requests.
+
+**All three "contradiction" findings were false positives produced by my own audit script.**
+
+| Apparent finding | Reality | My script's flaw |
+|---|---|---|
+| `aspir` claims spec/plan gates | Prose says it **removes** them — correct | Read a *mention* as a *claim* |
+| `pir` claims spec/verify-approval | A **SPIR-vs-PIR comparison table row** — correct | Same |
+| `research` claims undefined `scope-approval` | It **is** defined — as a dict, not a string | Extractor only handled string-valued `gate` |
+
+The real, much weaker finding after fixing the extractor: five protocols never *mention* a gate
+their JSON defines (`verify-approval` in spir/aspir; the `*-complete` gates in
+experiment/maintain/research). That is incompleteness, not contradiction, and P6 dissolves it —
+referencing the structured source means the prose cannot be less complete than the truth.
+
+**This is the fifth instance of the family** (delegated `wc`, overloaded `cmp` exit code,
+truncated grep, `pipefail`+`grep -q`, now a naive regex + a type-blind JSON walk). But it differs
+in the way that matters: **I caught it before reporting it as fact.** Every previous instance
+reached a commit message, a spec, or the architect before being corrected. The habit of verifying
+in-context before characterising is what stopped an alarming and wrong claim from going out.
+
+Worth stating because it cuts against my own interest: an audit script written *by* the person
+whose work it audits is subject to exactly the bias the audit exists to remove. Mine was crude in
+the direction that made the codebase look worse and my upcoming phase look more necessary. The
+correction was cheap only because I checked the raw text before believing the summary.

--- a/packages/codev/scripts/forge/github/pr-search.sh
+++ b/packages/codev/scripts/forge/github/pr-search.sh
@@ -2,4 +2,6 @@
 # Forge concept: pr-search (GitHub via gh CLI)
 # Input: CODEV_SEARCH_QUERY
 # Output: JSON [{number, headRefName, baseRefName}]
-exec gh pr list --search "$CODEV_SEARCH_QUERY" --json number,headRefName,baseRefName
+# --state all is required so the search includes merged/closed PRs; without it
+# `gh pr list` defaults to --state open and post-merge lookups return nothing (#759).
+exec gh pr list --state all --search "$CODEV_SEARCH_QUERY" --json number,headRefName,baseRefName

--- a/packages/codev/scripts/forge/gitlab/pr-search.sh
+++ b/packages/codev/scripts/forge/gitlab/pr-search.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 # Forge concept: pr-search (GitLab via glab CLI)
-exec glab mr list --search "$CODEV_SEARCH_QUERY" --output json
+# --all is required so the search includes merged/closed MRs; without it
+# `glab mr list` defaults to opened only and post-merge lookups return nothing (#759).
+exec glab mr list --all --search "$CODEV_SEARCH_QUERY" --output json

--- a/packages/codev/src/__tests__/spec-1280-measurement-instrument.test.ts
+++ b/packages/codev/src/__tests__/spec-1280-measurement-instrument.test.ts
@@ -280,29 +280,45 @@ describe('T12 — determinism', () => {
   });
 });
 
-describe('the corrected baseline is what the spec claims', () => {
+describe('the instrument is self-consistent and the frozen baseline is immutable', () => {
   let out: string;
   beforeAll(() => { out = run(); });
 
-  it('reproduces ALWAYS_ON_WORDS = 34,231 for a SPIR builder at I=10', () => {
-    // 34,231 — not the 34,255 quoted in the spec. Two corrections, both making the
-    // instrument more honest and neither moving an acceptance criterion (size is
-    // reporting-only under the amended charter):
-    //   -20  the 1252 additive include model counted a `{{> path}}` directive's own
-    //        tokens AND the content substituted for them; this one substitutes.
-    //    -4  `wc -w` is not portable: BSD wc in a UTF-8 locale splits `⚠️` into two
-    //        words where GNU wc and Python's split() see one. Counting is now
-    //        defined explicitly rather than delegated to the platform's wc.
-    expect(num(out, 'ALWAYS_ON_WORDS')).toBe(34231);
+  // NOT a hardcoded live total. This project rewrites the prompt surface phase by phase, so
+  // pinning ALWAYS_ON to a literal would force an edit every phase — and a test edited every
+  // phase is a test edited carelessly. (That is M10's own argument turned on this suite.)
+  // Instead: assert the arithmetic the report claims, which holds at ANY surface size.
+  it('ALWAYS_ON equals SHARED + BUILDER_SPAWN[spir] + I x (HOT + PHASE mean[spir])', () => {
+    const shared = Number(out.match(/\| SHARED [^|]*\| (\d+) \|/)![1]);
+    const spirRow = out.match(/^\| spir \| (\d+) \| (\d+) \| \d+ \|$/m)!;
+    const spawn = Number(spirRow[1]);
+    const phaseMean = Number(spirRow[2]);
+    const hot = Number(out.match(/= arch-critical\((\d+)\) \+ lessons-critical\((\d+)\) = (\d+)/)![3]);
+    expect(num(out, 'ALWAYS_ON_WORDS')).toBe(shared + spawn + 10 * (hot + phaseMean));
   });
 
-  it('reproduces the architect load (8,599)', () => {
-    expect(out).toMatch(/\| Architect \(per session\) \| 8599 \|/);
+  it('architect load equals SHARED + ARCHITECT', () => {
+    const shared = Number(out.match(/\| SHARED [^|]*\| (\d+) \|/)![1]);
+    const architect = Number(out.match(/\| ARCHITECT [^|]*\| (\d+) \|/)![1]);
+    const reported = Number(out.match(/\| Architect \(per session\) \| (\d+) \|/)![1]);
+    expect(reported).toBe(shared + architect);
   });
 
   it('honours PHASE_ITERS as a comparison constant', () => {
     const one = num(run(repoRoot, { PHASE_ITERS: '1' }), 'ALWAYS_ON_WORDS');
     const two = num(run(repoRoot, { PHASE_ITERS: '2' }), 'ALWAYS_ON_WORDS');
-    expect(two - one).toBe(736 + 1396); // HOT + spir phase mean
+    const spirRow = out.match(/^\| spir \| \d+ \| (\d+) \| \d+ \|$/m)!;
+    const hot = Number(out.match(/= arch-critical\(\d+\) \+ lessons-critical\(\d+\) = (\d+)/)![1]);
+    expect(two - one).toBe(hot + Number(spirRow[1]));
+  });
+
+  // The frozen PRE-REWRITE baseline is a historical record, not a live measurement. It must
+  // never drift: every later reduction claim is measured against this number.
+  it('the frozen pre-rewrite baseline still records 34,231', () => {
+    const baseline = fs.readFileSync(
+      path.join(repoRoot, 'codev/resources/1280-word-baseline.md'),
+      'utf-8',
+    );
+    expect(baseline).toMatch(/^ALWAYS_ON_WORDS=34231$/m);
   });
 });

--- a/packages/codev/src/__tests__/spec-1280-p6-delivery.test.ts
+++ b/packages/codev/src/__tests__/spec-1280-p6-delivery.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Spec 1280 — T18: P6 delivery of the structured source, in BOTH consumption modes.
+ *
+ * Principle P6 ("simple specs → rich references") lets `protocol.md` stop narrating the state
+ * machine and reference `protocol.json` instead. That is only safe if the reference actually
+ * ARRIVES. A prose instruction to "read protocol.json" would be the fetch-by-path CLAUDE.md
+ * forbids: in a fresh adopter project `codev/protocols/<p>/protocol.json` does not exist on
+ * disk at all — it resolves from the installed package skeleton — so the builder would be told
+ * to open a file that is not there.
+ *
+ * The mechanism is therefore a `{{> ... }}` include, expanded by the same resolver the runtime
+ * uses. These tests assert the delivery, not the intention.
+ *
+ * The two modes are NOT symmetric, which is why both are tested:
+ *   STRICT — porch drives; the builder also receives gates and checks as task JSON, so the
+ *            include is corroborating.
+ *   SOFT   — no porch. The spawn-inlined `protocol.md` is the ONLY place the builder learns
+ *            the phase order, gates and checks. Here the include is load-bearing, and a
+ *            silent expansion failure would leave a soft-mode builder with a protocol document
+ *            that describes nothing.
+ *
+ * Budgets are explicit from the outset rather than inherited: these shell out and read the
+ * whole protocol tree.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { resolveCodevIncludes } from '../lib/skeleton.js';
+
+const repoRoot = path.resolve(import.meta.dirname, '../../../..');
+
+/** Protocols that ship a protocol.json — the ones P6 applies to. */
+function protocolsWithJson(): string[] {
+  const seen = new Map<string, boolean>();
+  for (const tree of ['codev/protocols', 'codev-skeleton/protocols']) {
+    const dir = path.join(repoRoot, tree);
+    if (!fs.existsSync(dir)) continue;
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (!e.isDirectory()) continue;
+      const hasJson = fs.existsSync(path.join(dir, e.name, 'protocol.json'));
+      seen.set(e.name, (seen.get(e.name) ?? false) || hasJson);
+    }
+  }
+  return [...seen].filter(([, hasJson]) => hasJson).map(([n]) => n).sort();
+}
+
+function resolveFile(rel: string): string | null {
+  for (const base of ['.codev', 'codev', 'codev-skeleton']) {
+    const p = path.join(repoRoot, base, rel);
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+}
+
+/** The served text of a protocol.md, expanded exactly as the runtime expands it. */
+function servedProtocolDoc(protocol: string): string {
+  const p = resolveFile(`protocols/${protocol}/protocol.md`);
+  if (!p) throw new Error(`no protocol.md for ${protocol}`);
+  return resolveCodevIncludes(fs.readFileSync(p, 'utf-8'), repoRoot);
+}
+
+function gatesAndChecks(protocol: string): { gates: string[]; checks: string[]; phases: string[] } {
+  const p = resolveFile(`protocols/${protocol}/protocol.json`)!;
+  const d = JSON.parse(fs.readFileSync(p, 'utf-8'));
+  const gates: string[] = [];
+  const checks: string[] = [];
+  const phases: string[] = [];
+  for (const ph of d.phases ?? []) {
+    phases.push(ph.id);
+    const g = typeof ph.gate === 'string' ? ph.gate : ph.gate?.name;
+    if (g) gates.push(g);
+    checks.push(...Object.keys(ph.checks ?? {}));
+  }
+  return { gates, checks, phases };
+}
+
+describe('T18 — P6 delivers the structured source, not a path to fetch', () => {
+  const targets = protocolsWithJson().filter((p) => resolveFile(`protocols/${p}/protocol.md`));
+
+  it('there is something to test', () => {
+    expect(targets.length).toBeGreaterThan(0);
+  });
+
+  for (const protocol of targets) {
+    describe(protocol, () => {
+      it('never instructs the agent to go READ protocol.json by path', () => {
+        const raw = fs.readFileSync(resolveFile(`protocols/${protocol}/protocol.md`)!, 'utf-8');
+        // An include directive is delivery. An imperative to open the path is a fetch, and
+        // fetch-by-path of a framework file fails in a fresh install.
+        const fetchy = /\b(read|open|see|consult|cat)\b[^.\n]{0,40}protocol\.json/i;
+        expect(raw, `${protocol}/protocol.md instructs a fetch instead of delivering`).not.toMatch(
+          fetchy,
+        );
+      });
+
+      it('SOFT mode: the served doc alone carries every phase, gate and check', () => {
+        // No porch. The spawn-inlined protocol.md is the only source.
+        const served = servedProtocolDoc(protocol);
+        const { gates, checks, phases } = gatesAndChecks(protocol);
+        for (const id of phases) {
+          expect(served, `${protocol}: phase "${id}" absent from served doc`).toContain(id);
+        }
+        for (const g of gates) {
+          expect(served, `${protocol}: gate "${g}" absent from served doc`).toContain(g);
+        }
+        for (const c of checks) {
+          expect(served, `${protocol}: check "${c}" absent from served doc`).toContain(c);
+        }
+      }, 60_000);
+
+      it('the include measurably expands — a silent no-op would look like success', () => {
+        const raw = fs.readFileSync(resolveFile(`protocols/${protocol}/protocol.md`)!, 'utf-8');
+        if (!raw.includes('{{>')) return; // protocol not yet migrated to P6; nothing to assert
+        const served = servedProtocolDoc(protocol);
+        expect(served.length).toBeGreaterThan(raw.length);
+        expect(served).not.toContain('{{>'); // every directive consumed
+      }, 60_000);
+    });
+  }
+
+  it('STRICT mode parity: the same resolver backs the spawn path', () => {
+    // spawn-roles.ts resolveProtocolReference() reads protocol.md and passes it through
+    // resolveCodevIncludes before inlining it as {{protocol_reference}}. If that ever stops,
+    // strict-mode builders lose the structured source too.
+    const spawn = fs.readFileSync(
+      path.join(repoRoot, 'packages/codev/src/agent-farm/commands/spawn-roles.ts'),
+      'utf-8',
+    );
+    expect(spawn).toMatch(/resolveCodevIncludes\(\s*readFileSync\(protocolDocPath/);
+  });
+
+  it('fresh-install shape: with no .codev/ and no codev/ tier, the include still resolves', () => {
+    // CORRECTION to an earlier version of this test, worth stating because it changed my model
+    // of the resolver: tier 4 is `getSkeletonDir()` — the INSTALLED NPM PACKAGE — not
+    // `<root>/codev-skeleton/`. The repo-local `codev-skeleton/` directory is a build SOURCE
+    // (copy-skeleton copies it into packages/codev/skeleton); the resolver never reads it.
+    // So a fresh install cannot be simulated by planting files under a temp root — it is
+    // simulated by giving the resolver a root with NO local tiers and letting it fall through.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'spec1280-p6-fresh-'));
+    const proto = targets[0];
+    const out = resolveCodevIncludes(
+      `\`\`\`json\n{{> protocols/${proto}/protocol.json}}\n\`\`\``,
+      dir,
+    );
+    expect(out, 'include collapsed to empty — an adopter would get a doc describing nothing')
+      .not.toMatch(/^```json\s*```$/);
+    expect(out).not.toContain('{{>');
+    expect(out).toContain('"phases"');
+  }, 60_000);
+
+  it('the shipped package actually contains the JSON the include depends on', () => {
+    // The adopter guarantee behind P6: tier 4 can only deliver what npm publishes.
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, 'packages/codev/package.json'), 'utf-8'),
+    );
+    expect(pkg.files, 'skeleton must be in the npm files allowlist').toContain('skeleton');
+    for (const protocol of targets) {
+      const shipped = path.join(repoRoot, 'packages/codev/skeleton/protocols', protocol, 'protocol.json');
+      expect(
+        fs.existsSync(shipped),
+        `${protocol}/protocol.json is not in the built skeleton — P6 would deliver nothing to adopters`,
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/codev/src/__tests__/spec-1280-phase-manifest.test.ts
+++ b/packages/codev/src/__tests__/spec-1280-phase-manifest.test.ts
@@ -30,6 +30,21 @@ interface Manifest {
   rows: { path: string; oldWords: string; newWords: string; principles: string }[];
 }
 
+/**
+ * Expand `{a,b}/rest` into `a/rest`, `b/rest`.
+ *
+ * DELIBERATE FORMAT DECISION (Spec 1280, Phase 3): the plan's inspection model is per
+ * DECISION, not per file — twins are byte-identical and T7 verifies the sync mechanically, so
+ * the architect reads ~66 decisions rather than 131 diffs. One manifest row therefore names
+ * both tree paths, and the ≤12 batch cap counts decisions. The parser has to understand that
+ * notation or the skeleton twins read as uninspectable — which is exactly what it reported.
+ */
+function expandBraces(p: string): string[] {
+  const m = p.match(/^\{([^}]+)\}(.*)$/);
+  if (!m) return [p];
+  return m[1].split(',').map((alt) => alt.trim() + m[2]);
+}
+
 function parseManifest(file: string): Manifest {
   const body = fs.readFileSync(file, 'utf-8');
   const rows: Manifest['rows'] = [];
@@ -37,12 +52,13 @@ function parseManifest(file: string): Manifest {
     // | path | old | new | principles | rationale |
     const m = line.match(/^\|\s*`?([^`|]+?)`?\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*([^|]*)\|/);
     if (m && !/^-+$/.test(m[1].trim())) {
-      rows.push({
-        path: m[1].trim(),
+      for (const expanded of expandBraces(m[1].trim())) rows.push({
+        path: expanded,
         oldWords: m[2],
         newWords: m[3],
         principles: m[4].trim(),
       });
+
     }
   }
   return { file, phase: path.basename(file, '.md'), rows };
@@ -97,10 +113,25 @@ describe('T16 — manifest completeness (M11)', () => {
   it('every prompt-bearing file changed on this branch appears in some manifest', () => {
     let changed: string[];
     try {
-      changed = execFileSync('git', ['diff', '--name-only', 'origin/main...HEAD'], {
+      // BOTH committed and uncommitted changes.
+      //
+      // `origin/main...HEAD` alone sees only COMMITTED work. Running the suite before
+      // committing therefore made this test pass VACUOUSLY — it diffed a HEAD that did not
+      // yet contain the rewrite, and a green run was reported for a state that did not exist.
+      // (Spec 1280 Phase 3; the architect caught the claim, and this is the root cause.)
+      // A guard that is green because it looked at the wrong tree is worse than no guard.
+      const committed = execFileSync('git', ['diff', '--name-only', 'origin/main...HEAD'], {
+        cwd: repoRoot,
+        encoding: 'utf-8',
+      });
+      const working = execFileSync('git', ['status', '--porcelain'], {
         cwd: repoRoot,
         encoding: 'utf-8',
       })
+        .split('\n')
+        .map((l) => l.slice(3).trim())
+        .join('\n');
+      changed = [committed, working].join('\n')
         .split('\n')
         .map((s) => s.trim())
         .filter((s) => PROMPT_BEARING.test(s));

--- a/packages/codev/src/__tests__/spec-1280-skills-parity.test.ts
+++ b/packages/codev/src/__tests__/spec-1280-skills-parity.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Spec 1280 — T17: four-tree parity for skills this project touches.
+ *
+ * Skills exist in FOUR places: `.claude/skills`, `.codex/skills`, and the skeleton's copies
+ * of both. Principles P3/P4 relocate how-to content out of CLAUDE.md into skills — and a
+ * relocation written to only one tree silently:
+ *   - leaves Codex agents without the content,
+ *   - leaves adopters without it after `codev update`, and
+ *   - is reported as a DELETION by the measurement instrument (M0c), inverting the
+ *     project's own honesty artifact.
+ *
+ * SCOPE — per the architect's plan-gate ruling (2026-08-01): every skill this project
+ * TOUCHES must be four-tree consistent. Skills it does not touch are EXEMPT; their
+ * pre-existing drift (`afx`, `porch`) and skeleton-absence (`forge`, `skill-creator`,
+ * `team`) belong to a separate architect-filed issue and must not fail this test.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const repoRoot = path.resolve(import.meta.dirname, '../../../..');
+
+/**
+ * Skills touched by Spec 1280. Adding a skill to this list is a deliberate act: it asserts
+ * the project now owns that skill's four-tree consistency.
+ */
+const TOUCHED_SKILLS = ['runnable-worktrees', 'codev'] as const;
+
+const TREES = [
+  '.claude/skills',
+  '.codex/skills',
+  'codev-skeleton/.claude/skills',
+  'codev-skeleton/.codex/skills',
+] as const;
+
+const skillPath = (tree: string, skill: string) =>
+  path.join(repoRoot, tree, skill, 'SKILL.md');
+
+describe('T17 — touched skills are consistent across all four trees', () => {
+  for (const skill of TOUCHED_SKILLS) {
+    it(`${skill}: present in every tree`, () => {
+      for (const tree of TREES) {
+        expect(
+          fs.existsSync(skillPath(tree, skill)),
+          `${skill} missing from ${tree} — relocated content would be invisible to that audience`,
+        ).toBe(true);
+      }
+    });
+
+    it(`${skill}: byte-identical across every tree`, () => {
+      const canonical = fs.readFileSync(skillPath('.claude/skills', skill), 'utf-8');
+      for (const tree of TREES.slice(1)) {
+        expect(
+          fs.readFileSync(skillPath(tree, skill), 'utf-8'),
+          `${skill} differs between .claude/skills and ${tree}`,
+        ).toBe(canonical);
+      }
+    });
+
+    it(`${skill}: carries usable frontmatter`, () => {
+      const body = fs.readFileSync(skillPath('.claude/skills', skill), 'utf-8');
+      expect(body.startsWith('---\n'), `${skill} has no frontmatter block`).toBe(true);
+      expect(body).toMatch(new RegExp(`^name:\\s*${skill}$`, 'm'));
+      // The description is the trigger surface — an empty one makes the skill undiscoverable,
+      // which for relocated content means the content is effectively lost.
+      const desc = body.match(/^description:\s*(.+)$/m);
+      expect(desc, `${skill} has no description`).not.toBeNull();
+      expect(desc![1].trim().length).toBeGreaterThan(40);
+    });
+  }
+
+  it('untouched skills are exempt — pre-existing drift must not fail this test', () => {
+    // Guards the ruling itself: if someone later widens TOUCHED_SKILLS to "all skills", this
+    // test starts failing on drift this project deliberately did not take on.
+    const claudeSkills = fs
+      .readdirSync(path.join(repoRoot, '.claude/skills'), { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+    const untouched = claudeSkills.filter((s) => !TOUCHED_SKILLS.includes(s as never));
+    expect(untouched.length, 'expected some skills to be out of scope').toBeGreaterThan(0);
+  });
+});

--- a/packages/codev/src/commands/porch/__tests__/bugfix-759-pr-search-state-all.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/bugfix-759-pr-search-state-all.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Regression test for pr-search forge scripts.
+ *
+ * Bugfix #759: pr-search must include all PR states so post-merge lookups
+ * (consult --type pr after a PR merges) still find the PR. Without it,
+ * `gh pr list --search` / `glab mr list --search` default to open-only and
+ * return nothing once the PR has merged.
+ *
+ * These tests validate the forge scripts directly, not protocol.json commands.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const SCRIPTS_ROOT = path.resolve(__dirname, '../../../../scripts/forge');
+
+describe('pr-search forge scripts', () => {
+  describe('github/pr-search.sh', () => {
+    const scriptPath = path.join(SCRIPTS_ROOT, 'github', 'pr-search.sh');
+
+    it('exists and is readable', () => {
+      expect(fs.existsSync(scriptPath)).toBe(true);
+    });
+
+    it('fetches all PR states (--state all) so merged PRs are found (#759)', () => {
+      const content = fs.readFileSync(scriptPath, 'utf-8');
+      expect(content).toContain('--state all');
+    });
+
+    it('still searches with the provided query', () => {
+      const content = fs.readFileSync(scriptPath, 'utf-8');
+      expect(content).toContain('--search "$CODEV_SEARCH_QUERY"');
+    });
+  });
+
+  describe('gitlab/pr-search.sh', () => {
+    const scriptPath = path.join(SCRIPTS_ROOT, 'gitlab', 'pr-search.sh');
+
+    it('exists and is readable', () => {
+      expect(fs.existsSync(scriptPath)).toBe(true);
+    });
+
+    it('fetches all MR states (--all) so merged MRs are found (#759)', () => {
+      const content = fs.readFileSync(scriptPath, 'utf-8');
+      expect(content).toContain('--all');
+    });
+
+    it('still searches with the provided query', () => {
+      const content = fs.readFileSync(scriptPath, 'utf-8');
+      expect(content).toContain('--search "$CODEV_SEARCH_QUERY"');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The `pr-search` forge concept only matched **open** PRs, so once a PR merged, the post-merge `consult --type pr` lookup failed with `No PR found for branch: ...`. Add an all-states flag so the search includes merged/closed PRs.

Fixes #759

## Root Cause

`packages/codev/scripts/forge/github/pr-search.sh` ran `gh pr list --search "$CODEV_SEARCH_QUERY"` with no `--state`. `gh pr list` defaults to `--state open` (confirmed via `gh pr list --help`), so merged PRs were excluded and the lookup returned nothing after merge. The GitLab counterpart (`glab mr list --search`) has the identical latent defect (defaults to opened).

## Fix

- `github/pr-search.sh`: add `--state all` to the `gh pr list` call.
- `gitlab/pr-search.sh`: add `--all` to the `glab mr list` call (the established GitLab all-states flag, per `gitlab/pr-exists.sh`).

This mirrors the pr-exists precedent (bugfix #568), which added `--state all` for the same reason. No gitea `pr-search.sh` exists; these scripts are single-source under `packages/codev/scripts/forge/` (no skeleton mirror).

## Test Plan

- [x] Regression test added (`bugfix-759-pr-search-state-all.test.ts`) — asserts each script fetches all states while preserving the search query; fails without the fix, passes with it
- [x] Build passes
- [x] All tests pass (4123 passed, 0 failed)