### PR TITLE
[#1352] Derive codev's build closure from the pnpm graph, not a hand-list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ pnpm build
 pnpm -w run local-install
 ```
 
-- `pnpm build` builds types, sdk, core, and artifact-canvas, then codev (including dashboard)
+- `pnpm build` builds artifact-canvas (needed by the VS Code extension, not part of codev's dependency closure), then the codev CLI; codev's own build script first builds its graph-derived workspace-dependency closure (types, sdk, core, dashboard) via `pnpm --filter "@cluesmith/codev^..." build`
 - `pnpm -w run local-install` runs `scripts/local-install.sh`, which:
   - Packs the `@cluesmith/codev-core`, `@cluesmith/codev-sdk`, and `@cluesmith/codev` tarballs into their package directories
   - Globally installs all three in one `npm install -g` (separate installs fail because `@cluesmith/codev-core` isn't on the public npm registry)
@@ -317,7 +317,7 @@ project-root/
 
 ## Directory Map
 - pnpm install → always run from the repository root (installs all workspace packages)
-- pnpm build / pnpm test → run from `packages/codev/` or use `pnpm --filter @cluesmith/codev build`
+- pnpm build / pnpm test → run from `packages/codev/` or use `pnpm --filter @cluesmith/codev build` (the build script first builds codev's workspace deps via the graph-derived `pnpm --filter "@cluesmith/codev^..." build` closure, so a missing or stale dep `dist/` can't surface as false TS errors in codev's own sources)
 - E2E tests → `packages/codev/tests/e2e/`
 - Unit tests → `packages/codev/tests/unit/`
 - Never run npm commands from the repository root unless explicitly told to.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ pnpm build
 pnpm -w run local-install
 ```
 
-- `pnpm build` builds types, sdk, core, and artifact-canvas, then codev (including dashboard)
+- `pnpm build` builds artifact-canvas (needed by the VS Code extension, not part of codev's dependency closure), then the codev CLI; codev's own build script first builds its graph-derived workspace-dependency closure (types, sdk, core, dashboard) via `pnpm --filter "@cluesmith/codev^..." build`
 - `pnpm -w run local-install` runs `scripts/local-install.sh`, which:
   - Packs the `@cluesmith/codev-core`, `@cluesmith/codev-sdk`, and `@cluesmith/codev` tarballs into their package directories
   - Globally installs all three in one `npm install -g` (separate installs fail because `@cluesmith/codev-core` isn't on the public npm registry)
@@ -317,7 +317,7 @@ project-root/
 
 ## Directory Map
 - pnpm install → always run from the repository root (installs all workspace packages)
-- pnpm build / pnpm test → run from `packages/codev/` or use `pnpm --filter @cluesmith/codev build`
+- pnpm build / pnpm test → run from `packages/codev/` or use `pnpm --filter @cluesmith/codev build` (the build script first builds codev's workspace deps via the graph-derived `pnpm --filter "@cluesmith/codev^..." build` closure, so a missing or stale dep `dist/` can't surface as false TS errors in codev's own sources)
 - E2E tests → `packages/codev/tests/e2e/`
 - Unit tests → `packages/codev/tests/unit/`
 - Never run npm commands from the repository root unless explicitly told to.

--- a/codev/projects/1352-packages-codev-build-doesn-t-b/status.yaml
+++ b/codev/projects/1352-packages-codev-build-doesn-t-b/status.yaml
@@ -1,0 +1,14 @@
+id: '1352'
+title: packages-codev-build-doesn-t-b
+protocol: air
+phase: implement
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-05T07:51:58.758Z'
+updated_at: '2026-08-05T07:51:58.758Z'

--- a/codev/projects/1352-packages-codev-build-doesn-t-b/status.yaml
+++ b/codev/projects/1352-packages-codev-build-doesn-t-b/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-08-05T08:02:36.865Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-05T07:51:58.758Z'
-updated_at: '2026-08-05T08:01:05.284Z'
+updated_at: '2026-08-05T08:02:36.866Z'
+pr_ready_for_human: true

--- a/codev/projects/1352-packages-codev-build-doesn-t-b/status.yaml
+++ b/codev/projects/1352-packages-codev-build-doesn-t-b/status.yaml
@@ -1,7 +1,7 @@
 id: '1352'
 title: packages-codev-build-doesn-t-b
 protocol: air
-phase: implement
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-05T07:51:58.758Z'
-updated_at: '2026-08-05T07:51:58.758Z'
+updated_at: '2026-08-05T08:01:05.284Z'

--- a/codev/projects/1352-packages-codev-build-doesn-t-b/status.yaml
+++ b/codev/projects/1352-packages-codev-build-doesn-t-b/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-08-05T08:02:36.865Z'
+    approved_at: '2026-08-05T08:10:31.557Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-05T07:51:58.758Z'
-updated_at: '2026-08-05T08:02:36.866Z'
-pr_ready_for_human: true
+updated_at: '2026-08-05T08:10:31.558Z'
+pr_ready_for_human: false

--- a/codev/resources/arch.md
+++ b/codev/resources/arch.md
@@ -816,7 +816,7 @@ packages/codev/dashboard/
 └── package.json
 ```
 
-**Building**: `npm run build` in `packages/codev/` includes `build:dashboard`. Output: ~64KB gzipped.
+**Building**: `pnpm build` in `packages/codev/` builds `apps/web` as part of the graph-derived workspace-dependency closure, then copies `apps/web/dist` into `dashboard-dist` via the `copy-dashboard` step (Issue #1352). Output: ~64KB gzipped.
 
 **Terminal Component** (`Terminal.tsx`):
 - xterm.js with `customGlyphs: true` for crisp Unicode block elements
@@ -1140,7 +1140,7 @@ duplication: Tower's own reconnect backoff + WS close code live in a private
 copy at `packages/codev/src/agent-farm/lib/reconnect-backoff.ts` because the
 server must not import the client sdk.
 
-**Build order:** `pnpm build` from root builds types → sdk → core → artifact-canvas → codev (including dashboard). `codev-types` is built first because the VS Code extension's esbuild bundle resolves the package's runtime `exports.default` (`./dist/index.js`); a missing `types/dist` breaks the extension build even though tsc and vite resolve it from source via `exports.types` (`./src/index.ts`).
+**Build order:** `pnpm build` from root builds artifact-canvas (consumed by the VS Code extension; zero workspace deps, so no ordering hazard) and then `@cluesmith/codev`, whose own build script first builds its graph-derived workspace-dependency closure via `pnpm --filter "@cluesmith/codev^..." build` (types, sdk, core, apps/web in topological order, then the dashboard copy — Issue #1352, replacing the drift-prone hand-list). The closure guarantees `types/dist` exists, which the VS Code extension's esbuild bundle needs: it resolves the package's runtime `exports.default` (`./dist/index.js`), and a missing `types/dist` breaks the extension build even though tsc and vite resolve it from source via `exports.types` (`./src/index.ts`).
 
 **Publishing:** `codev-core` and `codev-sdk` must be published to npm before `codev` (runtime dependencies).
 

--- a/codev/state/air-1352_thread.md
+++ b/codev/state/air-1352_thread.md
@@ -1,0 +1,23 @@
+# air-1352 thread — packages/codev build doesn't build its workspace deps
+
+## 2026-08-05 Implement phase
+
+Verified the issue's claims against source:
+- `packages/codev` build script: `pnpm clean && tsc && pnpm build:dashboard && pnpm copy-skeleton`. Never builds workspace deps.
+- Root chain hand-lists types, sdk, core, artifact-canvas, codev. Confirmed drift: `pnpm --filter "@cluesmith/codev^..." list --depth -1` resolves to types, sdk, core, and codev-web (apps/web). artifact-canvas is NOT in the closure; apps/web IS (devDependency).
+- artifact-canvas has zero workspace deps and is consumed by apps/vscode. Root builds it for the extension dev flow, so it stays as an explicit root entry (a deliberate extra, not dep-closure drift).
+- `build:dashboard` is referenced only by codev's own `build`. apps/web's package build (`tsc -b && vite build`) is exactly what build:dashboard ran via `cd ../../apps/web && pnpm build`.
+
+Plan (per architect guidance: fix A + D, project references out of scope):
+- codev build gets a graph-derived prefix: `pnpm --filter "@cluesmith/codev^..." build`. Since the closure now builds apps/web, `build:dashboard` collapses to a copy-only step (`copy-dashboard`), avoiding a double vite build.
+- Root chain: check-main-fresh + artifact-canvas + codev (codev now self-sufficient).
+- Docs: CLAUDE.md/AGENTS.md line 66 (Local Build Testing) and line 320 (Directory Map), kept byte-identical. Existing governance-sweep test enforces identity.
+- check-main-fresh.sh is a no-op off main, so builder-branch root builds are safe.
+
+Acceptance: clean-tree (rm -rf packages/*/dist apps/web/dist) builds succeed from filter, from packages/codev, and from root.
+
+## Implement complete
+
+- All three clean-tree acceptance builds passed: `pnpm --filter @cluesmith/codev build` from root, `pnpm build` from packages/codev, root `pnpm build` (check-main-fresh is a no-op off main).
+- Added `packages/codev/src/__tests__/build-scripts.test.ts`: asserts the closure prefix on codev's build and that the root script no longer hand-lists codev's workspace deps. governance-sweep byte-identity test covers the CLAUDE.md/AGENTS.md edits.
+- `porch check 1352`: build + tests green. Moving to PR phase.

--- a/codev/state/air-1352_thread.md
+++ b/codev/state/air-1352_thread.md
@@ -26,3 +26,16 @@ Acceptance: clean-tree (rm -rf packages/*/dist apps/web/dist) builds succeed fro
 
 - PR #1355 created with the review embedded in the body (AIR: no spec/plan/review files). Follow-up noted in the PR body: TypeScript project references for the stale-dist case, out of scope per architect guidance.
 - PR-phase checks green (pr_exists, e2e_tests). `porch gate 1352` requested; architect notified via afx send. Waiting for human approval of the pr gate.
+
+## AIR consult at PR (architect-requested at gate)
+
+I had skipped the consult, reading AIR's "optional" clause as builder discretion; the architect corrected this at the gate. First attempt failed on project auto-detection ("Multiple projects found", no verdicts produced); re-ran with `--issue 1352`.
+
+- gemini: APPROVE (HIGH). No issues.
+- codex: APPROVE (HIGH). No issues.
+- claude: REQUEST_CHANGES (HIGH). Two stale build-wiring lines in `codev/resources/arch.md` (819: `build:dashboard` reference; 1143: the deleted hand-list build order plus stale types-first rationale). Non-blocking notes: CI workflows still hand-build sdk/core before codev (redundant but harmless, and test.yml's dep builds feed their own unit-test steps, so not blindly deletable); root guard test is absence-only.
+
+Dispositions:
+- arch.md 819 + 1143: FIXED in-branch (same doc-misdirection class the issue targets). Repo-wide grep: remaining `build:dashboard` mentions are historical artifacts (plans/reviews/release notes), left as history.
+- CI workflow hand-builds: follow-up candidate, out of AIR scope; flagged to architect rather than expanded.
+- Absence-only guard test: accepted as minor; the positive closure-prefix assertion is the load-bearing guard.

--- a/codev/state/air-1352_thread.md
+++ b/codev/state/air-1352_thread.md
@@ -21,3 +21,8 @@ Acceptance: clean-tree (rm -rf packages/*/dist apps/web/dist) builds succeed fro
 - All three clean-tree acceptance builds passed: `pnpm --filter @cluesmith/codev build` from root, `pnpm build` from packages/codev, root `pnpm build` (check-main-fresh is a no-op off main).
 - Added `packages/codev/src/__tests__/build-scripts.test.ts`: asserts the closure prefix on codev's build and that the root script no longer hand-lists codev's workspace deps. governance-sweep byte-identity test covers the CLAUDE.md/AGENTS.md edits.
 - `porch check 1352`: build + tests green. Moving to PR phase.
+
+## PR gate
+
+- PR #1355 created with the review embedded in the body (AIR: no spec/plan/review files). Follow-up noted in the PR body: TypeScript project references for the stale-dist case, out of scope per architect guidance.
+- PR-phase checks green (pr_exists, e2e_tests). `porch gate 1352` requested; architect notified via afx send. Waiting for human approval of the pr gate.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {
-    "build": "scripts/check-main-fresh.sh && pnpm --filter @cluesmith/codev-types build && pnpm --filter @cluesmith/codev-sdk build && pnpm --filter @cluesmith/codev-core build && pnpm --filter @cluesmith/codev-artifact-canvas build && pnpm --filter @cluesmith/codev build",
+    "build": "scripts/check-main-fresh.sh && pnpm --filter @cluesmith/codev-artifact-canvas build && pnpm --filter @cluesmith/codev build",
     "test": "pnpm --filter @cluesmith/codev test",
     "local-install": "scripts/local-install.sh",
     "bump-version": "scripts/bump-all.sh",

--- a/packages/codev/package.json
+++ b/packages/codev/package.json
@@ -22,8 +22,8 @@
   ],
   "scripts": {
     "clean": "rm -rf dist",
-    "build": "pnpm clean && tsc && pnpm build:dashboard && pnpm copy-skeleton",
-    "build:dashboard": "cd ../../apps/web && pnpm build && rm -rf ../../packages/codev/dashboard-dist && cp -r dist ../../packages/codev/dashboard-dist",
+    "build": "pnpm --filter \"@cluesmith/codev^...\" build && pnpm clean && tsc && pnpm copy-dashboard && pnpm copy-skeleton",
+    "copy-dashboard": "rm -rf dashboard-dist && cp -r ../../apps/web/dist dashboard-dist",
     "dev:dashboard": "cd ../../apps/web && pnpm dev",
     "copy-skeleton": "rm -rf skeleton && cp -r ../../codev-skeleton skeleton",
     "dev": "tsx src/cli.ts",

--- a/packages/codev/src/__tests__/build-scripts.test.ts
+++ b/packages/codev/src/__tests__/build-scripts.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Issue #1352: packages/codev's build must derive its workspace-dependency
+ * closure from the pnpm graph, never from a hand-maintained package list.
+ *
+ * The hand-list in the root build script had already drifted from the graph
+ * (it built artifact-canvas, which is not in codev's closure, and omitted
+ * apps/web, which is). A missing or stale dep dist/ then surfaced as
+ * convincing false TS errors in codev's own sources (TS2339/TS2307).
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const repoRoot = path.resolve(import.meta.dirname, '../../../..');
+const readScripts = (rel: string): Record<string, string> =>
+  JSON.parse(fs.readFileSync(path.join(repoRoot, rel), 'utf-8')).scripts;
+
+describe('Issue #1352 — graph-derived build closure', () => {
+  it('packages/codev build starts with the graph-derived dependency closure', () => {
+    const scripts = readScripts('packages/codev/package.json');
+    expect(scripts.build).toContain('--filter "@cluesmith/codev^..." build');
+  });
+
+  it('root build does not hand-list codev workspace deps (drift class removed)', () => {
+    const scripts = readScripts('package.json');
+    for (const dep of ['codev-types', 'codev-sdk', 'codev-core', 'codev-web']) {
+      expect(scripts.build, `root build should not hand-list ${dep}`).not.toContain(dep);
+    }
+  });
+});


### PR DESCRIPTION
Closes #1352

## Summary

After the sdk split, building from `packages/codev` (or via `pnpm --filter @cluesmith/codev build`) failed with convincing false TS errors (TS2339 on `TowerClient`, TS2307 on `@cluesmith/codev-sdk/constants`) whenever workspace deps had no fresh `dist`. The root chain papered over this with a hand-maintained package list that had already drifted from the dependency graph.

This PR implements the issue's fix A + D:

- **A (graph-derived closure)**: `packages/codev`'s build now starts with `pnpm --filter "@cluesmith/codev^..." build`, so its workspace deps (types, sdk, core, apps/web) are built in topological order straight from the pnpm graph. The root chain drops the hand-list entirely and calls the now self-sufficient codev build.
- **D (docs)**: the stale Local Build Testing bullet and Directory Map line in `CLAUDE.md` and `AGENTS.md` are updated; the two files remain byte-identical (enforced by the existing governance-sweep test).

## Key decisions

- **`build:dashboard` collapsed to `copy-dashboard`.** The issue flagged this nuance for reconciliation: the closure now builds `apps/web` (its package build is `tsc -b && vite build`, exactly what `build:dashboard` ran via `cd ../../apps/web && pnpm build`). Keeping the old step would double-build the dashboard, so the codev-side step is now copy-only (`apps/web/dist` to `dashboard-dist`). `build:dashboard` had no other callers (verified by grep).
- **artifact-canvas stays as one explicit root entry.** It has zero workspace deps and is consumed by `apps/vscode`, so it is not part of codev's closure and not dep-closure drift; the root builds it for the extension dev flow. This is documented in the updated CLAUDE.md/AGENTS.md bullet.
- **`check-main-fresh.sh` untouched.** It is a no-op off `main`, so worktree and builder-branch root builds are unaffected.
- **local-install path unaffected.** `scripts/local-install.sh` packs core, sdk, and codev; packing does not trigger `prepublishOnly`, and `prepublishOnly` (`pnpm build`) still works from `packages/codev` since pnpm resolves the workspace from any member directory.

## Test plan

- New `packages/codev/src/__tests__/build-scripts.test.ts`: asserts codev's build script carries the graph-derived closure prefix, and that the root build script no longer hand-lists any codev workspace dep (types, sdk, core, web). This encodes the invariant "dep closure comes from the graph, not a hand-list".
- Existing `governance-sweep.test.ts` continues to enforce CLAUDE.md and AGENTS.md byte-identity over the doc edits.
- Acceptance (all run from a clean tree, `rm -rf packages/*/dist apps/web/dist packages/codev/dashboard-dist`):
  1. `pnpm --filter @cluesmith/codev build` from the repo root: PASS
  2. `pnpm build` from `packages/codev/`: PASS
  3. Root `pnpm build` on the builder branch: PASS
- `porch check 1352`: build and unit tests green.

## Follow-up (out of scope per architect guidance)

TypeScript project references (`composite` + `tsc -b`) would additionally catch the STALE-dist case (deps built but outdated), which neither the closure prefix nor a preflight guard catches. The closure prefix mitigates it in practice (every codev build re-runs the deps' builds, so their `dist` is refreshed), but incremental correctness across packages without full rebuilds would need project references. Worth weighing against the build-tooling churn in a separate issue if stale-dist bites again.


## Consultation (AIR 3-way at PR, `consult --protocol air --type pr --issue 1352`)

| Lane | Verdict | Confidence | Key issues |
|------|---------|------------|------------|
| gemini | APPROVE | HIGH | None |
| codex | APPROVE | HIGH | None |
| claude | REQUEST_CHANGES | HIGH | Two stale build-wiring lines in `codev/resources/arch.md` (819, 1143) |

Dispositions:

- **arch.md:819 (`build:dashboard` reference) and arch.md:1143 (deleted hand-list build order)**: fixed in commit `1db87032`. This is the same doc-misdirection class the issue was filed about, so it belongs in this PR. The types-first rationale for the VS Code extension's esbuild bundle still holds and is now stated as a guarantee of the closure rather than of hand-ordering. A repo-wide grep confirmed the only remaining `build:dashboard` mentions are historical artifacts (past plans, reviews, release notes), left untouched as history.
- **Non-blocking (claude): CI workflows still hand-build sdk/core before codev.** Redundant now but harmless, and in `test.yml` those builds also feed their own unit-test steps, so they cannot be deleted blindly. Flagged as a follow-up candidate rather than expanded here (AIR scope).
- **Non-blocking (claude): root guard test is absence-only** (a hand-list re-expressed as `--filter ./packages/sdk` would slip through). Accepted as minor; the positive closure-prefix assertion is the load-bearing guard.

Note: the consult ran at the architect's direction at the PR gate; the first attempt failed on project auto-detection ("Multiple projects found") and produced no verdicts, re-run with `--issue 1352`.
