### PR TITLE
Fix skill parity: sync .codex afx skill copies missed by #1143

### DIFF
--- a/.codex/skills/afx/SKILL.md
+++ b/.codex/skills/afx/SKILL.md
@@ -217,7 +217,20 @@ afx cron enable <name>          # Enable
 afx cron disable <name>         # Disable
 ```
 
-There is NO `afx cron add` — create YAML files in `.af-cron/` directly.
+There is NO `afx cron add` — create YAML files in `.af-cron/` directly:
+
+```yaml
+name: Service Health Check      # required, unique per workspace
+schedule: "*/15 * * * *"        # required, cron expression (or @hourly/@daily/@startup)
+command: ./health-check.sh      # required, run via shell
+message: "Health alert: ${output}"  # required, ${output} = trimmed command output
+condition: "exitCode != 0"      # optional JS expression, see below
+target: architect               # optional, default architect
+timeout: 30                     # optional, seconds, default 30
+enabled: true                   # optional, default true
+```
+
+`condition` is a JavaScript expression with two variables in scope: `output` (string — the command's trimmed output) and `exitCode` (number — 0 on success, the command's exit code on non-zero exit, 124 on timeout, -1 on spawn failure). With a `condition`, the message is delivered exactly when it evaluates truthy — including on failed runs (e.g. `exitCode != 0` alerts when the command fails). Without a `condition`, the message is delivered only when the command exits 0.
 
 ## Other commands
 

--- a/codev-skeleton/.codex/skills/afx/SKILL.md
+++ b/codev-skeleton/.codex/skills/afx/SKILL.md
@@ -144,7 +144,20 @@ afx cron enable <name>          # Enable
 afx cron disable <name>         # Disable
 ```
 
-There is NO `afx cron add` — create YAML files in `.af-cron/` directly.
+There is NO `afx cron add` — create YAML files in `.af-cron/` directly:
+
+```yaml
+name: Service Health Check      # required, unique per workspace
+schedule: "*/15 * * * *"        # required, cron expression (or @hourly/@daily/@startup)
+command: ./health-check.sh      # required, run via shell
+message: "Health alert: ${output}"  # required, ${output} = trimmed command output
+condition: "exitCode != 0"      # optional JS expression, see below
+target: architect               # optional, default architect
+timeout: 30                     # optional, seconds, default 30
+enabled: true                   # optional, default true
+```
+
+`condition` is a JavaScript expression with two variables in scope: `output` (string — the command's trimmed output) and `exitCode` (number — 0 on success, the command's exit code on non-zero exit, 124 on timeout, -1 on spawn failure). With a `condition`, the message is delivered exactly when it evaluates truthy — including on failed runs (e.g. `exitCode != 0` alerts when the command fails). Without a `condition`, the message is delivered only when the command exits 0.
 
 ## Other commands
 


### PR DESCRIPTION
PR #1143 updated `.claude/skills/afx/SKILL.md` in both trees (the new `### afx cron` condition-environment docs) but not the `.codex` twins. Its 6/6 CI green was from July 6 — predating the skill-parity guards the repo has since grown (1280's T17, 1273's wait-discipline parity test) — so main went red at merge: 3 failures across two parity suites.

Mechanical fix: copy the two .claude files over their .codex twins. md5-verified identical; parity tests green locally.

Gate-check lesson recorded by the architect: a stale CI green must be re-validated against invariants added since the run — zero drift of the touched files is not zero drift of the repo's expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)