### PR TITLE
Post-merge completion records: bugfix-1372 + air-1370

### DIFF
--- a/codev/projects/1370-cloud-disconnect-one-click-unc/status.yaml
+++ b/codev/projects/1370-cloud-disconnect-one-click-unc/status.yaml
@@ -13,10 +13,12 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-08T22:19:17.153Z'
-updated_at: '2026-08-09T00:35:20.146Z'
+updated_at: '2026-08-09T00:45:15.381Z'
 pr_history:
   - phase: pr
     pr_number: 1374
     branch: builder/air-1370
     created_at: '2026-08-08T22:42:07.329Z'
+    merged: true
+    merged_at: '2026-08-09T00:45:15.380Z'
 pr_ready_for_human: false

--- a/codev/projects/1370-cloud-disconnect-one-click-unc/status.yaml
+++ b/codev/projects/1370-cloud-disconnect-one-click-unc/status.yaml
@@ -1,7 +1,7 @@
 id: '1370'
 title: cloud-disconnect-one-click-unc
 protocol: air
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,7 +13,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-08T22:19:17.153Z'
-updated_at: '2026-08-09T00:45:15.381Z'
+updated_at: '2026-08-09T00:46:15.874Z'
 pr_history:
   - phase: pr
     pr_number: 1374

--- a/codev/projects/bugfix-1372-tunnel-client-wedges-after-sus/status.yaml
+++ b/codev/projects/bugfix-1372-tunnel-client-wedges-after-sus/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1372
 title: tunnel-client-wedges-after-sus
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,7 +13,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-08T22:18:55.516Z'
-updated_at: '2026-08-09T00:38:24.680Z'
+updated_at: '2026-08-09T00:38:38.553Z'
 pr_history:
   - phase: pr
     pr_number: 1373

--- a/codev/projects/bugfix-1372-tunnel-client-wedges-after-sus/status.yaml
+++ b/codev/projects/bugfix-1372-tunnel-client-wedges-after-sus/status.yaml
@@ -13,10 +13,12 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-08T22:18:55.516Z'
-updated_at: '2026-08-09T00:34:35.054Z'
+updated_at: '2026-08-09T00:38:24.680Z'
 pr_history:
   - phase: pr
     pr_number: 1373
     branch: builder/bugfix-1372
     created_at: '2026-08-08T23:05:22.956Z'
+    merged: true
+    merged_at: '2026-08-09T00:38:24.679Z'
 pr_ready_for_human: false


### PR DESCRIPTION
Batched stranded-records PR per the #1345/#1369 pattern: porch's post-merge status.yaml commits for the two tunnel fixes (PR #1373 / issue #1372 and PR #1374 / issue #1370) — merged/completion bookkeeping only, no code. Four cherry-picked commits touching exactly the two projects' status.yaml files.