### PR TITLE
[Air #1403] Filter Stream Deck Zoom Navigator dial to active workspaces

### DIFF
--- a/apps/streamdeck/src/__tests__/actions.test.ts
+++ b/apps/streamdeck/src/__tests__/actions.test.ts
@@ -232,6 +232,62 @@ describe('CodevStore.syncToWorkspace (focus following)', () => {
   });
 });
 
+describe('CodevStore active-workspace filtering', () => {
+  const mixed = () => [
+    workspace('/work/a', 'a', true),
+    workspace('/work/dormant', 'dormant', false),
+    workspace('/work/b', 'b', true),
+  ];
+
+  it('refresh() stores only active workspaces, so the zoom dial cycles active ones alone', async () => {
+    const ctx = makeStore();
+    ctx.listWorkspaces.mockResolvedValue(mixed() as never);
+    await ctx.store.refresh();
+    expect(ctx.store.workspaces.map((w) => w.path)).toEqual(['/work/a', '/work/b']);
+
+    // The cursor cycles only the two active entries (clamped, never the dormant one).
+    expect(ctx.store.selectedWorkspacePath()).toBe('/work/a');
+    ctx.store.rotateCursor(1);
+    expect(ctx.store.selectedWorkspacePath()).toBe('/work/b');
+    ctx.store.rotateCursor(1); // clamped at the end of the 2-entry active list
+    expect(ctx.store.selectedWorkspacePath()).toBe('/work/b');
+    ctx.store.rotateCursor(-1);
+    expect(ctx.store.selectedWorkspacePath()).toBe('/work/a'); // back to the first active, dormant skipped
+  });
+
+  it('clamps the cursor to a valid index when the selected workspace deactivates', async () => {
+    const ctx = makeStore();
+    // Start on the second of two active workspaces.
+    ctx.listWorkspaces.mockResolvedValueOnce([
+      workspace('/work/a', 'a', true),
+      workspace('/work/b', 'b', true),
+    ] as never);
+    await ctx.store.refresh();
+    ctx.store.rotateCursor(1);
+    expect(ctx.store.cursor.workspace).toBe(1);
+
+    // /work/b goes dormant; the next refresh drops it and the cursor snaps back.
+    ctx.listWorkspaces.mockResolvedValueOnce([
+      workspace('/work/a', 'a', true),
+    ] as never);
+    await ctx.store.refresh();
+    expect(ctx.store.workspaces.map((w) => w.path)).toEqual(['/work/a']);
+    expect(ctx.store.cursor.workspace).toBe(0);
+    expect(ctx.store.selectedWorkspacePath()).toBe('/work/a'); // valid, not past the end
+  });
+
+  it('syncToWorkspace treats a dormant registration like an unknown path (no-op)', async () => {
+    const ctx = makeStore();
+    ctx.store.workspaces = [workspace('/work/a', 'a', true)];
+    // Tower still lists the dormant one, but the fetch filters it out, so the
+    // focus-follow finds no match and leaves the cursor put.
+    ctx.listWorkspaces.mockResolvedValue(mixed() as never);
+    await ctx.store.syncToWorkspace('/work/dormant');
+    expect(ctx.store.cursor.workspace).toBe(0); // unchanged
+    expect(ctx.getOverview).not.toHaveBeenCalled();
+  });
+});
+
 describe('zoomInVerb (phase-aware zoom-in)', () => {
   const b = (over: Record<string, unknown>) => ({ id: 'x', blockedGate: null, protocolPhase: '', ...over }) as never;
   it('opens the spec when blocked on spec-approval or in the specify phase', () => {

--- a/apps/streamdeck/src/__tests__/actions.test.ts
+++ b/apps/streamdeck/src/__tests__/actions.test.ts
@@ -276,6 +276,34 @@ describe('CodevStore active-workspace filtering', () => {
     expect(ctx.store.selectedWorkspacePath()).toBe('/work/a'); // valid, not past the end
   });
 
+  it('resets the deeper cursor indices when the clamp fires (new workspace has its own builders)', async () => {
+    const ctx = makeStore();
+    ctx.listWorkspaces.mockResolvedValueOnce([
+      workspace('/work/a', 'a', true),
+      workspace('/work/b', 'b', true),
+    ] as never);
+    await ctx.store.refresh();
+    ctx.store.rotateCursor(1); // → workspace 1
+    ctx.store.cursor.builder = 3; // pretend we were deep in /work/b's builders
+    ctx.store.cursor.file = 2;
+
+    ctx.listWorkspaces.mockResolvedValueOnce([workspace('/work/a', 'a', true)] as never);
+    await ctx.store.refresh(); // /work/b deactivates → clamp back to /work/a
+    expect(ctx.store.cursor.workspace).toBe(0);
+    expect(ctx.store.cursor.builder).toBe(0); // not left pointing into /work/b's builder list
+    expect(ctx.store.cursor.file).toBe(0);
+  });
+
+  it('does not fetch an overview when no workspace is active (avoids Tower dormant fallback)', async () => {
+    const ctx = makeStore();
+    ctx.listWorkspaces.mockResolvedValue([workspace('/work/dormant', 'dormant', false)] as never);
+    await ctx.store.refresh();
+    expect(ctx.store.workspaces).toEqual([]);
+    expect(ctx.store.overview).toBeNull();
+    expect(ctx.store.loadingOverview).toBe(false);
+    expect(ctx.getOverview).not.toHaveBeenCalled(); // never asked Tower for an undefined-path overview
+  });
+
   it('syncToWorkspace treats a dormant registration like an unknown path (no-op)', async () => {
     const ctx = makeStore();
     ctx.store.workspaces = [workspace('/work/a', 'a', true)];

--- a/apps/streamdeck/src/store.ts
+++ b/apps/streamdeck/src/store.ts
@@ -76,8 +76,28 @@ export class CodevStore {
 
   /** Re-fetch workspaces + the selected workspace's overview, then notify. */
   async refresh(): Promise<void> {
-    this.workspaces = await this.client.listWorkspaces();
+    this.workspaces = await this.fetchActiveWorkspaces();
+    // A workspace can deactivate while it is the current selection; after the
+    // refresh drops it the cursor may point past the end of the (shorter) list.
+    // Snap back to a valid index so `selectedWorkspacePath()` and the zoom cursor
+    // stay coherent.
+    if (this.cursor.workspace >= this.workspaces.length) {
+      this.cursor = { ...this.cursor, workspace: 0 };
+    }
     await this.refreshOverview();
+  }
+
+  /**
+   * Fetch the workspace list, keeping only entries Tower reports as active
+   * (`active === true`). Dormant registrations are dead stops on the zoom dial:
+   * they carry no actionable overview and every command requires the workspace
+   * active in Tower, so they are filtered out at fetch time. Filtering here (not
+   * per-render) keeps the stored array — which the zoom cursor and
+   * `selectedWorkspacePath()` index into — coherent.
+   */
+  private async fetchActiveWorkspaces(): Promise<TowerWorkspace[]> {
+    const all = await this.client.listWorkspaces();
+    return all.filter((w) => w.active);
   }
 
   /** Re-fetch just the selected workspace's overview (e.g. after zooming to a
@@ -167,14 +187,17 @@ export class CodevStore {
   /**
    * Follow the focused editor provider: point the cursor at `path` and load that
    * workspace's overview, so the plugin targets the workspace the user is looking
-   * at. No-op if `path` isn't a registered workspace (e.g. a builder worktree
-   * window, which isn't in the workspaces list).
+   * at. No-op if `path` isn't an *active* registered workspace (e.g. a builder
+   * worktree window, or a dormant registration — neither is in the filtered list).
    */
   async syncToWorkspace(path: string): Promise<void> {
     let index = this.workspaces.findIndex((w) => w.path === path);
     if (index < 0) {
       // The list may be stale (a workspace was registered since the last fetch).
-      this.workspaces = await this.client.listWorkspaces();
+      // A dormant registration is filtered out here, so a path that is registered
+      // but not active stays unfound and this falls through to the no-op below —
+      // the same behavior as an unknown path.
+      this.workspaces = await this.fetchActiveWorkspaces();
       index = this.workspaces.findIndex((w) => w.path === path);
     }
     if (index < 0 || index === this.cursor.workspace) return;

--- a/apps/streamdeck/src/store.ts
+++ b/apps/streamdeck/src/store.ts
@@ -80,9 +80,11 @@ export class CodevStore {
     // A workspace can deactivate while it is the current selection; after the
     // refresh drops it the cursor may point past the end of the (shorter) list.
     // Snap back to a valid index so `selectedWorkspacePath()` and the zoom cursor
-    // stay coherent.
+    // stay coherent. Reset the deeper indices too (as `rotate()` and
+    // `syncToWorkspace()` do on a workspace change) — the new workspace has its
+    // own builders, so a stale `builder`/`file` would point into the wrong list.
     if (this.cursor.workspace >= this.workspaces.length) {
-      this.cursor = { ...this.cursor, workspace: 0 };
+      this.cursor = { ...this.cursor, workspace: 0, builder: 0, file: 0 };
     }
     await this.refreshOverview();
   }
@@ -104,6 +106,17 @@ export class CodevStore {
    * different workspace), then notify. A request token guards against a slower
    * earlier fetch landing after a newer one (rapid workspace switching). */
   async refreshOverview(): Promise<void> {
+    // With the active-only filter, "no workspaces" is now a routine state (Tower
+    // up, nothing started) rather than a degenerate one. Skip the fetch: passing
+    // an undefined path makes Tower fall back to an arbitrary registered (likely
+    // dormant) workspace's overview, which would render its builders on a dial
+    // that has no active workspace to act on.
+    if (this.workspaces.length === 0) {
+      this.overview = null;
+      this.loadingOverview = false;
+      this.emit();
+      return;
+    }
     const req = ++this.overviewReq;
     const data = await this.client.getOverview(this.selectedWorkspacePath());
     if (req !== this.overviewReq) return; // superseded by a newer fetch

--- a/codev/projects/1403-stream-deck-zoom-navigator-cyc/status.yaml
+++ b/codev/projects/1403-stream-deck-zoom-navigator-cyc/status.yaml
@@ -6,16 +6,17 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-08-11T11:48:42.812Z'
+    approved_at: '2026-08-11T11:52:34.544Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-11T11:35:13.139Z'
-updated_at: '2026-08-11T11:48:42.813Z'
+updated_at: '2026-08-11T11:52:34.544Z'
 pr_history:
   - phase: implement
     pr_number: 1405
     branch: builder/air-1403
     created_at: '2026-08-11T11:42:53.117Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/1403-stream-deck-zoom-navigator-cyc/status.yaml
+++ b/codev/projects/1403-stream-deck-zoom-navigator-cyc/status.yaml
@@ -1,7 +1,7 @@
 id: '1403'
 title: stream-deck-zoom-navigator-cyc
 protocol: air
-phase: implement
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,7 +11,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-11T11:35:13.139Z'
-updated_at: '2026-08-11T11:42:53.117Z'
+updated_at: '2026-08-11T11:43:36.052Z'
 pr_history:
   - phase: implement
     pr_number: 1405

--- a/codev/projects/1403-stream-deck-zoom-navigator-cyc/status.yaml
+++ b/codev/projects/1403-stream-deck-zoom-navigator-cyc/status.yaml
@@ -11,4 +11,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-11T11:35:13.139Z'
-updated_at: '2026-08-11T11:35:13.140Z'
+updated_at: '2026-08-11T11:42:53.117Z'
+pr_history:
+  - phase: implement
+    pr_number: 1405
+    branch: builder/air-1403
+    created_at: '2026-08-11T11:42:53.117Z'

--- a/codev/projects/1403-stream-deck-zoom-navigator-cyc/status.yaml
+++ b/codev/projects/1403-stream-deck-zoom-navigator-cyc/status.yaml
@@ -1,0 +1,14 @@
+id: '1403'
+title: stream-deck-zoom-navigator-cyc
+protocol: air
+phase: implement
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-11T11:35:13.139Z'
+updated_at: '2026-08-11T11:35:13.140Z'

--- a/codev/projects/1403-stream-deck-zoom-navigator-cyc/status.yaml
+++ b/codev/projects/1403-stream-deck-zoom-navigator-cyc/status.yaml
@@ -7,13 +7,15 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-08-11T11:48:42.812Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-11T11:35:13.139Z'
-updated_at: '2026-08-11T11:43:36.052Z'
+updated_at: '2026-08-11T11:48:42.813Z'
 pr_history:
   - phase: implement
     pr_number: 1405
     branch: builder/air-1403
     created_at: '2026-08-11T11:42:53.117Z'
+pr_ready_for_human: true

--- a/codev/projects/1403-stream-deck-zoom-navigator-cyc/status.yaml
+++ b/codev/projects/1403-stream-deck-zoom-navigator-cyc/status.yaml
@@ -1,7 +1,7 @@
 id: '1403'
 title: stream-deck-zoom-navigator-cyc
 protocol: air
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,7 +13,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-11T11:35:13.139Z'
-updated_at: '2026-08-11T11:52:34.544Z'
+updated_at: '2026-08-11T11:52:49.899Z'
 pr_history:
   - phase: implement
     pr_number: 1405

--- a/codev/state/air-1403_thread.md
+++ b/codev/state/air-1403_thread.md
@@ -1,0 +1,45 @@
+# air-1403 — Stream Deck: filter Zoom Navigator dial to active workspaces
+
+## Issue
+#1403 — Rotating the Zoom Navigator at the workspace altitude walks every
+registered workspace, dormant ones included. Dormant entries are dead stops on
+the dial (no overview, every command needs the workspace active in Tower).
+Requirement (owner-ratified 2026-08-11, strict filter): the plugin store keeps
+only `active === true` workspaces.
+
+## Approach (AIR, ~83 LOC)
+All the change is in `apps/streamdeck/src/store.ts`. The zoom cursor and
+`selectedWorkspacePath()` index into the stored `workspaces` array, so I filter
+at fetch time (not per-render) to keep indices coherent:
+
+- New private `fetchActiveWorkspaces()` wraps `client.listWorkspaces()` and
+  returns only `active` entries. Both fetch sites (`refresh()` and
+  `syncToWorkspace()`'s stale-list re-fetch) go through it.
+- `refresh()` now clamps `cursor.workspace` back to 0 when it points past the
+  end of the (shorter) filtered list — handles a workspace deactivating while
+  it is the current selection.
+- `syncToWorkspace()`: a dormant registration is filtered out, so its path stays
+  unfound and falls through to the existing no-op (same as an unknown path /
+  builder-worktree window). Updated the docstring + inline comment.
+
+No change to `cursor.ts`, actions, or the SDK — the fix lives entirely in how
+the store populates its list.
+
+## Tests
+Added `describe('CodevStore active-workspace filtering')` in
+`apps/streamdeck/src/__tests__/actions.test.ts`:
+- refresh() stores only active entries; the dial cycles active ones (clamped,
+  dormant skipped).
+- cursor clamps to a valid index when the selected workspace deactivates.
+- syncToWorkspace treats a dormant path like an unknown path (no-op).
+
+Note: existing tests that set `store.workspaces` directly with dormant fixtures
+are unaffected — the filter runs only at fetch time, not on hand-set arrays.
+
+## Verification
+check-types clean, esbuild build OK, `vitest run` 66/66 pass.
+(check-types needs `@cluesmith/codev-types` + `@cluesmith/codev-sdk` built first
+in a fresh worktree — those emit `dist/` the streamdeck tsconfig resolves.)
+
+## Status
+Implementation + tests done and green. Next: commit, open PR with review in body.

--- a/codev/state/air-1403_thread.md
+++ b/codev/state/air-1403_thread.md
@@ -41,5 +41,28 @@ check-types clean, esbuild build OK, `vitest run` 66/66 pass.
 (check-types needs `@cluesmith/codev-types` + `@cluesmith/codev-sdk` built first
 in a fresh worktree — those emit `dist/` the streamdeck tsconfig resolves.)
 
+## CMAP (PR phase, issue #1403)
+- gemini: APPROVE (high) — no issues.
+- codex: SKIPPED — API had no credits remaining (non-blocking).
+- claude: COMMENT (high) — two real edge-case gaps + one suggestion.
+
+## Post-review fixes (round 2)
+Claude's review + the architect's PR review both flagged the same clamp defect;
+fixed both raised gaps:
+1. **Clamp reset (Issue 1)**: the deactivation clamp did `{ ...cursor, workspace: 0 }`
+   and carried the OLD builder/file indices into the new workspace →
+   `selectedBuilder()` could point at an unrelated builder (slot/dev keys act on the
+   wrong one). Now resets `builder: 0, file: 0` too, matching `rotate()` /
+   `syncToWorkspace()`. + test asserting builder/file reset on deactivation.
+2. **Zero-active guard (Issue 2)**: strict filter makes "0 active workspaces"
+   routine (Tower up, nothing started). `refreshOverview()` now returns early on an
+   empty list instead of calling `getOverview(undefined)`, which made Tower serve an
+   arbitrary dormant workspace's overview onto a dial with nothing to act on. + test.
+- Skipped Issue 3 (path re-anchoring): the issue explicitly sanctioned "reset to 0
+  is fine", so kept the simple clamp.
+
+check-types/build/vitest green again (68/68).
+
 ## Status
-Implementation + tests done and green. Next: commit, open PR with review in body.
+Round-2 fixes committed + pushed to PR #1405. At the `pr` gate — awaiting human
+gate approval from the architect.


### PR DESCRIPTION
## Summary

Closes #1403. Rotating the Stream Deck Zoom Navigator at the workspace altitude walked **every** registered workspace, dormant ones included. Dormant entries are dead stops on the dial: zooming into one yields no overview, and any action from there fails because Tower commands require the workspace active. This filters the plugin store's workspace list to `active === true` (strict filter, owner-ratified 2026-08-11).

## What changed

All in `apps/streamdeck/src/store.ts` — the fix lives entirely in how the store populates its list; `cursor.ts`, the action layer, and the SDK are untouched.

- **`fetchActiveWorkspaces()`** (new private): wraps `client.listWorkspaces()` and keeps only `active` entries. Both fetch sites route through it — `refresh()` and the stale-list re-fetch inside `syncToWorkspace()`. Filtering happens **at fetch time, not per-render**, because the zoom cursor and `selectedWorkspacePath()` index into the stored array; filtering per-render would desync the indices.
- **Cursor clamp in `refresh()`**: when a workspace deactivates while it is the current selection, the next refresh drops it and the cursor could point past the end of the shorter list. `refresh()` snaps `cursor.workspace` back to 0 so `selectedWorkspacePath()` stays valid.
- **`syncToWorkspace()` (focus-follow)**: a dormant registration is filtered out, so its path stays unfound and falls through to the existing no-op — a registered-but-dormant path now behaves exactly like an unknown path (e.g. a builder-worktree window). Docstring + inline comment updated.

## Tests

New `describe('CodevStore active-workspace filtering')` in `apps/streamdeck/src/__tests__/actions.test.ts`:

- `refresh()` stores only active workspaces, and the dial cycles the active ones alone (clamped, dormant skipped) — the requested regression test with a mix of active + dormant entries.
- Cursor clamps to a valid index when the selected workspace deactivates mid-session.
- `syncToWorkspace` treats a dormant registration like an unknown path (no-op, no overview fetch).

Existing tests that set `store.workspaces` directly with dormant fixtures are unaffected — the filter runs only at fetch time, not on hand-assigned arrays.

## Verification

- `pnpm check-types` — clean
- `pnpm build` (esbuild) — OK
- `pnpm test` — 66/66 pass

(check-types needs `@cluesmith/codev-types` and `@cluesmith/codev-sdk` built first in a fresh worktree so their `dist/` type declarations resolve.)

## Notes / lessons

- The `TowerWorkspace.active` field was already delivered on every `/api/workspaces` response and simply never consulted — this wires up existing data, no API change.
- The dial clamps rather than wraps (per `cursor.ts`), so the regression test asserts clamp-at-end + reverse, not wrap-around.

## Protocol

AIR — small, fully described in the issue, no architectural decisions. ~83 LOC of source change. No spec/plan/review files (AIR produces none; this PR body is the review).
