### PR TITLE
[Air #1383] docs: add area/streamdeck to the area-label vocabulary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,8 @@ are no `type:*` labels.
 
 `area/`: docs · vscode · dashboard · consult · tower (includes afx; there is no
 `area/agent-farm`) · porch · protocols (definitions, distinct from porch orchestration) ·
-config · terminal · scaffold · release · web · core · cross-cutting
+config · terminal · scaffold · release · web · streamdeck (Stream Deck plugin,
+apps/streamdeck; Elgato channel: profiles, Maker Console, packaging) · core · cross-cutting
 
 ## Multi-agent consultation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,8 @@ are no `type:*` labels.
 
 `area/`: docs · vscode · dashboard · consult · tower (includes afx; there is no
 `area/agent-farm`) · porch · protocols (definitions, distinct from porch orchestration) ·
-config · terminal · scaffold · release · web · core · cross-cutting
+config · terminal · scaffold · release · web · streamdeck (Stream Deck plugin,
+apps/streamdeck; Elgato channel: profiles, Maker Console, packaging) · core · cross-cutting
 
 ## Multi-agent consultation
 

--- a/codev/projects/1383-docs-add-area-streamdeck-to-th/status.yaml
+++ b/codev/projects/1383-docs-add-area-streamdeck-to-th/status.yaml
@@ -11,4 +11,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-10T03:04:59.272Z'
-updated_at: '2026-08-10T03:07:29.919Z'
+updated_at: '2026-08-10T03:08:03.894Z'
+pr_history:
+  - phase: pr
+    pr_number: 1384
+    branch: builder/air-1383
+    created_at: '2026-08-10T03:08:03.893Z'

--- a/codev/projects/1383-docs-add-area-streamdeck-to-th/status.yaml
+++ b/codev/projects/1383-docs-add-area-streamdeck-to-th/status.yaml
@@ -7,13 +7,15 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-08-10T03:08:12.295Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-10T03:04:59.272Z'
-updated_at: '2026-08-10T03:08:03.894Z'
+updated_at: '2026-08-10T03:08:12.296Z'
 pr_history:
   - phase: pr
     pr_number: 1384
     branch: builder/air-1383
     created_at: '2026-08-10T03:08:03.893Z'
+pr_ready_for_human: true

--- a/codev/projects/1383-docs-add-area-streamdeck-to-th/status.yaml
+++ b/codev/projects/1383-docs-add-area-streamdeck-to-th/status.yaml
@@ -6,16 +6,17 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-08-10T03:08:12.295Z'
+    approved_at: '2026-08-10T03:14:18.150Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-10T03:04:59.272Z'
-updated_at: '2026-08-10T03:08:12.296Z'
+updated_at: '2026-08-10T03:14:18.151Z'
 pr_history:
   - phase: pr
     pr_number: 1384
     branch: builder/air-1383
     created_at: '2026-08-10T03:08:03.893Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/1383-docs-add-area-streamdeck-to-th/status.yaml
+++ b/codev/projects/1383-docs-add-area-streamdeck-to-th/status.yaml
@@ -1,7 +1,7 @@
 id: '1383'
 title: docs-add-area-streamdeck-to-th
 protocol: air
-phase: implement
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-10T03:04:59.272Z'
-updated_at: '2026-08-10T03:04:59.272Z'
+updated_at: '2026-08-10T03:07:29.919Z'

--- a/codev/projects/1383-docs-add-area-streamdeck-to-th/status.yaml
+++ b/codev/projects/1383-docs-add-area-streamdeck-to-th/status.yaml
@@ -1,0 +1,14 @@
+id: '1383'
+title: docs-add-area-streamdeck-to-th
+protocol: air
+phase: implement
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-10T03:04:59.272Z'
+updated_at: '2026-08-10T03:04:59.272Z'

--- a/codev/state/air-1383_thread.md
+++ b/codev/state/air-1383_thread.md
@@ -1,0 +1,19 @@
+# Builder thread — air-1383
+
+## 2026-08-10 — Implement
+
+AIR (strict) for issue #1383: add `streamdeck` to the `area/` vocabulary in the
+`## Issue labels` section of CLAUDE.md and AGENTS.md.
+
+- Applied the exact insertion from the issue between `web` and `core`, with the
+  parenthetical clarification, rewrapped to the file's prevailing width.
+- Verified `diff CLAUDE.md AGENTS.md` → byte-identical.
+- Verified `grep -rn "cross-cutting" codev/resources/ codev-skeleton/` → no other
+  file carries the codev-specific area list (hits are generic skeleton guidance
+  and unrelated prose, exactly as the issue anticipated).
+- Purely declarative docs change → no new tests written (per AIR implement
+  prompt's allowance for declarative changes). Ran full `pnpm build && pnpm test`
+  anyway to satisfy phase checks.
+- Committed as `[Air #1383] docs: add area/streamdeck to the area-label vocabulary`.
+
+No surprises, no blockers.


### PR DESCRIPTION
## Summary

Adds `streamdeck` to the documented `area/*` label vocabulary in the `## Issue labels` section of `CLAUDE.md` and its byte-identical twin `AGENTS.md`. The label itself was ratified and created on 2026-08-10 and is already carried by issues #1347 and #1381; this catches the docs up.

Closes #1383

## What Changed

Inserted the entry between `web` and `core`, exactly as specified in the issue, following the list's existing conventions (parenthetical clarification like the `tower` and `protocols` entries, `cross-cutting` last, rewrapped to the file's prevailing width):

```
config · terminal · scaffold · release · web · streamdeck (Stream Deck plugin,
apps/streamdeck; Elgato channel: profiles, Maker Console, packaging) · core · cross-cutting
```

## Key Decisions

None — the issue specified the exact text and placement.

## Test Plan

- [x] `diff CLAUDE.md AGENTS.md` — files remain byte-identical
- [x] `grep -rn "cross-cutting" codev/resources/ codev-skeleton/` — no other file carries the codev-specific area list (all hits are generic skeleton guidance or unrelated prose, as the issue anticipated)
- [x] Build passes (`pnpm build`)
- [x] All tests pass (`pnpm test`)
- No new unit tests: purely declarative docs change with nothing executable to test

## Review Notes

Single-entry vocabulary addition, no other content changed. CMAP skipped per AIR judgment call for a docs-only change.