### PR TITLE
vscode: one-step view issue/PR from QuickPick + Cmd+K P Open PR by ID

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -190,6 +190,10 @@
         "title": "Codev: Open Issue by ID..."
       },
       {
+        "command": "codev.openPRById",
+        "title": "Codev: Open PR by ID..."
+      },
+      {
         "command": "codev.refreshTeam",
         "title": "Codev: Refresh Team",
         "icon": "$(refresh)"
@@ -919,6 +923,11 @@
         "command": "codev.openIssueById",
         "key": "ctrl+k i",
         "mac": "cmd+k i"
+      },
+      {
+        "command": "codev.openPRById",
+        "key": "ctrl+k p",
+        "mac": "cmd+k p"
       },
       {
         "command": "codev.diffNextFile",

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -926,8 +926,8 @@
       },
       {
         "command": "codev.openPRById",
-        "key": "ctrl+k p",
-        "mac": "cmd+k p"
+        "key": "ctrl+k shift+p",
+        "mac": "cmd+k shift+p"
       },
       {
         "command": "codev.diffNextFile",

--- a/apps/vscode/src/__tests__/backlog-search.test.ts
+++ b/apps/vscode/src/__tests__/backlog-search.test.ts
@@ -104,15 +104,15 @@ describe('toQuickPickItems', () => {
 describe('parseSearchDynamicQuery (type-ahead grammar, #1179)', () => {
   it('offers both targets for a bare number, issue first', () => {
     expect(parseSearchDynamicQuery('1350')).toEqual([
-      { kind: 'issue', id: '1350' },
-      { kind: 'pr', id: '1350' },
+      { target: 'issue', id: '1350' },
+      { target: 'pr', id: '1350' },
     ]);
   });
 
   it('tolerates a leading # on the bare form', () => {
     expect(parseSearchDynamicQuery('#1350')).toEqual([
-      { kind: 'issue', id: '1350' },
-      { kind: 'pr', id: '1350' },
+      { target: 'issue', id: '1350' },
+      { target: 'pr', id: '1350' },
     ]);
   });
 
@@ -121,18 +121,18 @@ describe('parseSearchDynamicQuery (type-ahead grammar, #1179)', () => {
   });
 
   it('narrows to issue for "issue N" and "view issue N"', () => {
-    expect(parseSearchDynamicQuery('issue 1350')).toEqual([{ kind: 'issue', id: '1350' }]);
-    expect(parseSearchDynamicQuery('view issue 1350')).toEqual([{ kind: 'issue', id: '1350' }]);
+    expect(parseSearchDynamicQuery('issue 1350')).toEqual([{ target: 'issue', id: '1350' }]);
+    expect(parseSearchDynamicQuery('view issue 1350')).toEqual([{ target: 'issue', id: '1350' }]);
   });
 
   it('narrows to pr for "pr N" and "view pr N"', () => {
-    expect(parseSearchDynamicQuery('pr 1350')).toEqual([{ kind: 'pr', id: '1350' }]);
-    expect(parseSearchDynamicQuery('view pr 1350')).toEqual([{ kind: 'pr', id: '1350' }]);
+    expect(parseSearchDynamicQuery('pr 1350')).toEqual([{ target: 'pr', id: '1350' }]);
+    expect(parseSearchDynamicQuery('view pr 1350')).toEqual([{ target: 'pr', id: '1350' }]);
   });
 
   it('is case-insensitive and tolerates # on the typed form', () => {
-    expect(parseSearchDynamicQuery('ISSUE #1350')).toEqual([{ kind: 'issue', id: '1350' }]);
-    expect(parseSearchDynamicQuery('View PR #1350')).toEqual([{ kind: 'pr', id: '1350' }]);
+    expect(parseSearchDynamicQuery('ISSUE #1350')).toEqual([{ target: 'issue', id: '1350' }]);
+    expect(parseSearchDynamicQuery('View PR #1350')).toEqual([{ target: 'pr', id: '1350' }]);
   });
 
   it('yields nothing for plain text searches', () => {
@@ -168,6 +168,6 @@ describe('toDynamicQuickPickItems', () => {
     const rows = toDynamicQuickPickItems('view pr 1350');
     expect(rows).toHaveLength(1);
     expect(rows[0].label).toBe('View PR #1350');
-    expect(rows[0].kind).toBe('pr');
+    expect(rows[0].target).toBe('pr');
   });
 });

--- a/apps/vscode/src/__tests__/backlog-search.test.ts
+++ b/apps/vscode/src/__tests__/backlog-search.test.ts
@@ -9,7 +9,12 @@
 
 import { describe, it, expect } from 'vitest';
 import type { OverviewBacklogItem, OverviewData } from '@cluesmith/codev-types';
-import { orderForSearch, toQuickPickItems } from '../views/backlog-search.js';
+import {
+  orderForSearch,
+  toQuickPickItems,
+  parseSearchDynamicQuery,
+  toDynamicQuickPickItems,
+} from '../views/backlog-search.js';
 
 function item(
   id: string,
@@ -93,5 +98,76 @@ describe('toQuickPickItems', () => {
       now,
     );
     expect(row.description).toBe('docs · 2h ago · @alice');
+  });
+});
+
+describe('parseSearchDynamicQuery (type-ahead grammar, #1179)', () => {
+  it('offers both targets for a bare number, issue first', () => {
+    expect(parseSearchDynamicQuery('1350')).toEqual([
+      { kind: 'issue', id: '1350' },
+      { kind: 'pr', id: '1350' },
+    ]);
+  });
+
+  it('tolerates a leading # on the bare form', () => {
+    expect(parseSearchDynamicQuery('#1350')).toEqual([
+      { kind: 'issue', id: '1350' },
+      { kind: 'pr', id: '1350' },
+    ]);
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseSearchDynamicQuery('  1350  ')).toHaveLength(2);
+  });
+
+  it('narrows to issue for "issue N" and "view issue N"', () => {
+    expect(parseSearchDynamicQuery('issue 1350')).toEqual([{ kind: 'issue', id: '1350' }]);
+    expect(parseSearchDynamicQuery('view issue 1350')).toEqual([{ kind: 'issue', id: '1350' }]);
+  });
+
+  it('narrows to pr for "pr N" and "view pr N"', () => {
+    expect(parseSearchDynamicQuery('pr 1350')).toEqual([{ kind: 'pr', id: '1350' }]);
+    expect(parseSearchDynamicQuery('view pr 1350')).toEqual([{ kind: 'pr', id: '1350' }]);
+  });
+
+  it('is case-insensitive and tolerates # on the typed form', () => {
+    expect(parseSearchDynamicQuery('ISSUE #1350')).toEqual([{ kind: 'issue', id: '1350' }]);
+    expect(parseSearchDynamicQuery('View PR #1350')).toEqual([{ kind: 'pr', id: '1350' }]);
+  });
+
+  it('yields nothing for plain text searches', () => {
+    expect(parseSearchDynamicQuery('')).toEqual([]);
+    expect(parseSearchDynamicQuery('tower')).toEqual([]);
+    expect(parseSearchDynamicQuery('12a3')).toEqual([]);
+  });
+
+  it('yields nothing when extra text follows the number', () => {
+    expect(parseSearchDynamicQuery('1350 fix')).toEqual([]);
+    expect(parseSearchDynamicQuery('view pr 1350 now')).toEqual([]);
+  });
+
+  it('yields nothing for a bare keyword without a number', () => {
+    expect(parseSearchDynamicQuery('issue')).toEqual([]);
+    expect(parseSearchDynamicQuery('view pr')).toEqual([]);
+    expect(parseSearchDynamicQuery('#')).toEqual([]);
+  });
+});
+
+describe('toDynamicQuickPickItems', () => {
+  it('labels rows "View Issue #N" / "View PR #N" and always shows them', () => {
+    const rows = toDynamicQuickPickItems('1350');
+    expect(rows.map(r => r.label)).toEqual(['View Issue #1350', 'View PR #1350']);
+    for (const row of rows) {
+      expect(row.alwaysShow).toBe(true);
+      expect(row.description).toBe('Open in browser');
+      expect(row.id).toBe('1350');
+    }
+  });
+
+  it('projects a single row for the typed form', () => {
+    const rows = toDynamicQuickPickItems('view pr 1350');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].label).toBe('View PR #1350');
+    expect(rows[0].kind).toBe('pr');
   });
 });

--- a/apps/vscode/src/__tests__/open-pr-by-id.test.ts
+++ b/apps/vscode/src/__tests__/open-pr-by-id.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for `codev.openPRById` (issue #1179) — the browser-open routing of the
+ * PR mirror of `openIssueById`. `open-pr-by-id.ts` imports `vscode` at module
+ * load, so we stub it (the established pattern from open-issue-by-id.test.ts)
+ * with controllable window / env spies.
+ *
+ * Input validation itself is `parseIssueId`, exhaustively covered in
+ * open-issue-by-id.test.ts — here we only assert the PR command wires it in
+ * (`#42` → fetches `42`).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const showInputBox = vi.fn();
+const showErrorMessage = vi.fn();
+const showWarningMessage = vi.fn();
+const openExternal = vi.fn();
+const executeCommand = vi.fn();
+
+vi.mock('vscode', () => ({
+  window: { showInputBox, showErrorMessage, showWarningMessage },
+  env: { openExternal },
+  commands: { executeCommand },
+  Uri: { parse: (s: string) => ({ toString: () => s, __parsed: s }) },
+}));
+
+const { openPRById, openPRInBrowser } = await import('../commands/open-pr-by-id.js');
+
+const makeConn = (overrides: Record<string, unknown> = {}) => ({
+  getState: () => 'connected',
+  getWorkspacePath: () => '/ws',
+  getClient: () => ({ getPR: vi.fn().mockResolvedValue({ title: 't', body: '', state: 'MERGED', url: 'https://forge/pull/42' }) }),
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('openPRById', () => {
+  it('opens the forge url in the browser when present', async () => {
+    showInputBox.mockResolvedValue('42');
+    await openPRById(makeConn() as never);
+    expect(openExternal).toHaveBeenCalledTimes(1);
+    expect(openExternal.mock.calls[0][0].__parsed).toBe('https://forge/pull/42');
+  });
+
+  it('accepts a #-prefixed id and fetches the bare number (parseIssueId reuse)', async () => {
+    showInputBox.mockResolvedValue('#42');
+    const getPR = vi.fn().mockResolvedValue({ title: 't', body: '', state: 'OPEN', url: 'https://forge/pull/42' });
+    await openPRById(makeConn({ getClient: () => ({ getPR }) }) as never);
+    expect(getPR).toHaveBeenCalledWith('42', '/ws');
+  });
+
+  it('warns when the PR is not found', async () => {
+    showInputBox.mockResolvedValue('42');
+    const conn = makeConn({ getClient: () => ({ getPR: vi.fn().mockResolvedValue(null) }) });
+    await openPRById(conn as never);
+    expect(showWarningMessage).toHaveBeenCalledTimes(1);
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('warns when the PR resolves without a url (no in-editor PR preview to fall back to)', async () => {
+    showInputBox.mockResolvedValue('42');
+    const conn = makeConn({ getClient: () => ({ getPR: vi.fn().mockResolvedValue({ title: 't', body: '', state: 'OPEN' }) }) });
+    await openPRById(conn as never);
+    expect(showWarningMessage).toHaveBeenCalledTimes(1);
+    expect(openExternal).not.toHaveBeenCalled();
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('errors when not connected to Tower', async () => {
+    showInputBox.mockResolvedValue('42');
+    const conn = makeConn({ getState: () => 'disconnected' });
+    await openPRById(conn as never);
+    expect(showErrorMessage).toHaveBeenCalledTimes(1);
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the input box is dismissed', async () => {
+    showInputBox.mockResolvedValue(undefined);
+    await openPRById(makeConn() as never);
+    expect(openExternal).not.toHaveBeenCalled();
+    expect(showWarningMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('openPRInBrowser', () => {
+  it('opens the browser directly without any input box (QuickPick dynamic-item path)', async () => {
+    await openPRInBrowser(makeConn() as never, '42');
+    expect(showInputBox).not.toHaveBeenCalled();
+    expect(openExternal).toHaveBeenCalledTimes(1);
+    expect(openExternal.mock.calls[0][0].__parsed).toBe('https://forge/pull/42');
+  });
+});

--- a/apps/vscode/src/__tests__/search-backlog-quickpick.test.ts
+++ b/apps/vscode/src/__tests__/search-backlog-quickpick.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Wiring tests for the Search Backlog Quick Pick's type-ahead (issue #1179):
+ * dynamic `View Issue #N` / `View PR #N` rows appear/disappear as the typed
+ * value changes, and accepting a row routes to the right handler (browser
+ * open for dynamic rows, `codev.viewBacklogIssue` for static rows).
+ *
+ * `search-backlog.ts` imports `vscode` at module load, so we stub it (the
+ * open-issue-by-id.test.ts pattern) with a fake `createQuickPick` that records
+ * its event handlers for the test to drive. The browser-open helpers are
+ * mocked at the module boundary — their fetch/open behavior is covered by
+ * their own test files.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+interface FakeQuickPick {
+  items: Array<Record<string, unknown>>;
+  placeholder: string;
+  matchOnDescription: boolean;
+  matchOnDetail: boolean;
+  selectedItems: Array<Record<string, unknown>>;
+  onChangeValue?: (value: string) => void;
+  onAccept?: () => void;
+  onHide?: () => void;
+  onDidChangeValue: (fn: (value: string) => void) => void;
+  onDidAccept: (fn: () => void) => void;
+  onDidHide: (fn: () => void) => void;
+  show: () => void;
+  hide: () => void;
+  dispose: () => void;
+}
+
+function makeFakeQuickPick(): FakeQuickPick {
+  const picker: FakeQuickPick = {
+    items: [],
+    placeholder: '',
+    matchOnDescription: false,
+    matchOnDetail: false,
+    selectedItems: [],
+    onDidChangeValue: (fn) => { picker.onChangeValue = fn; },
+    onDidAccept: (fn) => { picker.onAccept = fn; },
+    onDidHide: (fn) => { picker.onHide = fn; },
+    show: vi.fn(),
+    hide: vi.fn(),
+    dispose: vi.fn(),
+  };
+  return picker;
+}
+
+let fakePicker: FakeQuickPick;
+const createQuickPick = vi.fn(() => fakePicker);
+const showInformationMessage = vi.fn();
+const executeCommand = vi.fn();
+const openIssueInBrowser = vi.fn();
+const openPRInBrowser = vi.fn();
+
+vi.mock('vscode', () => ({
+  window: { createQuickPick, showInformationMessage },
+  commands: { executeCommand },
+}));
+vi.mock('../commands/open-issue-by-id.js', () => ({ openIssueInBrowser }));
+vi.mock('../commands/open-pr-by-id.js', () => ({ openPRInBrowser }));
+
+const { searchBacklog } = await import('../commands/search-backlog.js');
+
+const conn = { getState: () => 'connected' } as never;
+
+function cacheWith(backlog: Array<Record<string, unknown>>) {
+  return { getData: () => ({ backlog, currentUser: undefined }) } as never;
+}
+
+const BACKLOG = [
+  { id: '918', title: 'search backlog', area: 'vscode', hasBuilder: false, assignees: [], createdAt: '2026-05-30T00:00:00.000Z' },
+  { id: '920', title: 'search panel', area: 'vscode', hasBuilder: false, assignees: [], createdAt: '2026-05-30T00:00:00.000Z' },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fakePicker = makeFakeQuickPick();
+});
+
+describe('searchBacklog type-ahead wiring', () => {
+  it('shows only static rows before any typing', async () => {
+    await searchBacklog(conn, cacheWith(BACKLOG));
+    expect(fakePicker.show).toHaveBeenCalled();
+    expect(fakePicker.items.map(i => i.label)).toEqual(['#918 search backlog', '#920 search panel']);
+  });
+
+  it('prepends View Issue / View PR rows when a bare number is typed', async () => {
+    await searchBacklog(conn, cacheWith(BACKLOG));
+    fakePicker.onChangeValue!('1350');
+    expect(fakePicker.items.map(i => i.label)).toEqual([
+      'View Issue #1350',
+      'View PR #1350',
+      '#918 search backlog',
+      '#920 search panel',
+    ]);
+    expect(fakePicker.items[0].alwaysShow).toBe(true);
+    expect(fakePicker.items[1].alwaysShow).toBe(true);
+  });
+
+  it('restores the static-only list when the value stops matching the grammar', async () => {
+    await searchBacklog(conn, cacheWith(BACKLOG));
+    fakePicker.onChangeValue!('1350');
+    fakePicker.onChangeValue!('1350 fix');
+    expect(fakePicker.items.map(i => i.label)).toEqual(['#918 search backlog', '#920 search panel']);
+  });
+
+  it('accepting the dynamic PR row opens the PR in the browser', async () => {
+    await searchBacklog(conn, cacheWith(BACKLOG));
+    fakePicker.onChangeValue!('view pr 1350');
+    fakePicker.selectedItems = [fakePicker.items[0]];
+    fakePicker.onAccept!();
+    expect(openPRInBrowser).toHaveBeenCalledWith(conn, '1350');
+    expect(openIssueInBrowser).not.toHaveBeenCalled();
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('accepting the dynamic Issue row opens the issue in the browser', async () => {
+    await searchBacklog(conn, cacheWith(BACKLOG));
+    fakePicker.onChangeValue!('1350');
+    fakePicker.selectedItems = [fakePicker.items[0]];
+    fakePicker.onAccept!();
+    expect(openIssueInBrowser).toHaveBeenCalledWith(conn, '1350');
+    expect(openPRInBrowser).not.toHaveBeenCalled();
+  });
+
+  it('accepting a static row still opens the in-editor preview', async () => {
+    await searchBacklog(conn, cacheWith(BACKLOG));
+    fakePicker.selectedItems = [fakePicker.items[1]];
+    fakePicker.onAccept!();
+    expect(executeCommand).toHaveBeenCalledWith('codev.viewBacklogIssue', '920');
+    expect(openIssueInBrowser).not.toHaveBeenCalled();
+    expect(openPRInBrowser).not.toHaveBeenCalled();
+  });
+
+  it('disposes the picker when it hides', async () => {
+    await searchBacklog(conn, cacheWith(BACKLOG));
+    fakePicker.onHide!();
+    expect(fakePicker.dispose).toHaveBeenCalled();
+  });
+
+  it('keeps the informational empty-backlog message (no picker)', async () => {
+    await searchBacklog(conn, cacheWith([]));
+    expect(showInformationMessage).toHaveBeenCalledTimes(1);
+    expect(createQuickPick).not.toHaveBeenCalled();
+  });
+});

--- a/apps/vscode/src/commands/open-issue-by-id.ts
+++ b/apps/vscode/src/commands/open-issue-by-id.ts
@@ -41,21 +41,16 @@ export function parseIssueId(input: string): string | undefined {
   return withoutHash;
 }
 
-export async function openIssueById(connectionManager: ConnectionManager): Promise<void> {
-  const input = await vscode.window.showInputBox({
-    title: 'Codev: Open Issue by ID',
-    placeHolder: 'Issue ID, e.g. 1096 or #1096',
-    prompt: 'Opens the issue in your browser — works for open, closed, or archived issues.',
-    validateInput: (value) =>
-      parseIssueId(value) === undefined
-        ? 'Enter a numeric issue id (e.g. 1096 or #1096).'
-        : undefined,
-  });
-  if (input === undefined) { return; }
-
-  const issueId = parseIssueId(input);
-  if (issueId === undefined) { return; }
-
+/**
+ * Fetch `issueId` and open its forge page in the external browser. The
+ * post-InputBox body of `openIssueById`, exported on its own so the backlog
+ * QuickPick's dynamic `View Issue #N` items (issue #1179) share the exact
+ * same fetch → browser → preview-fallback path.
+ */
+export async function openIssueInBrowser(
+  connectionManager: ConnectionManager,
+  issueId: string,
+): Promise<void> {
   const client = connectionManager.getClient();
   const workspacePath = connectionManager.getWorkspacePath();
   if (!client || !workspacePath || connectionManager.getState() !== 'connected') {
@@ -78,4 +73,22 @@ export async function openIssueById(connectionManager: ConnectionManager): Promi
 
   // Forge supplied no URL — degrade to the in-editor preview rather than fail.
   await vscode.commands.executeCommand('codev.viewBacklogIssue', issueId);
+}
+
+export async function openIssueById(connectionManager: ConnectionManager): Promise<void> {
+  const input = await vscode.window.showInputBox({
+    title: 'Codev: Open Issue by ID',
+    placeHolder: 'Issue ID, e.g. 1096 or #1096',
+    prompt: 'Opens the issue in your browser — works for open, closed, or archived issues.',
+    validateInput: (value) =>
+      parseIssueId(value) === undefined
+        ? 'Enter a numeric issue id (e.g. 1096 or #1096).'
+        : undefined,
+  });
+  if (input === undefined) { return; }
+
+  const issueId = parseIssueId(input);
+  if (issueId === undefined) { return; }
+
+  await openIssueInBrowser(connectionManager, issueId);
 }

--- a/apps/vscode/src/commands/open-pr-by-id.ts
+++ b/apps/vscode/src/commands/open-pr-by-id.ts
@@ -1,0 +1,67 @@
+/**
+ * Codev: Open PR by ID — open a specific pull request by typing its id,
+ * mirroring `open-issue-by-id.ts` (issue #1179).
+ *
+ * Bound to `Cmd+K P` / `Ctrl+K P`, completing the keyboard family alongside
+ * `Cmd+K I` (issue). Fetches via the SDK's forge-agnostic `getPR` (Tower's
+ * GET /api/pr → the `pr-view` forge concept) and opens the PR's canonical
+ * forge page in the external browser.
+ *
+ * Unlike issues, there is no in-editor PR preview to degrade to (no
+ * `codev.viewBacklogPR`), so a PR that resolves without a `url` warns
+ * instead — same message as not-found, since either way the browser page
+ * can't be opened.
+ *
+ * Reuses `parseIssueId` for input validation: its docstring already declares
+ * it forge-neutral id normalization, and PR ids share the same `#`-tolerant
+ * numeric grammar.
+ */
+
+import * as vscode from 'vscode';
+import type { ConnectionManager } from '../connection-manager.js';
+import { parseIssueId } from './open-issue-by-id.js';
+
+/**
+ * Fetch `prId` and open its forge page in the external browser. Exported on
+ * its own (like `openIssueInBrowser`) so the backlog QuickPick's dynamic
+ * `View PR #N` items share the exact same path as the keybound command.
+ */
+export async function openPRInBrowser(
+  connectionManager: ConnectionManager,
+  prId: string,
+): Promise<void> {
+  const client = connectionManager.getClient();
+  const workspacePath = connectionManager.getWorkspacePath();
+  if (!client || !workspacePath || connectionManager.getState() !== 'connected') {
+    vscode.window.showErrorMessage('Codev: Not connected to Tower');
+    return;
+  }
+
+  const pr = await client.getPR(prId, workspacePath);
+  if (!pr || !pr.url) {
+    vscode.window.showWarningMessage(
+      `Codev: Could not open PR #${prId} (not found, or forge unavailable).`,
+    );
+    return;
+  }
+
+  await vscode.env.openExternal(vscode.Uri.parse(pr.url));
+}
+
+export async function openPRById(connectionManager: ConnectionManager): Promise<void> {
+  const input = await vscode.window.showInputBox({
+    title: 'Codev: Open PR by ID',
+    placeHolder: 'PR ID, e.g. 1398 or #1398',
+    prompt: 'Opens the pull request in your browser — works for open, closed, or merged PRs.',
+    validateInput: (value) =>
+      parseIssueId(value) === undefined
+        ? 'Enter a numeric PR id (e.g. 1398 or #1398).'
+        : undefined,
+  });
+  if (input === undefined) { return; }
+
+  const prId = parseIssueId(input);
+  if (prId === undefined) { return; }
+
+  await openPRInBrowser(connectionManager, prId);
+}

--- a/apps/vscode/src/commands/open-pr-by-id.ts
+++ b/apps/vscode/src/commands/open-pr-by-id.ts
@@ -2,8 +2,11 @@
  * Codev: Open PR by ID — open a specific pull request by typing its id,
  * mirroring `open-issue-by-id.ts` (issue #1179).
  *
- * Bound to `Cmd+K P` / `Ctrl+K P`, completing the keyboard family alongside
- * `Cmd+K I` (issue). Fetches via the SDK's forge-agnostic `getPR` (Tower's
+ * Bound to `Cmd+K Shift+P` / `Ctrl+K Shift+P`, completing the keyboard family
+ * alongside `Cmd+K I` (issue). The unshifted `Cmd+K P` chord is a VS Code
+ * built-in (Copy Path of Active File), so the shifted variant keeps the
+ * P-for-PR mnemonic without shadowing it (issue #1179 pr-gate decision).
+ * Fetches via the SDK's forge-agnostic `getPR` (Tower's
  * GET /api/pr → the `pr-view` forge concept) and opens the PR's canonical
  * forge page in the external browser.
  *

--- a/apps/vscode/src/commands/search-backlog.ts
+++ b/apps/vscode/src/commands/search-backlog.ts
@@ -1,36 +1,83 @@
 import * as vscode from 'vscode';
+import type { ConnectionManager } from '../connection-manager.js';
 import type { OverviewCache } from '../views/overview-data.js';
-import { orderForSearch, toQuickPickItems } from '../views/backlog-search.js';
+import {
+  orderForSearch,
+  toQuickPickItems,
+  toDynamicQuickPickItems,
+  type BacklogQuickPickItem,
+  type DynamicQuickPickItem,
+} from '../views/backlog-search.js';
+import { openIssueInBrowser } from './open-issue-by-id.js';
+import { openPRInBrowser } from './open-pr-by-id.js';
 
 /**
  * `codev.searchBacklog` — open a Quick Pick over the current backlog and, on
  * selection, open the chosen issue via the same `codev.viewBacklogIssue` flow
  * a single sidebar-row click uses (issue #918).
  *
+ * Type-ahead (issue #1179): when the typed value matches the numeric grammar
+ * (`1350`, `#1350`, `issue 1350`, `view pr 1350`, ...), dynamic
+ * `View Issue #N` / `View PR #N` rows are prepended. Accepting one skips the
+ * pick-then-InputBox two-step and opens the target directly in the browser
+ * via the same fetch path as `codev.openIssueById` / `codev.openPRById` —
+ * reaching issues outside the loaded backlog (closed, claimed) and PRs, which
+ * the static rows never contain. Any other input filters the static rows
+ * exactly as before.
+ *
  * Snapshots `overviewCache` at invoke time (a one-shot picker; live-updating
  * rows while the user types would be jittery and unlike `Cmd+P`). Search runs
  * over the full spawnable backlog — NOT the mine-only set — so a user can find
  * an issue they didn't author.
  */
-export async function searchBacklog(overviewCache: OverviewCache): Promise<void> {
+export async function searchBacklog(
+  connectionManager: ConnectionManager,
+  overviewCache: OverviewCache,
+): Promise<void> {
   const data = overviewCache.getData();
-  const items = data ? orderForSearch(data) : [];
-  if (items.length === 0) {
+  let staticItems: BacklogQuickPickItem[];
+  if (data) {
+    staticItems = toQuickPickItems(orderForSearch(data), Date.now());
+  } else {
+    staticItems = [];
+  }
+  if (staticItems.length === 0) {
     vscode.window.showInformationMessage(
       'Codev: No backlog issues to search (not connected, or the backlog is empty).',
     );
     return;
   }
 
-  const picked = await vscode.window.showQuickPick(
-    toQuickPickItems(items, Date.now()),
-    {
-      placeHolder: 'Search backlog by id, title, area, assignee...',
-      matchOnDescription: true,
-      matchOnDetail: true,
-    },
-  );
-  if (!picked) { return; }
+  const picker = vscode.window.createQuickPick<BacklogQuickPickItem | DynamicQuickPickItem>();
+  picker.items = staticItems;
+  picker.placeholder = 'Search backlog by id, title, area, assignee...';
+  picker.matchOnDescription = true;
+  picker.matchOnDetail = true;
 
-  await vscode.commands.executeCommand('codev.viewBacklogIssue', picked.issueId);
+  picker.onDidChangeValue((value) => {
+    const dynamicItems = toDynamicQuickPickItems(value);
+    if (dynamicItems.length === 0) {
+      picker.items = staticItems;
+    } else {
+      picker.items = [...dynamicItems, ...staticItems];
+    }
+  });
+
+  picker.onDidAccept(() => {
+    const picked = picker.selectedItems[0];
+    picker.hide();
+    if (!picked) { return; }
+    if ('kind' in picked) {
+      if (picked.kind === 'issue') {
+        openIssueInBrowser(connectionManager, picked.id);
+      } else {
+        openPRInBrowser(connectionManager, picked.id);
+      }
+      return;
+    }
+    vscode.commands.executeCommand('codev.viewBacklogIssue', picked.issueId);
+  });
+
+  picker.onDidHide(() => picker.dispose());
+  picker.show();
 }

--- a/apps/vscode/src/commands/search-backlog.ts
+++ b/apps/vscode/src/commands/search-backlog.ts
@@ -67,8 +67,8 @@ export async function searchBacklog(
     const picked = picker.selectedItems[0];
     picker.hide();
     if (!picked) { return; }
-    if ('kind' in picked) {
-      if (picked.kind === 'issue') {
+    if ('target' in picked) {
+      if (picked.target === 'issue') {
         openIssueInBrowser(connectionManager, picked.id);
       } else {
         openPRInBrowser(connectionManager, picked.id);

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -1098,7 +1098,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			viewBacklogIssue(connectionManager!, extractIssueId(arg))),
 		reg('codev.openBacklogSearch', () =>
 			BacklogSearchPanel.createOrShow(connectionManager!, overviewCache, context.extensionUri)),
-		reg('codev.searchBacklog', () => searchBacklog(overviewCache)),
+		reg('codev.searchBacklog', () => searchBacklog(connectionManager!, overviewCache)),
 		reg('codev.openIssueById', () => openIssueById(connectionManager!)),
 		reg('codev.openPRById', () => openPRById(connectionManager!)),
 		reg('codev.openMarkdownPreview', async () => {

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -28,6 +28,7 @@ import { activateIssueView, viewBacklogIssue } from './commands/view-issue.js';
 import { BacklogSearchPanel } from './webviews/backlog-search-panel.js';
 import { searchBacklog } from './commands/search-backlog.js';
 import { openIssueById } from './commands/open-issue-by-id.js';
+import { openPRById } from './commands/open-pr-by-id.js';
 import { connectTunnel, disconnectTunnel } from './commands/tunnel.js';
 import { listCronTasks } from './commands/cron.js';
 import { addReviewComment } from './commands/review.js';
@@ -1099,6 +1100,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			BacklogSearchPanel.createOrShow(connectionManager!, overviewCache, context.extensionUri)),
 		reg('codev.searchBacklog', () => searchBacklog(overviewCache)),
 		reg('codev.openIssueById', () => openIssueById(connectionManager!)),
+		reg('codev.openPRById', () => openPRById(connectionManager!)),
 		reg('codev.openMarkdownPreview', async () => {
 			const uri = vscode.window.activeTextEditor?.document.uri;
 			if (!uri) {

--- a/apps/vscode/src/views/backlog-search.ts
+++ b/apps/vscode/src/views/backlog-search.ts
@@ -65,6 +65,72 @@ export function toQuickPickItems(
   });
 }
 
+/** Target kind of a dynamic type-ahead row in the Search Backlog Quick Pick. */
+export type DynamicPickKind = 'issue' | 'pr';
+
+/**
+ * A dynamic `View Issue #N` / `View PR #N` row (issue #1179), prepended to the
+ * Quick Pick when the typed value matches the numeric grammar. `alwaysShow`
+ * exempts the row from VS Code's fuzzy filter: the label is synthesized from
+ * the input, so filtering it against that same input is meaningless and (for
+ * forms like `view pr 1350`) would hide it.
+ */
+export interface DynamicQuickPickItem {
+  label: string;
+  description: string;
+  alwaysShow: true;
+  kind: DynamicPickKind;
+  id: string;
+}
+
+const BARE_ID = /^#?(\d+)$/;
+const TYPED_ID = /^(?:view\s+)?(issue|pr)\s+#?(\d+)$/i;
+
+/**
+ * Parse the Quick Pick's typed value against the dynamic type-ahead grammar:
+ *
+ * - `1350` / `#1350` (bare id) is ambiguous, so both targets are offered,
+ *   issue first.
+ * - `issue 1350` / `view issue 1350` names the target explicitly; likewise
+ *   `pr 1350` / `view pr 1350`. Case-insensitive, leading `#` on the number
+ *   tolerated (the `parseIssueId` convention).
+ * - Anything else (non-numeric, trailing text, bare keyword) yields no
+ *   dynamic rows: the input is an ordinary text search over the static rows.
+ */
+export function parseSearchDynamicQuery(
+  value: string,
+): Array<{ kind: DynamicPickKind; id: string }> {
+  const trimmed = value.trim();
+  const bare = BARE_ID.exec(trimmed);
+  if (bare) {
+    return [{ kind: 'issue', id: bare[1] }, { kind: 'pr', id: bare[1] }];
+  }
+  const typed = TYPED_ID.exec(trimmed);
+  if (typed) {
+    return [{ kind: typed[1].toLowerCase() as DynamicPickKind, id: typed[2] }];
+  }
+  return [];
+}
+
+/** Project the parsed dynamic grammar into ready-to-insert Quick Pick rows. */
+export function toDynamicQuickPickItems(value: string): DynamicQuickPickItem[] {
+  return parseSearchDynamicQuery(value).map(({ kind, id }) => {
+    let noun: string;
+    if (kind === 'issue') {
+      noun = 'Issue';
+    } else {
+      noun = 'PR';
+    }
+    return {
+      label: `View ${noun} #${id}`,
+      description: 'Open in browser',
+      alwaysShow: true,
+      kind,
+      id,
+    };
+  });
+}
+
 /**
  * Relative age of an ISO timestamp, e.g. `3d ago`. Same granularity ladder as
  * `commands/view-artifact.ts`'s helper. Returns an empty string for an

--- a/apps/vscode/src/views/backlog-search.ts
+++ b/apps/vscode/src/views/backlog-search.ts
@@ -65,21 +65,22 @@ export function toQuickPickItems(
   });
 }
 
-/** Target kind of a dynamic type-ahead row in the Search Backlog Quick Pick. */
-export type DynamicPickKind = 'issue' | 'pr';
+/** Target of a dynamic type-ahead row in the Search Backlog Quick Pick. */
+export type DynamicPickTarget = 'issue' | 'pr';
 
 /**
  * A dynamic `View Issue #N` / `View PR #N` row (issue #1179), prepended to the
  * Quick Pick when the typed value matches the numeric grammar. `alwaysShow`
  * exempts the row from VS Code's fuzzy filter: the label is synthesized from
  * the input, so filtering it against that same input is meaningless and (for
- * forms like `view pr 1350`) would hide it.
+ * forms like `view pr 1350`) would hide it. The discriminator is named
+ * `target` because `QuickPickItem` reserves `kind` for its separator enum.
  */
 export interface DynamicQuickPickItem {
   label: string;
   description: string;
   alwaysShow: true;
-  kind: DynamicPickKind;
+  target: DynamicPickTarget;
   id: string;
 }
 
@@ -99,24 +100,24 @@ const TYPED_ID = /^(?:view\s+)?(issue|pr)\s+#?(\d+)$/i;
  */
 export function parseSearchDynamicQuery(
   value: string,
-): Array<{ kind: DynamicPickKind; id: string }> {
+): Array<{ target: DynamicPickTarget; id: string }> {
   const trimmed = value.trim();
   const bare = BARE_ID.exec(trimmed);
   if (bare) {
-    return [{ kind: 'issue', id: bare[1] }, { kind: 'pr', id: bare[1] }];
+    return [{ target: 'issue', id: bare[1] }, { target: 'pr', id: bare[1] }];
   }
   const typed = TYPED_ID.exec(trimmed);
   if (typed) {
-    return [{ kind: typed[1].toLowerCase() as DynamicPickKind, id: typed[2] }];
+    return [{ target: typed[1].toLowerCase() as DynamicPickTarget, id: typed[2] }];
   }
   return [];
 }
 
 /** Project the parsed dynamic grammar into ready-to-insert Quick Pick rows. */
 export function toDynamicQuickPickItems(value: string): DynamicQuickPickItem[] {
-  return parseSearchDynamicQuery(value).map(({ kind, id }) => {
+  return parseSearchDynamicQuery(value).map(({ target, id }) => {
     let noun: string;
-    if (kind === 'issue') {
+    if (target === 'issue') {
       noun = 'Issue';
     } else {
       noun = 'PR';
@@ -125,7 +126,7 @@ export function toDynamicQuickPickItems(value: string): DynamicQuickPickItem[] {
       label: `View ${noun} #${id}`,
       description: 'Open in browser',
       alwaysShow: true,
-      kind,
+      target,
       id,
     };
   });

--- a/codev/plans/1179-vscode-one-step-view-issue-n-v.md
+++ b/codev/plans/1179-vscode-one-step-view-issue-n-v.md
@@ -1,0 +1,201 @@
+# PIR Plan: One-step "view issue N" / "view pr N" from the backlog QuickPick + Cmd+K P Open-PR-by-ID
+
+## Understanding
+
+Issue #1179 asks for two additive changes to the VS Code extension:
+
+1. **Type-ahead in the backlog search QuickPick.** The picker the issue describes is
+   `codev.searchBacklog` (`apps/vscode/src/commands/search-backlog.ts` — the issue said
+   "verify at implement time"; verified, this is the only issue-navigation QuickPick).
+   Today it only filters the loaded backlog rows; an issue outside that set (closed,
+   claimed by a builder, or any PR) is unreachable from it. The fix: when the typed value
+   matches a numeric grammar (`1350`, `#1350`, `issue 1350`, `view pr 1350`, ...), prepend
+   dynamic `View Issue #1350` / `View PR #1350` items that open the target directly in the
+   browser — one gesture instead of picker → command → InputBox → Enter.
+
+2. **`codev.openPRById` + Cmd+K P.** Mirror of `codev.openIssueById`
+   (`apps/vscode/src/commands/open-issue-by-id.ts`, bound to Cmd+K I): InputBox with
+   `parseIssueId` validation, forge-agnostic fetch, `vscode.env.openExternal(pr.url)`.
+
+### Corrections to the issue text (verified against the tree)
+
+- **Paths**: the extension lives at `apps/vscode/`, not `packages/vscode/`. The client is
+  `TowerClient` in `packages/sdk/src/tower-client.ts` (the extension's
+  `connection-manager.ts` just holds it); the server is Tower in
+  `packages/codev/src/agent-farm/servers/tower-routes.ts`.
+- **`client.getPR` does not exist, and neither does its server side.** `getIssue`
+  (`tower-client.ts:473`) calls Tower's `GET /api/issue` (`tower-routes.ts:182` →
+  `handleIssueView` → `fetchIssue` → the `issue-view` forge concept). There is no
+  `GET /api/pr`. A `pr-view` forge concept **does** exist
+  (`packages/codev/src/lib/forge.ts:67`, scripts in `packages/codev/scripts/forge/*/pr-view.sh`)
+  but its output contract (`PrViewResult`, `forge-contracts.ts:121`) carries **no `url`**
+  — the GitHub script doesn't request the field. So Part 2 needs a thin vertical slice:
+  add `url` to the `pr-view` concept output, a `fetchPR` helper, a `GET /api/pr` route, a
+  `PRView` wire type, and `TowerClient.getPR`.
+- **"straight to `codev.openBacklogIssue`" can't be taken literally**: that command
+  (`extension.ts:1085`) opens `arg.issueUrl` from a `BacklogTreeItem` — for a typed number
+  we have no URL yet. The dynamic items instead route through the same fetch-then-open
+  logic `openIssueById` uses, extracted into a shared helper. Same outcome (browser), one
+  code path.
+- **No in-editor PR preview exists** (no `codev.viewBacklogPR`), so the issue's own
+  fallback applies: PR fetched but no `url` → `showWarningMessage`. Not-found → warning
+  too (Q2c).
+- **`ctrl+k p` / `cmd+k p` confirmed free** in `contributes.keybindings` (current family:
+  a, d, g, b, i).
+
+## Proposed Change
+
+Three commits inside one PR, plumbing-first so each layer lands testable.
+
+### Commit 1 — PR-fetch plumbing (forge → Tower → SDK)
+
+- **`pr-view` concept gains `url`** (browser URL, forge-mapped), following exactly the
+  `issue-view` precedent:
+  - `packages/codev/scripts/forge/github/pr-view.sh` — add `url` to the `--json` field
+    list (valid `gh pr view` field; the `CODEV_INCLUDE_COMMENTS=1` text branch is
+    untouched).
+  - `packages/codev/scripts/forge/gitlab/pr-view.sh` — pipe through
+    `jq '. + {url: .web_url}'` (same as gitlab `issue-view.sh`).
+  - `packages/codev/scripts/forge/gitea/pr-view.sh` — `jq '.url = (.html_url // .url)'`
+    (same as gitea `issue-view.sh`; Gitea's `url` is the API endpoint).
+  - `packages/codev/src/lib/forge-contracts.ts` — `PrViewResult` gains `url?: string`
+    (optional, forge-neutral, mirroring `IssueViewResult`).
+- **`fetchPR`** in `packages/codev/src/lib/github.ts`, next to `fetchIssue`: executes
+  `pr-view` with `CODEV_PR_NUMBER`, returns the parsed result or null (non-fatal).
+- **`GET /api/pr`** in `tower-routes.ts`: `handlePRView` mirroring `handleIssueView`
+  (workspace resolution, `?number=` param, 400/404/200) calling `fetchPR`.
+- **`PRView` wire type** in `packages/types/src/api.ts` (name verified free): `title`,
+  `body`, `state`, `url?` (with the same web-URL-not-API-endpoint doc note as
+  `IssueView.url`), plus the fields `pr-view` already emits (`author`, `baseRefName`,
+  `headRefName`, `additions`, `deletions`).
+- **`TowerClient.getPR(prNumber, workspacePath?)`** in `packages/sdk/src/tower-client.ts`,
+  directly below `getIssue`, same shape (`URLSearchParams`, null on failure).
+
+### Commit 2 — `codev.openPRById` + Cmd+K P
+
+- Refactor `apps/vscode/src/commands/open-issue-by-id.ts`: extract the post-InputBox body
+  (connection guard → `getIssue` → `openExternal` → `viewBacklogIssue` fallback) into an
+  exported `openIssueInBrowser(connectionManager, issueId)`. `openIssueById` becomes
+  InputBox + delegate. No behavior change; existing tests must pass unmodified.
+- New `apps/vscode/src/commands/open-pr-by-id.ts`:
+  - `openPRInBrowser(connectionManager, prId)` — connection guard (`Not connected to
+    Tower` error, matching the issue sibling), `client.getPR`, on success
+    `openExternal(pr.url)`; PR missing **or** url-less →
+    `Codev: Could not open PR #N (not found, or forge unavailable).`
+  - `openPRById(connectionManager)` — `showInputBox` titled `Codev: Open PR by ID`,
+    reusing `parseIssueId` (imported from `open-issue-by-id.js`; already forge-neutral
+    per its docstring) as validator, then delegate.
+- `apps/vscode/src/extension.ts` — `reg('codev.openPRById', ...)` next to
+  `codev.openIssueById` (`extension.ts:1101`).
+- `apps/vscode/package.json` — command declaration `Codev: Open PR by ID...` +
+  keybinding `ctrl+k p` / `cmd+k p` (no `when`, matching the i binding).
+
+### Commit 3 — QuickPick type-ahead
+
+- **Pure grammar helper** in `apps/vscode/src/views/backlog-search.ts` (vscode-free file,
+  vitest-testable — the established pattern):
+  `parseSearchDynamicQuery(value): Array<{ kind: 'issue' | 'pr'; id: string }>`
+  - `1350` / `#1350` → `[issue, pr]` (issue first)
+  - `issue 1350` / `view issue 1350` (case-insensitive, `#` tolerated) → `[issue]`
+  - `pr 1350` / `view pr 1350` → `[pr]`
+  - anything else (non-numeric, trailing text, bare keyword) → `[]`
+- **`search-backlog.ts`** switches from `showQuickPick` to `createQuickPick` (required
+  for `onDidChangeValue`):
+  - static items, `matchOnDescription/Detail`, placeholder unchanged;
+  - `onDidChangeValue` → `items = [...dynamicItems, ...staticItems]`; dynamic items get
+    `alwaysShow: true` so VS Code's fuzzy filter can't hide them (Q1a/Q1b) and are
+    labeled `View Issue #N` / `View PR #N`; empty grammar result restores the plain
+    static list (Q1c — normal filtering untouched);
+  - `onDidAccept`: dynamic issue → `openIssueInBrowser`, dynamic pr → `openPRInBrowser`,
+    static row → `codev.viewBacklogIssue` (unchanged in-editor preview);
+    `onDidHide` → `dispose`.
+  - `searchBacklog` gains a `connectionManager` parameter; registration at
+    `extension.ts:1100` updated.
+  - The existing empty-backlog early-return stays as-is (see Risks).
+
+## Files to Change
+
+- `packages/codev/scripts/forge/github/pr-view.sh` — add `url` to `--json` list
+- `packages/codev/scripts/forge/gitlab/pr-view.sh` — map `web_url` → `url` via jq
+- `packages/codev/scripts/forge/gitea/pr-view.sh` — map `html_url` → `url` via jq
+- `packages/codev/src/lib/forge-contracts.ts:121-131` — `PrViewResult.url?: string`
+- `packages/codev/src/lib/github.ts` (near `fetchIssue`, :47) — new `fetchPR`
+- `packages/codev/src/agent-farm/servers/tower-routes.ts:182` area — route
+  `GET /api/pr` + `handlePRView` (mirror of `handleIssueView`, :1149)
+- `packages/types/src/api.ts` (after `IssueView`, :391) — new `PRView`
+- `packages/sdk/src/tower-client.ts:473` area — new `getPR`
+- `apps/vscode/src/commands/open-issue-by-id.ts` — extract `openIssueInBrowser`
+- `apps/vscode/src/commands/open-pr-by-id.ts` — new file
+- `apps/vscode/src/views/backlog-search.ts` — new `parseSearchDynamicQuery` + item
+  projection
+- `apps/vscode/src/commands/search-backlog.ts` — `createQuickPick` + dynamic items +
+  accept routing
+- `apps/vscode/src/extension.ts:1100-1101` — register `codev.openPRById`; pass
+  `connectionManager` to `searchBacklog`
+- `apps/vscode/package.json` — command + `ctrl+k p`/`cmd+k p` keybinding
+- Tests: `apps/vscode/src/__tests__/open-pr-by-id.test.ts` (new),
+  `backlog-search.test.ts` (extend), `search-backlog-quickpick.test.ts` (new),
+  `packages/sdk/src/__tests__/tower-client.test.ts` (extend)
+
+Not touched (per issue scope): `codev.openIssueById` behavior, `codev.referencePRInArchitect`,
+other QuickPicks. No `codev-skeleton/` mirror needed — the forge scripts and all touched
+code ship from `packages/`, and skeleton carries no copy (verified by grep).
+
+## Risks & Alternatives Considered
+
+- **Risk: `gh pr view --json url` availability.** `url` is a standard `gh` pr field;
+  verified in `gh` docs and used elsewhere in the repo for merged-PR queries
+  (`forge-contracts.ts` `MergedPrItem.url`). Mitigation: exercised in Commit 1's manual
+  check against this very repo.
+- **Risk: dynamic items swallowed by QuickPick filtering.** Typing `view pr 1350` must not
+  let VS Code's fuzzy matcher drop the injected item. `alwaysShow: true` is the API's
+  dedicated escape hatch; unit test asserts it's set.
+- **Risk: gitlab/gitea pr-view scripts already deviate from `PrViewResult`** (raw CLI
+  JSON). Adding the jq url-mapping follows the issue-view precedent and doesn't tighten
+  or loosen anything else — out of scope to fully align those contracts.
+- **Alternative: route dynamic issue items to `codev.openBacklogIssue`** (issue's
+  wording). Rejected: that command needs a `BacklogTreeItem` carrying a known URL; a
+  typed number has none. The shared `openIssueInBrowser` helper gives the same browser
+  outcome through the already-tested fetch path.
+- **Alternative: skip the server slice and build the PR URL client-side.** Rejected:
+  forge-neutrality is a stated invariant (`parseIssueId` doc, `IssueView.url` doc); URL
+  synthesis would hardcode GitHub.
+- **Alternative: also open the picker when the backlog is empty** (so the type-ahead
+  works with no rows). Deliberately not done — current guard behavior kept, surgical
+  scope. Flag at review if wanted.
+- **Alternative: `when`-gated keybinding.** The sibling `cmd+k i` ships ungated; matching
+  it keeps the family consistent.
+
+## Test Plan
+
+Unit (vitest — `apps/vscode`, `packages/sdk`; run from this worktree):
+
+- `backlog-search.test.ts` — grammar table for `parseSearchDynamicQuery`: bare `1350`,
+  `#1350` → issue+pr; `issue 1350`, `view issue 1350`, `ISSUE #1350` → issue; `pr 1350`,
+  `view pr 1350` → pr; `abc`, `12a3`, `1350 fix`, `issue`, `view pr` → empty.
+- `search-backlog-quickpick.test.ts` (new; vscode mocked with a fake `createQuickPick`,
+  per the `open-issue-by-id.test.ts` stub pattern) — typing `1350` prepends both dynamic
+  items with `alwaysShow`; non-numeric input restores static-only items; accepting the
+  PR dynamic item calls `openPRInBrowser` with `1350`; accepting a static row executes
+  `codev.viewBacklogIssue`.
+- `open-pr-by-id.test.ts` (new; mirrors `open-issue-by-id.test.ts`) — opens `pr.url` in
+  browser; warns on not-found (Q2c); warns when `url` absent; errors when disconnected;
+  no-ops on dismissed InputBox; `#42` → fetches `42` (Q2b via `parseIssueId` reuse).
+- `open-issue-by-id.test.ts` — must pass unmodified after the `openIssueInBrowser`
+  extraction (refactor guard).
+- `tower-client.test.ts` — `getPR` hits `/api/pr?number=N&workspace=...` and unwraps /
+  nulls like `getIssue`.
+
+Manual (dev-approval gate, reviewer-driven):
+
+- Build + launch the extension against this worktree (Extension Development Host).
+- **Q1a**: open backlog search, type `1350` → `View Issue #1350` + `View PR #1350` on
+  top; Enter on the first opens the issue in the browser.
+- **Q1b**: type `view pr 1350` → `View PR #1350` on top; Enter opens the PR in the
+  browser.
+- **Q1c**: type `tower` → normal filtering, no dynamic items.
+- **Q2a**: `Cmd+K P` → InputBox; `1398` + Enter opens PR #1398 in the browser.
+- **Q2b**: type `abc` → validation message, cannot submit.
+- **Q2c**: enter `999999` → warning toast, no crash.
+- Regression: `Cmd+K I` still opens an issue; backlog row Enter still opens the
+  in-editor preview.

--- a/codev/projects/1179-vscode-one-step-view-issue-n-v/1179-review-iter1-rebuttals.md
+++ b/codev/projects/1179-vscode-one-step-view-issue-n-v/1179-review-iter1-rebuttals.md
@@ -1,0 +1,34 @@
+# Rebuttal — iteration 1 (gemini: APPROVE, codex: APPROVE, claude: REQUEST_CHANGES)
+
+## Claude finding 1 (blocker): `Ctrl+K P` / `Cmd+K P` shadows `workbench.action.files.copyPathOfActiveFile`
+
+**Verdict on the finding: CONFIRMED.** I independently verified it against Cursor's
+bundled `workbench.desktop.main.js`: the built-in is registered via
+`registerCommandAndKeybindingRule({weight:200, when:void 0, primary:chord(ctrl+k, 46),
+mac:chord(cmd+k, 46), id:"workbench.action.files.copyPathOfActiveFile"})` — KeyCode 46 is
+KeyP, and extension-contributed keybindings outrank weight-200 workbench rules. The
+issue's and plan's "verified free" claim only covered the extension's own keybindings map.
+
+**What I changed:** the reviewer explicitly did not ask for a rebind — they asked that the
+collision reach the human as a decision instead of shipping as a silent side effect. The
+`Cmd+K P` key choice was specified in the issue itself, so changing it unilaterally would
+override a decision that isn't mine, now that its "slot is free" premise is known false.
+I added a prominent ⚠️ entry to the review file's "Things to Look At During PR Review"
+(commit `f7409002c`, PR body re-synced) stating the confirmed collision, the evidence, and
+the three options at the gate: keep (accept shadowing; the built-in stays reachable via
+Command Palette / context menu), scope with a `when` clause, or rebind. The architect
+notification leads with this finding, flagged as not-re-reviewed (single-pass PIR).
+
+**No code change** unless the human picks scope/rebind at the gate — either is a
+one-line `package.json` edit I can apply immediately on request.
+
+## Claude finding 2 (minor, non-blocking): bare async calls in `onDidAccept`
+
+`openIssueInBrowser` / `openPRInBrowser` are called without `await`/`.catch()` inside the
+sync `onDidAccept` callback, so a rejected `openExternal` would surface as an unhandled
+rejection. **Disposition: accepted as-is, documented.** House style prefers bare
+fire-and-forget calls; both helpers already handle their realistic failure modes (not
+connected, not found, no url) internally with user-facing toasts, leaving only an
+`openExternal` rejection — which the keybound command paths (`openIssueById`/`openPRById`)
+would surface identically, since VS Code receives those commands' promises. Noted in the
+review file alongside the blocker so the pr-gate reviewer sees both dispositions.

--- a/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
+++ b/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-11T05:28:14.613Z'
-updated_at: '2026-08-11T06:01:58.170Z'
+updated_at: '2026-08-11T06:03:58.362Z'
+pr_history:
+  - phase: review
+    pr_number: 1399
+    branch: builder/pir-1179
+    created_at: '2026-08-11T06:03:58.362Z'

--- a/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
+++ b/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-08-11T05:52:44.880Z'
     approved_at: '2026-08-11T06:01:46.974Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-08-11T06:11:28.066Z'
+    approved_at: '2026-08-11T06:30:42.496Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-08-11T05:28:14.613Z'
-updated_at: '2026-08-11T06:11:28.067Z'
+updated_at: '2026-08-11T06:30:42.498Z'
 pr_history:
   - phase: review
     pr_number: 1399
     branch: builder/pir-1179
     created_at: '2026-08-11T06:03:58.362Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
+++ b/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
@@ -1,7 +1,7 @@
 id: '1179'
 title: vscode-one-step-view-issue-n-v
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-11T05:28:14.613Z'
-updated_at: '2026-08-11T06:01:46.975Z'
+updated_at: '2026-08-11T06:01:58.170Z'

--- a/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
+++ b/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-08-11T05:34:19.904Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-11T05:28:14.613Z'
-updated_at: '2026-08-11T05:28:14.613Z'
+updated_at: '2026-08-11T05:34:19.905Z'

--- a/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
+++ b/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-08-11T05:34:19.904Z'
     approved_at: '2026-08-11T05:39:15.706Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-08-11T05:52:44.880Z'
+    approved_at: '2026-08-11T06:01:46.974Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-11T05:28:14.613Z'
-updated_at: '2026-08-11T05:52:44.881Z'
+updated_at: '2026-08-11T06:01:46.975Z'

--- a/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
+++ b/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
@@ -1,7 +1,7 @@
 id: '1179'
 title: vscode-one-step-view-issue-n-v
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-11T05:28:14.613Z'
-updated_at: '2026-08-11T05:39:15.707Z'
+updated_at: '2026-08-11T05:39:23.983Z'

--- a/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
+++ b/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
@@ -1,0 +1,18 @@
+id: '1179'
+title: vscode-one-step-view-issue-n-v
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-11T05:28:14.613Z'
+updated_at: '2026-08-11T05:28:14.613Z'

--- a/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
+++ b/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-08-11T06:01:46.974Z'
   pr:
     status: pending
+    requested_at: '2026-08-11T06:11:28.066Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-08-11T05:28:14.613Z'
-updated_at: '2026-08-11T06:04:05.448Z'
+updated_at: '2026-08-11T06:11:28.067Z'
 pr_history:
   - phase: review
     pr_number: 1399
     branch: builder/pir-1179
     created_at: '2026-08-11T06:03:58.362Z'
+pr_ready_for_human: true

--- a/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
+++ b/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-08-11T05:28:14.613Z'
-updated_at: '2026-08-11T06:03:58.362Z'
+updated_at: '2026-08-11T06:04:05.448Z'
 pr_history:
   - phase: review
     pr_number: 1399

--- a/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
+++ b/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-08-11T05:39:15.706Z'
   dev-approval:
     status: pending
+    requested_at: '2026-08-11T05:52:44.880Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-11T05:28:14.613Z'
-updated_at: '2026-08-11T05:39:23.983Z'
+updated_at: '2026-08-11T05:52:44.881Z'

--- a/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
+++ b/codev/projects/1179-vscode-one-step-view-issue-n-v/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-08-11T05:34:19.904Z'
+    approved_at: '2026-08-11T05:39:15.706Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-11T05:28:14.613Z'
-updated_at: '2026-08-11T05:34:19.905Z'
+updated_at: '2026-08-11T05:39:15.707Z'

--- a/codev/resources/lessons-learned.md
+++ b/codev/resources/lessons-learned.md
@@ -328,6 +328,12 @@ Generalizable wisdom extracted from review documents, ordered by impact. Updated
 
 ## UI/UX
 
+- [From #1179] `vscode.QuickPickItem` reserves the `kind` property for its separator enum
+  (`QuickPickItemKind`), so a custom item type using `kind` as its own discriminator fails
+  the `createQuickPick<T extends QuickPickItem>` constraint. Pick a different name
+  (`target`, `action`) for domain discriminators on QuickPick item types. Relatedly:
+  dynamic rows injected via `onDidChangeValue` need `alwaysShow: true`, or VS Code's fuzzy
+  filter hides a row whose label was synthesized from the very input being filtered on.
 - [From #1380] Chromium does NOT honor `break-inside: avoid` for a block taller than the
   fragmentainer — it fragments it anyway AND lets a fragment overflow (unreachable under
   `overflow-y: hidden`). Protected-block designs need height caps (inner scroll) so that

--- a/codev/reviews/1179-vscode-one-step-view-issue-n-v.md
+++ b/codev/reviews/1179-vscode-one-step-view-issue-n-v.md
@@ -1,4 +1,4 @@
-# PIR Review: One-step "view issue N" / "view pr N" QuickPick type-ahead + Cmd+K P Open-PR-by-ID
+# PIR Review: One-step "view issue N" / "view pr N" QuickPick type-ahead + Cmd+K Shift+P Open-PR-by-ID
 
 Fixes #1179
 
@@ -8,14 +8,14 @@ Two additive VS Code navigation improvements sharing one code path. The backlog 
 QuickPick now recognizes numeric input (`1350`, `#1350`, `issue 1350`, `view pr 1350`) and
 prepends dynamic `View Issue #N` / `View PR #N` rows that fetch live and open in the
 browser, reaching issues outside the loaded backlog (closed, claimed) and PRs in one
-gesture. A new `codev.openPRById` command on `Cmd+K P` mirrors `codev.openIssueById`,
+gesture. A new `codev.openPRById` command on `Cmd+K Shift+P` mirrors `codev.openIssueById`,
 backed by a new forge-agnostic PR-fetch slice: the `pr-view` concept now emits the PR's
 browser `url` on all three forges, surfaced through Tower's new `GET /api/pr`, a `PRView`
 wire type, and `TowerClient.getPR`.
 
 ## Files Changed
 
-- `apps/vscode/package.json` (+9 / -0) — command declaration + `ctrl+k p` / `cmd+k p`
+- `apps/vscode/package.json` (+9 / -0) — command declaration + `ctrl+k shift+p` / `cmd+k shift+p`
 - `apps/vscode/src/__tests__/backlog-search.test.ts` (+78 / -1) — grammar table
 - `apps/vscode/src/__tests__/open-pr-by-id.test.ts` (+95 / -0) — new
 - `apps/vscode/src/__tests__/search-backlog-quickpick.test.ts` (+148 / -0) — new
@@ -79,19 +79,18 @@ section documents the concept mechanism generically and already lists `pr-view` 
 
 ## Things to Look At During PR Review
 
-- **⚠️ Consultation finding (Claude, REQUEST_CHANGES — confirmed, needs a human decision):
-  `Ctrl+K P` / `Cmd+K P` shadows a VS Code built-in.** The issue said "verified P slot is
-  free," but that verification (plan's included) only covered the extension's own
-  keybindings map. VS Code registers `workbench.action.files.copyPathOfActiveFile` on
-  exactly this chord (weight 200, no `when` clause — confirmed in Cursor's bundled
-  `workbench.desktop.main.js`: `registerCommandAndKeybindingRule({weight:200, when:void 0,
-  primary:chord(ctrl+k, KeyP), mac:chord(cmd+k, KeyP)})`), and extension-contributed
-  keybindings outrank workbench ones, so installing Codev takes "Copy Path of Active File"
-  away on both platforms. The binding ships as the issue specified; options at the gate:
-  **keep** (accept shadowing — common among extensions, and the command remains reachable
-  via palette/context menu), **scope** with a `when` clause, or **rebind**. Since the key
-  choice was baked into the issue on a false premise, I did not change it unilaterally —
-  decide here. (PIR consultation is single-pass; this disposition was not re-reviewed.)
+- **Consultation finding (Claude, REQUEST_CHANGES — confirmed, RESOLVED by rebind):** the
+  originally planned `Ctrl+K P` / `Cmd+K P` shadowed a VS Code built-in. The issue said
+  "verified P slot is free," but that verification (plan's included) only covered the
+  extension's own keybindings map; VS Code registers
+  `workbench.action.files.copyPathOfActiveFile` on exactly that chord (weight 200, no
+  `when` clause — confirmed in the bundled `workbench.desktop.main.js`), and
+  extension-contributed keybindings outrank workbench ones. **Resolution (human decision
+  at the pr gate): rebound to `Ctrl+K Shift+P` / `Cmd+K Shift+P`** — verified free across
+  the core workbench chord table (no shift-modified KeyP chord exists), built-in
+  extensions, and our own map, and it keeps the P-for-PR mnemonic the issue intended.
+  (PIR consultation is single-pass; the rebind itself was verified by the human reviewer,
+  not re-reviewed by the models.)
 - Consultation minor (Claude, non-blocking): in `search-backlog.ts` the async browser-open
   helpers are invoked bare inside the sync `onDidAccept` callback, so an `openExternal`
   rejection would be an unhandled rejection. Left as-is per house style (bare
@@ -119,7 +118,8 @@ section documents the concept mechanism generically and already lists `pr-view` 
     Enter on the first opens the issue in the browser
   - Q1b: type `view pr 1350` → `View PR #1350` on top; Enter opens the PR in the browser
   - Q1c: type `tower` → normal filtering, no dynamic rows
-  - Q2a: `Cmd+K P` → InputBox; `1398` + Enter opens PR #1398 in the browser
+  - Q2a: `Cmd+K Shift+P` → InputBox; `1398` + Enter opens PR #1398 in the browser
+  - Regression: `Cmd+K P` (unshifted) still runs the built-in Copy Path of Active File
   - Q2b: non-numeric input → validation message
   - Q2c: `999999` → warning toast, no crash
   - Regression: `Cmd+K I` unchanged; backlog row Enter still opens the in-editor preview

--- a/codev/reviews/1179-vscode-one-step-view-issue-n-v.md
+++ b/codev/reviews/1179-vscode-one-step-view-issue-n-v.md
@@ -1,0 +1,107 @@
+# PIR Review: One-step "view issue N" / "view pr N" QuickPick type-ahead + Cmd+K P Open-PR-by-ID
+
+Fixes #1179
+
+## Summary
+
+Two additive VS Code navigation improvements sharing one code path. The backlog search
+QuickPick now recognizes numeric input (`1350`, `#1350`, `issue 1350`, `view pr 1350`) and
+prepends dynamic `View Issue #N` / `View PR #N` rows that fetch live and open in the
+browser, reaching issues outside the loaded backlog (closed, claimed) and PRs in one
+gesture. A new `codev.openPRById` command on `Cmd+K P` mirrors `codev.openIssueById`,
+backed by a new forge-agnostic PR-fetch slice: the `pr-view` concept now emits the PR's
+browser `url` on all three forges, surfaced through Tower's new `GET /api/pr`, a `PRView`
+wire type, and `TowerClient.getPR`.
+
+## Files Changed
+
+- `apps/vscode/package.json` (+9 / -0) — command declaration + `ctrl+k p` / `cmd+k p`
+- `apps/vscode/src/__tests__/backlog-search.test.ts` (+78 / -1) — grammar table
+- `apps/vscode/src/__tests__/open-pr-by-id.test.ts` (+95 / -0) — new
+- `apps/vscode/src/__tests__/search-backlog-quickpick.test.ts` (+148 / -0) — new
+- `apps/vscode/src/commands/open-issue-by-id.ts` (+30 / -13) — extract `openIssueInBrowser`
+- `apps/vscode/src/commands/open-pr-by-id.ts` (+67 / -0) — new
+- `apps/vscode/src/commands/search-backlog.ts` (+64 / -11) — `createQuickPick` + dynamic rows
+- `apps/vscode/src/extension.ts` (+3 / -1) — register `codev.openPRById`
+- `apps/vscode/src/views/backlog-search.ts` (+67 / -0) — type-ahead grammar helpers
+- `packages/codev/scripts/forge/github/pr-view.sh` (+1 / -1) — add `url` to `--json`
+- `packages/codev/scripts/forge/gitlab/pr-view.sh` (+4 / -1) — map `web_url` → `url`
+- `packages/codev/scripts/forge/gitea/pr-view.sh` (+4 / -1) — map `html_url` → `url`
+- `packages/codev/src/agent-farm/servers/tower-routes.ts` (+30 / -0) — `GET /api/pr`
+- `packages/codev/src/lib/forge-contracts.ts` (+9 / -0) — `PrViewResult.url?`
+- `packages/codev/src/lib/github.ts` (+23 / -2) — `fetchPR`
+- `packages/sdk/src/tower-client.ts` (+14 / -1) — `getPR`
+- `packages/sdk/src/__tests__/tower-client.test.ts` (+13 / -0) — `getPR` tests
+- `packages/types/src/api.ts` (+27 / -0) — `PRView` wire type
+- `packages/types/src/index.ts` (+1 / -0) — export
+- `codev/plans/1179-vscode-one-step-view-issue-n-v.md` (+201 / -0), thread log, porch state
+
+## Commits
+
+- `55451226f` [PIR #1179] PR-fetch plumbing: pr-view url, fetchPR, GET /api/pr, PRView, TowerClient.getPR
+- `0689c8248` [PIR #1179] codev.openPRById command + Cmd+K P keybinding
+- `5608aa1cd` [PIR #1179] Backlog QuickPick type-ahead: dynamic View Issue/PR #N rows
+- `3d50408d0` [PIR #1179] Thread log: implement phase notes
+- `2a747cb52` [PIR #1179] dev-approval feedback: rename dynamic-row discriminator kind -> target (QuickPickItem reserves kind)
+- (plus `9c5ced324` plan draft and porch `chore(porch)` bookkeeping commits)
+
+## Test Results
+
+- Build: extension `pnpm compile` (tsc + eslint + esbuild) ✓; `tsc --noEmit` verified
+  directly after the `kind`→`target` fix; porch `build` check ✓
+- Tests: vscode vitest 777/777 (26 new across three files); codev 4786 passed / 48
+  pre-existing skips / 0 failed; sdk 75/75 (2 new `getPR` tests); porch `tests` check ✓
+- Manual verification (human, dev-approval gate): ran the Extension Development Host,
+  exercised the Command Palette and QuickPick flows; caught a real `tsc` error my piped
+  compile run had masked (see Lessons)
+- Real-forge check: `CODEV_PR_NUMBER=1398 sh packages/codev/scripts/forge/github/pr-view.sh`
+  returns title/url/state from GitHub
+
+## Architecture Updates
+
+No arch changes — `GET /api/pr` / `TowerClient.getPR` / `fetchPR` deliberately mirror the
+already-documented `GET /api/issue` / `getIssue` / `fetchIssue` pattern (arch.md's forge
+section documents the concept mechanism generically and already lists `pr-view` among the
+15 concepts; it doesn't enumerate per-concept output fields or individual Tower routes).
+
+## Lessons Learned Updates
+
+- **COLD `lessons-learned.md` (UI/UX)**: `vscode.QuickPickItem` reserves `kind`
+  (`QuickPickItemKind` separators) — a custom discriminator named `kind` on a QuickPick
+  item type fails the `createQuickPick<T extends QuickPickItem>` constraint; use a
+  domain name like `target`. Plus: dynamic rows injected via `onDidChangeValue` need
+  `alwaysShow: true` to survive the fuzzy filter.
+- **Re-confirmed, not re-added**: existing lesson [From #1150] (piping a build through
+  `tail` reports the filter's exit code) bit again in this project — my background
+  `pnpm compile 2>&1 | tail -6` reported success while `tsc` was failing on the `kind`
+  collision; the human reviewer caught it at the gate. The lesson already exists; noting
+  the recurrence here rather than duplicating it.
+
+## Things to Look At During PR Review
+
+- `search-backlog.ts` accept-routing: dynamic rows are discriminated by `'target' in picked`
+  — static `BacklogQuickPickItem` rows never carry `target`, so the check is sound, but
+  it's the one structural assumption tying the two item shapes together.
+- A bare number offers **both** `View Issue #N` and `View PR #N` (ambiguous input);
+  explicit `issue N` / `pr N` forms narrow to one. `1350 fix` (trailing text) deliberately
+  yields no dynamic rows.
+- PR-not-found and PR-without-url both surface the same warning toast — there's no
+  in-editor PR preview to degrade to (unlike the issue path's `viewBacklogIssue` fallback).
+- The gitlab/gitea `pr-view.sh` scripts gained a `jq` dependency (mirroring their
+  `issue-view.sh` siblings, which already use it). GitHub's script (the default) does not.
+- Per plan, the empty-backlog early-return is unchanged: type-ahead requires at least one
+  loaded backlog row. Flagged in the plan as a deliberate scope cut.
+
+## How to Test Locally
+
+- **View diff**: VSCode sidebar → right-click builder pir-1179 → **Review Diff**
+- **Run dev**: VSCode sidebar → **Run Dev**, or `afx dev pir-1179`
+- **What to verify** (maps to the plan's Test Plan / issue acceptance):
+  - Q1a: backlog search picker, type `1350` → `View Issue #1350` + `View PR #1350` on top;
+    Enter on the first opens the issue in the browser
+  - Q1b: type `view pr 1350` → `View PR #1350` on top; Enter opens the PR in the browser
+  - Q1c: type `tower` → normal filtering, no dynamic rows
+  - Q2a: `Cmd+K P` → InputBox; `1398` + Enter opens PR #1398 in the browser
+  - Q2b: non-numeric input → validation message
+  - Q2c: `999999` → warning toast, no crash
+  - Regression: `Cmd+K I` unchanged; backlog row Enter still opens the in-editor preview

--- a/codev/reviews/1179-vscode-one-step-view-issue-n-v.md
+++ b/codev/reviews/1179-vscode-one-step-view-issue-n-v.md
@@ -79,6 +79,24 @@ section documents the concept mechanism generically and already lists `pr-view` 
 
 ## Things to Look At During PR Review
 
+- **⚠️ Consultation finding (Claude, REQUEST_CHANGES — confirmed, needs a human decision):
+  `Ctrl+K P` / `Cmd+K P` shadows a VS Code built-in.** The issue said "verified P slot is
+  free," but that verification (plan's included) only covered the extension's own
+  keybindings map. VS Code registers `workbench.action.files.copyPathOfActiveFile` on
+  exactly this chord (weight 200, no `when` clause — confirmed in Cursor's bundled
+  `workbench.desktop.main.js`: `registerCommandAndKeybindingRule({weight:200, when:void 0,
+  primary:chord(ctrl+k, KeyP), mac:chord(cmd+k, KeyP)})`), and extension-contributed
+  keybindings outrank workbench ones, so installing Codev takes "Copy Path of Active File"
+  away on both platforms. The binding ships as the issue specified; options at the gate:
+  **keep** (accept shadowing — common among extensions, and the command remains reachable
+  via palette/context menu), **scope** with a `when` clause, or **rebind**. Since the key
+  choice was baked into the issue on a false premise, I did not change it unilaterally —
+  decide here. (PIR consultation is single-pass; this disposition was not re-reviewed.)
+- Consultation minor (Claude, non-blocking): in `search-backlog.ts` the async browser-open
+  helpers are invoked bare inside the sync `onDidAccept` callback, so an `openExternal`
+  rejection would be an unhandled rejection. Left as-is per house style (bare
+  fire-and-forget calls); both helpers handle their real failure modes (not connected /
+  not found) internally with toasts.
 - `search-backlog.ts` accept-routing: dynamic rows are discriminated by `'target' in picked`
   — static `BacklogQuickPickItem` rows never carry `target`, so the check is sound, but
   it's the one structural assumption tying the two item shapes together.

--- a/codev/state/pir-1179_thread.md
+++ b/codev/state/pir-1179_thread.md
@@ -20,3 +20,26 @@ Investigated issue #1179 (one-step "view issue N / view pr N" QuickPick type-ahe
 
 Plan written to `codev/plans/1179-vscode-one-step-view-issue-n-v.md`; three commits:
 plumbing → openPRById command → QuickPick type-ahead. Sitting at plan-approval gate.
+
+## 2026-08-11 — Implement phase
+
+Plan approved as written (reviewer asked one clarifying question about typing id+title
+together; no plan change needed). Implemented in the three planned commits:
+
+1. `5545122` PR-fetch plumbing: `pr-view` scripts emit `url` (github --json field;
+   gitlab/gitea jq mappings mirroring issue-view), `PrViewResult.url`, `fetchPR`,
+   Tower `GET /api/pr` (mirror of handleIssueView), `PRView` wire type,
+   `TowerClient.getPR` + sdk tests.
+2. `0689c82` `codev.openPRById` + Cmd+K P: extracted `openIssueInBrowser` from
+   `openIssueById` (behavior unchanged, tests pass unmodified), new
+   `open-pr-by-id.ts` with `openPRInBrowser`, manifest command + keybinding.
+3. `5608aa1` QuickPick type-ahead: `parseSearchDynamicQuery` grammar +
+   `toDynamicQuickPickItems` (alwaysShow rows) in vscode-free `backlog-search.ts`;
+   `search-backlog.ts` moved to `createQuickPick` with dynamic rows and accept
+   routing (dynamic → browser helpers, static → in-editor preview unchanged).
+
+Notes for reviewers: fresh-worktree builds need `pnpm -C packages/types build`,
+`packages/core build`, `packages/sdk build`, `packages/artifact-canvas build` before
+type-checking codev/vscode (dist-based workspace resolution; not caused by this change).
+Verified the real forge path: `CODEV_PR_NUMBER=1398 sh .../github/pr-view.sh` returns
+title/url/state. vscode vitest 777/777 green.

--- a/codev/state/pir-1179_thread.md
+++ b/codev/state/pir-1179_thread.md
@@ -38,6 +38,17 @@ together; no plan change needed). Implemented in the three planned commits:
    `search-backlog.ts` moved to `createQuickPick` with dynamic rows and accept
    routing (dynamic → browser helpers, static → in-editor preview unchanged).
 
+## 2026-08-11 — Review phase / pr gate
+
+Dev-approval feedback caught a real tsc error my piped `pnpm compile | tail` had masked
+(lesson #1150 struck again): `DynamicQuickPickItem.kind` collided with VS Code's reserved
+`QuickPickItem.kind`; renamed to `target` (2a747cb5). PR #1399 opened; retrospective +
+COLD lesson (QuickPickItem reserves `kind`; alwaysShow for injected rows) committed.
+Consultation: gemini APPROVE, codex APPROVE, claude REQUEST_CHANGES — confirmed finding:
+Cmd+K P shadows the built-in Copy Path of Active File (issue's "free slot" premise only
+covered our own map). Key kept as issue-specified; collision escalated to the human at
+the pr gate via review "Things to Look At" + rebuttal file. Sitting at pr gate.
+
 Notes for reviewers: fresh-worktree builds need `pnpm -C packages/types build`,
 `packages/core build`, `packages/sdk build`, `packages/artifact-canvas build` before
 type-checking codev/vscode (dist-based workspace resolution; not caused by this change).

--- a/codev/state/pir-1179_thread.md
+++ b/codev/state/pir-1179_thread.md
@@ -49,6 +49,15 @@ Cmd+K P shadows the built-in Copy Path of Active File (issue's "free slot" premi
 covered our own map). Key kept as issue-specified; collision escalated to the human at
 the pr gate via review "Things to Look At" + rebuttal file. Sitting at pr gate.
 
+## 2026-08-11 — pr gate: keybinding rebound
+
+Architect decision on the shadowing finding: rebind. `codev.openPRById` moved from
+`ctrl+k p` / `cmd+k p` to `ctrl+k shift+p` / `cmd+k shift+p` — verified free in the core
+workbench chord table (no shift+KeyP chord; I cross-checked via chord-code enumeration of
+the bundled workbench, architect verified independently incl. built-in extensions),
+keeps the P-for-PR mnemonic. Review file + PR body updated to record the resolution.
+Earlier "verified free" notes above stand as the historical record of the bad premise.
+
 Notes for reviewers: fresh-worktree builds need `pnpm -C packages/types build`,
 `packages/core build`, `packages/sdk build`, `packages/artifact-canvas build` before
 type-checking codev/vscode (dist-based workspace resolution; not caused by this change).

--- a/codev/state/pir-1179_thread.md
+++ b/codev/state/pir-1179_thread.md
@@ -1,0 +1,22 @@
+# Builder thread — pir-1179
+
+## 2026-08-11 — Plan phase
+
+Investigated issue #1179 (one-step "view issue N / view pr N" QuickPick type-ahead +
+`codev.openPRById` with Cmd+K P). Key findings that shaped the plan:
+
+- The issue's paths are stale: extension is `apps/vscode/`, not `packages/vscode/`.
+- The "View Issue QuickPick" is `codev.searchBacklog` (`commands/search-backlog.ts`) —
+  the only issue-navigation QuickPick in the extension.
+- `client.getPR` doesn't exist anywhere in the chain: no SDK method, no Tower route.
+  A `pr-view` forge concept exists but emits no `url`. Plan therefore includes a thin
+  vertical slice: forge scripts (github/gitlab/gitea) + `PrViewResult.url` + `fetchPR`
+  + `GET /api/pr` + `PRView` wire type + `TowerClient.getPR`.
+- `codev.openBacklogIssue` can't serve the dynamic items (needs a tree item with a
+  pre-known URL); routing through an extracted `openIssueInBrowser` helper instead.
+- No in-editor PR preview exists → url-less/missing PR degrades to a warning, per the
+  issue's own fallback clause.
+- `ctrl+k p` / `cmd+k p` verified free.
+
+Plan written to `codev/plans/1179-vscode-one-step-view-issue-n-v.md`; three commits:
+plumbing → openPRById command → QuickPick type-ahead. Sitting at plan-approval gate.

--- a/packages/codev/scripts/forge/gitea/pr-view.sh
+++ b/packages/codev/scripts/forge/gitea/pr-view.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 # Forge concept: pr-view (Gitea via tea CLI)
-exec tea pulls view "$CODEV_PR_NUMBER" --output json
+# Sets `url` to the PR's browser page (`html_url`). Gitea's own `url` field is
+# the API endpoint (would render raw JSON in a browser), so we prefer `html_url`
+# and fall back to the existing `url` only if `html_url` is absent.
+tea pulls view "$CODEV_PR_NUMBER" --output json | jq '.url = (.html_url // .url)'

--- a/packages/codev/scripts/forge/github/pr-view.sh
+++ b/packages/codev/scripts/forge/github/pr-view.sh
@@ -7,5 +7,5 @@ if [ "$CODEV_INCLUDE_COMMENTS" = "1" ]; then
   exec gh pr view "$CODEV_PR_NUMBER" --comments
 else
   exec gh pr view "$CODEV_PR_NUMBER" \
-    --json title,body,state,author,baseRefName,headRefName,additions,deletions
+    --json title,body,state,url,author,baseRefName,headRefName,additions,deletions
 fi

--- a/packages/codev/scripts/forge/gitlab/pr-view.sh
+++ b/packages/codev/scripts/forge/gitlab/pr-view.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 # Forge concept: pr-view (GitLab via glab CLI)
-exec glab mr view "$CODEV_PR_NUMBER" --output json
+# Adds a `url` field mapped from GitLab's `web_url` (the MR's browser page);
+# all other fields glab emits are passed through unchanged. `. + {url: …}` is
+# non-destructive — if `web_url` is absent, `url` is null (optional by contract).
+glab mr view "$CODEV_PR_NUMBER" --output json | jq '. + {url: .web_url}'

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -86,6 +86,7 @@ import {
 import { OverviewCache } from './overview.js';
 import {
   fetchIssue,
+  fetchPR,
   searchIssues,
   fetchPRList,
   fetchCurrentUser,
@@ -180,6 +181,7 @@ const ROUTES: Record<string, RouteEntry> = {
   'GET /api/version':     (_req, res, _url, ctx) => handleVersion(res, ctx),
   'GET /api/overview':    (_req, res, url, ctx) => handleOverview(res, url, undefined, ctx),
   'GET /api/issue':       (_req, res, url) => handleIssueView(res, url),
+  'GET /api/pr':          (_req, res, url) => handlePRView(res, url),
   'GET /api/issue-search': (_req, res, url) => handleIssueSearch(res, url),
   'GET /api/worktree-config': (_req, res, url) => handleWorktreeConfigView(res, url),
   'GET /api/activity-hooks': (_req, res, url) => handleActivityHooksView(res, url),
@@ -1172,6 +1174,34 @@ async function handleIssueView(res: http.ServerResponse, url: URL): Promise<void
 
   res.writeHead(200, { 'Content-Type': 'application/json' });
   res.end(JSON.stringify(issue));
+}
+
+async function handlePRView(res: http.ServerResponse, url: URL): Promise<void> {
+  // Mirror of handleIssueView for PRs: same workspace resolution, same
+  // ?number= param, routed through the `pr-view` forge concept. Powers the
+  // VSCode `codev.openPRById` / QuickPick "View PR #N" browser-open flow.
+  let workspaceRoot = url.searchParams.get('workspace');
+  if (!workspaceRoot) {
+    const knownPaths = getKnownWorkspacePaths();
+    workspaceRoot = knownPaths.find(p => !p.includes('/.builders/')) || null;
+  }
+
+  const number = url.searchParams.get('number');
+  if (!workspaceRoot || !number) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Missing workspace or number' }));
+    return;
+  }
+
+  const pr = await fetchPR(number, { cwd: workspaceRoot });
+  if (!pr) {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: `PR #${number} not found or forge unavailable` }));
+    return;
+  }
+
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(pr));
 }
 
 /**

--- a/packages/codev/src/lib/forge-contracts.ts
+++ b/packages/codev/src/lib/forge-contracts.ts
@@ -123,6 +123,15 @@ export interface PrViewResult {
   title: string;
   body: string;
   state: string;
+  /**
+   * The PR's **browser/web** URL (NOT an API endpoint), when the concept
+   * supplies it. Each forge script maps its own web-URL field here: GitHub
+   * `url`, GitLab `web_url`, Gitea `html_url` (Gitea's `url` is the API
+   * endpoint — do not use it). Optional to keep the contract forge-neutral
+   * (a forge script that doesn't emit it degrades gracefully) — same shape
+   * as `IssueViewResult.url`.
+   */
+  url?: string;
   author: { login: string };
   baseRefName: string;
   headRefName: string;

--- a/packages/codev/src/lib/github.ts
+++ b/packages/codev/src/lib/github.ts
@@ -12,7 +12,7 @@
 import { UNCATEGORIZED_AREA } from '@cluesmith/codev-sdk/constants';
 import { executeForgeCommand, type ForgeConfig } from './forge.js';
 import { getRepoInfo } from './team-github.js';
-import type { IssueViewResult, PrListItem, IssueListItem } from './forge-contracts.js';
+import type { IssueViewResult, PrListItem, PrViewResult, IssueListItem } from './forge-contracts.js';
 
 // =============================================================================
 // Types — re-export forge-contracts types under generic names
@@ -22,6 +22,8 @@ import type { IssueViewResult, PrListItem, IssueListItem } from './forge-contrac
 export type ForgeIssue = IssueViewResult;
 /** A single PR/MR item as returned by the `pr-list` concept command. */
 export type ForgePR = PrListItem;
+/** A single PR/MR as returned by the `pr-view` concept command. */
+export type ForgePRView = PrViewResult;
 /** A single issue item as returned by the `issue-list` concept command. */
 export type ForgeIssueListItem = IssueListItem;
 
@@ -83,6 +85,27 @@ export async function fetchIssueOrThrow(
 export const fetchGitHubIssue = fetchIssue;
 /** @deprecated Use fetchIssueOrThrow instead. */
 export const fetchGitHubIssueOrThrow = fetchIssueOrThrow;
+
+/**
+ * Fetch a single PR by number.
+ * Routes through the `pr-view` concept command.
+ * Returns null if the concept command fails (bad number, forge unavailable).
+ *
+ * @param prId - PR identifier (number or string)
+ * @param options - Optional forge config and cwd
+ */
+export async function fetchPR(
+  prId: string | number,
+  options?: { cwd?: string; forgeConfig?: ForgeConfig | null },
+): Promise<ForgePRView | null> {
+  const result = await executeForgeCommand('pr-view', {
+    CODEV_PR_NUMBER: String(prId),
+  }, {
+    cwd: options?.cwd,
+    forgeConfig: options?.forgeConfig,
+  });
+  return result as ForgePRView | null;
+}
 
 /**
  * Fetch open PRs for the current repo.

--- a/packages/sdk/src/__tests__/tower-client.test.ts
+++ b/packages/sdk/src/__tests__/tower-client.test.ts
@@ -74,6 +74,19 @@ describe('TowerClient REST', () => {
     expect(await new TowerClient(opts(impl)).listWorkspaces()).toEqual(ws);
   });
 
+  it('getPR hits /api/pr with number + workspace and unwraps the payload', async () => {
+    const pr = { title: 't', body: '', state: 'MERGED', url: 'https://forge/pull/7' };
+    const { impl, calls } = jsonFetch(200, pr);
+    const got = await new TowerClient(opts(impl)).getPR('7', '/work/a b');
+    expect(calls[0].url).toBe('http://localhost:4100/api/pr?number=7&workspace=%2Fwork%2Fa+b');
+    expect(got).toEqual(pr);
+  });
+
+  it('getPR returns null on a non-2xx response (PR not found)', async () => {
+    const { impl } = jsonFetch(404, { error: 'PR #7 not found or forge unavailable' });
+    expect(await new TowerClient(opts(impl)).getPR('7')).toBeNull();
+  });
+
   it('normalizes a connection refusal to "Tower not running" (not a throw)', async () => {
     const impl = vi.fn(async () => { throw new Error('ECONNREFUSED'); }) as unknown as typeof fetch;
     const res = await new TowerClient(opts(impl)).sendCommand('view-diff');

--- a/packages/sdk/src/tower-client.ts
+++ b/packages/sdk/src/tower-client.ts
@@ -13,7 +13,7 @@
  * the read-only reader for standalone Node controllers).
  */
 
-import type { DashboardState, OverviewData, IssueView, IssueSearchResponse, ResolvedWorktreeConfig, ResolvedActivityHooks, TowerVersionInfo, CommandRequest } from '@cluesmith/codev-types';
+import type { DashboardState, OverviewData, IssueView, PRView, IssueSearchResponse, ResolvedWorktreeConfig, ResolvedActivityHooks, TowerVersionInfo, CommandRequest } from '@cluesmith/codev-types';
 import { DEFAULT_TOWER_PORT } from './constants.js';
 import { parseSseText, type SseEnvelope } from './sse.js';
 
@@ -474,6 +474,19 @@ export class TowerClient {
     const params = new URLSearchParams({ number: issueNumber });
     if (workspacePath) { params.set('workspace', workspacePath); }
     const result = await this.request<IssueView>(`/api/issue?${params.toString()}`);
+    return result.ok ? result.data! : null;
+  }
+
+  /**
+   * Fetch a single PR's title/state/url via Tower's forge-backed
+   * GET /api/pr — the PR counterpart of getIssue. Returns null if the PR
+   * can't be resolved (forge unavailable, bad number) so callers can
+   * degrade.
+   */
+  async getPR(prNumber: string, workspacePath?: string): Promise<PRView | null> {
+    const params = new URLSearchParams({ number: prNumber });
+    if (workspacePath) { params.set('workspace', workspacePath); }
+    const result = await this.request<PRView>(`/api/pr?${params.toString()}`);
     return result.ok ? result.data! : null;
   }
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -408,6 +408,33 @@ export interface IssueView {
   }>;
 }
 
+// --- PR view (GET /api/pr) ---
+
+/**
+ * A single PR as returned by the `pr-view` forge concept and surfaced
+ * verbatim by Tower's GET /api/pr. Mirrors the server-side PrViewResult
+ * (packages/codev/src/lib/forge-contracts.ts).
+ */
+export interface PRView {
+  title: string;
+  body: string;
+  state: string;
+  /**
+   * The PR's **browser/web** URL (NOT an API endpoint), when the forge
+   * concept supplies it. Each forge maps its own web-URL field into this:
+   * GitHub `url`, GitLab `web_url`, Gitea `html_url` (Gitea's `url` is the
+   * API endpoint — do not use it). Optional so the contract stays
+   * forge-neutral; consumers that open the PR in a browser degrade
+   * gracefully when it's absent (e.g. a forge script that doesn't emit it).
+   */
+  url?: string;
+  author: { login: string };
+  baseRefName: string;
+  headRefName: string;
+  additions: number;
+  deletions: number;
+}
+
 // --- Issue search (GET /api/issue-search) ---
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -33,6 +33,7 @@ export {
   type OverviewRecentlyClosed,
   type OverviewData,
   type IssueView,
+  type PRView,
   type IssueSearchItem,
   type IssueSearchResponse,
   type WorktreeDevUrl,


### PR DESCRIPTION
# PIR Review: One-step "view issue N" / "view pr N" QuickPick type-ahead + Cmd+K Shift+P Open-PR-by-ID

Fixes #1179

## Summary

Two additive VS Code navigation improvements sharing one code path. The backlog search
QuickPick now recognizes numeric input (`1350`, `#1350`, `issue 1350`, `view pr 1350`) and
prepends dynamic `View Issue #N` / `View PR #N` rows that fetch live and open in the
browser, reaching issues outside the loaded backlog (closed, claimed) and PRs in one
gesture. A new `codev.openPRById` command on `Cmd+K Shift+P` mirrors `codev.openIssueById`,
backed by a new forge-agnostic PR-fetch slice: the `pr-view` concept now emits the PR's
browser `url` on all three forges, surfaced through Tower's new `GET /api/pr`, a `PRView`
wire type, and `TowerClient.getPR`.

## Files Changed

- `apps/vscode/package.json` (+9 / -0) — command declaration + `ctrl+k shift+p` / `cmd+k shift+p`
- `apps/vscode/src/__tests__/backlog-search.test.ts` (+78 / -1) — grammar table
- `apps/vscode/src/__tests__/open-pr-by-id.test.ts` (+95 / -0) — new
- `apps/vscode/src/__tests__/search-backlog-quickpick.test.ts` (+148 / -0) — new
- `apps/vscode/src/commands/open-issue-by-id.ts` (+30 / -13) — extract `openIssueInBrowser`
- `apps/vscode/src/commands/open-pr-by-id.ts` (+67 / -0) — new
- `apps/vscode/src/commands/search-backlog.ts` (+64 / -11) — `createQuickPick` + dynamic rows
- `apps/vscode/src/extension.ts` (+3 / -1) — register `codev.openPRById`
- `apps/vscode/src/views/backlog-search.ts` (+67 / -0) — type-ahead grammar helpers
- `packages/codev/scripts/forge/github/pr-view.sh` (+1 / -1) — add `url` to `--json`
- `packages/codev/scripts/forge/gitlab/pr-view.sh` (+4 / -1) — map `web_url` → `url`
- `packages/codev/scripts/forge/gitea/pr-view.sh` (+4 / -1) — map `html_url` → `url`
- `packages/codev/src/agent-farm/servers/tower-routes.ts` (+30 / -0) — `GET /api/pr`
- `packages/codev/src/lib/forge-contracts.ts` (+9 / -0) — `PrViewResult.url?`
- `packages/codev/src/lib/github.ts` (+23 / -2) — `fetchPR`
- `packages/sdk/src/tower-client.ts` (+14 / -1) — `getPR`
- `packages/sdk/src/__tests__/tower-client.test.ts` (+13 / -0) — `getPR` tests
- `packages/types/src/api.ts` (+27 / -0) — `PRView` wire type
- `packages/types/src/index.ts` (+1 / -0) — export
- `codev/plans/1179-vscode-one-step-view-issue-n-v.md` (+201 / -0), thread log, porch state

## Commits

- `55451226f` [PIR #1179] PR-fetch plumbing: pr-view url, fetchPR, GET /api/pr, PRView, TowerClient.getPR
- `0689c8248` [PIR #1179] codev.openPRById command + Cmd+K P keybinding
- `5608aa1cd` [PIR #1179] Backlog QuickPick type-ahead: dynamic View Issue/PR #N rows
- `3d50408d0` [PIR #1179] Thread log: implement phase notes
- `2a747cb52` [PIR #1179] dev-approval feedback: rename dynamic-row discriminator kind -> target (QuickPickItem reserves kind)
- (plus `9c5ced324` plan draft and porch `chore(porch)` bookkeeping commits)

## Test Results

- Build: extension `pnpm compile` (tsc + eslint + esbuild) ✓; `tsc --noEmit` verified
  directly after the `kind`→`target` fix; porch `build` check ✓
- Tests: vscode vitest 777/777 (26 new across three files); codev 4786 passed / 48
  pre-existing skips / 0 failed; sdk 75/75 (2 new `getPR` tests); porch `tests` check ✓
- Manual verification (human, dev-approval gate): ran the Extension Development Host,
  exercised the Command Palette and QuickPick flows; caught a real `tsc` error my piped
  compile run had masked (see Lessons)
- Real-forge check: `CODEV_PR_NUMBER=1398 sh packages/codev/scripts/forge/github/pr-view.sh`
  returns title/url/state from GitHub

## Architecture Updates

No arch changes — `GET /api/pr` / `TowerClient.getPR` / `fetchPR` deliberately mirror the
already-documented `GET /api/issue` / `getIssue` / `fetchIssue` pattern (arch.md's forge
section documents the concept mechanism generically and already lists `pr-view` among the
15 concepts; it doesn't enumerate per-concept output fields or individual Tower routes).

## Lessons Learned Updates

- **COLD `lessons-learned.md` (UI/UX)**: `vscode.QuickPickItem` reserves `kind`
  (`QuickPickItemKind` separators) — a custom discriminator named `kind` on a QuickPick
  item type fails the `createQuickPick<T extends QuickPickItem>` constraint; use a
  domain name like `target`. Plus: dynamic rows injected via `onDidChangeValue` need
  `alwaysShow: true` to survive the fuzzy filter.
- **Re-confirmed, not re-added**: existing lesson [From #1150] (piping a build through
  `tail` reports the filter's exit code) bit again in this project — my background
  `pnpm compile 2>&1 | tail -6` reported success while `tsc` was failing on the `kind`
  collision; the human reviewer caught it at the gate. The lesson already exists; noting
  the recurrence here rather than duplicating it.

## Things to Look At During PR Review

- **Consultation finding (Claude, REQUEST_CHANGES — confirmed, RESOLVED by rebind):** the
  originally planned `Ctrl+K P` / `Cmd+K P` shadowed a VS Code built-in. The issue said
  "verified P slot is free," but that verification (plan's included) only covered the
  extension's own keybindings map; VS Code registers
  `workbench.action.files.copyPathOfActiveFile` on exactly that chord (weight 200, no
  `when` clause — confirmed in the bundled `workbench.desktop.main.js`), and
  extension-contributed keybindings outrank workbench ones. **Resolution (human decision
  at the pr gate): rebound to `Ctrl+K Shift+P` / `Cmd+K Shift+P`** — verified free across
  the core workbench chord table (no shift-modified KeyP chord exists), built-in
  extensions, and our own map, and it keeps the P-for-PR mnemonic the issue intended.
  (PIR consultation is single-pass; the rebind itself was verified by the human reviewer,
  not re-reviewed by the models.)
- Consultation minor (Claude, non-blocking): in `search-backlog.ts` the async browser-open
  helpers are invoked bare inside the sync `onDidAccept` callback, so an `openExternal`
  rejection would be an unhandled rejection. Left as-is per house style (bare
  fire-and-forget calls); both helpers handle their real failure modes (not connected /
  not found) internally with toasts.
- `search-backlog.ts` accept-routing: dynamic rows are discriminated by `'target' in picked`
  — static `BacklogQuickPickItem` rows never carry `target`, so the check is sound, but
  it's the one structural assumption tying the two item shapes together.
- A bare number offers **both** `View Issue #N` and `View PR #N` (ambiguous input);
  explicit `issue N` / `pr N` forms narrow to one. `1350 fix` (trailing text) deliberately
  yields no dynamic rows.
- PR-not-found and PR-without-url both surface the same warning toast — there's no
  in-editor PR preview to degrade to (unlike the issue path's `viewBacklogIssue` fallback).
- The gitlab/gitea `pr-view.sh` scripts gained a `jq` dependency (mirroring their
  `issue-view.sh` siblings, which already use it). GitHub's script (the default) does not.
- Per plan, the empty-backlog early-return is unchanged: type-ahead requires at least one
  loaded backlog row. Flagged in the plan as a deliberate scope cut.

## How to Test Locally

- **View diff**: VSCode sidebar → right-click builder pir-1179 → **Review Diff**
- **Run dev**: VSCode sidebar → **Run Dev**, or `afx dev pir-1179`
- **What to verify** (maps to the plan's Test Plan / issue acceptance):
  - Q1a: backlog search picker, type `1350` → `View Issue #1350` + `View PR #1350` on top;
    Enter on the first opens the issue in the browser
  - Q1b: type `view pr 1350` → `View PR #1350` on top; Enter opens the PR in the browser
  - Q1c: type `tower` → normal filtering, no dynamic rows
  - Q2a: `Cmd+K Shift+P` → InputBox; `1398` + Enter opens PR #1398 in the browser
  - Regression: `Cmd+K P` (unshifted) still runs the built-in Copy Path of Active File
  - Q2b: non-numeric input → validation message
  - Q2c: `999999` → warning toast, no crash
  - Regression: `Cmd+K I` unchanged; backlog row Enter still opens the in-editor preview
