### PR TITLE
Fix #1372: bound the tunnel `connecting` state so an uplink flap can't wedge it

### DIFF
--- a/codev/projects/bugfix-1372-tunnel-client-wedges-after-sus/status.yaml
+++ b/codev/projects/bugfix-1372-tunnel-client-wedges-after-sus/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1372
 title: tunnel-client-wedges-after-sus
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-08T22:18:55.516Z'
-updated_at: '2026-08-08T22:23:36.701Z'
+updated_at: '2026-08-08T22:30:58.822Z'

--- a/codev/projects/bugfix-1372-tunnel-client-wedges-after-sus/status.yaml
+++ b/codev/projects/bugfix-1372-tunnel-client-wedges-after-sus/status.yaml
@@ -7,13 +7,15 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-08-08T23:05:33.160Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-08T22:18:55.516Z'
-updated_at: '2026-08-08T23:05:22.957Z'
+updated_at: '2026-08-08T23:05:33.161Z'
 pr_history:
   - phase: pr
     pr_number: 1373
     branch: builder/bugfix-1372
     created_at: '2026-08-08T23:05:22.956Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1372-tunnel-client-wedges-after-sus/status.yaml
+++ b/codev/projects/bugfix-1372-tunnel-client-wedges-after-sus/status.yaml
@@ -6,16 +6,17 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-08-08T23:05:33.160Z'
+    approved_at: '2026-08-09T00:34:35.053Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-08T22:18:55.516Z'
-updated_at: '2026-08-08T23:05:33.161Z'
+updated_at: '2026-08-09T00:34:35.054Z'
 pr_history:
   - phase: pr
     pr_number: 1373
     branch: builder/bugfix-1372
     created_at: '2026-08-08T23:05:22.956Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1372-tunnel-client-wedges-after-sus/status.yaml
+++ b/codev/projects/bugfix-1372-tunnel-client-wedges-after-sus/status.yaml
@@ -11,4 +11,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-08T22:18:55.516Z'
-updated_at: '2026-08-08T22:30:58.822Z'
+updated_at: '2026-08-08T23:05:22.957Z'
+pr_history:
+  - phase: pr
+    pr_number: 1373
+    branch: builder/bugfix-1372
+    created_at: '2026-08-08T23:05:22.956Z'

--- a/codev/projects/bugfix-1372-tunnel-client-wedges-after-sus/status.yaml
+++ b/codev/projects/bugfix-1372-tunnel-client-wedges-after-sus/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1372
 title: tunnel-client-wedges-after-sus
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-08T22:18:55.516Z'
-updated_at: '2026-08-08T22:18:55.517Z'
+updated_at: '2026-08-08T22:23:36.701Z'

--- a/codev/projects/bugfix-1372-tunnel-client-wedges-after-sus/status.yaml
+++ b/codev/projects/bugfix-1372-tunnel-client-wedges-after-sus/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1372
+title: tunnel-client-wedges-after-sus
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-08T22:18:55.516Z'
+updated_at: '2026-08-08T22:18:55.517Z'

--- a/codev/state/bugfix-1372_thread.md
+++ b/codev/state/bugfix-1372_thread.md
@@ -1,0 +1,129 @@
+# bugfix-1372 — tunnel client wedges after sustained uplink flap
+
+Issue #1372. Protocol: BUGFIX (strict). Branch `builder/bugfix-1372`.
+
+---
+
+## Investigate (2026-08-08)
+
+### Reproduced
+
+`tmp/`-scratch vitest repro: a `net` server that accepts the TCP connection and never
+answers the HTTP upgrade — i.e. a post-flap half-open path (stale NAT/conntrack entry,
+which is exactly what a 2-minute uplink flap leaves behind).
+
+```
+state after 6s:                       connecting
+state after explicit connect():       connecting
+state after resetCircuitBreaker():    connecting
+```
+
+Zero state transitions after the initial `disconnected → connecting`. Matches the observed
+22:06:44Z wedge precisely, and reproduces the second half of the report too: **nothing the
+tower can do to itself breaks the wedge.**
+
+### Root cause — `connecting` is an unbounded state
+
+`lib/tunnel-client.ts:369 doConnect()` does `new WebSocket(wsUrl)` with **no
+`handshakeTimeout`** and arms **no watchdog**. Two sub-phases can hang forever:
+
+1. TCP connect / TLS / HTTP upgrade — Node sets no socket timeout by default, and `ws`
+   only enforces a handshake deadline when `handshakeTimeout` is passed. It isn't.
+2. After `open`, `onWsOpen()` (line 399) sends the auth frame and waits on `message`. If
+   the relay never replies, it waits forever.
+
+Every recovery path is gated on *leaving* `connecting`, so none of them fire:
+
+| Path | Why it can't help |
+|---|---|
+| `scheduleReconnect()` | only reached from `ws.on('error')` / `ws.on('close')` / pong timeout — a silent hang emits none of those |
+| `startHeartbeat()` | armed only after `connected` (line 478), so ping/pong never covers `connecting` |
+| `connect()` | early-returns when `state === 'connecting'` (line 193) — an external nudge is a no-op |
+| `resetCircuitBreaker()` | only acts when `state === 'auth_failed'` (line 215) |
+
+That is why `POST /api/tunnel/connect` recovered it instantly: `connectTunnel()`
+(`tower-tunnel.ts:126`) `disconnect()`s the old client and constructs a **brand-new
+`TunnelClient`**. The recovery came from replacing the object, not from
+`resetCircuitBreaker()`.
+
+### Contributing defects
+
+2. **`auth_failed` is terminal.** `handleAuthError('invalid_api_key')` → `auth_failed`, and
+   `scheduleReconnect()` returns early on that state forever (line 284). One misclassified
+   auth error during a blip parks the tunnel permanently. (Issue ask #2.)
+3. **No failure reason logged.** `handleConnectionError(_err)` (line 455) discards the
+   error; `tower-tunnel.ts:142` logs bare `Tunnel: ${prev} → ${state}`. Hence "diagnosis
+   archaeology". (Issue ask #3.)
+4. **Backoff off-by-one + timer leak.** `handleConnectionError` and `handleAuthError` call
+   `scheduleReconnect()` *before* `this.consecutiveFailures++`, so every delay is computed
+   one attempt behind. `scheduleReconnect()` also doesn't clear an existing timer.
+
+### On the ~4ms instant-fail cycles (issue observation 1, ask #4)
+
+Consistent with the kernel refusing `connect()` outright — `ENETUNREACH`/`EHOSTUNREACH`,
+no default route during the flap, DNS already cached. The socket errors in a few ms,
+`handleConnectionError` fires, backoff schedules a retry. **That path is working as
+designed**; the off-by-one just makes it retry a notch faster than intended.
+
+Ask #4 (rebuild the client after K instant failures) is **not needed and I don't plan to
+implement it**: `doConnect()` already builds a fresh `WebSocket` every attempt, and
+`cleanup()` nulls the h2 server/session/stream. The only state the old client actually
+carried across was the stuck `connecting` flag — the watchdog dissolves it. Adding a
+rebuild path would be a second, redundant recovery mechanism. Flagging the reasoning here
+rather than silently dropping the ask.
+
+### Scope
+
+Four focused changes in `lib/tunnel-client.ts` + a reason string threaded through the
+state-change callback into `tower-tunnel.ts`. Well under the 300-LOC ceiling. Proceeding
+with BUGFIX.
+
+`<signal>PHASE_COMPLETE</signal>`
+
+---
+
+## Fix (2026-08-08)
+
+Four changes in `lib/tunnel-client.ts`, one log line in `servers/tower-tunnel.ts`. ~115 LOC
+of source, well inside the BUGFIX ceiling.
+
+1. **`CONNECT_TIMEOUT_MS = 20_000` watchdog** armed in `doConnect()`, disarmed by `setState`
+   on any transition out of `connecting` and by `cleanup()`. On fire: warn, tear down,
+   `consecutiveFailures++`, `disconnected`, `scheduleReconnect()`. Covers both silent-hang
+   phases (handshake and auth-response wait) with one timer.
+2. **`AUTH_RETRY_INTERVAL_MS = 15 * 60_000` half-open** via `scheduleAuthRetry()`.
+   `auth_failed` now leaves the state and retries once per interval; a genuinely revoked key
+   fails again and re-parks, so the cycle is self-limiting.
+3. **Reasons on every transition.** `setState(state, reason?)` → third callback arg →
+   `Tunnel: connecting → disconnected (connect timeout after 20000ms)`. Close frames now
+   carry their code and reason text; `handleConnectionError` no longer discards the error.
+4. **Backoff ordering + timer hygiene.** `consecutiveFailures++` moved before every
+   `scheduleReconnect()` call; `scheduleReconnect()` and the rate-limit path now
+   `clearReconnectTimer()` first.
+
+### Verification
+
+Five regression tests in `__tests__/tunnel-client.test.ts` (`#1372 self-healing`). Verified
+by mutation — each fix reverted individually, tests re-run:
+
+| Mutation | Tests that fail |
+|---|---|
+| A: watchdog body `return`s early | watchdog test |
+| B: `scheduleAuthRetry()` call removed | auth half-open test |
+| C: `reason` dropped from listener call | watchdog + reason tests |
+| D: `consecutiveFailures++` moved back after `scheduleReconnect()` | ordering test |
+
+All four detected; all 5 pass with the fix restored. Build green.
+
+The connect-watchdog test uses a real `net` blackhole server (accept, never answer the
+upgrade) under `vi.useFakeTimers({ shouldAdvanceTime: true })`. The auth half-open test is
+driven through the private handler with plain fake timers — mixing a 15-minute fake clock
+with real socket I/O was flaky, and the heartbeat tests already established that idiom.
+
+### Deliberately not done
+
+Issue ask #4 (rebuild the client object after K instant failures). `doConnect()` already
+builds a fresh `WebSocket` per attempt and `cleanup()` nulls the h2 server/session/stream —
+the only cross-attempt state was the stuck `connecting` flag, which the watchdog dissolves.
+A rebuild path would be a redundant second recovery mechanism. Reasoning recorded above
+under Investigate; flagging rather than silently dropping.

--- a/codev/state/bugfix-1372_thread.md
+++ b/codev/state/bugfix-1372_thread.md
@@ -120,6 +120,41 @@ upgrade) under `vi.useFakeTimers({ shouldAdvanceTime: true })`. The auth half-op
 driven through the private handler with plain fake timers — mixing a 15-minute fake clock
 with real socket I/O was flaky, and the heartbeat tests already established that idiom.
 
+### CMAP round 1 (PR #1373)
+
+| Lane | Verdict |
+|---|---|
+| gemini | APPROVE — no issues |
+| claude | APPROVE — three minor, non-blocking |
+| codex | **REQUEST_CHANGES** — one real defect |
+
+**codex was right, and it's a defect my own watchdog introduced.** `onWsOpen`'s `onMessage`
+had no `ws === this.ws` guard, unlike the `error`/`close` handlers. Before this PR nothing
+tore an attempt down mid-flight, so the hole was latent; the watchdog makes it reachable —
+an `auth_ok` queued before `cleanup()` could call `startH2Server()`, clobber the h2 handles
+and flip state back to `connected` on a dead socket while a reconnect was already pending.
+Exactly the "wedged internal state" the issue speculated about, and I'd have shipped it.
+
+Fixed with stale guards in `onWsOpen`, `onMessage`, `startH2Server`, and the h2 `session`
+callback (which destroys the late session). Regression test added; mutation-verified — with
+the guard removed the test fails.
+
+From claude, applied:
+- `new WebSocket()` wrapped in try/catch. A synchronous throw would have left `connecting`
+  unbounded with no watchdog armed — the same wedge class this PR exists to close.
+- `sanitizeCloseReason()` strips control characters and caps length. The close-frame reason
+  is remote-supplied and was being logged verbatim (log-forging vector).
+
+### Correction to my own framing (claude's third point, verified)
+
+I implied the auth breaker addresses the observed incident. It does not. `auth_failed` is
+reachable **only** from an explicit `{type:'auth_error', reason:'invalid_api_key'}` JSON
+frame. A Cloudflare 5xx/HTML body fails `JSON.parse` and routes to `handleConnectionError`
+(transient, retries); a failed upgrade never opens the socket at all. So the issue's
+hypothesis — "a proxy error page misclassified as an auth error" — cannot happen on this
+code path. The half-open breaker is **defensive hardening, not the corrective fix**; the
+watchdog is what resolves the reported wedge. PR body corrected to say so.
+
 ### Deliberately not done
 
 Issue ask #4 (rebuild the client object after K instant failures). `doConnect()` already

--- a/codev/state/bugfix-1372_thread.md
+++ b/codev/state/bugfix-1372_thread.md
@@ -245,6 +245,34 @@ Two patterns, both mine:
 
 The consultation loop caught all four. Solo review would have shipped every one.
 
+### CMAP round 4 — converged
+
+| Lane | Verdict |
+|---|---|
+| gemini | APPROVE — no issues |
+| codex | COMMENT — no defects |
+| claude | COMMENT — no blocking |
+
+**First round with no defect in the code.** Both commenting lanes raised polish:
+
+- *codex:* PR body carried stale counts ("seven new tests"; pre-round-3 suite total) — real
+  figure is 15. And the blackhole test was named "tears down **and reschedules**" while only
+  asserting the teardown; a watchdog that only tore down would trade a wedged `connecting`
+  for a wedged `disconnected`. Added the reschedule assertion. Fixed in `35cbf328`.
+- *claude:* two points were races with in-flight work (now committed). The third was real:
+  `cleanup()` called `ws.close()` *before* nulling `this.ws`, so the watchdog's reason
+  survived only because `ws` happens to defer abortHandshake's error via `process.nextTick`.
+  Inverted to detach-then-close, removing the dependency on a third party's internals
+  rather than commenting on it (`573dae73`).
+
+Left undone, flagged for the architect: the tower UI cloud chip briefly flickers
+`auth failed → connecting… → auth failed` every 15 min. Inherent to half-opening, and only
+with a genuinely revoked key.
+
+**Final state:** 4579 tests passing, build green, 16 mutation-verified regression tests
+(14 client-side, 2 tower-side — the first coverage `tower-tunnel.ts` had for either
+behaviour). Four CMAP rounds, twelve lane-runs.
+
 ### Deliberately not done
 
 Issue ask #4 (rebuild the client object after K instant failures). `doConnect()` already

--- a/codev/state/bugfix-1372_thread.md
+++ b/codev/state/bugfix-1372_thread.md
@@ -197,6 +197,54 @@ across `codev/` and `codev-skeleton/`.
 - *Uncommitted round-2 work not in the PR.* Correct at the time it looked — it was
   mid-flight. Committed now.
 
+### CMAP round 3
+
+| Lane | Verdict |
+|---|---|
+| gemini | APPROVE — no issues |
+| claude | APPROVE — three minor |
+| codex | **REQUEST_CHANGES** — one real defect |
+
+**codex and claude independently found the same thing, and it is the worst one yet.**
+Round 1 I wrapped `new WebSocket()` in a try/catch and wrote a comment saying it covered a
+"malformed URL". It did not: `buildTunnelWsUrl()` (which calls `new URL()`) sat *outside*
+the try, after `setState('connecting')`. So a malformed `serverUrl` threw out of
+`doConnect()` and left the client wedged in `connecting` with no watchdog — **the exact bug
+this PR exists to fix, reintroduced by the fix for it**, behind a comment claiming the
+opposite. Moved inside the guard; mutation-verified test.
+
+claude's two minor points, both taken:
+- ERROR-log suppression coupled two files by a bare string literal → exported
+  `AUTH_RETRY_FAILED_MARKER`. Added the first tower-side tests for the alarm-once contract
+  and the reason-in-log-line behaviour.
+- `sanitizeRemoteDetail` widened to strip U+2028/U+2029 and bidi overrides.
+
+Also removed a raw NUL byte an earlier heredoc had written into the test source; verified
+no raw control bytes remain.
+
+### Running tally — worth reading before the next bugfix
+
+Four real defects found across three rounds. **Three of the four were introduced by this
+fix, not by the original code.** A 115-LOC change to reconnection logic had a far larger
+blast radius than "minimal fix" implies:
+
+| Round | Defect | Whose |
+|---|---|---|
+| 1 | late `auth_ok` resurrects a torn-down socket | mine (watchdog made it reachable) |
+| 2 | three unsanitized relay-text paths into the log | mine (round-1 fix, half-applied) |
+| 2 | auth alarm every 15 min forever | mine (half-open breaker) |
+| 3 | `new URL()` outside the try → same wedge class | mine (round-1 hardening) |
+
+Two patterns, both mine:
+1. **Fixing the instance, not the class.** Rounds 1→2 on sanitization, rounds 1→3 on
+   synchronous-throw guarding. Each time I patched exactly what was pointed at.
+   `lessons-critical.md` already says "grep the whole repo before claiming all fixed" —
+   it applies *within a file*, not just across `codev/` and `codev-skeleton/`.
+2. **Comments asserting coverage the code lacks.** The round-3 defect hid behind my own
+   comment. A comment is a claim; it needs the same verification as an assertion.
+
+The consultation loop caught all four. Solo review would have shipped every one.
+
 ### Deliberately not done
 
 Issue ask #4 (rebuild the client object after K instant failures). `doConnect()` already

--- a/codev/state/bugfix-1372_thread.md
+++ b/codev/state/bugfix-1372_thread.md
@@ -155,6 +155,48 @@ hypothesis — "a proxy error page misclassified as an auth error" — cannot ha
 code path. The half-open breaker is **defensive hardening, not the corrective fix**; the
 watchdog is what resolves the reported wedge. PR body corrected to say so.
 
+### CMAP round 2
+
+| Lane | Verdict |
+|---|---|
+| gemini | APPROVE — no issues |
+| claude | APPROVE — four points, three real |
+| codex | **REQUEST_CHANGES** — one real defect |
+
+**codex, again, and it's the same mistake twice.** Round 1 I sanitized the close
+frame; codex pointed out I'd missed every sibling path carrying relay-controlled text
+into the same log: `auth rejected: ${reason}`, `Unexpected auth response type: ${msg.type}`,
+and worst, `Invalid auth response: ${data.toString()}` — echoing the **entire raw payload**
+unbounded into the tower log. Generalized `sanitizeCloseReason` → `sanitizeRemoteDetail`
+and applied it at all four sites plus `handleConnectionError` as a choke point.
+
+Lesson, and it is the one already in `lessons-critical.md`: *after any change, grep for
+siblings before claiming it's fixed.* I fixed the instance I was handed, twice, instead of
+sweeping the class. Worth remembering that this applies within a single file, not just
+across `codev/` and `codev-skeleton/`.
+
+**claude's points — three real, one wrong:**
+
+- *Auth alarm every 15 min.* Real, and a regression I introduced: a revoked key now
+  re-parks forever, and both `console.error` and the tower ERROR line fired each time.
+  Now raised once; later re-parks are tagged `(half-open retry failed)` so the tower logs
+  them quietly. Test added.
+- *`resetCircuitBreaker()` cancels the pending retry without reconnecting.* Real — my
+  `clearReconnectTimer()` made a standalone call worse than before the fix. Now schedules
+  a reconnect. Test added.
+- *Backoff framing.* **Claude's facts were wrong, its point was right.** It claimed "the
+  old ordering matched the documented formula and its existing test." There was no single
+  old ordering — pong/close incremented before, error/auth after, a 2-vs-2 inconsistency
+  where the same failure drew a different delay depending on which event surfaced first
+  (and for a WebSocket an `error` is *always* followed by a `close`, so it was arbitrary).
+  No existing test pins client scheduling either; the suite stayed green through the change.
+  But I *did* frame "unify an inconsistency" as "fix an off-by-one," and I unified on the
+  slower branch — the error path's first retry moves ~1.5s → ~2.5s. Docstring, PR body and
+  the section above now say that plainly. Immaterial next to a 20s watchdog, and trivially
+  revertible if the architect prefers the faster branch.
+- *Uncommitted round-2 work not in the PR.* Correct at the time it looked — it was
+  mid-flight. Committed now.
+
 ### Deliberately not done
 
 Issue ask #4 (rebuild the client object after K instant failures). `doConnect()` already

--- a/packages/codev/src/agent-farm/__tests__/tower-tunnel.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tower-tunnel.test.ts
@@ -74,6 +74,7 @@ vi.mock('../lib/cloud-config.js', () => ({
 }));
 
 vi.mock('../lib/tunnel-client.js', () => ({
+  AUTH_RETRY_FAILED_MARKER: 'half-open retry failed',
   TunnelClient: class MockTunnelClient {
     connect = mockConnect;
     disconnect = mockDisconnect;
@@ -645,6 +646,45 @@ describe('tower-tunnel', () => {
 
       expect(mockConnect).toHaveBeenCalled();
       expect(mockSendMetadata).toHaveBeenCalled();
+    });
+
+    /**
+     * The breaker half-opens every 15 minutes (#1372), so a genuinely revoked
+     * key re-parks forever. Only the first park may raise the alarm.
+     */
+    it('logs the auth-failure alarm once, not on every half-open re-park', async () => {
+      mockReadCloudConfig.mockReturnValue(FAKE_CONFIG);
+      const deps = makeDeps();
+      await initTunnel(deps, { getInstances: async () => [] });
+
+      const onState = mockOnStateChange.mock.calls[0][0] as (
+        s: string, p: string, reason?: string,
+      ) => void;
+
+      onState('auth_failed', 'connecting', 'auth rejected: invalid_api_key');
+      onState('disconnected', 'auth_failed', 'auth circuit breaker half-open, retrying');
+      onState('auth_failed', 'connecting', 'auth rejected: invalid_api_key (half-open retry failed)');
+
+      const alarms = (deps.log as ReturnType<typeof vi.fn>).mock.calls.filter(
+        ([level, msg]) => level === 'ERROR' && String(msg).includes('invalid or revoked'),
+      );
+      expect(alarms).toHaveLength(1);
+    });
+
+    it('includes the transition reason in the tunnel state log line', async () => {
+      mockReadCloudConfig.mockReturnValue(FAKE_CONFIG);
+      const deps = makeDeps();
+      await initTunnel(deps, { getInstances: async () => [] });
+
+      const onState = mockOnStateChange.mock.calls[0][0] as (
+        s: string, p: string, reason?: string,
+      ) => void;
+      onState('disconnected', 'connecting', 'connect timeout after 20000ms');
+
+      expect(deps.log).toHaveBeenCalledWith(
+        'INFO',
+        'Tunnel: connecting → disconnected (connect timeout after 20000ms)',
+      );
     });
 
     it('handles cloud config read failure gracefully', async () => {

--- a/packages/codev/src/agent-farm/__tests__/tunnel-client.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tunnel-client.test.ts
@@ -19,7 +19,7 @@ import {
   PONG_TIMEOUT_MS,
   CONNECT_TIMEOUT_MS,
   AUTH_RETRY_INTERVAL_MS,
-  sanitizeCloseReason,
+  sanitizeRemoteDetail,
 } from '../lib/tunnel-client.js';
 import { MockTunnelServer } from './helpers/mock-tunnel-server.js';
 
@@ -1126,13 +1126,121 @@ describe('#1372 self-healing', () => {
     c.disconnect();
   });
 
-  it('sanitizes a remote-supplied close reason before logging it', () => {
-    // A relay could otherwise forge log lines through the close frame.
-    expect(sanitizeCloseReason('going away\nTunnel: connected → forged')).toBe(
+  it('sanitizes remote-supplied text before it reaches a log line', () => {
+    // A relay could otherwise forge log lines or inflate the log.
+    expect(sanitizeRemoteDetail('going away\nTunnel: connected → forged')).toBe(
       'going away Tunnel: connected → forged',
     );
-    expect(sanitizeCloseReason('a'.repeat(200))).toHaveLength(121); // 120 + ellipsis
-    expect(sanitizeCloseReason('  tidy  ')).toBe('tidy');
+    expect(sanitizeRemoteDetail('a\r\nb\tc d')).toBe('a  b c d');
+    expect(sanitizeRemoteDetail('a'.repeat(200))).toHaveLength(121); // 120 + ellipsis
+    expect(sanitizeRemoteDetail('  tidy  ')).toBe('tidy');
+  });
+
+  /**
+   * Every relay-controlled string that reaches a transition reason must be
+   * sanitized, not just the close frame. (Raised by codex in CMAP round 2.)
+   */
+  it.each([
+    ['auth_error reason', { type: 'auth_error', reason: 'nope\ninjected' }],
+    ['unexpected type', { type: 'weird\ninjected' }],
+  ])('sanitizes the %s carried into the transition reason', (_label, payload) => {
+    vi.useFakeTimers();
+    const c = createClient();
+    const ws = createMockWs();
+    (ws as unknown as { send: () => void }).send = vi.fn();
+    (c as unknown as { ws: WebSocket | null }).ws = ws;
+    (c as unknown as { state: string }).state = 'connecting';
+
+    const reasons: Array<string | undefined> = [];
+    c.onStateChange((_s, _p, reason) => reasons.push(reason));
+
+    (c as unknown as { onWsOpen: (w: WebSocket) => void }).onWsOpen(ws);
+    ws.emit('message', Buffer.from(JSON.stringify(payload)));
+
+    expect(reasons.length).toBeGreaterThan(0);
+    for (const r of reasons) expect(r ?? '').not.toMatch(/[\u0000-\u001f\u007f]/);
+
+    c.disconnect();
+  });
+
+  it('bounds an oversized malformed auth response instead of echoing it', () => {
+    vi.useFakeTimers();
+    const c = createClient();
+    const ws = createMockWs();
+    (ws as unknown as { send: () => void }).send = vi.fn();
+    (c as unknown as { ws: WebSocket | null }).ws = ws;
+    (c as unknown as { state: string }).state = 'connecting';
+
+    const reasons: Array<string | undefined> = [];
+    c.onStateChange((_s, _p, reason) => reasons.push(reason));
+
+    (c as unknown as { onWsOpen: (w: WebSocket) => void }).onWsOpen(ws);
+    // Not JSON, and far too large to echo into the tower log.
+    ws.emit('message', Buffer.from('<html>' + 'x'.repeat(100_000) + '</html>'));
+
+    const reason = reasons.find((r) => r?.includes('invalid auth response'));
+    expect(reason).toBeDefined();
+    expect(reason!.length).toBeLessThan(200);
+
+    c.disconnect();
+  });
+
+  /**
+   * A revoked key re-parks every 15 minutes forever. Raising the same alarm
+   * each time would be crying wolf. (Raised by claude in CMAP round 2.)
+   */
+  it('raises the auth alarm once, not on every half-open re-park', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.useFakeTimers();
+
+    const c = createClient();
+    const reasons: Array<string | undefined> = [];
+    c.onStateChange((_s, _p, reason) => reasons.push(reason));
+
+    const priv = c as unknown as { handleAuthError: (r: string) => void; doConnect: () => void };
+    vi.spyOn(priv, 'doConnect').mockImplementation(() => {});
+
+    // Three full park → half-open → re-park cycles, as a revoked key produces.
+    priv.handleAuthError('invalid_api_key');
+    for (let i = 0; i < 2; i++) {
+      vi.advanceTimersByTime(AUTH_RETRY_INTERVAL_MS);
+      expect(c.getState()).toBe('disconnected');
+      priv.handleAuthError('invalid_api_key');
+    }
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    // Later re-parks are tagged so the tower log can stay quiet too.
+    expect(reasons.filter((r) => r?.includes('half-open retry failed'))).toHaveLength(2);
+
+    c.disconnect();
+    errorSpy.mockRestore();
+  });
+
+  /**
+   * Cancelling the pending half-open retry without scheduling a fresh attempt
+   * would leave a standalone caller worse off than before the fix.
+   * (Raised by claude in CMAP round 2.)
+   */
+  it('resetCircuitBreaker schedules a reconnect rather than just cancelling', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.useFakeTimers();
+
+    const c = createClient();
+    const priv = c as unknown as { handleAuthError: (r: string) => void; doConnect: () => void };
+    const doConnect = vi.spyOn(priv, 'doConnect').mockImplementation(() => {});
+
+    priv.handleAuthError('invalid_api_key');
+    expect(c.getState()).toBe('auth_failed');
+
+    c.resetCircuitBreaker();
+    expect(c.getState()).toBe('disconnected');
+
+    // Counter was reset, so this is a first-attempt backoff — well under the
+    // 15-minute half-open interval it replaced.
+    vi.advanceTimersByTime(calculateBackoff(0, () => 0.999) + 1);
+    expect(doConnect).toHaveBeenCalled();
+
+    c.disconnect();
   });
 
   it('state transitions carry a failure reason', async () => {

--- a/packages/codev/src/agent-farm/__tests__/tunnel-client.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tunnel-client.test.ts
@@ -1285,6 +1285,33 @@ describe('#1372 self-healing', () => {
     c.disconnect();
   });
 
+  /**
+   * `close()` on a CONNECTING socket aborts the handshake and emits `error`.
+   * `ws` defers that via process.nextTick today, but if it ever emitted
+   * synchronously the handler would still see `ws === this.ws` and overwrite
+   * the watchdog's "connect timeout" reason. cleanup() must detach first so
+   * the ordering can't depend on a third party's internals.
+   * (Raised by claude in CMAP round 4.)
+   */
+  it('detaches the socket before closing it, so late events cannot race', () => {
+    const c = createClient();
+    const ws = createMockWs();
+
+    let wsSeenDuringClose: unknown = 'never called';
+    (ws as unknown as { close: () => void }).close = vi.fn(() => {
+      wsSeenDuringClose = (c as unknown as { ws: WebSocket | null }).ws;
+    });
+    (ws as unknown as { readyState: number }).readyState = WebSocket.CONNECTING;
+    (c as unknown as { ws: WebSocket | null }).ws = ws;
+
+    (c as unknown as { cleanup: () => void }).cleanup();
+
+    expect(ws.close).toHaveBeenCalled();
+    // Already detached at the moment close() runs — a synchronous error emitted
+    // from inside close() would hit the `ws !== this.ws` stale guard.
+    expect(wsSeenDuringClose).toBeNull();
+  });
+
   it('state transitions carry a failure reason', async () => {
     // Nothing is listening on this port — ECONNREFUSED.
     const probe = net.createServer();

--- a/packages/codev/src/agent-farm/__tests__/tunnel-client.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tunnel-client.test.ts
@@ -19,6 +19,7 @@ import {
   PONG_TIMEOUT_MS,
   CONNECT_TIMEOUT_MS,
   AUTH_RETRY_INTERVAL_MS,
+  sanitizeCloseReason,
 } from '../lib/tunnel-client.js';
 import { MockTunnelServer } from './helpers/mock-tunnel-server.js';
 
@@ -1083,6 +1084,55 @@ describe('#1372 self-healing', () => {
     expect(doConnect).toHaveBeenCalledTimes(2);
 
     c.disconnect();
+  });
+
+  /**
+   * The watchdog tears attempts down mid-flight, so an `auth_ok` queued before
+   * cleanup can still arrive. Unguarded it would resurrect the dead socket —
+   * clobbering the h2 handles and flipping state back to `connected` while a
+   * reconnect is already pending. (Raised by codex in CMAP review of #1373.)
+   */
+  it('ignores a late auth response from a timed-out attempt', () => {
+    vi.useFakeTimers();
+    const c = createClient();
+
+    // Stand in for the socket the watchdog is about to discard.
+    const staleWs = createMockWs();
+    (staleWs as unknown as { send: () => void }).send = vi.fn();
+    (c as unknown as { ws: WebSocket | null }).ws = staleWs;
+    (c as unknown as { state: string }).state = 'connecting';
+
+    const priv = c as unknown as {
+      onWsOpen: (ws: WebSocket) => void;
+      startH2Server: (ws: WebSocket) => void;
+      ws: WebSocket | null;
+    };
+    const startH2Server = vi.spyOn(priv, 'startH2Server');
+
+    priv.onWsOpen(staleWs);
+
+    // Watchdog fires: cleanup() drops the socket and the client moves on.
+    priv.ws = null;
+    (c as unknown as { state: string }).state = 'disconnected';
+
+    // The in-flight auth_ok lands after the teardown.
+    staleWs.emit('message', Buffer.from(JSON.stringify({ type: 'auth_ok', towerId: 'zombie' })));
+
+    expect(startH2Server).not.toHaveBeenCalled();
+    expect(c.getState()).toBe('disconnected');
+    expect((c as unknown as { h2Session: unknown }).h2Session).toBeNull();
+    expect((c as unknown as { wsStream: unknown }).wsStream).toBeNull();
+
+    c.disconnect();
+  });
+
+  it('sanitizes a remote-supplied close reason before logging it', () => {
+    // A relay could otherwise forge log lines through the close frame.
+    expect(sanitizeCloseReason('going away\nTunnel: connected → forged')).toBe(
+      'going away Tunnel: connected → forged',
+    );
+    expect(sanitizeCloseReason('a'.repeat(200))).toHaveLength(121); // 120 + ellipsis
+    expect(sanitizeCloseReason('  tidy  ')).toBe('tidy');
   });
 
   it('state transitions carry a failure reason', async () => {

--- a/packages/codev/src/agent-farm/__tests__/tunnel-client.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tunnel-client.test.ts
@@ -17,6 +17,8 @@ import {
   TunnelClient,
   PING_INTERVAL_MS,
   PONG_TIMEOUT_MS,
+  CONNECT_TIMEOUT_MS,
+  AUTH_RETRY_INTERVAL_MS,
 } from '../lib/tunnel-client.js';
 import { MockTunnelServer } from './helpers/mock-tunnel-server.js';
 
@@ -947,5 +949,182 @@ describe('tunnel-client integration', () => {
         await stopServer(headerServer);
       }
     });
+  });
+});
+
+// === Regression: #1372 — wedges after sustained uplink flap ===
+
+describe('#1372 self-healing', () => {
+  let blackhole: net.Server | null = null;
+  let client: TunnelClient | null = null;
+
+  afterEach(async () => {
+    client?.disconnect();
+    client = null;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    if (blackhole) {
+      const srv = blackhole;
+      blackhole = null;
+      await new Promise<void>((r) => srv.close(() => r()));
+    }
+  });
+
+  /**
+   * The wedge itself. A server that accepts the TCP connection and never answers
+   * the HTTP upgrade is what an uplink flap leaves behind (stale NAT/conntrack
+   * entry): no `error`, no `close`, and the heartbeat isn't armed until
+   * `connected`. Without the watchdog the client sits in `connecting` forever and
+   * only a brand-new TunnelClient recovers it.
+   */
+  it('connect watchdog tears down and reschedules a hung `connecting` attempt', async () => {
+    const sockets: net.Socket[] = [];
+    blackhole = net.createServer((sock) => {
+      sockets.push(sock);
+      sock.on('error', () => {});
+    });
+    await new Promise<void>((r) => blackhole!.listen(0, '127.0.0.1', () => r()));
+    const port = (blackhole.address() as net.AddressInfo).port;
+
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    client = new TunnelClient({
+      serverUrl: `http://127.0.0.1:${port}`,
+      apiKey: 'ctk_test',
+      towerId: 't',
+      localPort: 4100,
+    });
+
+    const transitions: Array<{ state: string; reason?: string }> = [];
+    client.onStateChange((state, _prev, reason) => transitions.push({ state, reason }));
+
+    client.connect();
+
+    // Let the TCP connection establish; the upgrade never completes.
+    await vi.advanceTimersByTimeAsync(500);
+    expect(client.getState()).toBe('connecting');
+
+    // Watchdog fires — this is the assertion that fails without the fix.
+    await vi.advanceTimersByTimeAsync(CONNECT_TIMEOUT_MS);
+
+    expect(client.getState()).toBe('disconnected');
+    const timedOut = transitions.find((t) => t.reason?.includes('connect timeout'));
+    expect(timedOut).toBeDefined();
+    expect(timedOut!.state).toBe('disconnected');
+
+    for (const s of sockets) s.destroy();
+  }, 20000);
+
+  /** A watchdog that tore down a healthy connection would be worse than the bug. */
+  it('disarms the connect watchdog once the tunnel reaches `connected`', async () => {
+    const server = new MockTunnelServer({});
+    const port = await server.start();
+    const echo = http.createServer((_req, res) => res.end());
+    const echoPort = await startServer(echo);
+
+    try {
+      client = new TunnelClient({
+        serverUrl: `http://127.0.0.1:${port}`,
+        apiKey: 'ctk_test',
+        towerId: '',
+        localPort: echoPort,
+      });
+
+      client.connect();
+      await waitFor(() => client!.getState() === 'connected');
+
+      expect((client as unknown as { connectTimeout: unknown }).connectTimeout).toBeNull();
+    } finally {
+      client?.disconnect();
+      client = null;
+      await server.stop();
+      await stopServer(echo);
+    }
+  }, 20000);
+
+  /**
+   * `auth_failed` used to be terminal, so a single misclassified auth error
+   * during a blip became a permanent cloud outage. Driven through the private
+   * handler (as the heartbeat tests do) so the clock is fully deterministic.
+   */
+  it('auth circuit breaker half-opens and retries after AUTH_RETRY_INTERVAL_MS', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.useFakeTimers();
+
+    const c = createClient();
+    const reasons: Array<string | undefined> = [];
+    c.onStateChange((_state, _prev, reason) => reasons.push(reason));
+
+    const priv = c as unknown as {
+      handleAuthError: (reason: string) => void;
+      doConnect: () => void;
+    };
+    const doConnect = vi.spyOn(priv, 'doConnect').mockImplementation(() => {});
+
+    priv.handleAuthError('invalid_api_key');
+    expect(c.getState()).toBe('auth_failed');
+
+    // Still parked right up to the interval — this is a long retry, not a flap.
+    vi.advanceTimersByTime(AUTH_RETRY_INTERVAL_MS - 1);
+    expect(c.getState()).toBe('auth_failed');
+    expect(doConnect).not.toHaveBeenCalled();
+
+    // Half-open. Fails without the fix: the old breaker never rearmed.
+    vi.advanceTimersByTime(1);
+    expect(c.getState()).toBe('disconnected');
+    expect(doConnect).toHaveBeenCalledTimes(1);
+    expect(reasons.some((r) => r?.includes('half-open'))).toBe(true);
+
+    // A genuinely revoked key re-parks and rearms, so the cycle is sustainable.
+    priv.handleAuthError('invalid_api_key');
+    expect(c.getState()).toBe('auth_failed');
+    vi.advanceTimersByTime(AUTH_RETRY_INTERVAL_MS);
+    expect(doConnect).toHaveBeenCalledTimes(2);
+
+    c.disconnect();
+  });
+
+  it('state transitions carry a failure reason', async () => {
+    // Nothing is listening on this port — ECONNREFUSED.
+    const probe = net.createServer();
+    await new Promise<void>((r) => probe.listen(0, '127.0.0.1', () => r()));
+    const deadPort = (probe.address() as net.AddressInfo).port;
+    await new Promise<void>((r) => probe.close(() => r()));
+
+    client = new TunnelClient({
+      serverUrl: `http://127.0.0.1:${deadPort}`,
+      apiKey: 'ctk_test',
+      towerId: 't',
+      localPort: 4100,
+    });
+
+    const reasons: Array<string | undefined> = [];
+    client.onStateChange((_state, _prev, reason) => reasons.push(reason));
+
+    client.connect();
+    await waitFor(() => reasons.some((r) => r?.startsWith('connection error')));
+
+    expect(reasons.some((r) => r?.includes('ECONNREFUSED'))).toBe(true);
+  }, 15000);
+
+  /**
+   * The failure counter must be incremented *before* the delay is computed —
+   * indexing the backoff curve one attempt behind retried faster than intended
+   * for the whole life of the flap.
+   */
+  it('increments consecutiveFailures before computing the backoff delay', () => {
+    const c = createClient();
+    const seenAtScheduleTime: number[] = [];
+    (c as unknown as { scheduleReconnect: () => void }).scheduleReconnect = () => {
+      seenAtScheduleTime.push((c as unknown as { consecutiveFailures: number }).consecutiveFailures);
+    };
+
+    (c as unknown as { handleConnectionError: (e: Error) => void })
+      .handleConnectionError(new Error('boom'));
+    (c as unknown as { handleConnectionError: (e: Error) => void })
+      .handleConnectionError(new Error('boom again'));
+
+    expect(seenAtScheduleTime).toEqual([1, 2]);
   });
 });

--- a/packages/codev/src/agent-farm/__tests__/tunnel-client.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tunnel-client.test.ts
@@ -1131,7 +1131,11 @@ describe('#1372 self-healing', () => {
     expect(sanitizeRemoteDetail('going away\nTunnel: connected → forged')).toBe(
       'going away Tunnel: connected → forged',
     );
-    expect(sanitizeRemoteDetail('a\r\nb\tc d')).toBe('a  b c d');
+    expect(sanitizeRemoteDetail('a\r\nb\tc\u0000d')).toBe('a  b c d');
+    // U+2028/U+2029 act as line terminators in many log and JSON consumers,
+    // and bidi overrides can visually reorder a log line (Trojan-Source style).
+    expect(sanitizeRemoteDetail('a\u2028b\u2029c')).toBe('a b c');
+    expect(sanitizeRemoteDetail('a\u202eb\u2066c')).toBe('a b c');
     expect(sanitizeRemoteDetail('a'.repeat(200))).toHaveLength(121); // 120 + ellipsis
     expect(sanitizeRemoteDetail('  tidy  ')).toBe('tidy');
   });
@@ -1238,6 +1242,38 @@ describe('#1372 self-healing', () => {
     // Counter was reset, so this is a first-attempt backoff — well under the
     // 15-minute half-open interval it replaced.
     vi.advanceTimersByTime(calculateBackoff(0, () => 0.999) + 1);
+    expect(doConnect).toHaveBeenCalled();
+
+    c.disconnect();
+  });
+
+  /**
+   * A malformed serverUrl throws inside `new URL()` — after the state is
+   * already `connecting`. Unguarded that recreates the exact wedge this PR
+   * closes, with no watchdog armed. (Raised by codex in CMAP round 3.)
+   */
+  it('does not wedge in `connecting` when the server URL is malformed', () => {
+    vi.useFakeTimers();
+
+    const c = new TunnelClient({
+      serverUrl: 'not a url',
+      apiKey: 'ctk_test',
+      towerId: 't',
+      localPort: 4100,
+    });
+    const reasons: Array<string | undefined> = [];
+    c.onStateChange((_s, _p, reason) => reasons.push(reason));
+
+    expect(() => c.connect()).not.toThrow();
+    expect(c.getState()).toBe('disconnected');
+    expect(reasons.some((r) => r?.includes('websocket construction failed'))).toBe(true);
+
+    // And it keeps retrying rather than parking silently.
+    const doConnect = vi.spyOn(
+      c as unknown as { doConnect: () => void },
+      'doConnect',
+    ).mockImplementation(() => {});
+    vi.advanceTimersByTime(calculateBackoff(1, () => 0.999) + 1);
     expect(doConnect).toHaveBeenCalled();
 
     c.disconnect();

--- a/packages/codev/src/agent-farm/__tests__/tunnel-client.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tunnel-client.test.ts
@@ -1014,6 +1014,12 @@ describe('#1372 self-healing', () => {
     expect(timedOut).toBeDefined();
     expect(timedOut!.state).toBe('disconnected');
 
+    // ...and it actually retries. A watchdog that only tore down would trade a
+    // wedged `connecting` for a wedged `disconnected`. consecutiveFailures is 1
+    // here, so the next attempt is due within calculateBackoff(1).
+    await vi.advanceTimersByTimeAsync(calculateBackoff(1, () => 0.999) + 100);
+    expect(client.getState()).toBe('connecting');
+
     for (const s of sockets) s.destroy();
   }, 20000);
 

--- a/packages/codev/src/agent-farm/lib/tunnel-client.ts
+++ b/packages/codev/src/agent-farm/lib/tunnel-client.ts
@@ -37,7 +37,11 @@ export interface TowerMetadata {
   terminals: Array<{ id: string; workspacePath: string }>;
 }
 
-type StateChangeCallback = (state: TunnelState, previousState: TunnelState) => void;
+type StateChangeCallback = (
+  state: TunnelState,
+  previousState: TunnelState,
+  reason?: string
+) => void;
 
 /** Headers that must be stripped when proxying between HTTP/2 and HTTP/1.1 */
 const HOP_BY_HOP_HEADERS = new Set([
@@ -59,6 +63,29 @@ export const PING_INTERVAL_MS = 30_000;
 
 /** Pong timeout — if no pong received within 10 seconds, declare connection dead */
 export const PONG_TIMEOUT_MS = 10_000;
+
+/**
+ * Connect watchdog (#1372) — maximum time the client may sit in `connecting`.
+ *
+ * Neither the WebSocket handshake nor the auth-response wait has a deadline of
+ * its own: `ws` only enforces one when `handshakeTimeout` is passed, and Node
+ * applies no socket timeout by default. After an uplink flap a half-open path
+ * (stale NAT/conntrack entry) accepts the TCP connection and then goes silent,
+ * so no `error` or `close` event ever fires. The heartbeat can't help — it is
+ * armed only after `connected`. Without this watchdog the client parks in
+ * `connecting` forever and only a brand-new TunnelClient recovers it.
+ */
+export const CONNECT_TIMEOUT_MS = 20_000;
+
+/**
+ * Auth circuit-breaker half-open interval (#1372).
+ *
+ * `invalid_api_key` used to be terminal, which turns any misclassified auth
+ * error during a network blip into a permanent cloud outage. Retrying at a long
+ * interval costs one cheap round-trip every 15 minutes; a genuinely revoked key
+ * just fails again and re-parks.
+ */
+export const AUTH_RETRY_INTERVAL_MS = 15 * 60_000;
 
 /**
  * Calculate reconnection backoff with exponential increase and jitter.
@@ -137,6 +164,7 @@ export class TunnelClient {
   private h2Server: http2.Http2Server | null = null;
   private h2Session: http2.ServerHttp2Session | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private connectTimeout: ReturnType<typeof setTimeout> | null = null;
   private consecutiveFailures = 0;
   private rateLimitCount = 0;
   private destroyed = false;
@@ -162,10 +190,12 @@ export class TunnelClient {
     this.stateListeners.push(callback);
   }
 
-  private setState(newState: TunnelState): void {
+  private setState(newState: TunnelState, reason?: string): void {
     if (this.state === newState) return;
     const prev = this.state;
     this.state = newState;
+    // Leaving `connecting` — the attempt resolved, so disarm its watchdog (#1372)
+    if (newState !== 'connecting') this.clearConnectTimeout();
     if (newState === 'connected') {
       this.connectedAt = Date.now();
       this.consecutiveFailures = 0;
@@ -179,7 +209,7 @@ export class TunnelClient {
     }
     for (const listener of this.stateListeners) {
       try {
-        listener(newState, prev);
+        listener(newState, prev, reason);
       } catch {
         // Ignore listener errors
       }
@@ -204,7 +234,7 @@ export class TunnelClient {
     this.clearReconnectTimer();
     this.stopHeartbeat();
     this.cleanup();
-    this.setState('disconnected');
+    this.setState('disconnected', 'disconnect() called');
   }
 
   /**
@@ -216,7 +246,8 @@ export class TunnelClient {
       this.destroyed = false;
       this.consecutiveFailures = 0;
       this.rateLimitCount = 0;
-      this.setState('disconnected');
+      this.clearReconnectTimer();
+      this.setState('disconnected', 'circuit breaker reset');
     }
   }
 
@@ -280,8 +311,16 @@ export class TunnelClient {
     }
   }
 
+  /**
+   * Schedule the next connect attempt.
+   *
+   * Callers increment `consecutiveFailures` *before* calling this (#1372) — the
+   * backoff curve is indexed by the number of failures so far, so incrementing
+   * afterwards computed every delay one attempt behind.
+   */
   private scheduleReconnect(): void {
     if (this.destroyed || this.state === 'auth_failed') return;
+    this.clearReconnectTimer();
     const delay = calculateBackoff(this.consecutiveFailures);
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
@@ -291,8 +330,16 @@ export class TunnelClient {
     }, delay);
   }
 
+  private clearConnectTimeout(): void {
+    if (this.connectTimeout) {
+      clearTimeout(this.connectTimeout);
+      this.connectTimeout = null;
+    }
+  }
+
   private cleanup(): void {
     this.stopHeartbeat();
+    this.clearConnectTimeout();
 
     if (this.h2Session && !this.h2Session.destroyed) {
       this.h2Session.destroy();
@@ -335,8 +382,8 @@ export class TunnelClient {
         if (!this.pongReceived && ws === this.ws) {
           console.warn('Tunnel heartbeat: pong timeout, reconnecting');
           this.cleanup();
-          this.setState('disconnected');
           this.consecutiveFailures++;
+          this.setState('disconnected', `heartbeat pong timeout after ${PONG_TIMEOUT_MS}ms`);
           this.scheduleReconnect();
         }
       }, PONG_TIMEOUT_MS);
@@ -367,12 +414,27 @@ export class TunnelClient {
   }
 
   private doConnect(): void {
-    this.setState('connecting');
+    this.setState('connecting', 'connect attempt started');
 
     const wsUrl = buildTunnelWsUrl(this.options.serverUrl);
 
     const ws = new WebSocket(wsUrl);
     this.ws = ws;
+
+    // Watchdog (#1372): tear down and reschedule any attempt that neither
+    // completes the handshake nor answers auth within CONNECT_TIMEOUT_MS.
+    // Covers both silent-hang phases — no `error`/`close` event is emitted on
+    // a half-open path, so this is the only thing that unsticks `connecting`.
+    this.clearConnectTimeout();
+    this.connectTimeout = setTimeout(() => {
+      this.connectTimeout = null;
+      if (ws !== this.ws || this.state !== 'connecting') return;
+      console.warn(`Tunnel: connect attempt timed out after ${CONNECT_TIMEOUT_MS}ms, retrying`);
+      this.cleanup();
+      this.consecutiveFailures++;
+      this.setState('disconnected', `connect timeout after ${CONNECT_TIMEOUT_MS}ms`);
+      this.scheduleReconnect();
+    }, CONNECT_TIMEOUT_MS);
 
     ws.on('open', () => {
       this.onWsOpen(ws);
@@ -384,13 +446,14 @@ export class TunnelClient {
       this.handleConnectionError(err);
     });
 
-    ws.on('close', () => {
+    ws.on('close', (code: number, reasonBuf: Buffer) => {
       // Ignore events from stale WebSockets (e.g. after disconnect + reconnect)
       if (ws !== this.ws) return;
       if (this.state === 'connected' || this.state === 'connecting') {
+        const detail = reasonBuf?.length ? `: ${reasonBuf.toString()}` : '';
         this.cleanup();
-        this.setState('disconnected');
         this.consecutiveFailures++;
+        this.setState('disconnected', `websocket closed (code ${code}${detail})`);
         this.scheduleReconnect();
       }
     });
@@ -425,23 +488,27 @@ export class TunnelClient {
 
   private handleAuthError(reason: string): void {
     this.cleanup();
+    this.consecutiveFailures++;
 
     if (reason === 'invalid_api_key') {
-      this.setState('auth_failed');
+      this.setState('auth_failed', 'auth rejected: invalid_api_key');
       console.error(
         "Cloud connection failed: API key is invalid or revoked. Run 'afx tower connect --reauth' to update credentials."
       );
-      // Circuit breaker: don't retry
+      // Circuit breaker: park, but half-open on a long interval (#1372) so a
+      // misclassified auth error during a network blip isn't a permanent outage.
+      this.scheduleAuthRetry();
       return;
     }
 
     // Transient errors: rate_limited, internal_error, etc.
-    this.setState('disconnected');
+    this.setState('disconnected', `auth rejected: ${reason}`);
 
     if (reason === 'rate_limited') {
       this.rateLimitCount++;
       // First rate limit: 60s. Subsequent: 5 minutes (per spec).
       const delay = this.rateLimitCount <= 1 ? 60_000 : 300_000;
+      this.clearReconnectTimer();
       this.reconnectTimer = setTimeout(() => {
         this.reconnectTimer = null;
         if (!this.destroyed) this.doConnect();
@@ -449,15 +516,30 @@ export class TunnelClient {
     } else {
       this.scheduleReconnect();
     }
-    this.consecutiveFailures++;
   }
 
-  private handleConnectionError(_err: Error): void {
+  /**
+   * Half-open the auth circuit breaker (#1372): after AUTH_RETRY_INTERVAL_MS,
+   * leave `auth_failed` and try once more. A genuinely revoked key fails again
+   * and re-parks here, so the cost is one round-trip per interval.
+   */
+  private scheduleAuthRetry(): void {
+    if (this.destroyed) return;
+    this.clearReconnectTimer();
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.destroyed || this.state !== 'auth_failed') return;
+      this.setState('disconnected', 'auth circuit breaker half-open, retrying');
+      this.doConnect();
+    }, AUTH_RETRY_INTERVAL_MS);
+  }
+
+  private handleConnectionError(err: Error): void {
     this.cleanup();
     if (this.state === 'auth_failed') return; // Don't override circuit breaker
-    this.setState('disconnected');
-    this.scheduleReconnect();
     this.consecutiveFailures++;
+    this.setState('disconnected', `connection error: ${err.message}`);
+    this.scheduleReconnect();
   }
 
   private startH2Server(ws: WebSocket): void {

--- a/packages/codev/src/agent-farm/lib/tunnel-client.ts
+++ b/packages/codev/src/agent-farm/lib/tunnel-client.ts
@@ -88,6 +88,13 @@ export const CONNECT_TIMEOUT_MS = 20_000;
 export const AUTH_RETRY_INTERVAL_MS = 15 * 60_000;
 
 /**
+ * Marks an `auth_failed` transition as a *repeat* park after a half-open retry
+ * (#1372). `tower-tunnel.ts` keys its "log the alarm once" rule off this, so it
+ * is a shared contract, not a free-form string — do not inline the literal.
+ */
+export const AUTH_RETRY_FAILED_MARKER = 'half-open retry failed';
+
+/**
  * Calculate reconnection backoff with exponential increase and jitter.
  * Exported for unit testing.
  *
@@ -153,7 +160,9 @@ export function filterHopByHopHeaders(
  */
 export function sanitizeRemoteDetail(text: string): string {
   // eslint-disable-next-line no-control-regex
-  const stripped = text.replace(/[\u0000-\u001f\u007f]/g, ' ').trim();
+  const stripped = text
+    .replace(/[\u0000-\u001f\u007f\u2028\u2029\u202a-\u202e\u2066-\u2069]/g, ' ')
+    .trim();
   return stripped.length > 120 ? `${stripped.slice(0, 120)}…` : stripped;
 }
 
@@ -441,14 +450,13 @@ export class TunnelClient {
   private doConnect(): void {
     this.setState('connecting', 'connect attempt started');
 
-    const wsUrl = buildTunnelWsUrl(this.options.serverUrl);
-
-    // A synchronous throw here (malformed URL, exhausted fds) would otherwise
-    // leave the client in `connecting` with no watchdog armed — the very wedge
-    // this fix exists to prevent.
+    // A synchronous throw anywhere in here — `new URL()` on a malformed
+    // serverUrl, or the WebSocket constructor — would otherwise leave the
+    // client in `connecting` with no watchdog armed, the very wedge this fix
+    // exists to prevent. URL construction must stay inside the guard.
     let ws: WebSocket;
     try {
-      ws = new WebSocket(wsUrl);
+      ws = new WebSocket(buildTunnelWsUrl(this.options.serverUrl));
     } catch (err) {
       this.consecutiveFailures++;
       this.setState('disconnected', `websocket construction failed: ${(err as Error).message}`);
@@ -546,7 +554,9 @@ export class TunnelClient {
       const repeat = this.authFailureLogged;
       this.setState(
         'auth_failed',
-        repeat ? 'auth rejected: invalid_api_key (half-open retry failed)' : 'auth rejected: invalid_api_key'
+        repeat
+          ? `auth rejected: invalid_api_key (${AUTH_RETRY_FAILED_MARKER})`
+          : 'auth rejected: invalid_api_key'
       );
       if (!repeat) {
         this.authFailureLogged = true;

--- a/packages/codev/src/agent-farm/lib/tunnel-client.ts
+++ b/packages/codev/src/agent-farm/lib/tunnel-client.ts
@@ -145,12 +145,15 @@ export function filterHopByHopHeaders(
 }
 
 /**
- * Make a remote-supplied WebSocket close reason safe to log: strip control
- * characters (no forged log lines) and cap the length. Exported for testing.
+ * Make any relay-supplied text safe to log: strip control characters (a
+ * newline would otherwise forge a tower log entry) and cap the length (an
+ * oversized payload would otherwise inflate the log). Every externally derived
+ * string that reaches a state-change reason must pass through here.
+ * Exported for testing.
  */
-export function sanitizeCloseReason(reason: string): string {
+export function sanitizeRemoteDetail(text: string): string {
   // eslint-disable-next-line no-control-regex
-  const stripped = reason.replace(/[\u0000-\u001f\u007f]/g, ' ').trim();
+  const stripped = text.replace(/[\u0000-\u001f\u007f]/g, ' ').trim();
   return stripped.length > 120 ? `${stripped.slice(0, 120)}…` : stripped;
 }
 
@@ -182,6 +185,8 @@ export class TunnelClient {
   private pongTimeout: ReturnType<typeof setTimeout> | null = null;
   private pongReceived = false;
   private heartbeatWs: WebSocket | null = null;
+  /** Suppresses repeat auth-failure alarms while the breaker half-opens (#1372) */
+  private authFailureLogged = false;
 
   constructor(options: TunnelClientOptions) {
     this.options = options;
@@ -210,6 +215,7 @@ export class TunnelClient {
       this.connectedAt = Date.now();
       this.consecutiveFailures = 0;
       this.rateLimitCount = 0;
+      this.authFailureLogged = false;
       // Push cached metadata on connect
       if (this._pendingMetadata) {
         this.pushMetadataViaHttp(this._pendingMetadata);
@@ -256,8 +262,13 @@ export class TunnelClient {
       this.destroyed = false;
       this.consecutiveFailures = 0;
       this.rateLimitCount = 0;
+      this.authFailureLogged = false;
+      // Cancelling the pending half-open retry without scheduling a fresh
+      // attempt would leave a standalone caller worse off than before, so
+      // reconnect here rather than relying on the caller to build a new client.
       this.clearReconnectTimer();
       this.setState('disconnected', 'circuit breaker reset');
+      this.scheduleReconnect();
     }
   }
 
@@ -324,9 +335,13 @@ export class TunnelClient {
   /**
    * Schedule the next connect attempt.
    *
-   * Callers increment `consecutiveFailures` *before* calling this (#1372) — the
-   * backoff curve is indexed by the number of failures so far, so incrementing
-   * afterwards computed every delay one attempt behind.
+   * Callers increment `consecutiveFailures` *before* calling this (#1372).
+   * Previously the pong-timeout and close paths incremented first while the
+   * error and auth paths incremented after, so the same failure drew a
+   * different delay depending on which event happened to surface it — and for
+   * a WebSocket an `error` is always followed by a `close`, making that
+   * arbitrary. Unified on increment-first (what the majority of paths already
+   * did); the error path's first retry moves ~1.5s → ~2.5s.
    */
   private scheduleReconnect(): void {
     if (this.destroyed || this.state === 'auth_failed') return;
@@ -471,7 +486,7 @@ export class TunnelClient {
       // Ignore events from stale WebSockets (e.g. after disconnect + reconnect)
       if (ws !== this.ws) return;
       if (this.state === 'connected' || this.state === 'connecting') {
-        const detail = reasonBuf?.length ? `: ${sanitizeCloseReason(reasonBuf.toString())}` : '';
+        const detail = reasonBuf?.length ? `: ${sanitizeRemoteDetail(reasonBuf.toString())}` : '';
         this.cleanup();
         this.consecutiveFailures++;
         this.setState('disconnected', `websocket closed (code ${code}${detail})`);
@@ -506,10 +521,14 @@ export class TunnelClient {
         } else if (msg.type === 'auth_error') {
           this.handleAuthError(msg.reason || 'unknown');
         } else {
-          this.handleConnectionError(new Error(`Unexpected auth response type: ${msg.type}`));
+          this.handleConnectionError(
+            new Error(`unexpected auth response type: ${sanitizeRemoteDetail(String(msg.type))}`)
+          );
         }
       } catch (err) {
-        this.handleConnectionError(new Error(`Invalid auth response: ${data.toString()}`));
+        this.handleConnectionError(
+          new Error(`invalid auth response: ${sanitizeRemoteDetail(data.toString())}`)
+        );
       }
     };
 
@@ -521,10 +540,20 @@ export class TunnelClient {
     this.consecutiveFailures++;
 
     if (reason === 'invalid_api_key') {
-      this.setState('auth_failed', 'auth rejected: invalid_api_key');
-      console.error(
-        "Cloud connection failed: API key is invalid or revoked. Run 'afx tower connect --reauth' to update credentials."
+      // A revoked key re-parks here every AUTH_RETRY_INTERVAL_MS. Raise the
+      // alarm once; tag later re-parks so the tower logs them quietly instead
+      // of crying wolf every 15 minutes.
+      const repeat = this.authFailureLogged;
+      this.setState(
+        'auth_failed',
+        repeat ? 'auth rejected: invalid_api_key (half-open retry failed)' : 'auth rejected: invalid_api_key'
       );
+      if (!repeat) {
+        this.authFailureLogged = true;
+        console.error(
+          "Cloud connection failed: API key is invalid or revoked. Run 'afx tower connect --reauth' to update credentials."
+        );
+      }
       // Circuit breaker: park, but half-open on a long interval (#1372) so a
       // misclassified auth error during a network blip isn't a permanent outage.
       this.scheduleAuthRetry();
@@ -532,7 +561,7 @@ export class TunnelClient {
     }
 
     // Transient errors: rate_limited, internal_error, etc.
-    this.setState('disconnected', `auth rejected: ${reason}`);
+    this.setState('disconnected', `auth rejected: ${sanitizeRemoteDetail(reason)}`);
 
     if (reason === 'rate_limited') {
       this.rateLimitCount++;
@@ -568,7 +597,9 @@ export class TunnelClient {
     this.cleanup();
     if (this.state === 'auth_failed') return; // Don't override circuit breaker
     this.consecutiveFailures++;
-    this.setState('disconnected', `connection error: ${err.message}`);
+    // Choke point: some errors originate from the relay (e.g. `ws`'s
+    // "Unexpected server response: <status>"), so sanitize here too.
+    this.setState('disconnected', `connection error: ${sanitizeRemoteDetail(err.message)}`);
     this.scheduleReconnect();
   }
 

--- a/packages/codev/src/agent-farm/lib/tunnel-client.ts
+++ b/packages/codev/src/agent-farm/lib/tunnel-client.ts
@@ -390,10 +390,18 @@ export class TunnelClient {
     }
     this.wsStream = null;
 
-    if (this.ws && this.ws.readyState !== WebSocket.CLOSED) {
-      this.ws.close();
-    }
+    // Detach *before* closing. `close()` on a CONNECTING socket aborts the
+    // handshake and emits `error`; `ws` currently defers that via
+    // process.nextTick, but if it ever emitted synchronously the handler would
+    // still see `ws === this.ws`, run handleConnectionError, and overwrite the
+    // caller's reason — the watchdog's "connect timeout" would be swallowed by
+    // the same-state check in setState. Nulling first makes every late event
+    // from this socket hit the stale guard regardless of when it fires.
+    const ws = this.ws;
     this.ws = null;
+    if (ws && ws.readyState !== WebSocket.CLOSED) {
+      ws.close();
+    }
   }
 
   private startHeartbeat(ws: WebSocket): void {

--- a/packages/codev/src/agent-farm/lib/tunnel-client.ts
+++ b/packages/codev/src/agent-farm/lib/tunnel-client.ts
@@ -145,6 +145,16 @@ export function filterHopByHopHeaders(
 }
 
 /**
+ * Make a remote-supplied WebSocket close reason safe to log: strip control
+ * characters (no forged log lines) and cap the length. Exported for testing.
+ */
+export function sanitizeCloseReason(reason: string): string {
+  // eslint-disable-next-line no-control-regex
+  const stripped = reason.replace(/[\u0000-\u001f\u007f]/g, ' ').trim();
+  return stripped.length > 120 ? `${stripped.slice(0, 120)}…` : stripped;
+}
+
+/**
  * Build the WebSocket tunnel URL from the server URL.
  * https:// → wss://, http:// → ws://
  */
@@ -418,7 +428,18 @@ export class TunnelClient {
 
     const wsUrl = buildTunnelWsUrl(this.options.serverUrl);
 
-    const ws = new WebSocket(wsUrl);
+    // A synchronous throw here (malformed URL, exhausted fds) would otherwise
+    // leave the client in `connecting` with no watchdog armed — the very wedge
+    // this fix exists to prevent.
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(wsUrl);
+    } catch (err) {
+      this.consecutiveFailures++;
+      this.setState('disconnected', `websocket construction failed: ${(err as Error).message}`);
+      this.scheduleReconnect();
+      return;
+    }
     this.ws = ws;
 
     // Watchdog (#1372): tear down and reschedule any attempt that neither
@@ -450,7 +471,7 @@ export class TunnelClient {
       // Ignore events from stale WebSockets (e.g. after disconnect + reconnect)
       if (ws !== this.ws) return;
       if (this.state === 'connected' || this.state === 'connecting') {
-        const detail = reasonBuf?.length ? `: ${reasonBuf.toString()}` : '';
+        const detail = reasonBuf?.length ? `: ${sanitizeCloseReason(reasonBuf.toString())}` : '';
         this.cleanup();
         this.consecutiveFailures++;
         this.setState('disconnected', `websocket closed (code ${code}${detail})`);
@@ -460,12 +481,21 @@ export class TunnelClient {
   }
 
   private onWsOpen(ws: WebSocket): void {
+    // Ignore a stale socket (e.g. one the connect watchdog already tore down)
+    if (ws !== this.ws) return;
+
     // Send JSON auth message (TICK-001 protocol)
     ws.send(JSON.stringify({ type: 'auth', apiKey: this.options.apiKey }));
 
     // Wait for auth response
     const onMessage = (data: WebSocket.RawData) => {
       ws.removeListener('message', onMessage);
+
+      // The watchdog tears attempts down mid-flight, so an `auth_ok` queued
+      // before cleanup can still arrive here. Without this guard it would
+      // resurrect a dead socket: startH2Server() would clobber the h2 handles
+      // and flip the state back to `connected` while a reconnect is pending.
+      if (ws !== this.ws) return;
 
       try {
         const msg = JSON.parse(data.toString());
@@ -543,6 +573,10 @@ export class TunnelClient {
   }
 
   private startH2Server(ws: WebSocket): void {
+    // Belt and braces alongside the onWsOpen guard — never build h2 state on a
+    // socket the client has already moved on from.
+    if (ws !== this.ws) return;
+
     // Convert WebSocket to a Node.js duplex stream
     const wsStream = createWebSocketStream(ws);
     this.wsStream = wsStream;
@@ -555,8 +589,13 @@ export class TunnelClient {
     this.h2Server = h2Server;
 
     h2Server.on('session', (session: http2.ServerHttp2Session) => {
+      // The session lands a tick later; the attempt may have been torn down since.
+      if (ws !== this.ws) {
+        session.destroy();
+        return;
+      }
       this.h2Session = session;
-      this.setState('connected');
+      this.setState('connected', 'h2 session established');
       this.startHeartbeat(ws);
     });
 

--- a/packages/codev/src/agent-farm/servers/tower-tunnel.ts
+++ b/packages/codev/src/agent-farm/servers/tower-tunnel.ts
@@ -147,7 +147,9 @@ async function connectTunnel(config: CloudConfig): Promise<TunnelClient> {
     } else if (prev === 'connected') {
       stopMetadataRefresh();
     }
-    if (state === 'auth_failed') {
+    // Only the first park raises the alarm — the breaker half-opens every 15
+    // minutes (#1372), and a revoked key would otherwise log ERROR forever.
+    if (state === 'auth_failed' && !reason?.includes('half-open retry failed')) {
       _deps!.log('ERROR', 'Cloud connection failed: API key is invalid or revoked. Run \'afx tower connect --reauth\' to update credentials.');
     }
   });

--- a/packages/codev/src/agent-farm/servers/tower-tunnel.ts
+++ b/packages/codev/src/agent-farm/servers/tower-tunnel.ts
@@ -138,8 +138,10 @@ async function connectTunnel(config: CloudConfig): Promise<TunnelClient> {
     localPort: _deps.port,
   });
 
-  client.onStateChange((state: TunnelState, prev: TunnelState) => {
-    _deps!.log('INFO', `Tunnel: ${prev} → ${state}`);
+  client.onStateChange((state: TunnelState, prev: TunnelState, reason?: string) => {
+    // #1372: always log *why* — a bare `prev → state` line made the uplink-flap
+    // wedge undiagnosable from the tower log.
+    _deps!.log('INFO', `Tunnel: ${prev} → ${state}${reason ? ` (${reason})` : ''}`);
     if (state === 'connected') {
       startMetadataRefresh();
     } else if (prev === 'connected') {

--- a/packages/codev/src/agent-farm/servers/tower-tunnel.ts
+++ b/packages/codev/src/agent-farm/servers/tower-tunnel.ts
@@ -10,7 +10,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import http from 'node:http';
 import os from 'node:os';
-import { TunnelClient, type TunnelState, type TowerMetadata } from '../lib/tunnel-client.js';
+import {
+  TunnelClient,
+  AUTH_RETRY_FAILED_MARKER,
+  type TunnelState,
+  type TowerMetadata,
+} from '../lib/tunnel-client.js';
 import {
   readCloudConfig,
   writeCloudConfig,
@@ -149,7 +154,7 @@ async function connectTunnel(config: CloudConfig): Promise<TunnelClient> {
     }
     // Only the first park raises the alarm — the breaker half-opens every 15
     // minutes (#1372), and a revoked key would otherwise log ERROR forever.
-    if (state === 'auth_failed' && !reason?.includes('half-open retry failed')) {
+    if (state === 'auth_failed' && !reason?.includes(AUTH_RETRY_FAILED_MARKER)) {
       _deps!.log('ERROR', 'Cloud connection failed: API key is invalid or revoked. Run \'afx tower connect --reauth\' to update credentials.');
     }
   });


### PR DESCRIPTION
## Summary

After a sustained uplink flap the tunnel client could enter `connecting` and never leave it — no reconnect, no error, no self-recovery, until someone manually hit `POST /api/tunnel/connect`. This bounds the `connecting` state with a watchdog, half-opens the auth circuit breaker, and logs *why* each transition happened.

Fixes #1372

## Root Cause

`doConnect()` created `new WebSocket(wsUrl)` with **no `handshakeTimeout`** and armed **no watchdog**. Two sub-phases can hang indefinitely:

1. TCP connect / TLS / HTTP upgrade — Node applies no socket timeout by default, and `ws` only enforces a handshake deadline when `handshakeTimeout` is passed.
2. After `open`, `onWsOpen()` sends the auth frame and waits on `message`. If the relay never replies, it waits forever.

A half-open path left behind by a flap (stale NAT/conntrack entry) accepts the TCP connection and then goes silent, so neither `error` nor `close` ever fires. Every recovery path is gated on *leaving* `connecting`, so none of them could help:

| Path | Why it couldn't help |
|---|---|
| `scheduleReconnect()` | only reached from `ws.on('error')` / `ws.on('close')` / pong timeout — a silent hang emits none |
| `startHeartbeat()` | armed only after `connected`, so ping/pong never covered `connecting` |
| `connect()` | early-returns when `state === 'connecting'` — an external nudge was a no-op |
| `resetCircuitBreaker()` | only acts when `state === 'auth_failed'` |

That is why `POST /api/tunnel/connect` recovered it instantly: `connectTunnel()` disconnects the old client and constructs a **brand-new `TunnelClient`**. The recovery came from replacing the object, not from `resetCircuitBreaker()`.

Reproduced with a `net` server that accepts the connection and never answers the upgrade: state stayed `connecting` indefinitely, and both `connect()` and `resetCircuitBreaker()` were no-ops against it.

## Fix

Four changes in `lib/tunnel-client.ts` plus one log line in `servers/tower-tunnel.ts` (~115 LOC of source):

1. **Connect watchdog** (`CONNECT_TIMEOUT_MS = 20_000`) armed in `doConnect()`, disarmed by `setState` on any transition out of `connecting` and by `cleanup()`. On fire: warn, tear down, `consecutiveFailures++`, `disconnected`, reschedule. One timer covers both silent-hang phases. (Issue ask #1)
2. **Self-healing auth breaker** (`AUTH_RETRY_INTERVAL_MS = 15 min`). `auth_failed` now half-opens instead of parking forever. A genuinely revoked key fails again cheaply and re-parks — the cycle is self-limiting. (Issue ask #2)

   **This is defensive hardening, not the corrective fix** — see the note below.
3. **Reasons on every transition.** `setState(state, reason?)` threads a reason to the state-change callback, which `tower-tunnel.ts` logs: `Tunnel: connecting → disconnected (connect timeout after 20000ms)`. Close frames now report their code and reason text; `handleConnectionError` no longer discards the error. (Issue ask #3)
4. **Unified backoff increment ordering + timer hygiene.** Not an off-by-one fix — the ordering on `main` was inconsistent: the pong-timeout and close paths incremented `consecutiveFailures` *before* scheduling, while the error and auth paths incremented *after*. The same failure therefore drew a different delay depending on which event surfaced it, which is arbitrary since a WebSocket `error` is always followed by a `close`. Unified on increment-first (what the majority of paths already did). **Effect: the error path's first retry moves ~1.5s → ~2.5s.** Immaterial next to a 20s watchdog, and trivially revertible if you'd prefer the faster branch. `scheduleReconnect()` and the rate-limit path now also clear any pending timer first.

### The issue's auth-misclassification hypothesis does not hold

The issue asked whether a Cloudflare 5xx/HTML body during a blip could be misclassified as an auth error and park the tunnel permanently. Verified against the code: it cannot. `auth_failed` is reachable **only** from an explicit `{type:'auth_error', reason:'invalid_api_key'}` JSON frame. An HTML body fails `JSON.parse` and routes to `handleConnectionError` (transient, retries with backoff); a failed upgrade never opens the socket at all.

So ask #2 is implemented as hardening against a future misclassification, not as the fix for the reported incident. **The connect watchdog is what resolves the observed wedge.** (Raised by claude in CMAP; confirmed by reading the path.)

### On the ~4ms instant-fail cycles (issue observation 1)

Consistent with the kernel refusing `connect()` outright — `ENETUNREACH`/`EHOSTUNREACH`, no default route during the flap, DNS already cached. That path was working as designed; only the off-by-one made it retry a notch faster than intended. Not the wedge.

### Deliberately not implemented: ask #4 (rebuild the client after K instant failures)

`doConnect()` already builds a fresh `WebSocket` every attempt and `cleanup()` nulls the h2 server/session/stream. The only state the old client actually carried across was the stuck `connecting` flag, which the watchdog dissolves. A rebuild path would be a redundant second recovery mechanism. Flagging rather than silently dropping — happy to add it if you disagree.

## Test Plan

- [x] Regression tests added — **16** in total: 14 under `#1372 self-healing` in `tunnel-client.test.ts`, plus 2 tower-side in `tower-tunnel.test.ts`
- [x] Build passes
- [x] All tests pass (**4579 passed, 0 failed** as of `573dae73`)

**Verified by mutation** — every fix reverted individually, tests re-run. The round-1 table below; rounds 2–4 each verified the same way:

| Mutation | Tests that fail |
|---|---|
| Watchdog body returns early | watchdog test |
| `scheduleAuthRetry()` call removed | auth half-open test |
| `reason` dropped from listener call | watchdog + reason tests |
| `consecutiveFailures++` moved back after `scheduleReconnect()` | ordering test |

All four detected; all five pass with the fix restored.

One test guards the inverse risk — a watchdog that tore down a *healthy* connection would be worse than the bug — by asserting the timer is disarmed once `connected`.


---

## CMAP round 1

| Lane | Verdict |
|---|---|
| gemini | APPROVE — no issues |
| claude | APPROVE — three minor, non-blocking |
| codex | REQUEST_CHANGES — one real defect |

**codex found a defect this PR's own watchdog introduced.** `onWsOpen`'s message handler had no `ws === this.ws` guard, unlike the sibling `error`/`close` handlers. The hole was latent before this PR — nothing tore an attempt down mid-flight — but the watchdog makes it reachable: an `auth_ok` queued before `cleanup()` could call `startH2Server()`, clobber the h2 handles and flip state back to `connected` on a dead socket while a reconnect was already scheduled. Precisely the "wedged internal state" the issue speculated about.

Fixed in `49e60fd6`:

- Stale guards in `onWsOpen`, its `onMessage`, `startH2Server`, and the h2 `session` callback (a late session is destroyed, not adopted). Regression test added; mutation-verified.
- `new WebSocket()` wrapped in try/catch — a synchronous throw would otherwise leave `connecting` unbounded with no watchdog armed, the same wedge class this PR closes. (claude)
- `sanitizeCloseReason()` strips control characters and caps length — the close-frame reason is remote-supplied and was logged verbatim, a log-forging vector. (claude)

Suite after round 1: **4570 passed, 0 failed.**



---

## CMAP round 2

| Lane | Verdict |
|---|---|
| gemini | APPROVE — no issues |
| claude | APPROVE — four points, three real |
| codex | REQUEST_CHANGES — one real defect |

**codex found the same defect class as round 1.** Round 1 sanitized the WebSocket close frame; it had missed every sibling path carrying relay-controlled text into the same tower log: `auth rejected: ${reason}`, the unexpected-auth-type message, and worst, `Invalid auth response: ${data.toString()}` — echoing the **entire raw payload** unbounded. I fixed the instance I was handed rather than sweeping the class, twice.

Fixed in `11552e00`: `sanitizeCloseReason` generalized to `sanitizeRemoteDetail`, applied at all four sites plus `handleConnectionError` as a choke point.

**claude flagged two regressions this PR introduced**, both fixed:

- A revoked key re-parks every 15 minutes forever, and both `console.error` and the tower ERROR line fired each time. The alarm is now raised once; later re-parks are tagged `(half-open retry failed)` so the tower logs them quietly.
- `resetCircuitBreaker()` cancelled the pending half-open retry without scheduling a fresh attempt — leaving a standalone caller *worse off* than before this PR. It now schedules a reconnect.

Its third point prompted the corrected framing of change #4 above. (Its supporting claim — that the old ordering "matched the documented formula and its existing test" — did not hold: there was no single old ordering, and no test pins client scheduling. The underlying point about framing and the delay change was right.)

Suite after round 2: **4575 passed, 0 failed.** All seven new tests are mutation-verified.



---

## CMAP round 3

| Lane | Verdict |
|---|---|
| gemini | APPROVE — no issues |
| claude | APPROVE — three minor |
| codex | REQUEST_CHANGES — one real defect |

**codex and claude independently found the same defect.** Round 1 wrapped `new WebSocket()` in a try/catch with a comment claiming "malformed URL" coverage — but `buildTunnelWsUrl()`, which calls `new URL()`, sat *outside* the try, after `setState('connecting')`. A malformed `serverUrl` therefore threw out of `doConnect()` and left the client wedged in `connecting` with no watchdog armed: **the exact bug this PR closes, reintroduced by the fix for it.**

Fixed in `546f71f7`, with a mutation-verified regression test asserting `connect()` does not throw, lands in `disconnected`, and keeps retrying.

claude's minor points, both taken:

- The ERROR-log suppression coupled `tunnel-client.ts` and `tower-tunnel.ts` by a bare string literal → now an exported `AUTH_RETRY_FAILED_MARKER`. This also adds the **first tower-side tests** for the alarm-once contract and the reason-in-log-line behaviour.
- `sanitizeRemoteDetail` widened to strip U+2028/U+2029 (line terminators to many log/JSON consumers) and bidi overrides (Trojan-Source style reordering).

Suite after round 3: **4578 passed, 0 failed.**

## Reviewer note: this fix's blast radius

Four real defects across three CMAP rounds — **three of them introduced by this PR**, not present in the original code:

| Round | Defect | Origin |
|---|---|---|
| 1 | late `auth_ok` resurrects a torn-down socket | this PR (the watchdog made it reachable) |
| 2 | three unsanitized relay-text paths into the tower log | this PR (round-1 fix, half-applied) |
| 2 | auth alarm repeating every 15 min forever | this PR (the half-open breaker) |
| 3 | `new URL()` outside the try → same wedge class | this PR (round-1 hardening) |

Worth weighing when reviewing: a 115-LOC change to reconnection logic proved to have a much larger blast radius than "minimal fix" suggests. Every finding is now covered by a mutation-verified regression test, but the pattern is a reason for a careful read rather than a quick one.



---

## CMAP round 4

| Lane | Verdict |
|---|---|
| gemini | APPROVE — no issues |
| codex | COMMENT — no defects; PR hygiene + one test-coverage gap |
| claude | COMMENT — no blocking |

First round with no defect found. codex raised two fair points:

- **Stale counts in this PR body** — it said "seven new tests" and quoted a pre-round-3 suite total. Corrected above: **15 new tests**, suite **4578 passed**.
- **The watchdog test under-verified its own name.** It is called "tears down *and reschedules* a hung `connecting` attempt" but asserted only the teardown — and a watchdog that only tore down would trade a wedged `connecting` for a wedged `disconnected`. Fixed in `35cbf328`: the test now advances through `calculateBackoff(1)` and asserts a fresh attempt begins.

Its third note is a sandbox limitation, not a finding: the review environment is read-only, so Vitest could not run (it wants to write `node_modules/.vite-temp`). Build and full suite were run locally every round.



**claude round 4** raised one substantive point beyond PR hygiene: the watchdog's ability to report its own reason depended on `ws` deferring `abortHandshake`'s error via `process.nextTick`. `cleanup()` called `ws.close()` while `this.ws` still referenced the socket, so a synchronous `error` emission would pass the stale guard, run `handleConnectionError`, and the watchdog's "connect timeout" reason would be swallowed by the same-state check in `setState`.

Rather than document the dependency, `573dae73` removes it — detach first, then close. Every late event from that socket now hits the stale guard regardless of when it fires. Mutation-verified.

**Left undone, for your call:** the tower UI cloud chip briefly flickers `auth failed → connecting… → auth failed` every 15 minutes while the breaker half-opens. Inherent to half-opening, and only with a genuinely revoked key.

---

## Final state

- **4579 tests passing**, build green, at `573dae73`
- **16 regression tests**, every one mutation-verified (14 in `tunnel-client.test.ts`, 2 in `tower-tunnel.test.ts` — the first coverage that file had for either behaviour)
- **4 CMAP rounds, 12 lane-runs.** Rounds 1–3 each found a real defect; round 4 found none.
