### PR TITLE
[Spec 1286] Post-merge state capture: thread narrative + porch completion record

### DIFF
--- a/codev/projects/1286-consult-configurable-per-lane-/status.yaml
+++ b/codev/projects/1286-consult-configurable-per-lane-/status.yaml
@@ -28,8 +28,9 @@ gates:
     requested_at: '2026-08-03T07:10:17.266Z'
     approved_at: '2026-08-05T04:27:12.811Z'
   verify-approval:
-    status: pending
+    status: approved
     requested_at: '2026-08-05T04:30:17.186Z'
+    approved_at: '2026-08-06T16:48:28.988Z'
 iteration: 1
 build_complete: true
 history:
@@ -161,7 +162,7 @@ history:
         file: >-
           /Users/mwk/Development/cluesmith/codev/.builders/aspir-1286/codev/projects/1286-consult-configurable-per-lane-/1286-phase_6-iter3-claude.txt
 started_at: '2026-07-29T11:33:26.698Z'
-updated_at: '2026-08-06T16:48:27.652Z'
+updated_at: '2026-08-06T16:48:28.988Z'
 force_advanced:
   phase: phase_6
   iteration: 3

--- a/codev/projects/1286-consult-configurable-per-lane-/status.yaml
+++ b/codev/projects/1286-consult-configurable-per-lane-/status.yaml
@@ -1,7 +1,7 @@
 id: '1286'
 title: consult-configurable-per-lane-
 protocol: aspir
-phase: review
+phase: verify
 plan_phases:
   - id: phase_1
     title: Config schema, validators, and resolvers
@@ -30,7 +30,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history:
   - iteration: 1
     build_output: ''
@@ -160,7 +160,7 @@ history:
         file: >-
           /Users/mwk/Development/cluesmith/codev/.builders/aspir-1286/codev/projects/1286-consult-configurable-per-lane-/1286-phase_6-iter3-claude.txt
 started_at: '2026-07-29T11:33:26.698Z'
-updated_at: '2026-08-05T04:27:12.811Z'
+updated_at: '2026-08-05T04:30:05.778Z'
 force_advanced:
   phase: phase_6
   iteration: 3

--- a/codev/projects/1286-consult-configurable-per-lane-/status.yaml
+++ b/codev/projects/1286-consult-configurable-per-lane-/status.yaml
@@ -31,7 +31,7 @@ gates:
     status: pending
     requested_at: '2026-08-05T04:30:17.186Z'
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     build_output: ''
@@ -161,7 +161,7 @@ history:
         file: >-
           /Users/mwk/Development/cluesmith/codev/.builders/aspir-1286/codev/projects/1286-consult-configurable-per-lane-/1286-phase_6-iter3-claude.txt
 started_at: '2026-07-29T11:33:26.698Z'
-updated_at: '2026-08-05T04:31:56.793Z'
+updated_at: '2026-08-06T16:48:27.652Z'
 force_advanced:
   phase: phase_6
   iteration: 3

--- a/codev/projects/1286-consult-configurable-per-lane-/status.yaml
+++ b/codev/projects/1286-consult-configurable-per-lane-/status.yaml
@@ -160,7 +160,7 @@ history:
         file: >-
           /Users/mwk/Development/cluesmith/codev/.builders/aspir-1286/codev/projects/1286-consult-configurable-per-lane-/1286-phase_6-iter3-claude.txt
 started_at: '2026-07-29T11:33:26.698Z'
-updated_at: '2026-08-05T04:30:05.778Z'
+updated_at: '2026-08-05T04:30:10.793Z'
 force_advanced:
   phase: phase_6
   iteration: 3
@@ -172,4 +172,6 @@ pr_history:
     pr_number: 1341
     branch: builder/aspir-1286
     created_at: '2026-08-03T06:59:58.895Z'
+    merged: true
+    merged_at: '2026-08-05T04:30:10.793Z'
 pr_ready_for_human: false

--- a/codev/projects/1286-consult-configurable-per-lane-/status.yaml
+++ b/codev/projects/1286-consult-configurable-per-lane-/status.yaml
@@ -1,7 +1,7 @@
 id: '1286'
 title: consult-configurable-per-lane-
 protocol: aspir
-phase: verify
+phase: verified
 plan_phases:
   - id: phase_1
     title: Config schema, validators, and resolvers
@@ -162,7 +162,7 @@ history:
         file: >-
           /Users/mwk/Development/cluesmith/codev/.builders/aspir-1286/codev/projects/1286-consult-configurable-per-lane-/1286-phase_6-iter3-claude.txt
 started_at: '2026-07-29T11:33:26.698Z'
-updated_at: '2026-08-06T16:48:28.988Z'
+updated_at: '2026-08-06T16:48:30.303Z'
 force_advanced:
   phase: phase_6
   iteration: 3

--- a/codev/projects/1286-consult-configurable-per-lane-/status.yaml
+++ b/codev/projects/1286-consult-configurable-per-lane-/status.yaml
@@ -29,6 +29,7 @@ gates:
     approved_at: '2026-08-05T04:27:12.811Z'
   verify-approval:
     status: pending
+    requested_at: '2026-08-05T04:30:17.186Z'
 iteration: 1
 build_complete: false
 history:
@@ -160,7 +161,7 @@ history:
         file: >-
           /Users/mwk/Development/cluesmith/codev/.builders/aspir-1286/codev/projects/1286-consult-configurable-per-lane-/1286-phase_6-iter3-claude.txt
 started_at: '2026-07-29T11:33:26.698Z'
-updated_at: '2026-08-05T04:30:10.793Z'
+updated_at: '2026-08-05T04:30:17.187Z'
 force_advanced:
   phase: phase_6
   iteration: 3

--- a/codev/projects/1286-consult-configurable-per-lane-/status.yaml
+++ b/codev/projects/1286-consult-configurable-per-lane-/status.yaml
@@ -161,7 +161,7 @@ history:
         file: >-
           /Users/mwk/Development/cluesmith/codev/.builders/aspir-1286/codev/projects/1286-consult-configurable-per-lane-/1286-phase_6-iter3-claude.txt
 started_at: '2026-07-29T11:33:26.698Z'
-updated_at: '2026-08-05T04:30:17.187Z'
+updated_at: '2026-08-05T04:31:56.793Z'
 force_advanced:
   phase: phase_6
   iteration: 3
@@ -175,4 +175,8 @@ pr_history:
     created_at: '2026-08-03T06:59:58.895Z'
     merged: true
     merged_at: '2026-08-05T04:30:10.793Z'
+  - phase: verify
+    pr_number: 1345
+    branch: builder/aspir-1286
+    created_at: '2026-08-05T04:31:56.792Z'
 pr_ready_for_human: false

--- a/codev/state/aspir-1286_thread.md
+++ b/codev/state/aspir-1286_thread.md
@@ -796,3 +796,37 @@ review that was skipped.** Honest reporting of a gap is not the same as closing 
 pass cost one consult and converted "trust the builder's self-check" into an independent verdict.
 
 **Still waiting for Waleed at the pr gate. Not merging.**
+
+## MERGED — PR #1341, and verify
+
+Waleed approved the pr gate; architect relayed it. `porch approve 1286 pr
+--a-human-explicitly-approved-this` (porch requires that flag, which is the right shape — the flag
+is an assertion a human said yes, not a bypass), then `gh pr merge 1341 --merge`.
+
+Merge commit `661cc8bd`, **two parents** — a real merge commit, not a squash, so the 96-commit
+development history survives on `main` as house rules require.
+
+CI was 6/6 green. `mergeStateStatus` read `BLOCKED` / `REVIEW_REQUIRED` beforehand, which I flagged
+rather than routing around; the merge went through, so the requirement was satisfied by Waleed's
+GitHub approval rather than something needing an admin override. **Never reach for `--admin` to make
+a red gate go green.**
+
+### Verify — against the merged build, not the branch
+
+"It compiled" is not "it works", so I exercised the two asks from issue #1286 through the freshly
+built `dist/` in a throwaway workspace:
+
+| Ask | Result |
+|---|---|
+| 1 — per-lane model config | `claude -> {"id":"claude-opus-5","key":"consult.models.claude"}`, `codex -> {"id":"gpt-5.6-sol",...}` — id **and** provenance key |
+| 2 — per-review-type / per-protocol lanes | `PIR -> gemini, codex` · `SPIR -> gemini, codex, claude` |
+| Fail-fast | typo'd lane → `Invalid consultation model "codexx" in porch.consultation.byProtocol.pir.models…` |
+| `--model-id` | live in the merged CLI's `--help`, with the hermes-is-an-error text |
+
+That last row is the one I most wanted to see. `--model-id` originally shipped **registered, parsed,
+documented, and inert** — that is the failure this spec was partly written to correct, and checking
+`--help` on the merged artifact is the difference between "the flag exists" and "the flag works".
+
+Full suite on the merged state: **4271 passed, 48 skipped, 0 failed**; tsc clean; build clean.
+
+Nothing here needed fixing, so verify is a genuine pass rather than a formality.


### PR DESCRIPTION
Post-merge state capture for Spec 1286 (follow-up to #1341, which is merged).

Two files, four commits, no code:

| File | What |
|---|---|
| `codev/projects/1286-consult-configurable-per-lane-/status.yaml` | records the PR-merge and the `verify` phase transition — the canonical completion record on `main` |
| `codev/state/aspir-1286_thread.md` | the merge + verify narrative, which the thread-retention rule wants on `main` alongside `codev/reviews/` |

These landed on the builder branch *after* #1341 merged, so they were stranded there. Opening this
at the architect's direction rather than leaving them behind.

## What the verify notes record

The verify phase was a real pass, exercised against the freshly built merged `dist/` rather than the
branch:

- **Ask 1** (per-lane models): `claude → claude-opus-5`, `codex → gpt-5.6-sol`, each returned with
  its provenance key
- **Ask 2** (lane selection): `PIR → gemini, codex` · `SPIR → gemini, codex, claude`
- **Fail-fast**: a typo'd lane gives
  `Invalid consultation model "codexx" in porch.consultation.byProtocol.pir.models…`
- **`--model-id`** is live in the merged CLI's `--help` — the check that mattered most, since that
  flag originally shipped registered, parsed, documented and **inert**, which is part of why Spec
  1286 exists
- Full suite on the merged state: **4271 passed, 48 skipped, 0 failed**; tsc and build clean

## Note

The `verify-approval` gate is still open with Waleed. If it is approved while this PR is open, porch
will add one more `status.yaml` commit to this branch and it will join this PR — which is the
intended completion record, not drift.

No code, no behavior change, no test impact.
