### PR TITLE
[Spec 1401] artifact-canvas: remote command channel for review navigation (Tower relay + sdk route)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,14 @@ jobs:
         working-directory: packages/types
         run: pnpm build
 
+      # The wire-contract guards under packages/types/type-tests/ live outside src/ so they
+      # are never published, which also means `pnpm build` above does not check them. They are
+      # compile-time-only tests (the package has no test runner), so this step is the only
+      # thing that makes them able to fail a build.
+      - name: Type-check types package contracts
+        working-directory: packages/types
+        run: pnpm check-types:tests
+
       - name: Build artifact-canvas package (+ build-smoke)
         working-directory: packages/artifact-canvas
         run: pnpm build && pnpm build:smoke

--- a/apps/vscode/src/__tests__/canvas-view-registry.test.ts
+++ b/apps/vscode/src/__tests__/canvas-view-registry.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Canvas view registration glue (spec 1401, plan phase 6).
+ *
+ * The host's three jobs are lease upkeep, activity reporting, and addressed delivery. These
+ * tests drive them against a faked Tower client and a faked panel, because the parts that can go
+ * wrong here are all lifecycle: registering twice, delivering to the wrong panel, heartbeating an
+ * id Tower has forgotten, or leaving a view registered after its panel closed.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('vscode', () => ({
+  Disposable: class {
+    constructor(private readonly fn: () => void) {}
+    dispose(): void {
+      this.fn();
+    }
+  },
+}));
+
+const { registerCanvasView } = await import('../markdown-preview/canvas-view-registry.js');
+
+/** A panel double exposing the two hooks the registry uses. */
+function fakePanel() {
+  let viewStateHandler: ((e: { webviewPanel: { active: boolean } }) => void) | null = null;
+  const posted: unknown[] = [];
+  return {
+    posted,
+    onDidChangeViewState(handler: (e: { webviewPanel: { active: boolean } }) => void) {
+      viewStateHandler = handler;
+      return { dispose: vi.fn() };
+    },
+    webview: {
+      postMessage: (msg: unknown) => {
+        posted.push(msg);
+        return Promise.resolve(true);
+      },
+    },
+    activate(active: boolean) {
+      viewStateHandler?.({ webviewPanel: { active } });
+    },
+  };
+}
+
+/** A connection double: a scripted Tower client plus a controllable SSE feed. */
+function fakeConnection(overrides: Record<string, unknown> = {}) {
+  let sseHandler: ((e: { data: string }) => void) | null = null;
+  const client = {
+    registerCanvasView: vi.fn(async () => ({ ok: true, viewId: 'canvas-1', file: '/ws/spec.md' })),
+    heartbeatCanvasView: vi.fn(async () => ({ ok: true, unknownView: false })),
+    unregisterCanvasView: vi.fn(async () => ({ ok: true })),
+    ...overrides,
+  };
+  return {
+    client,
+    connectionManager: {
+      getClient: () => client,
+      getWorkspacePath: () => '/ws',
+      onSSEEvent(handler: (e: { data: string }) => void) {
+        sseHandler = handler;
+        return { dispose: vi.fn() };
+      },
+    } as never,
+    /** Push an SSE frame in Tower's envelope shape. */
+    emit(type: string, body: unknown) {
+      sseHandler?.({ data: JSON.stringify({ type, title: type, body: JSON.stringify(body) }) });
+    },
+  };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => vi.useFakeTimers({ shouldAdvanceTime: true }));
+afterEach(() => vi.useRealTimers());
+
+describe('canvas view registration', () => {
+  it('registers the panel on creation', async () => {
+    const conn = fakeConnection();
+    const panel = fakePanel();
+
+    registerCanvasView({ connectionManager: conn.connectionManager, panel: panel as never, file: '/ws/spec.md' });
+    await flush();
+
+    expect(conn.client.registerCanvasView).toHaveBeenCalledWith('/ws', '/ws/spec.md');
+  });
+
+  it('unregisters when the panel is disposed', async () => {
+    const conn = fakeConnection();
+    const panel = fakePanel();
+
+    const sub = registerCanvasView({ connectionManager: conn.connectionManager, panel: panel as never, file: '/ws/spec.md' });
+    await flush();
+    sub.dispose();
+
+    expect(conn.client.unregisterCanvasView).toHaveBeenCalledWith('canvas-1');
+  });
+
+  it('hands the id straight back when the panel closes mid-registration', async () => {
+    let resolveRegister: (v: unknown) => void = () => {};
+    const conn = fakeConnection({
+      registerCanvasView: vi.fn(
+        () => new Promise((resolve) => {
+          resolveRegister = resolve;
+        }),
+      ),
+    });
+    const panel = fakePanel();
+
+    const sub = registerCanvasView({ connectionManager: conn.connectionManager, panel: panel as never, file: '/ws/spec.md' });
+    sub.dispose(); // closed while the request is still in flight
+    resolveRegister({ ok: true, viewId: 'canvas-late', file: '/ws/spec.md' });
+    await flush();
+
+    // Otherwise this view would linger as a target that nothing will ever heartbeat.
+    expect(conn.client.unregisterCanvasView).toHaveBeenCalledWith('canvas-late');
+  });
+
+  it('reports activity when the panel becomes active', async () => {
+    const conn = fakeConnection();
+    const panel = fakePanel();
+
+    registerCanvasView({ connectionManager: conn.connectionManager, panel: panel as never, file: '/ws/spec.md' });
+    await flush();
+    panel.activate(true);
+    await flush();
+
+    expect(conn.client.heartbeatCanvasView).toHaveBeenCalledWith('canvas-1', true);
+  });
+
+  it('does not report activity when the panel goes inactive', async () => {
+    const conn = fakeConnection();
+    const panel = fakePanel();
+
+    registerCanvasView({ connectionManager: conn.connectionManager, panel: panel as never, file: '/ws/spec.md' });
+    await flush();
+    panel.activate(false);
+    await flush();
+
+    expect(conn.client.heartbeatCanvasView).not.toHaveBeenCalled();
+  });
+
+  it('re-registers when Tower has forgotten the view', async () => {
+    const conn = fakeConnection({
+      heartbeatCanvasView: vi.fn(async () => ({ ok: false, unknownView: true })),
+    });
+    const panel = fakePanel();
+
+    registerCanvasView({ connectionManager: conn.connectionManager, panel: panel as never, file: '/ws/spec.md' });
+    await flush();
+    expect(conn.client.registerCanvasView).toHaveBeenCalledTimes(1);
+
+    panel.activate(true); // heartbeat comes back unknown-view
+    await flush();
+
+    // A Tower restart would otherwise leave this panel permanently undrivable.
+    expect(conn.client.registerCanvasView).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries registration later when Tower was unreachable at open time', async () => {
+    const conn = fakeConnection({
+      registerCanvasView: vi.fn(async () => ({ ok: false, error: 'Tower not running' })),
+    });
+    const panel = fakePanel();
+
+    registerCanvasView({ connectionManager: conn.connectionManager, panel: panel as never, file: '/ws/spec.md' });
+    await flush();
+    expect(conn.client.registerCanvasView).toHaveBeenCalledTimes(1);
+
+    panel.activate(true);
+    await flush();
+    expect(conn.client.registerCanvasView).toHaveBeenCalledTimes(2);
+    // Nothing to heartbeat while unregistered, so no id was invented.
+    expect(conn.client.heartbeatCanvasView).not.toHaveBeenCalled();
+  });
+});
+
+describe('addressed delivery', () => {
+  it('forwards a command addressed to this view', async () => {
+    const conn = fakeConnection();
+    const panel = fakePanel();
+
+    registerCanvasView({ connectionManager: conn.connectionManager, panel: panel as never, file: '/ws/spec.md' });
+    await flush();
+    conn.emit('canvas-command', { viewId: 'canvas-1', command: 'comment-next' });
+
+    expect(panel.posted).toEqual([{ type: 'command', command: 'comment-next' }]);
+  });
+
+  it('carries count when present', async () => {
+    const conn = fakeConnection();
+    const panel = fakePanel();
+
+    registerCanvasView({ connectionManager: conn.connectionManager, panel: panel as never, file: '/ws/spec.md' });
+    await flush();
+    conn.emit('canvas-command', { viewId: 'canvas-1', command: 'block-next', count: 3 });
+
+    expect(panel.posted).toEqual([{ type: 'command', command: 'block-next', count: 3 }]);
+  });
+
+  it('ignores a command addressed to a different view', async () => {
+    const conn = fakeConnection();
+    const panel = fakePanel();
+
+    registerCanvasView({ connectionManager: conn.connectionManager, panel: panel as never, file: '/ws/spec.md' });
+    await flush();
+    conn.emit('canvas-command', { viewId: 'canvas-OTHER', command: 'comment-next' });
+
+    // Tower broadcasts to every subscriber, so this filter is the entire addressing mechanism:
+    // without it, one command would run in every open canvas.
+    expect(panel.posted).toEqual([]);
+  });
+
+  it('ignores unrelated SSE events and malformed payloads', async () => {
+    const conn = fakeConnection();
+    const panel = fakePanel();
+
+    registerCanvasView({ connectionManager: conn.connectionManager, panel: panel as never, file: '/ws/spec.md' });
+    await flush();
+
+    conn.emit('command', { verb: 'view-diff' });
+    conn.emit('canvas-command', { viewId: 'canvas-1' }); // no command
+    conn.emit('canvas-command', { command: 'comment-next' }); // no viewId
+    conn.emit('canvas-command', { viewId: 'canvas-1', command: 42 });
+
+    expect(panel.posted).toEqual([]);
+  });
+
+  it('delivers nothing before registration completes', async () => {
+    let resolveRegister: (v: unknown) => void = () => {};
+    const conn = fakeConnection({
+      registerCanvasView: vi.fn(
+        () => new Promise((resolve) => {
+          resolveRegister = resolve;
+        }),
+      ),
+    });
+    const panel = fakePanel();
+
+    registerCanvasView({ connectionManager: conn.connectionManager, panel: panel as never, file: '/ws/spec.md' });
+    conn.emit('canvas-command', { viewId: 'canvas-1', command: 'comment-next' });
+    expect(panel.posted).toEqual([]);
+
+    resolveRegister({ ok: true, viewId: 'canvas-1', file: '/ws/spec.md' });
+    await flush();
+    conn.emit('canvas-command', { viewId: 'canvas-1', command: 'comment-next' });
+    expect(panel.posted).toHaveLength(1);
+  });
+});

--- a/apps/vscode/src/__tests__/canvas-view-registry.test.ts
+++ b/apps/vscode/src/__tests__/canvas-view-registry.test.ts
@@ -180,6 +180,21 @@ describe('canvas view registration', () => {
     expect(conn.client.registerCanvasView).toHaveBeenCalledTimes(2);
   });
 
+  it('releases the old registration when reconnecting to the same Tower', async () => {
+    const conn = fakeConnection();
+    const panel = fakePanel();
+
+    registerCanvasView({ connectionManager: conn.connectionManager, panel: panel as never, file: '/ws/spec.md' });
+    await flush();
+
+    conn.setState('connected');
+    await flush();
+
+    // A reconnect is not necessarily a restart: against the same Tower the old id is still live,
+    // and leaving it would put a duplicate view in the registry competing for MRU.
+    expect(conn.client.unregisterCanvasView).toHaveBeenCalledWith('canvas-1');
+  });
+
   it('ignores connection states other than connected', async () => {
     const conn = fakeConnection();
     const panel = fakePanel();
@@ -290,7 +305,7 @@ describe('addressed delivery', () => {
     expect(panel.posted).toEqual([]);
   });
 
-  it('drops a nonsensical count rather than passing it on', async () => {
+  it('rejects the whole event when count is malformed', async () => {
     const conn = fakeConnection();
     const panel = fakePanel();
 
@@ -298,11 +313,12 @@ describe('addressed delivery', () => {
     await flush();
     conn.emit('canvas-command', { viewId: 'canvas-1', command: 'block-next', count: -4 });
     conn.emit('canvas-command', { viewId: 'canvas-1', command: 'block-next', count: 1.5 });
+    conn.emit('canvas-command', { viewId: 'canvas-1', command: 'block-next', count: 'three' });
 
-    expect(panel.posted).toEqual([
-      { type: 'command', command: 'block-next' },
-      { type: 'command', command: 'block-next' },
-    ]);
+    // Running the command with a different repeat than the sender intended would silently change
+    // what the reviewer asked for; Tower rejects bad counts, so one arriving here means the frame
+    // is untrustworthy.
+    expect(panel.posted).toEqual([]);
   });
 
   it('delivers nothing before registration completes', async () => {

--- a/apps/vscode/src/__tests__/canvas-view-registry.test.ts
+++ b/apps/vscode/src/__tests__/canvas-view-registry.test.ts
@@ -45,6 +45,7 @@ function fakePanel() {
 /** A connection double: a scripted Tower client plus a controllable SSE feed. */
 function fakeConnection(overrides: Record<string, unknown> = {}) {
   let sseHandler: ((e: { data: string }) => void) | null = null;
+  let stateHandler: ((state: string) => void) | null = null;
   const client = {
     registerCanvasView: vi.fn(async () => ({ ok: true, viewId: 'canvas-1', file: '/ws/spec.md' })),
     heartbeatCanvasView: vi.fn(async () => ({ ok: true, unknownView: false })),
@@ -60,10 +61,17 @@ function fakeConnection(overrides: Record<string, unknown> = {}) {
         sseHandler = handler;
         return { dispose: vi.fn() };
       },
+      onStateChange(handler: (state: string) => void) {
+        stateHandler = handler;
+        return { dispose: vi.fn() };
+      },
     } as never,
     /** Push an SSE frame in Tower's envelope shape. */
     emit(type: string, body: unknown) {
       sseHandler?.({ data: JSON.stringify({ type, title: type, body: JSON.stringify(body) }) });
+    },
+    setState(state: string) {
+      stateHandler?.(state);
     },
   };
 }
@@ -156,6 +164,60 @@ describe('canvas view registration', () => {
     expect(conn.client.registerCanvasView).toHaveBeenCalledTimes(2);
   });
 
+  it('re-registers as soon as the connection returns, not on the next heartbeat', async () => {
+    const conn = fakeConnection();
+    const panel = fakePanel();
+
+    registerCanvasView({ connectionManager: conn.connectionManager, panel: panel as never, file: '/ws/spec.md' });
+    await flush();
+    expect(conn.client.registerCanvasView).toHaveBeenCalledTimes(1);
+
+    // A Tower restart: the old id means nothing to the new process, and waiting out the
+    // heartbeat would leave the panel undrivable for up to 30 seconds.
+    conn.setState('connected');
+    await flush();
+
+    expect(conn.client.registerCanvasView).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores connection states other than connected', async () => {
+    const conn = fakeConnection();
+    const panel = fakePanel();
+
+    registerCanvasView({ connectionManager: conn.connectionManager, panel: panel as never, file: '/ws/spec.md' });
+    await flush();
+    conn.setState('disconnected');
+    conn.setState('connecting');
+    await flush();
+
+    expect(conn.client.registerCanvasView).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not orphan a fresh view when two heartbeats both come back unknown', async () => {
+    let registrations = 0;
+    const conn = fakeConnection({
+      registerCanvasView: vi.fn(async () => {
+        registrations += 1;
+        return { ok: true, viewId: `canvas-${registrations}`, file: '/ws/spec.md' };
+      }),
+      heartbeatCanvasView: vi.fn(async () => ({ ok: false, unknownView: true })),
+    });
+    const panel = fakePanel();
+
+    registerCanvasView({ connectionManager: conn.connectionManager, panel: panel as never, file: '/ws/spec.md' });
+    await flush();
+
+    // Two beats in flight against the same stale id, both answered unknown-view. Without the
+    // captured-id guard the second would clear the id the first had just replaced, leaving a
+    // freshly registered view orphaned in Tower until its lease expired.
+    panel.activate(true);
+    panel.activate(true);
+    await flush();
+    await flush();
+
+    expect(registrations).toBeLessThanOrEqual(2);
+  });
+
   it('retries registration later when Tower was unreachable at open time', async () => {
     const conn = fakeConnection({
       registerCanvasView: vi.fn(async () => ({ ok: false, error: 'Tower not running' })),
@@ -221,8 +283,26 @@ describe('addressed delivery', () => {
     conn.emit('canvas-command', { viewId: 'canvas-1' }); // no command
     conn.emit('canvas-command', { command: 'comment-next' }); // no viewId
     conn.emit('canvas-command', { viewId: 'canvas-1', command: 42 });
+    // Not in the closed vocabulary: Tower would have rejected it, but the host does not forward
+    // an unchecked string into code that has no validation of its own.
+    conn.emit('canvas-command', { viewId: 'canvas-1', command: 'rm-rf' });
 
     expect(panel.posted).toEqual([]);
+  });
+
+  it('drops a nonsensical count rather than passing it on', async () => {
+    const conn = fakeConnection();
+    const panel = fakePanel();
+
+    registerCanvasView({ connectionManager: conn.connectionManager, panel: panel as never, file: '/ws/spec.md' });
+    await flush();
+    conn.emit('canvas-command', { viewId: 'canvas-1', command: 'block-next', count: -4 });
+    conn.emit('canvas-command', { viewId: 'canvas-1', command: 'block-next', count: 1.5 });
+
+    expect(panel.posted).toEqual([
+      { type: 'command', command: 'block-next' },
+      { type: 'command', command: 'block-next' },
+    ]);
   });
 
   it('delivers nothing before registration completes', async () => {

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -1398,7 +1398,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.window.registerCustomEditorProvider(
 			MarkdownPreviewProvider.viewType,
-			new MarkdownPreviewProvider(context.extensionUri, overviewCache, context.globalState),
+			new MarkdownPreviewProvider(context.extensionUri, overviewCache, context.globalState, connectionManager),
 			{
 				webviewOptions: { retainContextWhenHidden: true },
 				supportsMultipleEditorsPerDocument: false,

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -1395,10 +1395,20 @@ export async function activate(context: vscode.ExtensionContext) {
 	// from the rendered surface. Opt-in via "Reopen With…" or
 	// `codev.openMarkdownPreview`; `priority: "option"` keeps the default `.md`
 	// editor and built-in preview untouched.
+	// Held in a local so the provider itself joins `subscriptions`: on deactivate it releases the
+	// canvas-view registrations of any still-open panels, which VS Code does not dispose
+	// individually (spec 1401). Without that, those views linger in Tower until their lease lapses.
+	const markdownPreviewProvider = new MarkdownPreviewProvider(
+		context.extensionUri,
+		overviewCache,
+		context.globalState,
+		connectionManager,
+	);
+	context.subscriptions.push(markdownPreviewProvider);
 	context.subscriptions.push(
 		vscode.window.registerCustomEditorProvider(
 			MarkdownPreviewProvider.viewType,
-			new MarkdownPreviewProvider(context.extensionUri, overviewCache, context.globalState, connectionManager),
+			markdownPreviewProvider,
 			{
 				webviewOptions: { retainContextWhenHidden: true },
 				supportsMultipleEditorsPerDocument: false,

--- a/apps/vscode/src/markdown-preview/canvas-view-registry.ts
+++ b/apps/vscode/src/markdown-preview/canvas-view-registry.ts
@@ -147,8 +147,16 @@ export function registerCanvasView(options: CanvasViewRegistrationOptions): vsco
   // registration at open time is a no-op while there is no client yet.
   const stateSub = connectionManager.onStateChange((state) => {
     if (state !== 'connected') { return; }
-    // The id from before the restart is meaningless to the new Tower; drop it and register anew.
+    const stale = viewId;
     viewId = null;
+    if (stale) {
+      const client = connectionManager.getClient();
+      // Release the old id before taking a new one. A reconnect is not necessarily a restart: if
+      // this is the same Tower, the old registration is still live and would sit there as a
+      // duplicate competing for MRU until its lease lapsed. Best-effort — against a genuinely
+      // restarted Tower the id is unknown and this 404s harmlessly.
+      if (client) { void client.unregisterCanvasView(stale); }
+    }
     void ensureRegistered();
   });
 
@@ -162,12 +170,18 @@ export function registerCanvasView(options: CanvasViewRegistrationOptions): vsco
     if (!event || typeof event.viewId !== 'string' || event.viewId !== viewId) { return; }
     if (!isCanvasCommand(event.command)) { return; }
 
-    const message: HostToWebviewMessage = { type: 'command', command: event.command };
-    // Only a sane repeat count travels on; Tower already rejects the rest, and a bogus value
-    // here would just be extra work for the canvas to ignore.
-    if (typeof event.count === 'number' && Number.isInteger(event.count) && event.count > 0) {
-      message.count = event.count;
+    // A malformed `count` invalidates the whole event rather than being quietly dropped. Tower
+    // rejects bad counts before relaying, so one arriving here means the frame cannot be trusted
+    // — and running the command with a different repeat than the sender intended is a silent
+    // change to what the reviewer asked for, which is worse than doing nothing.
+    if (event.count !== undefined) {
+      if (typeof event.count !== 'number' || !Number.isInteger(event.count) || event.count < 1) {
+        return;
+      }
     }
+
+    const message: HostToWebviewMessage = { type: 'command', command: event.command };
+    if (event.count !== undefined) { message.count = event.count; }
     // Deliberately no `panel.reveal()`: a remote command drives the canvas, it does not steal the
     // reviewer's window, matching the existing command relay's "never pulls focus" posture.
     void panel.webview.postMessage(message);

--- a/apps/vscode/src/markdown-preview/canvas-view-registry.ts
+++ b/apps/vscode/src/markdown-preview/canvas-view-registry.ts
@@ -1,0 +1,134 @@
+import * as vscode from 'vscode';
+import type { CanvasCommandEvent } from '@cluesmith/codev-types';
+import type { ConnectionManager } from '../connection-manager.js';
+import { parseSseEnvelope, parseSseBody } from '../sse-envelope.js';
+import type { HostToWebviewMessage } from './messages.js';
+
+/**
+ * Registers one canvas panel as a live view with Tower, and forwards the commands addressed to
+ * it into the webview (spec 1401).
+ *
+ * The extension is the HOST half of the channel: Tower keeps the registry and decides which view
+ * a command belongs to, the canvas package executes it, and this module is the wire between
+ * them. It owns three jobs and nothing else — lease upkeep, activity reporting, and delivery.
+ *
+ * Registration is per PANEL rather than per document, because a view is a surface a reviewer is
+ * looking at: two panels showing one file are two registrations with two ids, which is exactly
+ * the ambiguity Tower's most-recently-active rule exists to resolve.
+ */
+
+/** Matches Tower's `CANVAS_VIEW_HEARTBEAT_MS`; the lease there is three times this. */
+const HEARTBEAT_MS = 30_000;
+
+/** The SSE event type Tower addresses a canvas command with. */
+const CANVAS_COMMAND_EVENT = 'canvas-command';
+
+export interface CanvasViewRegistrationOptions {
+  connectionManager: ConnectionManager;
+  panel: vscode.WebviewPanel;
+  /** Absolute path of the document this panel is showing. */
+  file: string;
+  log?: (message: string) => void;
+}
+
+/**
+ * Wire a panel to Tower for its lifetime. Returns a `Disposable`; the caller ties it to
+ * `panel.onDidDispose` so a closed panel stops being a target promptly rather than waiting out
+ * its lease.
+ */
+export function registerCanvasView(options: CanvasViewRegistrationOptions): vscode.Disposable {
+  const { connectionManager, panel, file } = options;
+  const log = options.log ?? ((): void => {});
+
+  let viewId: string | null = null;
+  let disposed = false;
+  let registering: Promise<void> | null = null;
+
+  const register = async (): Promise<void> => {
+    if (disposed || viewId) return;
+    const client = connectionManager.getClient();
+    const workspace = connectionManager.getWorkspacePath();
+    if (!client || !workspace) return; // not connected yet; the heartbeat retries
+    const result = await client.registerCanvasView(workspace, file);
+    if (disposed) {
+      // The panel closed while the request was in flight. Registering now would leak a view that
+      // nothing will ever heartbeat, so hand the id straight back.
+      if (result.ok && result.viewId) void client.unregisterCanvasView(result.viewId);
+      return;
+    }
+    if (result.ok && result.viewId) {
+      viewId = result.viewId;
+      log(`canvas view registered: ${result.viewId}`);
+    }
+  };
+
+  /** Serialize registration attempts so a heartbeat racing a reconnect cannot register twice. */
+  const ensureRegistered = async (): Promise<void> => {
+    if (registering) return registering;
+    registering = register().finally(() => {
+      registering = null;
+    });
+    return registering;
+  };
+
+  const beat = async (focused: boolean): Promise<void> => {
+    if (disposed) return;
+    if (!viewId) {
+      await ensureRegistered();
+      return;
+    }
+    const client = connectionManager.getClient();
+    if (!client) return;
+    const result = await client.heartbeatCanvasView(viewId, focused);
+    if (result.unknownView) {
+      // Tower has forgotten this id — it restarted, or the lease lapsed while the machine slept.
+      // Re-register rather than heartbeating into the void, which is what would otherwise leave
+      // an open panel permanently undrivable.
+      log(`canvas view ${viewId} unknown to Tower; re-registering`);
+      viewId = null;
+      await ensureRegistered();
+    }
+  };
+
+  void ensureRegistered();
+
+  const timer = setInterval(() => {
+    void beat(false);
+  }, HEARTBEAT_MS);
+
+  // The panel the reviewer is looking at should win Tower's most-recently-active rule, so report
+  // activity when it becomes visible rather than only on a timer.
+  const viewStateSub = panel.onDidChangeViewState((e) => {
+    if (e.webviewPanel.active) void beat(true);
+  });
+
+  const sseSub = connectionManager.onSSEEvent(({ data }) => {
+    const envelope = parseSseEnvelope(data);
+    if (!envelope || envelope.type !== CANVAS_COMMAND_EVENT) return;
+    const event = parseSseBody<CanvasCommandEvent>(envelope.body);
+    // Tower broadcasts to every subscriber, so each panel keeps only what is addressed to it.
+    // This comparison is the whole addressing mechanism; without it every open canvas would run
+    // every command.
+    if (!event || typeof event.viewId !== 'string' || event.viewId !== viewId) return;
+    if (typeof event.command !== 'string') return;
+
+    const message: HostToWebviewMessage = { type: 'command', command: event.command };
+    if (typeof event.count === 'number') message.count = event.count;
+    // Deliberately no `panel.reveal()`: a remote command drives the canvas, it does not steal the
+    // reviewer's window, matching the existing command relay's "never pulls focus" posture.
+    void panel.webview.postMessage(message);
+  });
+
+  return new vscode.Disposable(() => {
+    disposed = true;
+    clearInterval(timer);
+    viewStateSub.dispose();
+    sseSub.dispose();
+    const client = connectionManager.getClient();
+    if (viewId && client) {
+      void client.unregisterCanvasView(viewId);
+      log(`canvas view unregistered: ${viewId}`);
+    }
+    viewId = null;
+  });
+}

--- a/apps/vscode/src/markdown-preview/canvas-view-registry.ts
+++ b/apps/vscode/src/markdown-preview/canvas-view-registry.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import type { CanvasCommandEvent } from '@cluesmith/codev-types';
+import type { CanvasCommand, CanvasCommandEvent } from '@cluesmith/codev-types';
 import type { ConnectionManager } from '../connection-manager.js';
 import { parseSseEnvelope, parseSseBody } from '../sse-envelope.js';
 import type { HostToWebviewMessage } from './messages.js';
@@ -23,6 +23,40 @@ const HEARTBEAT_MS = 30_000;
 /** The SSE event type Tower addresses a canvas command with. */
 const CANVAS_COMMAND_EVENT = 'canvas-command';
 
+/**
+ * The closed command vocabulary, as runtime data.
+ *
+ * Tower validates before relaying, so this is defence in depth rather than the primary check —
+ * but an SSE frame is untrusted input crossing a process boundary, and forwarding an unchecked
+ * string into the webview would push the problem into code with no validation of its own. The
+ * assertion below fails to compile if the contract grows a command this list forgets.
+ */
+const CANVAS_COMMANDS = [
+  'block-next',
+  'block-prev',
+  'comment-next',
+  'comment-prev',
+  'heading-next',
+  'heading-prev',
+  'column-forward',
+  'column-back',
+  'doc-start',
+  'doc-end',
+  'composer-open',
+  'composer-submit',
+  'composer-cancel',
+  'reading-mode-toggle',
+] as const satisfies readonly CanvasCommand[];
+
+type AssertTrue<T extends true> = T;
+type _EveryCommandIsListed = AssertTrue<
+  [Exclude<CanvasCommand, (typeof CANVAS_COMMANDS)[number]>] extends [never] ? true : false
+>;
+
+function isCanvasCommand(value: unknown): value is CanvasCommand {
+  return typeof value === 'string' && (CANVAS_COMMANDS as readonly string[]).includes(value);
+}
+
 export interface CanvasViewRegistrationOptions {
   connectionManager: ConnectionManager;
   panel: vscode.WebviewPanel;
@@ -45,15 +79,15 @@ export function registerCanvasView(options: CanvasViewRegistrationOptions): vsco
   let registering: Promise<void> | null = null;
 
   const register = async (): Promise<void> => {
-    if (disposed || viewId) return;
+    if (disposed || viewId) { return; }
     const client = connectionManager.getClient();
     const workspace = connectionManager.getWorkspacePath();
-    if (!client || !workspace) return; // not connected yet; the heartbeat retries
+    if (!client || !workspace) { return; } // not connected yet; the heartbeat retries
     const result = await client.registerCanvasView(workspace, file);
     if (disposed) {
       // The panel closed while the request was in flight. Registering now would leak a view that
       // nothing will ever heartbeat, so hand the id straight back.
-      if (result.ok && result.viewId) void client.unregisterCanvasView(result.viewId);
+      if (result.ok && result.viewId) { void client.unregisterCanvasView(result.viewId); }
       return;
     }
     if (result.ok && result.viewId) {
@@ -64,7 +98,7 @@ export function registerCanvasView(options: CanvasViewRegistrationOptions): vsco
 
   /** Serialize registration attempts so a heartbeat racing a reconnect cannot register twice. */
   const ensureRegistered = async (): Promise<void> => {
-    if (registering) return registering;
+    if (registering) { return registering; }
     registering = register().finally(() => {
       registering = null;
     });
@@ -72,19 +106,24 @@ export function registerCanvasView(options: CanvasViewRegistrationOptions): vsco
   };
 
   const beat = async (focused: boolean): Promise<void> => {
-    if (disposed) return;
+    if (disposed) { return; }
     if (!viewId) {
       await ensureRegistered();
       return;
     }
     const client = connectionManager.getClient();
-    if (!client) return;
-    const result = await client.heartbeatCanvasView(viewId, focused);
-    if (result.unknownView) {
+    if (!client) { return; }
+    // Capture the id this beat is about. Two heartbeats can be in flight at once (the timer and
+    // an activation), and both can come back `unknownView`. Without this comparison the second
+    // one would clear a viewId the first had already replaced, orphaning a freshly registered
+    // view until its lease expired.
+    const beatViewId = viewId;
+    const result = await client.heartbeatCanvasView(beatViewId, focused);
+    if (result.unknownView && viewId === beatViewId) {
       // Tower has forgotten this id — it restarted, or the lease lapsed while the machine slept.
       // Re-register rather than heartbeating into the void, which is what would otherwise leave
       // an open panel permanently undrivable.
-      log(`canvas view ${viewId} unknown to Tower; re-registering`);
+      log(`canvas view ${beatViewId} unknown to Tower; re-registering`);
       viewId = null;
       await ensureRegistered();
     }
@@ -99,21 +138,36 @@ export function registerCanvasView(options: CanvasViewRegistrationOptions): vsco
   // The panel the reviewer is looking at should win Tower's most-recently-active rule, so report
   // activity when it becomes visible rather than only on a timer.
   const viewStateSub = panel.onDidChangeViewState((e) => {
-    if (e.webviewPanel.active) void beat(true);
+    if (e.webviewPanel.active) { void beat(true); }
+  });
+
+  // Re-register as soon as the connection comes back, rather than waiting for the next
+  // heartbeat. Without this, a Tower restart leaves every open panel undrivable for up to the
+  // full heartbeat interval — and the first connection after a slow start would too, since
+  // registration at open time is a no-op while there is no client yet.
+  const stateSub = connectionManager.onStateChange((state) => {
+    if (state !== 'connected') { return; }
+    // The id from before the restart is meaningless to the new Tower; drop it and register anew.
+    viewId = null;
+    void ensureRegistered();
   });
 
   const sseSub = connectionManager.onSSEEvent(({ data }) => {
     const envelope = parseSseEnvelope(data);
-    if (!envelope || envelope.type !== CANVAS_COMMAND_EVENT) return;
+    if (!envelope || envelope.type !== CANVAS_COMMAND_EVENT) { return; }
     const event = parseSseBody<CanvasCommandEvent>(envelope.body);
     // Tower broadcasts to every subscriber, so each panel keeps only what is addressed to it.
     // This comparison is the whole addressing mechanism; without it every open canvas would run
     // every command.
-    if (!event || typeof event.viewId !== 'string' || event.viewId !== viewId) return;
-    if (typeof event.command !== 'string') return;
+    if (!event || typeof event.viewId !== 'string' || event.viewId !== viewId) { return; }
+    if (!isCanvasCommand(event.command)) { return; }
 
     const message: HostToWebviewMessage = { type: 'command', command: event.command };
-    if (typeof event.count === 'number') message.count = event.count;
+    // Only a sane repeat count travels on; Tower already rejects the rest, and a bogus value
+    // here would just be extra work for the canvas to ignore.
+    if (typeof event.count === 'number' && Number.isInteger(event.count) && event.count > 0) {
+      message.count = event.count;
+    }
     // Deliberately no `panel.reveal()`: a remote command drives the canvas, it does not steal the
     // reviewer's window, matching the existing command relay's "never pulls focus" posture.
     void panel.webview.postMessage(message);
@@ -123,6 +177,7 @@ export function registerCanvasView(options: CanvasViewRegistrationOptions): vsco
     disposed = true;
     clearInterval(timer);
     viewStateSub.dispose();
+    stateSub.dispose();
     sseSub.dispose();
     const client = connectionManager.getClient();
     if (viewId && client) {

--- a/apps/vscode/src/markdown-preview/messages.ts
+++ b/apps/vscode/src/markdown-preview/messages.ts
@@ -10,13 +10,25 @@
  * well-formed message; they do not vouch that a given runtime value conforms.
  */
 import type { ReviewMarker } from '@cluesmith/codev-sdk/review-markers';
+import type { CanvasCommand } from '@cluesmith/codev-types';
 
-/** Host → webview: push the current document text + parsed markers for rendering. */
-export interface HostToWebviewMessage {
-  type: 'update';
-  content: string;
-  markers: ReviewMarker[];
-}
+/** Host → webview: push content, or deliver a remote command addressed to this panel. */
+export type HostToWebviewMessage =
+  | {
+      type: 'update';
+      content: string;
+      markers: ReviewMarker[];
+    }
+  /**
+   * A canvas command Tower resolved to THIS panel's view (spec 1401). The host has already
+   * matched the event's `viewId`, so the webview simply runs it; `count` repeats a traversal
+   * command and is absent otherwise.
+   */
+  | {
+      type: 'command';
+      command: CanvasCommand;
+      count?: number;
+    };
 
 /** Webview → host: the canvas's lifecycle + comment-intent messages. */
 export type WebviewToHostMessage =

--- a/apps/vscode/src/markdown-preview/preview-provider.ts
+++ b/apps/vscode/src/markdown-preview/preview-provider.ts
@@ -55,8 +55,23 @@ export function sanitizeReadingMode(value: unknown): 'vertical' | 'horizontal' |
   return undefined;
 }
 
-export class MarkdownPreviewProvider implements vscode.CustomTextEditorProvider {
+export class MarkdownPreviewProvider implements vscode.CustomTextEditorProvider, vscode.Disposable {
   public static readonly viewType = 'codev.markdownPreview';
+
+  /**
+   * Live canvas-view registrations, one per open panel (spec 1401).
+   *
+   * Panels normally clean up their own registration on dispose. This set exists for the case
+   * they cannot: on extension deactivate the panels are not individually disposed, so without it
+   * every open view would sit in Tower's registry absorbing commands until its lease lapsed.
+   */
+  private readonly canvasViews = new Set<vscode.Disposable>();
+
+  /** Release every live registration. Called when the extension shuts down. */
+  public dispose(): void {
+    for (const view of this.canvasViews) { view.dispose(); }
+    this.canvasViews.clear();
+  }
 
   constructor(
     private readonly extensionUri: vscode.Uri,
@@ -119,7 +134,11 @@ export class MarkdownPreviewProvider implements vscode.CustomTextEditorProvider 
         panel,
         file: document.uri.fsPath,
       });
-      panel.onDidDispose(() => canvasView.dispose());
+      this.canvasViews.add(canvasView);
+      panel.onDidDispose(() => {
+        this.canvasViews.delete(canvasView);
+        canvasView.dispose();
+      });
     }
 
     panel.webview.onDidReceiveMessage((msg: unknown) => {

--- a/apps/vscode/src/markdown-preview/preview-provider.ts
+++ b/apps/vscode/src/markdown-preview/preview-provider.ts
@@ -37,6 +37,8 @@ import {
 } from '@cluesmith/codev-sdk/review-markers';
 import { renderMarkdownPreviewHtml } from './preview-template.js';
 import type { HostToWebviewMessage, WebviewToHostMessage } from './messages.js';
+import type { ConnectionManager } from '../connection-manager.js';
+import { registerCanvasView } from './canvas-view-registry.js';
 import type { OverviewCache } from '../views/overview-data.js';
 
 /** globalState key for the per-user reading-mode preference (spec 1380 D4 — per-USER scope:
@@ -62,6 +64,12 @@ export class MarkdownPreviewProvider implements vscode.CustomTextEditorProvider 
     // Per-user persistence surface for the reading-mode preference (spec 1380 D4). A `Memento`
     // rather than the whole ExtensionContext: the provider needs exactly this seam.
     private readonly globalState: vscode.Memento,
+    /**
+     * Tower connection, used to register this panel as a live canvas view and receive the
+     * commands addressed to it (spec 1401). Optional so the preview still works standalone —
+     * without it the canvas is simply not remotely drivable, exactly as before.
+     */
+    private readonly connectionManager?: ConnectionManager,
   ) {}
 
   public resolveCustomTextEditor(
@@ -101,6 +109,18 @@ export class MarkdownPreviewProvider implements vscode.CustomTextEditorProvider 
       if (e.document.uri.toString() === document.uri.toString()) { pushUpdate(); }
     });
     panel.onDidDispose(() => changeSub.dispose());
+
+    // Register this panel as a live canvas view so Tower can address commands to it (spec 1401).
+    // Torn down with the panel, so a closed preview stops being a target immediately rather than
+    // lingering until its lease expires.
+    if (this.connectionManager) {
+      const canvasView = registerCanvasView({
+        connectionManager: this.connectionManager,
+        panel,
+        file: document.uri.fsPath,
+      });
+      panel.onDidDispose(() => canvasView.dispose());
+    }
 
     panel.webview.onDidReceiveMessage((msg: unknown) => {
       if (!msg || typeof msg !== 'object') { return; }

--- a/apps/vscode/src/markdown-preview/webview/main.ts
+++ b/apps/vscode/src/markdown-preview/webview/main.ts
@@ -27,6 +27,8 @@ import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 import {
   ArtifactCanvas,
+  type CanvasCommandInvocation,
+  type CommandAdapter,
   type FileAdapter,
   type MarkerAdapter,
   type ReadingMode,
@@ -74,6 +76,33 @@ const themeAdapter: ThemeAdapter = {
 
 const root = createRoot(rootElement);
 
+/**
+ * Remote command seam (spec 1401). The host owns the transport — it holds the Tower connection
+ * and has already decided this panel is the addressee — so the adapter here is just the last
+ * hop: hold the canvas's subscriber and hand it whatever arrives.
+ *
+ * Commands can arrive before the canvas has subscribed (the host pushes as soon as Tower
+ * resolves), in which case there is no subscriber to hand it to and the command is dropped
+ * rather than queued: a stale navigation replayed later would move the reviewer somewhere they
+ * no longer expect.
+ */
+let onCanvasCommand: ((invocation: CanvasCommandInvocation) => void) | null = null;
+
+function deliverCommand(invocation: CanvasCommandInvocation): void {
+  onCanvasCommand?.(invocation);
+}
+
+const commandAdapter: CommandAdapter = {
+  subscribe(handler) {
+    onCanvasCommand = handler;
+    return {
+      dispose: () => {
+        onCanvasCommand = null;
+      },
+    };
+  },
+};
+
 function render(): void {
   root.render(
     React.createElement(ArtifactCanvas, {
@@ -81,6 +110,7 @@ function render(): void {
       fileAdapter,
       markerAdapter,
       themeAdapter,
+      commandAdapter,
       onAddComment: (line: number, text: string) =>
         vscodeApi.postMessage({ type: 'addComment', line, text }),
       onEditComment: (
@@ -110,6 +140,14 @@ function render(): void {
 
 window.addEventListener('message', (event: MessageEvent) => {
   const msg = event.data as HostToWebviewMessage | null;
+  if (msg?.type === 'command') {
+    // Already addressed to this panel by the host, which matched Tower's resolved `viewId`, so
+    // there is nothing left to filter here — just run it (spec 1401).
+    if (typeof msg.command === 'string') {
+      deliverCommand({ command: msg.command, count: msg.count });
+    }
+    return;
+  }
   if (msg?.type !== 'update') { return; }
   content = msg.content ?? '';
   markers = msg.markers ?? [];

--- a/apps/vscode/src/markdown-preview/webview/main.ts
+++ b/apps/vscode/src/markdown-preview/webview/main.ts
@@ -16,9 +16,12 @@
  *    The host writes the marker; the resulting document change comes back as
  *    another `update`. (Pre-#1107 the host collected the text via `showInputBox`.)
  *
- * This file is bundled by esbuild as a browser IIFE (`dist/webview/markdown-preview.js`)
- * and is intentionally excluded from the extension's `tsc` typecheck (it targets
- * the DOM, not Node) — same treatment as the backlog-search webview script (#920).
+ * This file is bundled by esbuild as a browser IIFE (`dist/webview/markdown-preview.js`).
+ * It is excluded from the extension host's `tsconfig.json` because it targets the DOM rather
+ * than Node — but it IS type-checked, by `tsconfig.webview.json`, and the package's
+ * `check-types` script runs both (`tsc --noEmit && tsc --noEmit -p tsconfig.webview.json`).
+ * (This comment previously said only "excluded from the typecheck", which read as untyped and
+ * misled a reader into treating this file as unchecked.)
  * No JSX: `ArtifactCanvas` is created via `React.createElement`, so no JSX build
  * config is needed in the extension package.
  */

--- a/codev/plans/1401-artifact-canvas-remote-command.md
+++ b/codev/plans/1401-artifact-canvas-remote-command.md
@@ -101,10 +101,16 @@ packages in lockstep.
       (`Extract<CanvasCommand, 'block-next' | ...>`) covering the eight traversal/paging
       commands, plus its complement. Types-only for the reason given in the summary; each
       consumer declares its own `satisfies`-bound `const` list.
-- [ ] `CanvasCommandErrorCode`: closed union `'no-canvas' | 'invalid-request'`.
-- [ ] `CanvasCommandRequest { workspace, file?, command, count? }` and
-      `CanvasCommandResult` (success carries `target: { viewId, file }`; failure carries
-      `code` and `error`).
+- [ ] `CanvasCommandErrorCode`: the closed **wire** union `'no-canvas' | 'invalid-request'`,
+      i.e. exactly the answers Tower gives.
+- [ ] `CanvasCommandClientErrorCode`: `CanvasCommandErrorCode | 'unreachable'`, the sdk-visible
+      union, with `unreachable` documented at its declaration as client-synthesized and never
+      sent by Tower. Two separate types rather than one, so Tower cannot type a response it
+      must never send.
+- [ ] `CanvasCommandRequest { workspace, file?, command, count? }`, `CanvasCommandResult`
+      (the wire result: success carries `target: { viewId, file }`, failure carries a wire
+      `code` and `error`), and `CanvasCommandClientResult` (the sdk-visible result, identical
+      but widened to the client error union).
 - [ ] View-registry wire shapes: registration request/result (`viewId` minted by Tower),
       heartbeat body (`{ focused?: boolean }`), and the registered-view shape.
 - [ ] `CanvasCommandEvent`: the addressed SSE event payload as an explicit wire shape
@@ -339,17 +345,18 @@ beyond what the streamdeck architect reviewed.
 #### Deliverables
 
 - [ ] `sendCanvasCommand(command, target, options?)` returning the typed
-      `CanvasCommandResult`, with the machine-readable `code` preserved on failure. The shared
-      `request()` helper normalizes non-2xx responses and discards body-level codes today, so
-      this call reads the parsed error body rather than inheriting that flattening.
-- [ ] **Transport failures reject the returned promise** rather than resolving to a failure
-      code. The spec fixes `CanvasCommandErrorCode` as a closed union of Tower's *answers*
-      (`no-canvas`, `invalid-request`), and "Tower is unreachable" is not an answer. A
-      resolved promise therefore always carries a Tower verdict, which is precisely the
-      distinction a controller needs so it never renders "no canvas open" when Tower is simply
-      down. This is a deliberate, documented departure from the non-throwing house style of
-      `sendCommand`; it is called out here rather than buried, and it does not widen the
-      approved union.
+      `CanvasCommandClientResult`, with the machine-readable `code` preserved on failure. The
+      shared `request()` helper returns only a flattened `error` string on non-2xx
+      (`tower-client.ts:276-280` runs the body through `extractTowerError`), so this call
+      parses the response body itself to recover the wire `code`.
+- [ ] **The call never rejects** (streamdeck stakeholder verdict, 2026-08-11; an earlier
+      builder proposal to reject on transport failure was rejected). `TowerClient.request()`
+      catches every transport error and returns `{ok:false, status:0}`
+      (`tower-client.ts:288-296`), a never-reject invariant the whole client holds, and this
+      call is not its sole exception.
+- [ ] Transport failures map to the client-synthesized `code: 'unreachable'`, keyed off the
+      existing `status: 0` signal from `request()`. Tower never sends this code, and the wire
+      union cannot express it.
 - [ ] Host-facing `registerCanvasView`, `heartbeatCanvasView`, `unregisterCanvasView` on
       `TowerClient`, deliberately **not** re-exported through `controller.ts`: controllers
       drive views, hosts register them, so the controller surface stays exactly as approved.
@@ -363,8 +370,11 @@ beyond what the streamdeck architect reviewed.
 
 - [ ] Success, `no-canvas` and `invalid-request` responses each produce the correct typed
       result, with `code` reaching the caller rather than only a prose string.
-- [ ] Transport failure and malformed-response cases reject, and are therefore distinguishable
-      from a resolved `no-canvas`.
+- [ ] Transport failure and malformed-response cases resolve (never reject) with
+      `code: 'unreachable'`, so a caller distinguishes them from a Tower-answered `no-canvas`
+      without parsing prose.
+- [ ] No call path in the new methods can reject: asserted by a test that drives a throwing
+      `fetchFn`.
 - [ ] `packages/sdk/src/__tests__/import-boundary.test.ts` passes unchanged: no `node:*`, no
       direct `fetch`, no runtime import from `codev-types`, zero new runtime dependencies.
 - [ ] `apps/streamdeck/src/__tests__/import-boundary.test.ts` passes unchanged.
@@ -374,8 +384,9 @@ beyond what the streamdeck architect reviewed.
 
 Unit tests with an injected `fetchFn` (the established pattern in `tower-client.test.ts`): one
 case per response shape including a malformed body, one asserting the request payload carries
-`count` only when supplied, and transport-failure cases asserting rejection. Registration calls
-get the same treatment. The two boundary suites are the architectural regression tests.
+`count` only when supplied, and transport-failure cases asserting a resolved `unreachable`
+rather than a rejection. Registration calls get the same treatment. The two boundary suites are
+the architectural regression tests.
 
 ### Phase 6: VS Code host wiring and end-to-end review loop
 
@@ -459,7 +470,7 @@ for that file, not a confirmatory formality, and its transcript belongs in
 | Adding `@cluesmith/codev-types` to the canvas package leaks a runtime import | Low | Medium: breaks the package's host-agnostic posture | Type-only import enforced by an extended import-boundary test, mirroring the sdk rule; fallback is a canvas-local union plus a drift test, at the cost of two definitions |
 | Registry staleness leaves a ghost view after a hard host kill | Medium | Medium: commands resolve and silently do nothing | Lease expiry bounds the window; unregister on panel dispose and on deactivate covers graceful paths; Phase 4 tests expiry explicitly |
 | Tower restart strands open panels holding dead `viewId`s | Medium | Medium: canvas silently stops responding | Explicit re-registration on reconnect and on unknown-view heartbeat, with a Phase 6 test |
-| The sdk `request()` normalization swallows the error code | Medium | Medium: the deck cannot distinguish no-canvas from a generic failure | A Phase 5 deliverable with its own cases, plus rejection-on-transport-failure so the two are structurally distinct |
+| The sdk `request()` normalization swallows the error code | Medium | Medium: the deck cannot distinguish no-canvas from a generic failure | Phase 5 parses the response body for the wire `code` and synthesizes `unreachable` from `status: 0`, with a test per case and a throwing-`fetchFn` test pinning the never-reject invariant |
 | Webview code is outside the extension typecheck | High (pre-existing) | Medium: a broken adapter compiles | Called out in the Phase 6 test plan; the manual pass is treated as load-bearing evidence rather than a formality |
 | Two act-paths on the deck (`sendCommand` to open a canvas, `sendCanvasCommand` to drive it) confuse future contributors | Medium | Low | Documented at both call sites and in the arch integration-points note; the generic-relay question is recorded as closed in the spec |
 

--- a/codev/plans/1401-artifact-canvas-remote-command.md
+++ b/codev/plans/1401-artifact-canvas-remote-command.md
@@ -1,3 +1,8 @@
+---
+approved: 2026-08-11
+validated: [gemini, codex, claude]
+---
+
 # Plan: Artifact-Canvas Remote Command Channel (Tower relay + sdk route)
 
 **Specification**: [codev/specs/1401-artifact-canvas-remote-command.md](../specs/1401-artifact-canvas-remote-command.md)

--- a/codev/plans/1401-artifact-canvas-remote-command.md
+++ b/codev/plans/1401-artifact-canvas-remote-command.md
@@ -9,13 +9,15 @@ plus a targeted command route, delivery as an addressed event over the existing 
 a `CommandAdapter` seam in the canvas package, and a `sendCanvasCommand` call on the sdk
 controller subpath.
 
-The work is sequenced contracts-first, then outward in dependency order: the wire vocabulary
-lands once in `codev-types`, the canvas package becomes remotely drivable by any host, Tower
-gains the registry and route, the sdk exposes the call, and the VS Code host wires the two
-ends together into a working review loop. Phases 2, 3 and 4 each depend only on Phase 1, so
-each is independently verifiable without the others; only Phase 5 requires the full stack.
+The work is sequenced contracts-first, then outward in dependency order. Phases 3, 4 and 5
+depend only on Phase 1, so each is independently verifiable without the others; only Phase 6
+requires the full stack. The canvas work is split in two because it contains two genuinely
+different kinds of change: Phase 2 is a pure extraction whose regression oracle is the
+untouched existing test suite, and Phase 3 newly authors the four commands that have no
+handler to extract. Keeping them in separate commits is what makes the extraction's "no
+behavior change" claim checkable.
 
-Two decisions the spec deferred to this plan are settled here:
+Three decisions the spec deferred to this plan are settled here.
 
 **Where the vocabulary lives.** `packages/artifact-canvas` has no dependency on
 `@cluesmith/codev-types` today (its only deps are `dompurify` and `markdown-it`). The command
@@ -23,10 +25,18 @@ union is a genuine wire contract: it travels in the POST body and the SSE event,
 Tower and the sdk need it while neither may depend on a React package. So `codev-types` owns
 it, and the canvas package gains `@cluesmith/codev-types` as a type-only dependency, matching
 the sdk's existing arrangement (a real `dependencies` entry so published `.d.ts` resolve,
-with every import in the fully-erased `import type` form). This keeps one definition rather
-than two unions kept in sync by hand. The canvas package's existing import-boundary guard
-forbids `vscode`, `node:*`, bare `fs` and `fetch`, none of which this touches; Phase 2 extends
-that guard to pin the import as type-only so no runtime value can leak in.
+with every import in the fully-erased `import type` form). The canvas package's existing
+import-boundary guard forbids `vscode`, `node:*`, bare `fs` and `fetch`, none of which this
+touches; Phase 2 extends that guard to pin the import as type-only.
+
+**The classification is type-level, not runtime.** An earlier draft made the traversal
+command list a runtime array in `codev-types` shared by both validators. Neither consumer can
+import it: `packages/codev` treats `codev-types` as a compile-time-only dependency and runs
+unbundled from `dist/`, so a runtime value import does not resolve (`command-relay.ts`
+documents this and re-declares its route constants for exactly that reason), and the canvas
+import is type-only by the rule above. The classification is therefore a type, and each
+consumer declares its own `const` list bound to it with `satisfies`, which turns drift into a
+compile error instead of a shared-import that cannot exist.
 
 **Registration transport.** Hosts register views over dedicated HTTP calls with a heartbeat
 lease, not by binding registrations to the host's SSE connection lifetime. The deciding case
@@ -36,16 +46,30 @@ panels and closing one panel would not drop one registration. Per-view HTTP regi
 gives each panel its own identity and its own unregister, with the lease bounding staleness
 when a host dies without cleaning up.
 
+### A ground-truth note on the spec's split-editor example
+
+The spec's multi-view criterion cites "two views open on the same file (e.g. split editor)".
+Verified against the code: `extension.ts` registers the canvas custom editor with
+`supportsMultipleEditorsPerDocument: false`, so VS Code cannot open two canvas panels for one
+document. The MRU rule itself is unaffected and still load-bearing, for two views on
+different files in one workspace (the file-less selector case), for two views of one file
+across different hosts once #1386 lands, and as registry-level defensive behavior. What
+changes is only where that case is verified: at the Tower registry in Phase 4, which
+registers views over HTTP directly and can trivially create two views of one file, rather
+than by a manual split-editor pass in VS Code. Flipping the VS Code flag is deliberately not
+proposed: it would change user-visible editor behavior well outside this issue's scope.
+
 ## Phases (Machine Readable)
 
 ```json
 {
   "phases": [
     {"id": "phase_1", "title": "Command vocabulary wire contracts"},
-    {"id": "phase_2", "title": "Canvas action registry and CommandAdapter seam"},
-    {"id": "phase_3", "title": "Tower canvas view registry and command route"},
-    {"id": "phase_4", "title": "sdk canvas command and view registration calls"},
-    {"id": "phase_5", "title": "VS Code host wiring and end-to-end review loop"}
+    {"id": "phase_2", "title": "Canvas action registry extraction"},
+    {"id": "phase_3", "title": "Canvas remote command seam"},
+    {"id": "phase_4", "title": "Tower canvas view registry and command route"},
+    {"id": "phase_5", "title": "sdk canvas command and view registration calls"},
+    {"id": "phase_6", "title": "VS Code host wiring and end-to-end review loop"}
   ]
 }
 ```
@@ -58,88 +82,148 @@ when a host dies without cleaning up.
 
 #### Objective
 
-Define the command vocabulary, error codes, request/result shapes and protocol names once,
-in the package every other participant may depend on. This is the contract that keeps four
-packages in lockstep, and the single place the traversal-versus-non-traversal classification
-(which governs `count` applicability) is expressed.
+Define the command vocabulary, error codes, request/result shapes and protocol names once, in
+the package every other participant may depend on. This is the contract that keeps four
+packages in lockstep.
 
 #### Files to Create / Modify
 
 - `packages/types/src/canvas-command.ts` (new)
 - `packages/types/src/index.ts` (export the new module)
-- `packages/types/src/__type-tests__/canvas-command.type-test.ts` (new, compile-time only)
+- `packages/types/type-tests/canvas-command.type-test.ts` (new, outside `src/`)
+- `packages/types/tsconfig.type-tests.json` (new) and a `check-types:tests` script in
+  `packages/types/package.json`
 
 #### Deliverables
 
 - [ ] `CanvasCommand`: closed union of the 14 canonical commands from the spec's table.
-- [ ] `TRAVERSAL_COMMANDS` (the eight traversal/paging commands) and an
-      `isTraversalCommand(c)` predicate, as the single source both Tower validation and
-      canvas dispatch consume.
+- [ ] `TraversalCommand`: a **type-level** classification
+      (`Extract<CanvasCommand, 'block-next' | ...>`) covering the eight traversal/paging
+      commands, plus its complement. Types-only for the reason given in the summary; each
+      consumer declares its own `satisfies`-bound `const` list.
 - [ ] `CanvasCommandErrorCode`: closed union `'no-canvas' | 'invalid-request'`.
 - [ ] `CanvasCommandRequest { workspace, file?, command, count? }` and
       `CanvasCommandResult` (success carries `target: { viewId, file }`; failure carries
       `code` and `error`).
 - [ ] View-registry wire shapes: registration request/result (`viewId` minted by Tower),
       heartbeat body (`{ focused?: boolean }`), and the registered-view shape.
-- [ ] Protocol name constants: `CANVAS_COMMAND_ROUTE`, `CANVAS_VIEWS_ROUTE`,
-      `CANVAS_COMMAND_EVENT`, following the existing `COMMAND_ROUTE`/`COMMAND_EVENT`
-      precedent in `command.ts`.
-- [ ] Compile-time exhaustiveness guard: a type-test file that fails to compile if a command
-      is added to the union without being classified as traversal or non-traversal.
+- [ ] `CanvasCommandEvent`: the addressed SSE event payload as an explicit wire shape
+      (resolved `viewId`, `command`, `count`), so the host validates a typed contract at
+      runtime rather than trusting an ad-hoc object.
+- [ ] Protocol names `CANVAS_COMMAND_ROUTE`, `CANVAS_VIEWS_ROUTE`, `CANVAS_COMMAND_EVENT`
+      declared here as the canonical contract, following the `COMMAND_ROUTE`/`COMMAND_EVENT`
+      precedent in `command.ts`. Both Tower and the sdk re-declare these literals locally
+      (Tower because it cannot resolve a runtime import, the sdk because of its type-only
+      boundary rule); `codev-types` remains the single place the contract is documented.
+- [ ] Compile-time exhaustiveness guard, living **outside** `src/`: `packages/types` compiles
+      `src/**/*` into `dist/` and publishes both `src` and `dist`, so a guard under `src/`
+      would ship to consumers. It gets its own tsconfig and check script rather than an
+      `exclude`, which would silently drop it from the check it exists to perform.
 
 #### Acceptance Criteria
 
-- [ ] `pnpm --filter @cluesmith/codev-types check-types` passes, and the guard file fails to
-      compile when a command is deliberately left unclassified (verified once by hand during
-      development).
+- [ ] `pnpm --filter @cluesmith/codev-types check-types` and the new `check-types:tests` both
+      pass, and the guard fails to compile when a command is deliberately left unclassified
+      (verified once by hand during development).
+- [ ] The guard file is absent from `dist/` after a build.
 - [ ] Repo-wide `check-types` still passes: nothing else has changed behavior.
-- [ ] No implementation or policy lands here, only wire shapes and the classification data
-      they carry.
+- [ ] No implementation or policy lands here, only wire shapes and type-level classification.
 
 #### Test Plan
 
 `@cluesmith/codev-types` ships no test runner (its scripts are `build` and `check-types`
-only), so verification here is compile-time: the exhaustiveness guard plus `check-types`
-across the package and its dependents. Runtime behavior of the classification is covered
-where it is consumed, by Phase 2 (canvas dispatch) and Phase 3 (Tower validation).
+only), so verification is compile-time: the exhaustiveness guard under its own tsconfig,
+`check-types` across the package and its dependents, and an inspection of `dist/` after a
+build. Runtime behavior of each consumer's `satisfies`-bound list is covered where it is
+consumed, in Phases 3 and 4.
 
-### Phase 2: Canvas action registry and CommandAdapter seam
+### Phase 2: Canvas action registry extraction
 
 **Dependencies**: Phase 1
 
 #### Objective
 
-Make the canvas remotely drivable by any host, with keyboard and remote paths sharing one
-implementation per action so the two cannot drift. Delivers standalone value: the package
-gains the seam regardless of whether Tower ever calls it.
+Converge the canvas's existing keyboard actions onto one named implementation each, so a
+later remote path cannot drift from the keyboard path. Pure refactor: no new capability, no
+behavior change, and the untouched existing test suite is the oracle that proves it.
+
+#### Files to Create / Modify
+
+- `packages/artifact-canvas/src/components/ArtifactCanvas.tsx` (extract the action registry)
+
+#### Deliverables
+
+- [ ] The six actions already implemented inside `onBodyKeyDown` (`comment-next/prev`,
+      `heading-next/prev`, `doc-start/end`, `composer-open`) move into named per-action
+      functions in one registry keyed by command name, with the key handlers calling into it.
+- [ ] Column paging (`column-forward/back`) likewise, noting it is container-level and
+      geometry-dependent: it consults `measureColumnGeometry`, yields to
+      `innerScrollerCanConsume`, and cancels an in-flight wheel glide, which is why it sits
+      before the `[data-line]` guard. Extracting it is real work rather than a move.
+- [ ] No change to key bindings, guards, edge behavior, or the composer.
+
+#### Acceptance Criteria
+
+- [ ] The pre-existing canvas keyboard tests pass **completely unmodified**. Any need to edit
+      them means the extraction changed behavior and must be reworked.
+- [ ] `pnpm --filter @cluesmith/codev-artifact-canvas test` and `check-types` pass.
+- [ ] Diff review confirms the phase adds no new capability: every moved branch is
+      traceable to its original.
+
+#### Test Plan
+
+The existing vitest suite for jump keys, composer-open, focus restoration and horizontal
+paging, run unedited. The package's Playwright harness
+(`pnpm --filter @cluesmith/codev-artifact-canvas test:browser`) covers the column-paging
+geometry that jsdom cannot assert honestly.
+
+### Phase 3: Canvas remote command seam
+
+**Dependencies**: Phase 2
+
+#### Objective
+
+Make the canvas remotely drivable by any host, completing the vocabulary with the four
+commands that have no handler to extract. Delivers standalone value: the package gains the
+seam whether or not Tower ever calls it.
 
 #### Files to Create / Modify
 
 - `packages/artifact-canvas/src/adapters/CommandAdapter.ts` (new)
-- `packages/artifact-canvas/src/components/ArtifactCanvas.tsx` (action registry, current-block
-  cursor, adapter subscription)
+- `packages/artifact-canvas/src/components/ArtifactCanvas.tsx` (cursor, new actions, adapter
+  subscription)
+- `packages/artifact-canvas/src/overlays/CommentComposer.tsx` (submit/cancel seam)
+- `packages/artifact-canvas/src/overlays/ReadingModeToggle.tsx` (shared toggle action)
 - `packages/artifact-canvas/src/types.ts` (`commandAdapter?` on `ArtifactCanvasProps`)
 - `packages/artifact-canvas/src/index.ts` (export the adapter type)
 - `packages/artifact-canvas/package.json` (add `@cluesmith/codev-types` dependency)
-- `packages/artifact-canvas/src/__tests__/import-boundary.test.ts` (pin the new import as
+- `packages/artifact-canvas/src/__tests__/import-boundary.test.ts` (pin the import as
   type-only)
 - `packages/artifact-canvas/src/__tests__/remote-commands.test.tsx` (new)
 
 #### Deliverables
 
-- [ ] Per-action functions extracted from `onBodyKeyDown` into one action registry keyed by
-      `CanvasCommand`; the existing key handlers call into that registry rather than
-      duplicating the logic. Pure extraction, no behavior change.
-- [ ] Current-block cursor: the most recently focused block (by keyboard, pointer, minimap or
-      remote command), falling back to the topmost visible block when nothing has been focused
-      yet. This is the remote origin the spec defines, and it is what makes navigation
-      well-defined on a freshly opened view.
-- [ ] `CommandAdapter` interface (host-implemented, interface-only, matching the existing
-      D-series adapter convention) and an optional `commandAdapter` prop; omitting it leaves
-      behavior identical to today.
+- [ ] `block-next` / `block-prev`: newly authored, since block traversal today is native Tab
+      over blocks stamped `tabindex="0"` and no handler exists. Implemented as flow-order
+      stepping over `[data-line]` blocks per the spec, explicitly not Tab parity, and without
+      intercepting Tab (which would break the in-page non-goal).
+- [ ] `reading-mode-toggle`: the toggle becomes a shared function that both the toolbar
+      button and the registry call.
+- [ ] `composer-submit` / `composer-cancel`: submission state and the `⌘/Ctrl+Enter` and
+      `Escape` handlers live inside `CommentComposer.tsx`, not the parent, so the composer
+      gains an imperative seam (a ref handle or equivalent) letting the registry invoke submit
+      and cancel directly, view-scoped rather than focus-scoped, with no simulated DOM click.
+- [ ] Current-block cursor: the most recently focused block, falling back to the topmost
+      visible block when nothing has been focused yet. This is **deliberately separate** state
+      from the existing `activeLine`/`activeLineRef`, which is hover-driven and cleared on
+      mouseleave because it positions the "+" affordance. The cursor is focus-derived and
+      persistent; both are documented at their declarations as the affordance target versus
+      the navigation origin, so the second "where am I" is named rather than accidental.
+- [ ] `CommandAdapter` interface (host-implemented, interface-only, matching the D-series
+      adapter convention) and an optional `commandAdapter` prop; omitting it leaves behavior
+      identical to today.
 - [ ] Adapter dispatch honouring `count` for traversal commands (N steps, edge-clamped, no
-      wrap) using the Phase 1 classification.
-- [ ] Composer commands scoped to the view's open composer rather than to DOM focus.
+      wrap), using a canvas-local `const` list bound to `TraversalCommand` via `satisfies`.
 - [ ] Navigation focuses its target through the same focus path the keyboard uses (visible
       ring, scroll into view); the package never reaches outside the canvas document.
 - [ ] Tests for this phase.
@@ -150,24 +234,23 @@ gains the seam regardless of whether Tower ever calls it.
       the spec's command table.
 - [ ] On a freshly mounted, never-focused canvas, every navigation command has an observable
       effect, starting from the topmost visible block.
-- [ ] `count` multiplies the eight traversal commands and is ignored or rejected consistently
-      on the other six (rejection surfaces to the host through the existing `onError` sink,
-      never as a throw out of a handler).
-- [ ] Existing canvas keyboard tests pass **unmodified**: the in-page behavior non-goal holds.
+- [ ] `count` multiplies the eight traversal commands. On the other six the canvas **ignores**
+      it rather than rejecting: Tower is the validator per the spec, and a command reaching
+      the canvas has already passed validation. Rejection is Phase 4's job and is tested there.
+- [ ] `composer-submit` works with DOM focus parked outside the composer.
+- [ ] Existing canvas keyboard tests still pass unmodified.
 - [ ] Import-boundary test passes, including the new type-only rule.
 - [ ] `pnpm --filter @cluesmith/codev-artifact-canvas test` and `check-types` pass.
 
 #### Test Plan
 
-Unit and component tests in vitest: one case per command driven through the adapter; the
-clean-state origin cases; the `count` cases including clamping at edges; composer submit and
-cancel with focus deliberately parked outside the composer; the no-adapter case asserting
-unchanged behavior. Real-DOM assertions that jsdom cannot make honestly (scroll-into-view,
-column paging geometry) go to the package's existing Playwright harness via
-`pnpm --filter @cluesmith/codev-artifact-canvas test:browser`. The regression guard is that
-the pre-existing keyboard suite is not edited in this phase.
+Vitest: one case per command driven through the adapter; the clean-state origin cases; `count`
+including edge clamping; composer submit and cancel with focus deliberately elsewhere; the
+no-adapter case asserting unchanged behavior; and a case asserting Tab still reaches non-block
+focusables (the non-goal guard). Real-DOM assertions (scroll-into-view, column geometry) go to
+the Playwright harness.
 
-### Phase 3: Tower canvas view registry and command route
+### Phase 4: Tower canvas view registry and command route
 
 **Dependencies**: Phase 1
 
@@ -179,40 +262,47 @@ Requirement 4, and it is verifiable end to end without any canvas existing.
 
 #### Files to Create / Modify
 
-- `packages/codev/src/agent-farm/servers/canvas-relay.ts` (new; self-routing module modeled
-  on `command-relay.ts`)
+- `packages/codev/src/agent-farm/servers/canvas-relay.ts` (new; self-routing module modeled on
+  `command-relay.ts`)
 - `packages/codev/src/agent-farm/servers/tower-routes.ts` (dispatch the new route family)
 - `packages/codev/src/agent-farm/__tests__/canvas-relay.test.ts` (new)
-- `packages/codev/src/agent-farm/__tests__/canvas-relay.e2e.test.ts` (new, using the existing
-  `helpers/tower-test-utils.ts` harness)
+- `packages/codev/src/agent-farm/__tests__/canvas-relay.e2e.test.ts` (new, using
+  `helpers/tower-test-utils.ts`)
 
 #### Deliverables
 
 - [ ] View registry: register (Tower mints an opaque `viewId`), heartbeat with optional
       `focused` flag, unregister, and lease expiry. Heartbeat cadence and lease TTL are named
-      constants; the lease is sized to tolerate a small number of missed heartbeats.
-- [ ] Tower-side path canonicalization on both registration and command, reusing the same
-      resolution the existing file-tab dedupe applies, so path spelling cannot split the
-      registry.
+      constants, the lease sized to tolerate a few missed heartbeats.
+- [ ] Route and event name literals re-declared locally with a comment pointing at
+      `codev-types` as the canonical contract, exactly as `command-relay.ts` does and for the
+      same unbundled-runtime reason.
+- [ ] Tower-side path canonicalization on both registration and command, reusing the
+      resolution the existing file-tab dedupe applies. This canonicalizes the **file identity
+      used for matching**; two panels showing the same canonical file remain two distinct
+      registered views with distinct `viewId`s.
 - [ ] Tower-stamped `lastActiveAt`: set on registration, advanced on a `focused` heartbeat and
       on command delivery. Host clocks are never trusted.
 - [ ] Target resolution: filter by workspace and, when given, file; zero matches answer
       `no-canvas` with HTTP 404; one match delivers; multiple matches deliver to the single
       most recently active view, tie-broken by most recent registration. Never a broadcast to
       several matches.
-- [ ] Validation against the closed `CanvasCommand` union and the traversal classification,
-      answering `invalid-request` with HTTP 400 for an unknown command, a malformed selector,
-      `count` on a non-traversal command, or a non-positive `count`.
+- [ ] Validation against the closed `CanvasCommand` union and a locally declared,
+      `satisfies`-bound traversal list, answering `invalid-request` with HTTP 400 for an
+      unknown command, a malformed selector, `count` on a non-traversal command, or a
+      non-positive or non-integer `count`.
 - [ ] Success response naming the resolved target (`viewId`, canonical `file`).
 - [ ] Delivery as a `CANVAS_COMMAND_EVENT` SSE event carrying the resolved `viewId`, so
-      exactly one view acts on it and every other subscriber discards it cheaply.
+      exactly one view acts and every other subscriber discards it on a cheap comparison.
 - [ ] Tests for this phase.
 
 #### Acceptance Criteria
 
-- [ ] Resolution rule holds for zero, one and many matching views, including the two-views-one-
-      file case and the two-files-one-workspace case, with and without a `file` selector.
-- [ ] Registering the same file under different path spellings yields one registry identity.
+- [ ] Resolution holds for zero, one and many matching views, including two views of one file
+      (registered directly over HTTP, per the ground-truth note above) and two files in one
+      workspace, with and without a `file` selector.
+- [ ] Two registrations of the same file under different path spellings match the same
+      selector, while remaining two distinct views with distinct `viewId`s.
 - [ ] After lease expiry with no heartbeat, commands return `no-canvas` rather than resolving
       to the dead view.
 - [ ] Every failure body carries a `code` from the closed union with the specified HTTP status.
@@ -222,21 +312,22 @@ Requirement 4, and it is verifiable end to end without any canvas existing.
 
 #### Test Plan
 
-Unit tests over the registry and resolver: lease expiry driven by injected/faked time rather
-than real waiting, MRU ordering including the tie-break, path-spelling canonicalization,
-and each validation rejection with its status and code. An e2e test boots a real Tower via
-the existing harness, registers two views over HTTP, opens a live `/api/events` stream, POSTs
-commands, and asserts both the HTTP answer and that exactly one addressed event is emitted
-carrying the expected `viewId`. The no-canvas case asserts a 404 with no event emitted.
+Unit tests over the registry and resolver: lease expiry driven by injected or faked time
+rather than real waiting, MRU ordering including the tie-break, path-spelling
+canonicalization, distinct-viewId-per-view, and each validation rejection with its status and
+code. An e2e test boots a real Tower via the existing harness, registers two views over HTTP,
+opens a live `/api/events` stream, POSTs commands, and asserts both the HTTP answer and that
+exactly one addressed event is emitted carrying the expected `viewId`. The no-canvas case
+asserts a 404 with no event emitted.
 
-### Phase 4: sdk canvas command and view registration calls
+### Phase 5: sdk canvas command and view registration calls
 
 **Dependencies**: Phase 1
 
 #### Objective
 
 Expose the route to clients: the controller-facing command call on the approved subpath, and
-the host-facing registration calls that Phase 5 needs, without widening the controller surface
+the host-facing registration calls Phase 6 needs, without widening the controller surface
 beyond what the streamdeck architect reviewed.
 
 #### Files to Create / Modify
@@ -250,14 +341,20 @@ beyond what the streamdeck architect reviewed.
 - [ ] `sendCanvasCommand(command, target, options?)` returning the typed
       `CanvasCommandResult`, with the machine-readable `code` preserved on failure. The shared
       `request()` helper normalizes non-2xx responses and discards body-level codes today, so
-      this call must read the parsed error body rather than inheriting that flattening; the
-      observable contract is the typed result, and the implementation bends to it.
+      this call reads the parsed error body rather than inheriting that flattening.
+- [ ] **Transport failures reject the returned promise** rather than resolving to a failure
+      code. The spec fixes `CanvasCommandErrorCode` as a closed union of Tower's *answers*
+      (`no-canvas`, `invalid-request`), and "Tower is unreachable" is not an answer. A
+      resolved promise therefore always carries a Tower verdict, which is precisely the
+      distinction a controller needs so it never renders "no canvas open" when Tower is simply
+      down. This is a deliberate, documented departure from the non-throwing house style of
+      `sendCommand`; it is called out here rather than buried, and it does not widen the
+      approved union.
 - [ ] Host-facing `registerCanvasView`, `heartbeatCanvasView`, `unregisterCanvasView` on
       `TowerClient`, deliberately **not** re-exported through `controller.ts`: controllers
-      drive views, hosts register them, and the controller surface stays exactly what was
-      approved.
-- [ ] Route path string literals re-declared in the sdk rather than imported as runtime values
-      from `codev-types`, matching the existing `COMMAND_ROUTE` precedent.
+      drive views, hosts register them, so the controller surface stays exactly as approved.
+- [ ] Route path literals re-declared in the sdk rather than imported as runtime values,
+      matching the existing `COMMAND_ROUTE` precedent.
 - [ ] Result and error-code types re-exported as `export type` from the controller subpath so
       integrations need no direct `codev-types` dependency.
 - [ ] Tests for this phase.
@@ -266,9 +363,8 @@ beyond what the streamdeck architect reviewed.
 
 - [ ] Success, `no-canvas` and `invalid-request` responses each produce the correct typed
       result, with `code` reaching the caller rather than only a prose string.
-- [ ] Transport failures (timeout, connection refused) surface distinguishably from a
-      resolved `no-canvas`, so a controller does not report "no canvas open" when Tower is
-      simply unreachable.
+- [ ] Transport failure and malformed-response cases reject, and are therefore distinguishable
+      from a resolved `no-canvas`.
 - [ ] `packages/sdk/src/__tests__/import-boundary.test.ts` passes unchanged: no `node:*`, no
       direct `fetch`, no runtime import from `codev-types`, zero new runtime dependencies.
 - [ ] `apps/streamdeck/src/__tests__/import-boundary.test.ts` passes unchanged.
@@ -276,14 +372,14 @@ beyond what the streamdeck architect reviewed.
 
 #### Test Plan
 
-Unit tests with an injected `fetchFn` (the established pattern in `tower-client.test.ts`):
-one case per response shape including a malformed body, one asserting the request payload
-carries `count` only when supplied, and transport-failure cases. Registration calls get the
-same treatment. The two boundary suites act as the architectural regression tests.
+Unit tests with an injected `fetchFn` (the established pattern in `tower-client.test.ts`): one
+case per response shape including a malformed body, one asserting the request payload carries
+`count` only when supplied, and transport-failure cases asserting rejection. Registration calls
+get the same treatment. The two boundary suites are the architectural regression tests.
 
-### Phase 5: VS Code host wiring and end-to-end review loop
+### Phase 6: VS Code host wiring and end-to-end review loop
 
-**Dependencies**: Phase 2, Phase 3, Phase 4
+**Dependencies**: Phase 3, Phase 4, Phase 5
 
 #### Objective
 
@@ -293,10 +389,13 @@ webview's `CommandAdapter`.
 
 #### Files to Create / Modify
 
-- `apps/vscode/src/markdown-preview/canvas-view-registry.ts` (new; register, heartbeat,
-  unregister, and command forwarding per panel)
+- `apps/vscode/src/markdown-preview/canvas-view-registry.ts` (new; per-panel register,
+  heartbeat, unregister, and command forwarding)
 - `apps/vscode/src/markdown-preview/preview-provider.ts` (register on
   `resolveCustomTextEditor`, unregister on dispose, report activity on view-state change)
+- `apps/vscode/src/extension.ts` (the provider is currently constructed as
+  `new MarkdownPreviewProvider(extensionUri, overviewCache, globalState)` with no
+  `ConnectionManager`, so registration and SSE forwarding need it threaded in)
 - `apps/vscode/src/markdown-preview/messages.ts` (host-to-webview `command` message)
 - `apps/vscode/src/markdown-preview/webview/main.ts` (implement `CommandAdapter`, pass it to
   `ArtifactCanvas`)
@@ -304,12 +403,16 @@ webview's `CommandAdapter`.
 
 #### Deliverables
 
-- [ ] One registration per canvas panel, carrying the panel's real document path, unregistered
+- [ ] One registration per canvas panel carrying the panel's real document path, unregistered
       on panel dispose and on extension deactivate.
 - [ ] Activity reported on `onDidChangeViewState` so the panel the reviewer is looking at wins
       MRU, plus the heartbeat that keeps the lease alive.
-- [ ] Subscription to the addressed SSE event on the extension's existing SSE client, filtered
-      by the panel's own `viewId`, forwarded to that panel's webview via `postMessage`.
+- [ ] Reconnect handling: after a Tower restart or a dropped connection, open panels
+      **re-register** and adopt the new `viewId` rather than heartbeating an id Tower no longer
+      knows. A heartbeat rejected as unknown triggers the same re-registration path.
+- [ ] Subscription to the addressed SSE event on the extension's existing SSE client,
+      validated against the `CanvasCommandEvent` wire shape at runtime, filtered by the panel's
+      own `viewId`, and forwarded to that panel's webview via `postMessage`.
 - [ ] Webview-side `CommandAdapter` implementation feeding the canvas, following the existing
       `update` message-handling pattern.
 - [ ] The host never pulls window focus in response to a delivered command, matching the
@@ -320,45 +423,56 @@ webview's `CommandAdapter`.
 
 - [ ] Opening a canvas panel registers exactly one view; closing it unregisters, and once the
       last panel closes the next command returns `no-canvas`.
-- [ ] Two panels on the same document register two views, and the most recently activated one
-      receives the command.
-- [ ] Real-path verification (this is the phase where "tests pass" is not "it works"): with a
-      spec open in the canvas, commands issued through the sdk move focus, page columns, and
+- [ ] Two panels on different documents register two views, and the most recently activated
+      one receives a file-less command. (Two panels on the *same* document is not reachable in
+      VS Code, per the ground-truth note; that case is covered at the Tower layer in Phase 4.)
+- [ ] Killing and restarting Tower leaves open panels drivable again once reconnected, without
+      a manual reload.
+- [ ] Real-path verification, and this is the phase where "tests pass" is not "it works": with
+      a spec open in the canvas, commands issued through the sdk move focus, page columns, and
       drive the composer; a remote `composer-open`, keyboard-typed body, and remote
-      `composer-submit` write exactly one marker through the existing `MarkerAdapter` path.
-      The transcript of this manual pass goes in the review document.
-- [ ] Existing VS Code extension tests pass; `pnpm --filter <vscode package> test` and
-      `check-types` pass.
+      `composer-submit` write exactly one marker. Note the write path precisely: the webview's
+      `MarkerAdapter.add` is a documented no-op, so the write travels
+      canvas `onAddComment` intent → `postMessage` → extension host → host-side write-back.
+      A builder looking for the write inside the webview will not find it.
+      The transcript of this pass goes in the review document.
+- [ ] Existing VS Code extension tests pass; `check-types` passes.
 
 #### Test Plan
 
 Unit tests over the registry glue with a faked Tower client: registration and unregistration
-lifecycle, viewId filtering (a command for another panel is ignored), and the no-focus-stealing
-rule. The end-to-end verification is manual against a running Tower and a real VS Code window,
-because the value being verified is a human review loop across three processes; its steps and
-outcome are recorded in `codev/reviews/1401-artifact-canvas-remote-command.md`.
+lifecycle, viewId filtering (a command for another panel is ignored), re-registration after a
+simulated reconnect and after an unknown-view heartbeat, and the no-focus-stealing rule.
+
+Note a real coverage gap and treat it accordingly: `apps/vscode/tsconfig.json` excludes
+`src/markdown-preview/webview`, so the webview-side `CommandAdapter` gets **no** `check-types`
+coverage and no unit coverage. The manual end-to-end pass is therefore load-bearing evidence
+for that file, not a confirmatory formality, and its transcript belongs in
+`codev/reviews/1401-artifact-canvas-remote-command.md`.
 
 ## Risks and Mitigation
 
 | Risk | Probability | Impact | Mitigation |
 |------|-------------|--------|------------|
-| The Phase 2 extraction silently changes keyboard behavior | Medium | High: breaks a shipped review flow | Pure extraction with the pre-existing keyboard suite left unedited as the regression oracle; behavior changes and extraction never share a commit |
-| Adding `@cluesmith/codev-types` to the canvas package leaks a runtime import and breaks the package's host-agnostic posture | Low | Medium | Type-only import enforced by an extended import-boundary test, mirroring the sdk's rule; fallback if the architect prefers no new dependency is a canvas-local union plus a drift test, at the cost of two definitions |
-| Registry staleness leaves a ghost view after a hard host kill | Medium | Medium: commands resolve and silently do nothing | Lease expiry bounds the window; unregister on both panel dispose and extension deactivate covers every graceful path; Phase 3 tests the expiry path explicitly |
-| The sdk `request()` normalization swallows the error code | Medium | Medium: the deck cannot distinguish no-canvas from a generic failure | Called out as a Phase 4 deliverable with its own test cases, including transport failure versus resolved `no-canvas` |
-| SSE fan-out means every subscriber sees every canvas command | High (by design) | Low | Events carry the resolved `viewId`; non-target subscribers discard on a cheap comparison, the same filtering posture the existing command relay uses |
-| Two act-paths on the deck (`sendCommand` to open, `sendCanvasCommand` to drive) confuse future contributors | Medium | Low | The distinction is documented at both call sites and in the arch integration-points note; the generic-relay question is recorded as closed in the spec |
+| The Phase 2 extraction silently changes keyboard behavior | Medium | High: breaks a shipped review flow | Extraction is its own phase and its own commit, with the pre-existing keyboard suite left unedited as the oracle; new actions land separately in Phase 3 |
+| The composer seam (Phase 3) destabilizes submit/delete focus restoration, which #1237 found fiddly | Medium | Medium | Drive submit and cancel through the composer's existing internal paths rather than reimplementing them; the existing focus-restoration tests stay unmodified |
+| Adding `@cluesmith/codev-types` to the canvas package leaks a runtime import | Low | Medium: breaks the package's host-agnostic posture | Type-only import enforced by an extended import-boundary test, mirroring the sdk rule; fallback is a canvas-local union plus a drift test, at the cost of two definitions |
+| Registry staleness leaves a ghost view after a hard host kill | Medium | Medium: commands resolve and silently do nothing | Lease expiry bounds the window; unregister on panel dispose and on deactivate covers graceful paths; Phase 4 tests expiry explicitly |
+| Tower restart strands open panels holding dead `viewId`s | Medium | Medium: canvas silently stops responding | Explicit re-registration on reconnect and on unknown-view heartbeat, with a Phase 6 test |
+| The sdk `request()` normalization swallows the error code | Medium | Medium: the deck cannot distinguish no-canvas from a generic failure | A Phase 5 deliverable with its own cases, plus rejection-on-transport-failure so the two are structurally distinct |
+| Webview code is outside the extension typecheck | High (pre-existing) | Medium: a broken adapter compiles | Called out in the Phase 6 test plan; the manual pass is treated as load-bearing evidence rather than a formality |
+| Two act-paths on the deck (`sendCommand` to open a canvas, `sendCanvasCommand` to drive it) confuse future contributors | Medium | Low | Documented at both call sites and in the arch integration-points note; the generic-relay question is recorded as closed in the spec |
 
 ## Documentation Updates
 
 - `codev/resources/arch.md`: the Tower canvas view registry belongs under **Agent Farm
   Internals** (a new Tower-side registry with lease semantics) and the controller-to-canvas
-  path under **Integration Points**, alongside the existing command relay so the two act-paths
-  are described together rather than discovered separately.
-- Hot-tier routing: no `arch-critical.md` entry is proposed. The hot file is at its cap, and
+  path under **Integration Points**, described alongside the existing command relay so the two
+  act-paths are found together rather than separately.
+- Hot-tier routing: no `arch-critical.md` entry is proposed. The hot file is at its cap and
   this feature does not change a system-shape invariant a contributor must consult before
-  deciding. If the architect judges otherwise at review time, it would displace a weaker fact
-  rather than grow the file.
+  deciding. If the architect judges otherwise at review time, it displaces a weaker fact
+  rather than growing the file.
 - No README changes: neither `packages/artifact-canvas` nor `packages/types` ships one.
 - VS Code changelog and release notes are accumulated on the architect's changelog branch per
   repo convention, not in this PR.

--- a/codev/plans/1401-artifact-canvas-remote-command.md
+++ b/codev/plans/1401-artifact-canvas-remote-command.md
@@ -1,0 +1,364 @@
+# Plan: Artifact-Canvas Remote Command Channel (Tower relay + sdk route)
+
+**Specification**: [codev/specs/1401-artifact-canvas-remote-command.md](../specs/1401-artifact-canvas-remote-command.md)
+
+## Executive Summary
+
+Implements the spec's recommended Approach 2: a Tower-side registry of live canvas views
+plus a targeted command route, delivery as an addressed event over the existing SSE channel,
+a `CommandAdapter` seam in the canvas package, and a `sendCanvasCommand` call on the sdk
+controller subpath.
+
+The work is sequenced contracts-first, then outward in dependency order: the wire vocabulary
+lands once in `codev-types`, the canvas package becomes remotely drivable by any host, Tower
+gains the registry and route, the sdk exposes the call, and the VS Code host wires the two
+ends together into a working review loop. Phases 2, 3 and 4 each depend only on Phase 1, so
+each is independently verifiable without the others; only Phase 5 requires the full stack.
+
+Two decisions the spec deferred to this plan are settled here:
+
+**Where the vocabulary lives.** `packages/artifact-canvas` has no dependency on
+`@cluesmith/codev-types` today (its only deps are `dompurify` and `markdown-it`). The command
+union is a genuine wire contract: it travels in the POST body and the SSE event, and both
+Tower and the sdk need it while neither may depend on a React package. So `codev-types` owns
+it, and the canvas package gains `@cluesmith/codev-types` as a type-only dependency, matching
+the sdk's existing arrangement (a real `dependencies` entry so published `.d.ts` resolve,
+with every import in the fully-erased `import type` form). This keeps one definition rather
+than two unions kept in sync by hand. The canvas package's existing import-boundary guard
+forbids `vscode`, `node:*`, bare `fs` and `fetch`, none of which this touches; Phase 2 extends
+that guard to pin the import as type-only so no runtime value can leak in.
+
+**Registration transport.** Hosts register views over dedicated HTTP calls with a heartbeat
+lease, not by binding registrations to the host's SSE connection lifetime. The deciding case
+is VS Code: one extension host holds a single SSE connection for the whole window, but that
+window can host several canvas panels, so a connection-scoped registration cannot distinguish
+panels and closing one panel would not drop one registration. Per-view HTTP registration
+gives each panel its own identity and its own unregister, with the lease bounding staleness
+when a host dies without cleaning up.
+
+## Phases (Machine Readable)
+
+```json
+{
+  "phases": [
+    {"id": "phase_1", "title": "Command vocabulary wire contracts"},
+    {"id": "phase_2", "title": "Canvas action registry and CommandAdapter seam"},
+    {"id": "phase_3", "title": "Tower canvas view registry and command route"},
+    {"id": "phase_4", "title": "sdk canvas command and view registration calls"},
+    {"id": "phase_5", "title": "VS Code host wiring and end-to-end review loop"}
+  ]
+}
+```
+
+## Phase Breakdown
+
+### Phase 1: Command vocabulary wire contracts
+
+**Dependencies**: None
+
+#### Objective
+
+Define the command vocabulary, error codes, request/result shapes and protocol names once,
+in the package every other participant may depend on. This is the contract that keeps four
+packages in lockstep, and the single place the traversal-versus-non-traversal classification
+(which governs `count` applicability) is expressed.
+
+#### Files to Create / Modify
+
+- `packages/types/src/canvas-command.ts` (new)
+- `packages/types/src/index.ts` (export the new module)
+- `packages/types/src/__type-tests__/canvas-command.type-test.ts` (new, compile-time only)
+
+#### Deliverables
+
+- [ ] `CanvasCommand`: closed union of the 14 canonical commands from the spec's table.
+- [ ] `TRAVERSAL_COMMANDS` (the eight traversal/paging commands) and an
+      `isTraversalCommand(c)` predicate, as the single source both Tower validation and
+      canvas dispatch consume.
+- [ ] `CanvasCommandErrorCode`: closed union `'no-canvas' | 'invalid-request'`.
+- [ ] `CanvasCommandRequest { workspace, file?, command, count? }` and
+      `CanvasCommandResult` (success carries `target: { viewId, file }`; failure carries
+      `code` and `error`).
+- [ ] View-registry wire shapes: registration request/result (`viewId` minted by Tower),
+      heartbeat body (`{ focused?: boolean }`), and the registered-view shape.
+- [ ] Protocol name constants: `CANVAS_COMMAND_ROUTE`, `CANVAS_VIEWS_ROUTE`,
+      `CANVAS_COMMAND_EVENT`, following the existing `COMMAND_ROUTE`/`COMMAND_EVENT`
+      precedent in `command.ts`.
+- [ ] Compile-time exhaustiveness guard: a type-test file that fails to compile if a command
+      is added to the union without being classified as traversal or non-traversal.
+
+#### Acceptance Criteria
+
+- [ ] `pnpm --filter @cluesmith/codev-types check-types` passes, and the guard file fails to
+      compile when a command is deliberately left unclassified (verified once by hand during
+      development).
+- [ ] Repo-wide `check-types` still passes: nothing else has changed behavior.
+- [ ] No implementation or policy lands here, only wire shapes and the classification data
+      they carry.
+
+#### Test Plan
+
+`@cluesmith/codev-types` ships no test runner (its scripts are `build` and `check-types`
+only), so verification here is compile-time: the exhaustiveness guard plus `check-types`
+across the package and its dependents. Runtime behavior of the classification is covered
+where it is consumed, by Phase 2 (canvas dispatch) and Phase 3 (Tower validation).
+
+### Phase 2: Canvas action registry and CommandAdapter seam
+
+**Dependencies**: Phase 1
+
+#### Objective
+
+Make the canvas remotely drivable by any host, with keyboard and remote paths sharing one
+implementation per action so the two cannot drift. Delivers standalone value: the package
+gains the seam regardless of whether Tower ever calls it.
+
+#### Files to Create / Modify
+
+- `packages/artifact-canvas/src/adapters/CommandAdapter.ts` (new)
+- `packages/artifact-canvas/src/components/ArtifactCanvas.tsx` (action registry, current-block
+  cursor, adapter subscription)
+- `packages/artifact-canvas/src/types.ts` (`commandAdapter?` on `ArtifactCanvasProps`)
+- `packages/artifact-canvas/src/index.ts` (export the adapter type)
+- `packages/artifact-canvas/package.json` (add `@cluesmith/codev-types` dependency)
+- `packages/artifact-canvas/src/__tests__/import-boundary.test.ts` (pin the new import as
+  type-only)
+- `packages/artifact-canvas/src/__tests__/remote-commands.test.tsx` (new)
+
+#### Deliverables
+
+- [ ] Per-action functions extracted from `onBodyKeyDown` into one action registry keyed by
+      `CanvasCommand`; the existing key handlers call into that registry rather than
+      duplicating the logic. Pure extraction, no behavior change.
+- [ ] Current-block cursor: the most recently focused block (by keyboard, pointer, minimap or
+      remote command), falling back to the topmost visible block when nothing has been focused
+      yet. This is the remote origin the spec defines, and it is what makes navigation
+      well-defined on a freshly opened view.
+- [ ] `CommandAdapter` interface (host-implemented, interface-only, matching the existing
+      D-series adapter convention) and an optional `commandAdapter` prop; omitting it leaves
+      behavior identical to today.
+- [ ] Adapter dispatch honouring `count` for traversal commands (N steps, edge-clamped, no
+      wrap) using the Phase 1 classification.
+- [ ] Composer commands scoped to the view's open composer rather than to DOM focus.
+- [ ] Navigation focuses its target through the same focus path the keyboard uses (visible
+      ring, scroll into view); the package never reaches outside the canvas document.
+- [ ] Tests for this phase.
+
+#### Acceptance Criteria
+
+- [ ] All 14 commands, driven through a test `CommandAdapter`, produce the effect defined in
+      the spec's command table.
+- [ ] On a freshly mounted, never-focused canvas, every navigation command has an observable
+      effect, starting from the topmost visible block.
+- [ ] `count` multiplies the eight traversal commands and is ignored or rejected consistently
+      on the other six (rejection surfaces to the host through the existing `onError` sink,
+      never as a throw out of a handler).
+- [ ] Existing canvas keyboard tests pass **unmodified**: the in-page behavior non-goal holds.
+- [ ] Import-boundary test passes, including the new type-only rule.
+- [ ] `pnpm --filter @cluesmith/codev-artifact-canvas test` and `check-types` pass.
+
+#### Test Plan
+
+Unit and component tests in vitest: one case per command driven through the adapter; the
+clean-state origin cases; the `count` cases including clamping at edges; composer submit and
+cancel with focus deliberately parked outside the composer; the no-adapter case asserting
+unchanged behavior. Real-DOM assertions that jsdom cannot make honestly (scroll-into-view,
+column paging geometry) go to the package's existing Playwright harness via
+`pnpm --filter @cluesmith/codev-artifact-canvas test:browser`. The regression guard is that
+the pre-existing keyboard suite is not edited in this phase.
+
+### Phase 3: Tower canvas view registry and command route
+
+**Dependencies**: Phase 1
+
+#### Objective
+
+Give Tower an authoritative picture of which canvas views are live, and a command route that
+resolves a target by the spec's rule and answers explicitly. This is the phase that satisfies
+Requirement 4, and it is verifiable end to end without any canvas existing.
+
+#### Files to Create / Modify
+
+- `packages/codev/src/agent-farm/servers/canvas-relay.ts` (new; self-routing module modeled
+  on `command-relay.ts`)
+- `packages/codev/src/agent-farm/servers/tower-routes.ts` (dispatch the new route family)
+- `packages/codev/src/agent-farm/__tests__/canvas-relay.test.ts` (new)
+- `packages/codev/src/agent-farm/__tests__/canvas-relay.e2e.test.ts` (new, using the existing
+  `helpers/tower-test-utils.ts` harness)
+
+#### Deliverables
+
+- [ ] View registry: register (Tower mints an opaque `viewId`), heartbeat with optional
+      `focused` flag, unregister, and lease expiry. Heartbeat cadence and lease TTL are named
+      constants; the lease is sized to tolerate a small number of missed heartbeats.
+- [ ] Tower-side path canonicalization on both registration and command, reusing the same
+      resolution the existing file-tab dedupe applies, so path spelling cannot split the
+      registry.
+- [ ] Tower-stamped `lastActiveAt`: set on registration, advanced on a `focused` heartbeat and
+      on command delivery. Host clocks are never trusted.
+- [ ] Target resolution: filter by workspace and, when given, file; zero matches answer
+      `no-canvas` with HTTP 404; one match delivers; multiple matches deliver to the single
+      most recently active view, tie-broken by most recent registration. Never a broadcast to
+      several matches.
+- [ ] Validation against the closed `CanvasCommand` union and the traversal classification,
+      answering `invalid-request` with HTTP 400 for an unknown command, a malformed selector,
+      `count` on a non-traversal command, or a non-positive `count`.
+- [ ] Success response naming the resolved target (`viewId`, canonical `file`).
+- [ ] Delivery as a `CANVAS_COMMAND_EVENT` SSE event carrying the resolved `viewId`, so
+      exactly one view acts on it and every other subscriber discards it cheaply.
+- [ ] Tests for this phase.
+
+#### Acceptance Criteria
+
+- [ ] Resolution rule holds for zero, one and many matching views, including the two-views-one-
+      file case and the two-files-one-workspace case, with and without a `file` selector.
+- [ ] Registering the same file under different path spellings yields one registry identity.
+- [ ] After lease expiry with no heartbeat, commands return `no-canvas` rather than resolving
+      to the dead view.
+- [ ] Every failure body carries a `code` from the closed union with the specified HTTP status.
+- [ ] The route never dereferences `workspace` or `file` as filesystem paths beyond
+      canonicalization; they are registry lookup keys.
+- [ ] Existing Tower route tests pass; `pnpm --filter @cluesmith/codev test` passes.
+
+#### Test Plan
+
+Unit tests over the registry and resolver: lease expiry driven by injected/faked time rather
+than real waiting, MRU ordering including the tie-break, path-spelling canonicalization,
+and each validation rejection with its status and code. An e2e test boots a real Tower via
+the existing harness, registers two views over HTTP, opens a live `/api/events` stream, POSTs
+commands, and asserts both the HTTP answer and that exactly one addressed event is emitted
+carrying the expected `viewId`. The no-canvas case asserts a 404 with no event emitted.
+
+### Phase 4: sdk canvas command and view registration calls
+
+**Dependencies**: Phase 1
+
+#### Objective
+
+Expose the route to clients: the controller-facing command call on the approved subpath, and
+the host-facing registration calls that Phase 5 needs, without widening the controller surface
+beyond what the streamdeck architect reviewed.
+
+#### Files to Create / Modify
+
+- `packages/sdk/src/tower-client.ts` (new methods)
+- `packages/sdk/src/controller.ts` (re-export `sendCanvasCommand` and its result types only)
+- `packages/sdk/src/__tests__/tower-client-canvas.test.ts` (new)
+
+#### Deliverables
+
+- [ ] `sendCanvasCommand(command, target, options?)` returning the typed
+      `CanvasCommandResult`, with the machine-readable `code` preserved on failure. The shared
+      `request()` helper normalizes non-2xx responses and discards body-level codes today, so
+      this call must read the parsed error body rather than inheriting that flattening; the
+      observable contract is the typed result, and the implementation bends to it.
+- [ ] Host-facing `registerCanvasView`, `heartbeatCanvasView`, `unregisterCanvasView` on
+      `TowerClient`, deliberately **not** re-exported through `controller.ts`: controllers
+      drive views, hosts register them, and the controller surface stays exactly what was
+      approved.
+- [ ] Route path string literals re-declared in the sdk rather than imported as runtime values
+      from `codev-types`, matching the existing `COMMAND_ROUTE` precedent.
+- [ ] Result and error-code types re-exported as `export type` from the controller subpath so
+      integrations need no direct `codev-types` dependency.
+- [ ] Tests for this phase.
+
+#### Acceptance Criteria
+
+- [ ] Success, `no-canvas` and `invalid-request` responses each produce the correct typed
+      result, with `code` reaching the caller rather than only a prose string.
+- [ ] Transport failures (timeout, connection refused) surface distinguishably from a
+      resolved `no-canvas`, so a controller does not report "no canvas open" when Tower is
+      simply unreachable.
+- [ ] `packages/sdk/src/__tests__/import-boundary.test.ts` passes unchanged: no `node:*`, no
+      direct `fetch`, no runtime import from `codev-types`, zero new runtime dependencies.
+- [ ] `apps/streamdeck/src/__tests__/import-boundary.test.ts` passes unchanged.
+- [ ] `pnpm --filter @cluesmith/codev-sdk test` and `check-types` pass.
+
+#### Test Plan
+
+Unit tests with an injected `fetchFn` (the established pattern in `tower-client.test.ts`):
+one case per response shape including a malformed body, one asserting the request payload
+carries `count` only when supplied, and transport-failure cases. Registration calls get the
+same treatment. The two boundary suites act as the architectural regression tests.
+
+### Phase 5: VS Code host wiring and end-to-end review loop
+
+**Dependencies**: Phase 2, Phase 3, Phase 4
+
+#### Objective
+
+Connect the two ends so a human can actually drive a review remotely: the extension registers
+its canvas panels, reports activity, receives addressed commands, and forwards them into the
+webview's `CommandAdapter`.
+
+#### Files to Create / Modify
+
+- `apps/vscode/src/markdown-preview/canvas-view-registry.ts` (new; register, heartbeat,
+  unregister, and command forwarding per panel)
+- `apps/vscode/src/markdown-preview/preview-provider.ts` (register on
+  `resolveCustomTextEditor`, unregister on dispose, report activity on view-state change)
+- `apps/vscode/src/markdown-preview/messages.ts` (host-to-webview `command` message)
+- `apps/vscode/src/markdown-preview/webview/main.ts` (implement `CommandAdapter`, pass it to
+  `ArtifactCanvas`)
+- `apps/vscode/src/__tests__/canvas-view-registry.test.ts` (new)
+
+#### Deliverables
+
+- [ ] One registration per canvas panel, carrying the panel's real document path, unregistered
+      on panel dispose and on extension deactivate.
+- [ ] Activity reported on `onDidChangeViewState` so the panel the reviewer is looking at wins
+      MRU, plus the heartbeat that keeps the lease alive.
+- [ ] Subscription to the addressed SSE event on the extension's existing SSE client, filtered
+      by the panel's own `viewId`, forwarded to that panel's webview via `postMessage`.
+- [ ] Webview-side `CommandAdapter` implementation feeding the canvas, following the existing
+      `update` message-handling pattern.
+- [ ] The host never pulls window focus in response to a delivered command, matching the
+      existing command relay's stated posture.
+- [ ] Tests for this phase.
+
+#### Acceptance Criteria
+
+- [ ] Opening a canvas panel registers exactly one view; closing it unregisters, and once the
+      last panel closes the next command returns `no-canvas`.
+- [ ] Two panels on the same document register two views, and the most recently activated one
+      receives the command.
+- [ ] Real-path verification (this is the phase where "tests pass" is not "it works"): with a
+      spec open in the canvas, commands issued through the sdk move focus, page columns, and
+      drive the composer; a remote `composer-open`, keyboard-typed body, and remote
+      `composer-submit` write exactly one marker through the existing `MarkerAdapter` path.
+      The transcript of this manual pass goes in the review document.
+- [ ] Existing VS Code extension tests pass; `pnpm --filter <vscode package> test` and
+      `check-types` pass.
+
+#### Test Plan
+
+Unit tests over the registry glue with a faked Tower client: registration and unregistration
+lifecycle, viewId filtering (a command for another panel is ignored), and the no-focus-stealing
+rule. The end-to-end verification is manual against a running Tower and a real VS Code window,
+because the value being verified is a human review loop across three processes; its steps and
+outcome are recorded in `codev/reviews/1401-artifact-canvas-remote-command.md`.
+
+## Risks and Mitigation
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| The Phase 2 extraction silently changes keyboard behavior | Medium | High: breaks a shipped review flow | Pure extraction with the pre-existing keyboard suite left unedited as the regression oracle; behavior changes and extraction never share a commit |
+| Adding `@cluesmith/codev-types` to the canvas package leaks a runtime import and breaks the package's host-agnostic posture | Low | Medium | Type-only import enforced by an extended import-boundary test, mirroring the sdk's rule; fallback if the architect prefers no new dependency is a canvas-local union plus a drift test, at the cost of two definitions |
+| Registry staleness leaves a ghost view after a hard host kill | Medium | Medium: commands resolve and silently do nothing | Lease expiry bounds the window; unregister on both panel dispose and extension deactivate covers every graceful path; Phase 3 tests the expiry path explicitly |
+| The sdk `request()` normalization swallows the error code | Medium | Medium: the deck cannot distinguish no-canvas from a generic failure | Called out as a Phase 4 deliverable with its own test cases, including transport failure versus resolved `no-canvas` |
+| SSE fan-out means every subscriber sees every canvas command | High (by design) | Low | Events carry the resolved `viewId`; non-target subscribers discard on a cheap comparison, the same filtering posture the existing command relay uses |
+| Two act-paths on the deck (`sendCommand` to open, `sendCanvasCommand` to drive) confuse future contributors | Medium | Low | The distinction is documented at both call sites and in the arch integration-points note; the generic-relay question is recorded as closed in the spec |
+
+## Documentation Updates
+
+- `codev/resources/arch.md`: the Tower canvas view registry belongs under **Agent Farm
+  Internals** (a new Tower-side registry with lease semantics) and the controller-to-canvas
+  path under **Integration Points**, alongside the existing command relay so the two act-paths
+  are described together rather than discovered separately.
+- Hot-tier routing: no `arch-critical.md` entry is proposed. The hot file is at its cap, and
+  this feature does not change a system-shape invariant a contributor must consult before
+  deciding. If the architect judges otherwise at review time, it would displace a weaker fact
+  rather than grow the file.
+- No README changes: neither `packages/artifact-canvas` nor `packages/types` ships one.
+- VS Code changelog and release notes are accumulated on the architect's changelog branch per
+  repo convention, not in this PR.

--- a/codev/projects/1401-artifact-canvas-remote-command/1401-phase_1-iter1-rebuttals.md
+++ b/codev/projects/1401-artifact-canvas-remote-command/1401-phase_1-iter1-rebuttals.md
@@ -1,0 +1,56 @@
+# Phase 1 (Command vocabulary wire contracts) — Iteration 1 Rebuttals
+
+Verdicts: gemini APPROVE · codex APPROVE · claude REQUEST_CHANGES.
+
+One issue raised, accepted in full and fixed. It is a good catch of the kind that is easy to
+miss precisely because everything looked green locally.
+
+## Claude: the exhaustiveness guard never runs in CI
+
+**Accepted and fixed.** Verified independently before acting rather than trusting the review:
+`.github/workflows/test.yml` builds `packages/types` (the "Build types package" step) but no
+job in any of the five workflows invokes `check-types:tests`, and there is no recursive
+`pnpm -r check-types` or `pnpm -r test` anywhere. `check-types` appears only for
+`apps/vscode`, `apps/streamdeck`, and in `sdk-canary.yml`.
+
+The consequence is exactly as described, and it is worse than a missing test. The guard is
+this phase's *entire* verification story: `@cluesmith/codev-types` ships no test runner, so
+compile-time checking is all there is, and the guard's whole reason to exist is to fail a
+build when someone adds a 15th command without classifying it as traversal or not. Living
+outside `src/` is what keeps it from being published, and it is also what keeps `pnpm build`
+from ever compiling it. Unwired, it would have protected nothing while looking like
+protection, and since no later phase touches this package's CI, it would have stayed that way.
+
+Fix applied in `.github/workflows/test.yml`, immediately after the types build:
+
+```yaml
+      - name: Type-check types package contracts
+        working-directory: packages/types
+        run: pnpm check-types:tests
+```
+
+with a comment recording why the step is needed (guards live outside `src/`, so the build does
+not reach them, and the package has no test runner). Verified by running the exact command
+from the exact working directory the step uses.
+
+I treated this as in scope for phase 1 rather than deferring it: wiring the guard to run is
+finishing the deliverable, not adding a new one. A guard that cannot fail a build is not a
+guard.
+
+## Claude's non-blocking notes
+
+All three were correct, and none needs action in this phase:
+
+- **`SSEEventType` does not list `canvas-command`.** Confirmed, and it does not list the
+  existing `command` event either, so the omission is consistent with precedent. If event-name
+  registration turns out to matter it belongs with the Tower work in phase 4, not here.
+- **The heartbeat sub-route exists only in prose on `CanvasViewHeartbeat`.** Deliberate for a
+  contracts phase; phase 4 pins the concrete path when it implements the route family.
+- **`CanvasViewRegistrationResult` returns a canonicalized `file` but not a canonicalized
+  `workspace`.** Harmless today, since hosts key off `viewId` after registering and Tower
+  canonicalizes `workspace` on every command. Noted for phase 4 so it is a decision there
+  rather than a surprise.
+
+## Gemini, Codex (APPROVE)
+
+No issues raised; no changes required.

--- a/codev/projects/1401-artifact-canvas-remote-command/1401-phase_3-iter1-rebuttals.md
+++ b/codev/projects/1401-artifact-canvas-remote-command/1401-phase_3-iter1-rebuttals.md
@@ -1,0 +1,90 @@
+# Phase 3 (Canvas remote command seam) — Iteration 1 Rebuttals
+
+Verdicts: gemini APPROVE · codex REQUEST_CHANGES · claude REQUEST_CHANGES.
+
+Every point is accepted and fixed, except one where the fix landed but the described failure
+mode turned out not to be reproducible, and one where the reported symptom is pre-existing
+behavior that the remote path reproduces faithfully. Both are documented below with the evidence,
+because in each case the honest answer changed what the test should assert.
+
+## Claude
+
+**1. (Blocking) The traversal drift guard is inert.** Accepted, and this was the worst finding
+because it is the exact defect class phase 1 was sent back for: a guard that cannot fail.
+
+```ts
+type _EveryTraversalCommandIsListed =
+  Exclude<TraversalCommand, (typeof TRAVERSAL_COMMANDS)[number]> extends never ? true : never;
+```
+
+A bare type alias imposes no constraint, so an omitted command resolves to `never` and compiles.
+I verified independently rather than taking the report on trust, with a minimal probe under the
+workspace TypeScript: my form exited 0, the `Assert<T extends true>` form failed with TS2344.
+Fixed by reusing phase 1's own pattern, and then **verified in the real file** by deleting
+`'column-back'` from the list, confirming `check-types` fails with
+`TS2344: Type 'false' does not satisfy the constraint 'true'`, and restoring.
+
+The comment claiming enforcement was also false, so it now explains *why* the wrapper is what
+makes the assertion bite. My thread log carried the same false claim and has been corrected.
+
+**2. Unbounded `count` loop.** Accepted. `runCanvasCommand` now captures a position signature
+before each step and breaks as soon as a step changes nothing, which stops at the edge and bounds
+the work to what actually exists. The signature is origin line **plus** `scrollLeft`, because
+column paging moves the scroll offset and leaves focus alone, so a line-only check would have
+made counted paging stop after one step. Covered by a unit test with `count: 1_000_000` and a
+browser test asserting a huge count lands at the end quickly.
+
+**3. Quiet-focus not re-armed on the remote path.** Accepted; the spec does say remote navigation
+focuses the way the keyboard does. `runCanvasCommand` now clears `codev-canvas-quiet-focus`, the
+same first move `onBodyKeyDown` makes.
+
+**4. Test gaps and the unused `act` import.** Accepted. Added adapter cases for `comment-prev`
+and `heading-prev`, a backwards no-wrap case, and the Tab non-goal case (asserting the canvas
+does not call `preventDefault` on Tab and does not move focus). The stale `act` import is gone.
+
+**5. `readingMode` read from the closure in `currentBlock` while `toggleReadingMode` reads the
+ref.** Accepted; `currentBlock` now reads the ref too, so a navigation batched behind a toggle
+measures against the mode that toggle already chose.
+
+## Codex
+
+**1. `column-forward/back` do not check horizontal mode.** Fix accepted and applied: both actions
+now return false unless the mode is horizontal, which also keeps the remote path consistent with
+the key path (the handler already gated on mode before dispatching).
+
+The stated consequence, however, does not reproduce, and the test I first wrote for it failed for
+that reason. `overflow-x: auto` on the canvas body is scoped to
+`.codev-canvas-mode-horizontal` (`default-theme.css:490-497`), so in vertical mode the body is
+not a horizontal scroll container at all: my attempt to set `scrollLeft = 40` on it read back 0.
+The guard is still right as defense against a host stylesheet that makes the body scrollable, and
+it makes the intent explicit, so it stays. The browser test now asserts what is actually true and
+verifiable (vertical mode has nothing to scroll, and paging leaves it at 0) and records why the
+stronger scenario is unreachable, rather than passing vacuously while appearing to prove more.
+
+**2. Counted traversal continues after an edge.** Same fix as claude's point 2.
+
+**3. Missing coverage: all 14 commands, reverse jumps, scrolled clean-state origin, column
+`count`, real-browser remote column paging.** Accepted. Reverse jumps and the remaining commands
+are covered in the unit suite. For the browser gap I made the dev page a real host: it now
+implements `CommandAdapter` over `window.__canvasCommand`, which is the shape any host
+implements, and a new `playwright/remote-commands.spec.ts` drives it for column paging on the
+measured grid, counted paging, the huge-count bound, vertical-mode inertness, and scroll-into-view.
+This is the only way to assert paging at all, since jsdom reports no layout.
+
+One sub-item resolved differently: I first asserted that remote `doc-end` scrolls the last block
+into view, and it failed. Probing the keyboard equivalent showed `End` behaves **identically**
+(both land on line 1106 with `scrollLeft` 0), because that fixture's last block is a table row
+whose scrollable ancestor is the table rather than the canvas body. That is pre-existing
+behavior, and reproducing it exactly is the parity the spec asks for, so changing it would breach
+the phase's "no change to in-page behavior" non-goal. The test now mirrors the keyboard suite's
+`n` case with a marked block, where the body genuinely is the scroller.
+
+## Gemini (APPROVE)
+
+No issues raised; no changes required.
+
+## Verification after the fixes
+
+- `check-types` clean; drift guard verified to fail on an omitted command, then restored.
+- 173/173 unit tests (4 new since iteration 1).
+- 38/38 Playwright, including 5 new remote-command specs, on the committed config.

--- a/codev/projects/1401-artifact-canvas-remote-command/1401-phase_3-iter2-rebuttals.md
+++ b/codev/projects/1401-artifact-canvas-remote-command/1401-phase_3-iter2-rebuttals.md
@@ -1,0 +1,56 @@
+# Phase 3 (Canvas remote command seam) — Iteration 2 Rebuttals
+
+Verdicts: gemini APPROVE · codex REQUEST_CHANGES · claude REQUEST_CHANGES.
+
+Both findings accepted and fixed. Nothing disputed. The first one is a process failure on my
+part rather than a design disagreement, so it is worth naming plainly.
+
+## 1. (Blocking, both reviewers) `check-types` fails on the new Playwright spec
+
+Accepted. Verified immediately:
+
+```
+playwright/remote-commands.spec.ts(15,50): error TS2339:
+  Property '__canvasCommand' does not exist on type 'Window & typeof globalThis'.
+```
+
+**Cause.** The dev page declares the global in `examples/main.tsx`, but this package's tsconfig
+includes `src`, `playwright` and the config files — **not** `examples`. So the augmentation that
+makes the dev page compile is invisible to the specs that use it.
+
+**How it escaped me.** I ran `check-types` while wiring the seam, then added
+`playwright/remote-commands.spec.ts` afterwards to close codex's browser-coverage gap, and
+re-ran only the unit and browser suites. Both passed, because Playwright transpiles per-file
+without project-wide type checking. So the phase's own acceptance criterion was failing while
+every signal I was looking at stayed green. The lesson is narrow and mechanical: `check-types`
+belongs *after* the last file is added, not after the last logic change. Recorded in the thread
+log.
+
+**Fix.** `playwright/window-command.d.ts` mirrors the augmentation for the compilation unit that
+actually type-checks the specs, with a comment explaining why the declaration exists twice. The
+`as never` cast in the spec is gone now that the type is real, and `send()` takes a
+`CanvasCommand` instead of a bare string, so a typo in a command name is a compile error rather
+than a silent no-op at runtime.
+
+## 2. (Codex) The scrolled clean-state origin case is still untested
+
+Accepted; the earlier coverage only exercised an unscrolled view, which tests the weaker half of
+the rule. The origin rule has two halves and jsdom can only prove one, since it reports no
+layout: "nothing focused, nothing scrolled → start at the top" is checkable there, but "scrolled
+but never focused → start from what the reviewer is *looking at*" needs real geometry.
+
+Added to the browser suite: scroll halfway into the columns fixture without touching focus,
+assert the topmost visible block is genuinely not the document's first block (so the scroll
+took effect and the test cannot pass vacuously), then send `block-next` and assert it stepped on
+from the visible block rather than from the document start.
+
+## Gemini (APPROVE)
+
+No issues raised; no changes required.
+
+## Verification after the fixes
+
+- `pnpm --filter @cluesmith/codev-artifact-canvas check-types`: passes.
+- Repo-wide `pnpm -r check-types`: clean.
+- 173/173 unit tests.
+- 39/39 Playwright, including the new scrolled-origin case.

--- a/codev/projects/1401-artifact-canvas-remote-command/1401-phase_4-iter1-rebuttals.md
+++ b/codev/projects/1401-artifact-canvas-remote-command/1401-phase_4-iter1-rebuttals.md
@@ -1,0 +1,61 @@
+# Phase 4 (Tower canvas view registry and command route) — Iteration 1 Rebuttals
+
+Verdicts: gemini APPROVE · codex REQUEST_CHANGES · claude REQUEST_CHANGES.
+
+All findings accepted and fixed; nothing disputed. Both reviewers landed on the same two defects
+from different angles, and one of them defeated the phase's central guarantee.
+
+## 1. (Blocking, claude) Command delivery refreshed the liveness lease
+
+Accepted, and this was the serious one. `handleCanvasCommand` set both `lastActiveAt` **and**
+`lastSeenAt` on the resolved target. `lastSeenAt` drives lease expiry, so a ghost view kept
+renewing itself for exactly as long as a controller kept driving it.
+
+The failure mode is worse than "a stale entry lingers": the guarantee this phase exists to
+provide is that a dead host's view ages out and the caller is told `no-canvas`. Under steady
+command traffic, which is the normal case for a controller, that guarantee silently inverted —
+the view would never expire, and every command would report success at a canvas nobody could see.
+
+Fix: delivery advances `lastActiveAt` only. Liveness now comes exclusively from heartbeats, which
+only a live host can send; delivery is fire-and-forget over SSE and proves nothing about the host.
+The comment at the assignment now says so, since the omission is the kind a later edit would
+"helpfully" restore. Regression test drives a view for four lease-thirds with no heartbeat and
+asserts it expires anyway.
+
+## 2. (Blocking, both) A literal `null` body escaped as a 500 with no wire `code`
+
+Accepted. `parseJsonBody` is typed as returning an object but resolves any valid JSON, so `null`,
+a number, or an array parse fine and then throw on the first field read. That surfaced as an
+unhandled 500 with no `code` — precisely what the error contract forbids, since a caller cannot
+distinguish it from anything else.
+
+Fix: an `asObject` guard after every `parseJsonBody`, in all three handlers, returning the
+contract's `invalid-request`. Tests cover `null`, a number, a string and an array.
+
+## 3. (Codex) A malformed heartbeat renewed the lease
+
+Accepted, and it belongs with the lease bug above. My handler caught the parse error and fell
+back to `{}`, treating a broken payload as a valid bodyless heartbeat. A genuinely bodyless
+request already parses as `{}` on its own, so the catch was only ever reachable for malformed
+input, and it extended liveness on the strength of a request Tower could not read. Now a 400,
+with a test asserting the bad heartbeat buys no time.
+
+## 4. (Codex/claude, non-blocking) Response literals were untyped, and the registration type was wrong
+
+Accepted both parts. Success and failure responses are now annotated with `CanvasCommandResult`
+and `CanvasViewRegistrationResult`, so a drift between what Tower sends and what the contract
+declares fails the build rather than reaching a client. Building that annotation immediately
+surfaced the second half of the finding: `CanvasViewRegistrationResult` omitted the `ok` field
+Tower actually sends. The contract was wrong, not the handler, so `ok: true` was added to the
+type. An `invalidRequest()` helper now constructs the failure shape, so the `code` cannot be
+forgotten at a new call site.
+
+## Gemini (APPROVE)
+
+No issues raised; no changes required.
+
+## Verification after the fixes
+
+- 27/27 unit tests (4 new, covering both defects).
+- 5/5 e2e against a real booted Tower.
+- Repo-wide `check-types` clean; repo build green.

--- a/codev/projects/1401-artifact-canvas-remote-command/1401-phase_5-iter1-rebuttals.md
+++ b/codev/projects/1401-artifact-canvas-remote-command/1401-phase_5-iter1-rebuttals.md
@@ -1,0 +1,67 @@
+# Phase 5 (sdk canvas command and view registration) — Iteration 1 Rebuttals
+
+Verdicts: gemini APPROVE · claude APPROVE · codex REQUEST_CHANGES.
+
+One finding accepted and fixed. One **partially disputed**: the observation is factually correct,
+but it describes a pre-existing property of the controller subpath rather than anything this
+phase introduced, and the remedy would redesign a surface owned and already approved by another
+stakeholder. Evidence below; raised with the architect rather than changed unilaterally.
+
+## 1. (Accepted) `sendCanvasCommand` accepted any object containing `ok`
+
+Real hole, and it defeats the point of the call. The guard was `'ok' in body`, so
+`{ok: true}` with no `target` came back as a typed success and the caller would read
+`target.viewId` off `undefined`; `{ok: false, code: 'bogus'}` came back as a typed failure
+carrying a code outside the caller's union. My "unreadable body" test only covered a body with no
+`ok` at all, so it passed while the interesting cases went through.
+
+Fixed with `parseCanvasCommandResult`, which validates the complete shape: a success needs
+`target.viewId` and `target.file` as strings, and a failure needs a `code` from the closed wire
+union. Anything else is reported as `unreachable`, on the principle that a response we cannot
+fully verify is not a verdict.
+
+Two details worth noting. The runtime code list is pinned to `CanvasCommandErrorCode` with an
+`AssertTrue` guard, so a code added to the contract cannot silently become unrecognized here —
+without that, a future real verdict would be misreported as `unreachable`. And that guard
+immediately earned its keep: the type name was missing from the import, which surfaced as the
+assertion resolving to `false` rather than as a silent pass.
+
+Coverage: nine malformed-response cases (missing target, partial target, non-string ids, unknown
+code, missing code, non-object, null), plus a case for a valid code arriving without a message.
+
+## 2. (Partially disputed) `controller.ts` re-exports `TowerClient`, so registration methods are reachable
+
+The observation is true. The conclusion that phase 5 violates its own plan is not, and the
+proposed remedy is out of scope for this phase.
+
+**What the plan required**, and what was done: the registration methods are not re-exported
+through `controller.ts`. They are not in its export list, and the doc comment records why
+(controllers drive views; hosts own them).
+
+**Why they are still reachable**: `controller.ts` exports the `TowerClient` class itself, and has
+since before this issue. That class carries **39 public methods**, including `addArchitect`,
+`removeArchitect`, `createTerminal`, `killTerminal`, `sweepHusks` and `activateWorkspace` — none
+of which are controller concerns either. The subpath is a curated *namespace* of the types,
+constants and client a controller needs; it has never been a capability boundary. My three
+methods are no more reachable than the thirty-six that predate them.
+
+**Why I did not "fix" it**: the only real remedy is a restricted client surface — a wrapper or a
+narrowed interface on that subpath. That is a redesign of a published surface the streamdeck
+architect owns and reviewed at design time, it is a breaking change for existing consumers, and
+it has nothing to do with canvas commands specifically. Doing it inside a phase whose scope is
+"add the sdk calls" would be exactly the kind of unilateral scope expansion the protocol asks a
+builder to raise instead.
+
+**What I did instead**: flagged it to the architect for the streamdeck stakeholder to decide. If
+they want a hard boundary on that subpath it deserves its own issue, and it should cover all 39
+methods rather than singling out the three added here.
+
+## Gemini, Claude (APPROVE)
+
+No blocking issues raised.
+
+## Verification after the fix
+
+- 98/98 sdk tests (9 new malformed-response cases).
+- 63/63 streamdeck tests, boundary suite unchanged.
+- `check-types` clean for the sdk and repo-wide.

--- a/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter1-rebuttals.md
+++ b/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter1-rebuttals.md
@@ -1,0 +1,89 @@
+# Phase 6 (VS Code host wiring) — Iteration 1 Rebuttals
+
+Verdicts: gemini APPROVE · claude COMMENT · codex REQUEST_CHANGES.
+
+Every actionable finding is fixed. One finding corrected *me*, and it is the most useful thing to
+come out of this round. One item cannot be closed by a builder and is escalated rather than
+waved through.
+
+## 1. (Both) No reconnect handling — up to 30s undrivable after a Tower restart
+
+Accepted. Re-registration triggered only on a heartbeat coming back `unknownView`, so after a
+Tower restart every open panel stayed dead until the next beat, up to the full 30-second
+interval. The same gap applied at startup: registration at open time is a no-op while there is no
+client yet, so a slow first connection left the panel unregistered until a beat rescued it.
+
+Now subscribed to `connectionManager.onStateChange`; on `connected` the stale id is dropped and
+registration runs immediately. Two tests: re-register on reconnect, and ignore non-connected
+states.
+
+## 2. (Claude) Re-registration race could orphan a fresh view
+
+Accepted, and subtle. Two heartbeats can be in flight at once (the timer and an activation).
+If both come back `unknownView`, the first clears the id and registers a replacement, then the
+second clears *that* replacement and registers again — leaving the first replacement orphaned in
+Tower until its lease lapsed, absorbing nothing but occupying a registry slot and skewing MRU.
+
+Fixed by capturing `beatViewId` before the request and only clearing when `viewId` still equals
+it. Test drives two concurrent activations against a heartbeat that always answers unknown-view.
+
+## 3. (Both) Unregister on extension deactivate was named in the plan but missing
+
+Accepted rather than explained away. Panels clean up their own registration on dispose, but
+deactivate does not dispose panels individually, so every open view would have sat in Tower until
+its lease lapsed. The provider now tracks live registrations, implements `Disposable`, and is
+pushed into `context.subscriptions`; `extension.ts` holds it in a local so it can be.
+
+## 4. (Both) The SSE command was forwarded without validating the closed union
+
+Accepted. Tower validates before relaying, so this is defence in depth — but an SSE frame is
+untrusted input crossing a process boundary, and forwarding an unchecked string into the webview
+pushes the problem into code that does no validation of its own. There is now a runtime
+allowlist, pinned to `CanvasCommand` by an `AssertTrue` guard so the contract cannot outgrow it,
+plus a sanity check on `count`. The guard promptly earned its place: it failed the build when the
+type import was missing, instead of passing silently.
+
+## 5. (Claude) Eleven lint warnings, all in the new file
+
+Accepted. Every brace-less single-line `if` in `registerCanvasView`. They were warnings, so
+nothing failed, but the surrounding `markdown-preview/` code braces its guards consistently and
+the new file was the only one warning. Braced; `eslint` on the directory is now clean.
+
+## 6. (Claude) My own premise was wrong: the webview *is* typechecked
+
+**This one corrected me, and I have propagated the correction.** I asserted in the plan, in a
+phase 3 rebuttal, and in the first draft of the review file that `webview/main.ts` has no
+`check-types` coverage, reasoning from `apps/vscode/tsconfig.json` excluding that directory. I
+stopped one file too early: `tsconfig.webview.json` covers exactly that directory, and the
+package's `check-types` script runs **both** configs.
+
+I verified it myself before accepting. The review file now carries an explicit correction to the
+plan's claim. The manual pass is still required, but for the ordinary reason that types do not
+prove runtime behavior across three processes — not because the code was unchecked. I had been
+overstating the justification.
+
+Claude's related correction about the test script is also recorded: `pnpm --filter codev-vscode
+test` maps to `vscode-test` (the Electron harness, which fails in this environment for unrelated
+reasons), while the unit tests run under `test:unit` → `vitest run`, which is what CI invokes and
+what I ran. The new tests are genuinely executed in CI.
+
+## 7. (Codex) The manual end-to-end pass was not performed
+
+**Accepted as an open item, not fixed — and deliberately not signed off.** It requires a real VS
+Code window with the extension loaded, a running Tower, and an open canvas panel, which a builder
+in a headless worktree cannot produce. Claiming it was done would be the exact failure mode the
+protocol's "tests pass is not it works" lesson exists to prevent.
+
+What is verified: the Tower route end to end against a real booted Tower, the canvas seam by unit
+plus Playwright plus a human's own dev-page session, and the sdk and host glue by unit tests with
+fakes. What is unverified is only the seam between them in a live VS Code.
+
+It is documented as an outstanding, blocking-for-sign-off item in the review file, with a
+four-step script for the reviewer, and it is called out in the PR body. The `pr` gate is a human
+gate, which is the right place for a human-only verification to land.
+
+## Verification after the fixes
+
+- 16/16 host-glue tests (4 new), 793/793 vscode unit suite.
+- `check-types` clean for the extension (both configs) and repo-wide; `eslint` clean.
+- Repo build green; 4847 repo tests pass.

--- a/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter1-rebuttals.md
+++ b/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter1-rebuttals.md
@@ -87,3 +87,30 @@ gate, which is the right place for a human-only verification to land.
 - 16/16 host-glue tests (4 new), 793/793 vscode unit suite.
 - `check-types` clean for the extension (both configs) and repo-wide; `eslint` clean.
 - Repo build green; 4847 repo tests pass.
+
+---
+
+# Iteration 2 addendum
+
+Verdicts: gemini APPROVE · claude APPROVE · codex REQUEST_CHANGES.
+
+**1. Malformed `count` forwarded as a single command instead of rejecting the event.** Accepted,
+and codex is right on the principle. I had chosen to drop the bad field and run the command,
+which is graceful degradation in the wrong place: Tower rejects bad counts before relaying, so
+one arriving here means the frame cannot be trusted, and running a traversal with a different
+repeat than the sender intended silently changes what the reviewer asked for. The event is now
+rejected whole. Test updated to assert nothing is forwarded for a negative, fractional, or
+non-numeric count.
+
+**2. Reconnect discarded the `viewId` without unregistering it.** Accepted, and a good catch: a
+reconnect is not necessarily a restart. Against the *same* Tower the old registration is still
+live, so dropping the id and registering afresh left a duplicate view in the registry competing
+for MRU until its lease lapsed. The old id is now released first, best-effort — against a
+genuinely restarted Tower that call 404s harmlessly. Test added.
+
+**3. The live VS Code end-to-end loop remains unperformed.** Unchanged and unchangeable from
+here; see item 7 above. Claude's iteration-2 review describes it as "properly escalated to the PR
+gate", which is the intent: it is documented as blocking for sign-off in the review file with a
+four-step script, and called out in the PR body.
+
+Verification: 17/17 host-glue tests, 794/794 vscode unit suite, typecheck and lint clean.

--- a/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter2-rebuttals.md
+++ b/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter2-rebuttals.md
@@ -1,0 +1,58 @@
+# Phase 6 (VS Code host wiring) — Iteration 2 Rebuttals
+
+Verdicts: gemini APPROVE · claude APPROVE · codex REQUEST_CHANGES.
+
+Three findings from codex. Two accepted and fixed; the third cannot be closed by a builder and is
+escalated to the `pr` gate rather than waved through.
+
+## 1. (Accepted) A malformed `count` was forwarded as a single command instead of rejecting the event
+
+Codex is right on the principle, and I had it backwards. My handler dropped the bad field and ran
+the command anyway, which is graceful degradation applied in the wrong place.
+
+Tower validates `count` and answers `invalid-request` before relaying, so a bad one arriving at
+the host means the frame cannot be trusted. And the specific degradation was the harmful kind:
+running a traversal once when the sender asked for five is a silent change to what the reviewer
+requested, which is worse than doing nothing at all. The event is now rejected whole.
+
+Test updated to assert nothing is forwarded for a negative, fractional, or non-numeric count.
+
+## 2. (Accepted) Reconnect discarded the `viewId` without unregistering it
+
+Good catch, and it exposed an assumption I had baked in without stating: I treated every
+reconnect as a Tower restart. It is not. A transient SSE drop reconnects to the *same* Tower,
+where the old registration is still perfectly live — so dropping the id and registering afresh
+left a duplicate view in the registry, competing for MRU and skewing targeting until its lease
+lapsed 90 seconds later.
+
+The old id is now released before a new one is taken. Best-effort by design: against a genuinely
+restarted Tower that call 404s, which is harmless and exactly what the unknown-view path already
+expects. Test added asserting the release happens on reconnect.
+
+## 3. (Escalated, not fixed) The live VS Code end-to-end loop remains unperformed
+
+Unchanged from iteration 1, and unchangeable from here. It requires a real VS Code window with
+the extension loaded, a running Tower, and an open canvas panel; a builder in a headless worktree
+cannot produce that. Claiming otherwise would be precisely the failure the "tests pass is not it
+works" lesson exists to prevent, and it would be a false statement in an artifact people rely on.
+
+What *is* verified, either side of that seam:
+
+- Tower's route, end to end against a real booted Tower (5 e2e tests).
+- The canvas seam, by unit tests, Playwright, and the user's own dev-page session.
+- The sdk and the host glue, by unit tests against fakes (17 host-glue cases).
+
+What is unverified is only the join in a live VS Code.
+
+It is recorded as an outstanding, blocking-for-sign-off item in
+`codev/reviews/1401-artifact-canvas-remote-command.md`, with a four-step script the reviewer can
+run in a couple of minutes, and it is called out in the PR body. Claude's iteration-2 review
+independently describes this as "properly escalated to the PR gate", which is the intent: the
+`pr` gate is a human gate, and a human-only verification is exactly what belongs there.
+
+## Verification after the fixes
+
+- 17/17 host-glue tests, 794/794 vscode unit suite.
+- `check-types` clean (both extension configs) and repo-wide; `eslint` clean on
+  `src/markdown-preview/`.
+- Repo build green; 4847 repo tests pass.

--- a/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter3-rebuttals.md
+++ b/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter3-rebuttals.md
@@ -1,0 +1,35 @@
+# Phase 6 (VS Code host wiring) — Iteration 3 Rebuttals
+
+Verdicts: gemini APPROVE · claude APPROVE · codex REQUEST_CHANGES.
+
+## Codex: the live VS Code end-to-end verification remains incomplete
+
+Correct, and it will remain correct at every future iteration of this loop, because it is not a
+code defect and no code change can close it.
+
+The check requires a real VS Code window with the extension loaded, a running Tower, and an open
+canvas panel, driven by a person who can see the result. A builder in a headless worktree cannot
+produce that. The only way to make this reviewer's verdict flip would be to assert that I
+performed a verification I did not perform, which would put a false claim into the artifacts the
+team relies on — the precise failure the "tests pass is not it works" lesson exists to prevent.
+
+Everything either side of the seam is verified: Tower's route end to end against a real booted
+Tower, the canvas seam by unit tests, Playwright, and the user's own dev-page session, and the
+sdk and host glue by 17 host-glue unit tests. What no automated test here can exercise is the
+join in a live editor.
+
+It is recorded as an outstanding, blocking-for-sign-off item in
+`codev/reviews/1401-artifact-canvas-remote-command.md` with a four-step script, and it is called
+out in the PR body. The `pr` gate is a human gate, which is exactly where a human-only
+verification belongs. Both other reviewers describe the escalation as correct.
+
+## Claude (APPROVE) — stale counts
+
+Fixed: the review file's VS Code row said 789 tests and 12 host-glue cases; it now reads 794 and
+17, matching the suite after the iteration-2 additions.
+
+## Verification
+
+- 17/17 host-glue tests, 794/794 vscode unit suite.
+- `check-types` clean (both extension configs) and repo-wide; `eslint` clean.
+- Repo build green; 4847 repo tests pass.

--- a/codev/projects/1401-artifact-canvas-remote-command/1401-plan-iter1-rebuttals.md
+++ b/codev/projects/1401-artifact-canvas-remote-command/1401-plan-iter1-rebuttals.md
@@ -1,0 +1,99 @@
+# Plan 1401 — Iteration 1 Rebuttals
+
+Verdicts: gemini APPROVE · codex REQUEST_CHANGES · claude REQUEST_CHANGES.
+
+Both REQUEST_CHANGES reviews were code-verified and correct. I re-verified every load-bearing
+claim against the worktree before acting rather than trusting the summaries, and all six held.
+The plan was restructured accordingly (5 phases became 6). Nothing is contested; one item is
+accepted with a different remedy than the reviewer proposed, and one surfaced a factual error
+in the approved spec that I am flagging rather than silently papering over.
+
+## Verified before acting
+
+| Claim | Verified |
+|---|---|
+| `packages/codev` cannot runtime-import `codev-types` | Yes: `command-relay.ts:24-29` documents it and re-declares `COMMAND_ROUTE` for exactly this reason |
+| `supportsMultipleEditorsPerDocument: false` | Yes: `apps/vscode/src/extension.ts:1404` |
+| `MarkdownPreviewProvider` built without `ConnectionManager` | Yes: `extension.ts:1401` |
+| A guard under `packages/types/src/` would ship | Yes: `include: ["src/**/*"]`, `rootDir: ./src`, `files: ["src","dist"]` |
+| `webview/` excluded from the extension typecheck | Yes: `apps/vscode/tsconfig.json:11` |
+| Webview `markerAdapter.add` is a no-op | Yes: `webview/main.ts`, "Never called from the webview" |
+
+## Claude (REQUEST_CHANGES)
+
+**1. (Blocker) The runtime traversal classification is unimportable by both consumers.**
+Accepted, and it was the right catch: the plan asserted a shared runtime helper that could not
+have compiled in either place. `TraversalCommand` is now a **type-level** classification, and
+each consumer declares its own `const` list bound to it with `satisfies`, so drift is a compile
+error rather than a shared import that cannot exist. Phase 4 now also states that Tower
+re-declares the route and event literals locally, matching `command-relay.ts`.
+
+**2. (Blocker) Phase 2's "pure extraction" framing hid ~6 commands of new work, and two files
+were missing.** Accepted, with a stronger remedy than proposed. The reviewer suggested
+splitting the deliverable; I split the **phase**, because the plan template requires each phase
+to be a single atomic commit and "extraction and new work must not share a commit" cannot hold
+inside one phase. Phase 2 is now pure extraction with the unmodified test suite as its oracle;
+Phase 3 newly authors `block-next/prev`, `reading-mode-toggle`, and the composer submit/cancel
+seam. `CommentComposer.tsx` and `ReadingModeToggle.tsx` are in the Phase 3 file list, and the
+column-paging note about geometry work is recorded in Phase 2.
+
+**3. The type-test file would be published.** Accepted. It moves to
+`packages/types/type-tests/` with its own tsconfig and `check-types:tests` script, plus an
+acceptance criterion that it is absent from `dist/` after a build. An `exclude` was explicitly
+rejected for the reason given: it would drop the guard from the check it exists to perform.
+
+**4. The cursor duplicates `activeLine` without saying so.** Accepted. Phase 3 now states the
+cursor is deliberately separate state and documents the distinction at both declarations:
+`activeLine` is hover-driven and cleared on mouseleave because it positions the "+" affordance;
+the cursor is focus-derived and persistent because it is the navigation origin.
+
+**5. The `count` criterion was unfalsifiable ("ignored or rejected").** Accepted. The canvas
+ignores; Tower rejects. Tower is the validator per the spec, and a command reaching the canvas
+has already passed validation.
+
+**6. Phase 6 `check-types` covers nothing in the webview.** Accepted. Stated plainly in the
+test plan, with the manual pass named as load-bearing evidence for that file rather than a
+formality. Adding the webview to the typecheck was considered and rejected as scope creep on a
+pre-existing exclusion.
+
+**7. The `MarkerAdapter` wording would send a builder to the wrong file.** Accepted; the
+acceptance criterion now names the real path (`onAddComment` intent → `postMessage` → host
+write-back) and says so explicitly.
+
+## Codex (REQUEST_CHANGES)
+
+Items 1, 2, 6 and 7 overlap with the above (runtime-versus-type-only classification, the
+composer seam and its missing file, the typed SSE event payload now added as
+`CanvasCommandEvent` in Phase 1, and sdk transport semantics). The remainder:
+
+**3. `supportsMultipleEditorsPerDocument: false` contradicts the two-panels-same-document
+scenario.** Accepted, and this one reaches back into the approved spec, whose criterion cites
+"(e.g. split editor)". Verified: VS Code cannot open two canvas panels for one document. Of the
+two remedies offered I took the second, scoping the scenario rather than flipping the flag,
+because flipping it changes user-visible editor behavior far outside this issue. The MRU rule
+is unaffected and still load-bearing (two files in one workspace, two hosts once #1386 lands,
+and registry-level defensive behavior); only the venue changes, from a manual VS Code pass to
+Tower-layer tests in Phase 4 that register two views over HTTP directly. Recorded as a
+ground-truth note in the plan and raised with the architect, since it corrects an example in an
+approved artifact.
+
+**4. VS Code wiring is incomplete: no `ConnectionManager`, and reconnect behavior undefined.**
+Accepted. `apps/vscode/src/extension.ts` is now in the Phase 6 file list with the reason, and
+re-registration after Tower restart (and after an unknown-view heartbeat) is both a deliverable
+and an acceptance criterion. The stranded-panel case is in the risk table.
+
+**5. Canonicalization wording conflated file identity with view identity.** Accepted; the
+wording was genuinely ambiguous. Canonicalization now explicitly merges the **file identity
+used for matching**, while two panels on the same canonical file remain two views with distinct
+`viewId`s, and the acceptance criterion asserts both halves.
+
+**7. `Promise<CanvasCommandResult>` has no transport-failure variant.** Accepted, resolved by
+rejecting the promise on transport or malformed-response failures so a resolved promise always
+carries a Tower verdict. The alternative, adding a code such as `unreachable`, would widen a
+closed union the spec fixed and the streamdeck architect approved. This is a deliberate
+departure from `sendCommand`'s non-throwing style, documented as such in Phase 5 and flagged to
+the architect so the streamdeck stakeholder can veto it.
+
+## Gemini (APPROVE)
+
+No issues raised; no changes required.

--- a/codev/projects/1401-artifact-canvas-remote-command/1401-review-iter1-rebuttals.md
+++ b/codev/projects/1401-artifact-canvas-remote-command/1401-review-iter1-rebuttals.md
@@ -2,32 +2,21 @@
 
 Verdicts: gemini APPROVE · claude APPROVE · codex REQUEST_CHANGES.
 
-Codex raised five items. Four are fixed. The fifth — a real security finding — is corrected in
-the documentation and escalated, because the honest fix is Tower-wide and patching one route
-would be theatre.
+Codex raised five items. Four are fixed here. The fifth is a Tower-wide concern outside this
+change's scope, verified and routed to the maintainers.
 
-## 1. (Security) Request trust on the command route
+## 1. Request handling on the command route
 
-**Accepted.** Codex is right, and I verified the finding independently before responding.
+**Accepted, and out of scope for this PR.** Codex raised a Tower-wide concern about how requests
+are handled. I verified it independently, and it is pre-existing rather than anything this
+channel introduces: addressing it properly is an architectural change with a client migration,
+and a partial measure applied to the newest route alone would not improve matters.
 
-Tower's existing request-trust boundary is weaker than my spec claimed. The specifics and the
-fix are tracked privately as a security advisory, so they are not restated here.
+The spec previously characterised Tower's request handling in terms it should not have; that
+wording is removed rather than restated, since this spec is not the place to describe
+Tower-wide behaviour it does not own.
 
-Two things follow, and both are settled:
-
-**The spec's claim is corrected.** It described a safeguard in terms that overstated what is
-actually in place. Documenting protection that is not there is worse than documenting none, so
-the wording was fixed in place.
-
-**The fix does not belong in this PR.** The property is pre-existing and Tower-wide rather than
-anything this channel introduces, and addressing it properly is an architectural change with a
-client migration — not a line in a builder's PR. Applying a partial measure to the newest route
-alone would move the label rather than the risk, and would leave an inconsistent model that is
-harder to reason about later than a known, tracked gap. What this PR adds is one more capability
-behind the existing boundary, and the spec now says exactly that.
-
-Escalated to the architect, who verified it independently and routed it to the owner for
-disclosure handling.
+Raised with the architect and routed to the maintainers, tracked separately from this PR.
 
 ## 2. The live VS Code end-to-end check is incomplete
 

--- a/codev/projects/1401-artifact-canvas-remote-command/1401-review-iter1-rebuttals.md
+++ b/codev/projects/1401-artifact-canvas-remote-command/1401-review-iter1-rebuttals.md
@@ -1,0 +1,66 @@
+# Review Phase (PR-level) — Iteration 1 Rebuttals
+
+Verdicts: gemini APPROVE · claude APPROVE · codex REQUEST_CHANGES.
+
+Codex raised five items. Four are fixed. The fifth — a real security finding — is corrected in
+the documentation and escalated, because the honest fix is Tower-wide and patching one route
+would be theatre.
+
+## 1. (Security) Request trust on the command route
+
+**Accepted.** Codex is right, and I verified the finding independently before responding.
+
+Tower's existing request-trust boundary is weaker than my spec claimed. The specifics and the
+fix are tracked privately as a security advisory, so they are not restated here.
+
+Two things follow, and both are settled:
+
+**The spec's claim is corrected.** It described a safeguard in terms that overstated what is
+actually in place. Documenting protection that is not there is worse than documenting none, so
+the wording was fixed in place.
+
+**The fix does not belong in this PR.** The property is pre-existing and Tower-wide rather than
+anything this channel introduces, and addressing it properly is an architectural change with a
+client migration — not a line in a builder's PR. Applying a partial measure to the newest route
+alone would move the label rather than the risk, and would leave an inconsistent model that is
+harder to reason about later than a known, tracked gap. What this PR adds is one more capability
+behind the existing boundary, and the spec now says exactly that.
+
+Escalated to the architect, who verified it independently and routed it to the owner for
+disclosure handling.
+
+## 2. The live VS Code end-to-end check is incomplete
+
+Unchanged and unclosable by a builder; see the phase 6 iteration-3 rebuttal. It is the PR's
+stated blocking human check, front and centre in the body with a four-step script, and both other
+reviewers describe the escalation as correct.
+
+## 3. The branch is 9 commits behind `main`
+
+**Fixed.** Rebased onto `origin/main` (70 commits replayed cleanly, no conflicts) and
+force-pushed with lease. The branch is now 0 behind, and the full suite was re-run against the
+merged state: build green, 4847 tests pass, repo-wide `check-types` clean. CI re-triggered on the
+new head.
+
+## 4. Spec and plan lack `approved` / `validated` frontmatter
+
+**Fixed.** Both now carry the convention used by sibling artifacts (e.g. spec 1380):
+`approved: 2026-08-11` with `validated: [gemini, codex, claude]`, matching the actual human gate
+dates and the three consultation lanes that ran.
+
+## 5. `webview/main.ts` claims it is excluded from type-checking
+
+**Fixed, and this one is the root of an error I propagated.** The file's own header said it was
+"intentionally excluded from the extension's `tsc` typecheck". That is half true — it is excluded
+from the *host* `tsconfig.json` — but `tsconfig.webview.json` checks it and `check-types` runs
+both configs.
+
+I read that comment early on and repeated its implication in the plan, in a phase 3 rebuttal, and
+in the review draft, each time overstating why the manual pass matters. A reviewer caught the
+claim in phase 6; this finding caught the source. The comment now states both halves explicitly,
+so the next reader does not inherit the same wrong conclusion.
+
+## Gemini, Claude (APPROVE)
+
+No blocking concerns. Claude's summary notes merge is conditional on the escalated live pass,
+which matches the PR body.

--- a/codev/projects/1401-artifact-canvas-remote-command/1401-specify-iter1-rebuttals.md
+++ b/codev/projects/1401-artifact-canvas-remote-command/1401-specify-iter1-rebuttals.md
@@ -1,0 +1,86 @@
+# Spec 1401 — Iteration 1 Rebuttals
+
+Verdicts: gemini APPROVE · codex REQUEST_CHANGES · claude REQUEST_CHANGES.
+All REQUEST_CHANGES points were accepted and folded into the spec (commit `dde480550`),
+alongside the streamdeck architect's design-review deltas (APPROVE with changes, issue #1401
+comment). Nothing is contested; per-point disposition below.
+
+## Claude (REQUEST_CHANGES)
+
+**1. (Blocking) Remote commands have no `e.target`; literal keyboard parity makes 8/14
+commands no-ops.** Accepted — this was the spec's central defect. The semantics rule is
+rewritten from "behaves exactly as its keyboard equivalent" to **effect parity with a
+defined remote origin**: relative navigation and `composer-open` operate on a *current
+block* (most recently focused block by any modality, falling back to the topmost visible
+block, i.e. the first block in an unscrolled document), so every command is well-defined on
+a freshly opened view. The spec also now states that remote navigation moves within-document
+focus via the same focus path (ring + scroll-into-view), that host-surface focus acquisition
+is host policy (no cross-surface focus stealing), and that `composer-submit`/`cancel` are
+view-scoped, not focus-scoped. New success criterion + test scenario 3 cover the clean-state
+origin.
+
+**2. (Blocking) `block-next`/`block-prev` cannot be native-Tab parity.** Accepted.
+Redefined as flow-order `[data-line]` block stepping, explicitly *not* Tab parity (Tab also
+visits affordances, card actions, toolbar, links). No Tab interception — the
+no-keyboard-change constraint and the untouched keyboard tests stand. `reading-mode-toggle`
+is now defined against its toolbar-button equivalent. Success criterion 1 reworded to "the
+effect defined in the command table" with the 12-keyed / 2-equivalent split.
+
+**3. `viewId` caller-visible but unusable.** Accepted. Now specified: Tower-minted at
+registration, opaque, stable for the registration's lifetime, returned for observability
+(it is what distinguishes two same-file views in results); not a selector today, admitting
+it as one is a named additive follow-up.
+
+**4. `file` matching normalization.** Accepted. Tower canonicalizes paths on both
+registration and command (same resolution as the existing file-tab dedupe); scenario 6 now
+asserts spelling variance cannot split the registry.
+
+**5. `lastActiveAt` clock ownership.** Accepted. Tower stamps receipt time for activity
+reports and command delivery; host clocks are never trusted. (Delivery advancing MRU was
+also explicitly endorsed by the streamdeck review.)
+
+**6. Security section.** Accepted. Added a security-posture paragraph: route inherits
+Tower's existing trust boundary (localhost + host/origin gate; BRIDGE_MODE exposure noted);
+`workspace`/`file` are registry lookup keys never dereferenced as filesystem paths; command
+payload validated against the closed union; the composer-submit-triggers-a-file-write
+consequence is stated explicitly (write path itself unchanged, host-side); Tower-minted
+`viewId` prevents identity claims across registrants.
+
+**7. Ranking nit (`canvas-*` verbs question marked Important, self-describes as
+blocking).** Overtaken by events: the streamdeck design review closed the question as
+**NO — targeted route only**. It is removed from Open Questions and recorded as a closed
+decision so it is not reopened.
+
+## Codex (REQUEST_CHANGES)
+
+**1. Resolve the Stream Deck surface question before approval.** Done — the streamdeck
+architect reviewed the sdk surface at design time and APPROVED with deltas, all folded in:
+optional `count` (default 1) on the eight traversal/paging commands only (rejected as
+`invalid-request` elsewhere), closed failure-code union, generic-relay exposure closed as
+NO, presence query recorded as a named non-goal with an additive path.
+
+**2. Exact HTTP status/body behavior and sdk normalization; open-ended `…` in the result
+union.** Accepted. Error contract is now explicit: failure codes are a **closed exported
+union in codev-types** (`CanvasCommandErrorCode = 'no-canvas' | 'invalid-request'`),
+`no-canvas` → 404, `invalid-request` → 400, body always `{ok:false, code, error}`. The spec
+fixes the observable sdk contract — the machine-readable `code` must survive to the caller
+(the noted `request()` flattening is acknowledged; how the implementation composes with it
+is plan detail, the contract is not).
+
+**3. Command parity not always "exactly" equivalent (Tab traverses controls;
+Escape/submit applicability focus-dependent).** Accepted — same substance as Claude's two
+blocking points; resolved by the effect-parity rewrite, the non-Tab definition of
+`block-*`, and view-scoped composer commands.
+
+**4. Canonical workspace/file matching and server-authoritative MRU timestamps.**
+Accepted — Tower canonicalization + Tower-stamped `lastActiveAt`, as above.
+
+**5. Security requirements for registration and mutation.** Accepted — security paragraph
+as above: Tower-minted view ids (uniqueness/ownership), registration/activity under the
+same Tower auth as every route, runtime validation against the closed union, trust boundary
+stated. Request-size limits are left to the plan as transport mechanics; the closed union
+plus `invalid-request` give the behavioral contract.
+
+## Gemini (APPROVE)
+
+No issues raised; no changes required.

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -36,7 +36,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -167,7 +167,7 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter3-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T23:48:04.915Z'
+updated_at: '2026-08-11T23:51:33.691Z'
 pr_history:
   - phase: implement
     pr_number: 1413

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -35,8 +35,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 1
-build_complete: true
+iteration: 2
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -102,5 +102,21 @@ history:
         verdict: REQUEST_CHANGES
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_4-iter1-claude.txt
+  - iteration: 1
+    plan_phase: phase_5
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_5-iter1-gemini.txt
+      - model: codex
+        verdict: REQUEST_CHANGES
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_5-iter1-codex.txt
+      - model: claude
+        verdict: APPROVE
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_5-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T23:04:45.206Z'
+updated_at: '2026-08-11T23:10:23.455Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   spec-approval:
-    status: pending
+    status: approved
     requested_at: '2026-08-11T11:16:29.331Z'
+    approved_at: '2026-08-11T11:27:04.259Z'
   plan-approval:
     status: pending
   pr:
@@ -18,4 +19,4 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T11:16:29.332Z'
+updated_at: '2026-08-11T11:27:04.259Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -36,7 +36,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T11:52:37.964Z'
+updated_at: '2026-08-11T11:59:12.900Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -36,7 +36,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 2
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -55,4 +55,4 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_1-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T18:58:21.191Z'
+updated_at: '2026-08-11T20:04:46.669Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -36,7 +36,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -119,4 +119,4 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_5-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T23:13:25.293Z'
+updated_at: '2026-08-11T23:18:32.074Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -36,7 +36,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 2
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -135,4 +135,4 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T23:29:27.159Z'
+updated_at: '2026-08-11T23:30:13.949Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -16,7 +16,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T11:27:38.151Z'
+updated_at: '2026-08-11T11:32:29.208Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -36,7 +36,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 3
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -151,4 +151,4 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter2-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T23:38:03.408Z'
+updated_at: '2026-08-11T23:38:50.475Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -36,7 +36,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -103,4 +103,4 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_4-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T23:00:28.289Z'
+updated_at: '2026-08-11T23:04:45.206Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -36,7 +36,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -87,4 +87,4 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_3-iter2-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T22:38:16.183Z'
+updated_at: '2026-08-11T22:46:40.932Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -11,6 +11,7 @@ gates:
     approved_at: '2026-08-11T11:27:04.259Z'
   plan-approval:
     status: pending
+    requested_at: '2026-08-11T11:41:09.935Z'
   pr:
     status: pending
   verify-approval:
@@ -19,4 +20,4 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T11:32:29.208Z'
+updated_at: '2026-08-11T11:41:09.935Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -35,8 +35,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 2
-build_complete: true
+iteration: 3
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -134,5 +134,21 @@ history:
         verdict: COMMENT
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter1-claude.txt
+  - iteration: 2
+    plan_phase: phase_6
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter2-gemini.txt
+      - model: codex
+        verdict: REQUEST_CHANGES
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter2-codex.txt
+      - model: claude
+        verdict: APPROVE
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter2-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T23:30:13.949Z'
+updated_at: '2026-08-11T23:38:03.408Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -11,17 +11,17 @@ plan_phases:
     status: complete
   - id: phase_3
     title: Canvas remote command seam
-    status: in_progress
+    status: complete
   - id: phase_4
     title: Tower canvas view registry and command route
-    status: pending
+    status: in_progress
   - id: phase_5
     title: sdk canvas command and view registration calls
     status: pending
   - id: phase_6
     title: VS Code host wiring and end-to-end review loop
     status: pending
-current_plan_phase: phase_3
+current_plan_phase: phase_4
 gates:
   spec-approval:
     status: approved
@@ -35,8 +35,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 3
-build_complete: true
+iteration: 1
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -87,4 +87,4 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_3-iter2-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T22:35:19.119Z'
+updated_at: '2026-08-11T22:38:16.183Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -1,7 +1,7 @@
 id: '1401'
 title: artifact-canvas-remote-command
 protocol: spir
-phase: specify
+phase: plan
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -16,7 +16,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T11:27:04.259Z'
+updated_at: '2026-08-11T11:27:38.151Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -36,7 +36,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 2
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -103,4 +103,4 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_4-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T22:56:08.133Z'
+updated_at: '2026-08-11T22:56:57.040Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -35,8 +35,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 2
-build_complete: true
+iteration: 3
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -70,5 +70,21 @@ history:
         verdict: REQUEST_CHANGES
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_3-iter1-claude.txt
+  - iteration: 2
+    plan_phase: phase_3
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_3-iter2-gemini.txt
+      - model: codex
+        verdict: REQUEST_CHANGES
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_3-iter2-codex.txt
+      - model: claude
+        verdict: REQUEST_CHANGES
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_3-iter2-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T22:19:50.342Z'
+updated_at: '2026-08-11T22:34:14.936Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -1,0 +1,20 @@
+id: '1401'
+title: artifact-canvas-remote-command
+protocol: spir
+phase: specify
+plan_phases: []
+current_plan_phase: null
+gates:
+  spec-approval:
+    status: pending
+  plan-approval:
+    status: pending
+  pr:
+    status: pending
+  verify-approval:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-11T10:57:41.092Z'
+updated_at: '2026-08-11T10:57:41.093Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -32,7 +32,8 @@ gates:
     requested_at: '2026-08-11T11:41:09.935Z'
     approved_at: '2026-08-11T11:52:27.580Z'
   pr:
-    status: pending
+    status: approved
+    approved_at: '2026-08-12T01:40:49.456Z'
   verify-approval:
     status: pending
 iteration: 1
@@ -167,7 +168,7 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter3-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T23:51:33.691Z'
+updated_at: '2026-08-12T01:40:49.457Z'
 pr_history:
   - phase: implement
     pr_number: 1413
@@ -179,3 +180,4 @@ force_advanced:
   max_iterations: 3
   rebuttal_file: 1401-phase_6-iter3-rebuttals.md
   at: '2026-08-11T23:48:03.147Z'
+pr_ready_for_human: false

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -10,8 +10,9 @@ gates:
     requested_at: '2026-08-11T11:16:29.331Z'
     approved_at: '2026-08-11T11:27:04.259Z'
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-08-11T11:41:09.935Z'
+    approved_at: '2026-08-11T11:52:27.580Z'
   pr:
     status: pending
   verify-approval:
@@ -20,4 +21,4 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T11:41:09.935Z'
+updated_at: '2026-08-11T11:52:27.580Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   spec-approval:
     status: pending
+    requested_at: '2026-08-11T11:16:29.331Z'
   plan-approval:
     status: pending
   pr:
@@ -17,4 +18,4 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T11:08:59.231Z'
+updated_at: '2026-08-11T11:16:29.332Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -36,7 +36,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 2
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -71,4 +71,4 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_3-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T22:18:56.022Z'
+updated_at: '2026-08-11T22:19:50.342Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -36,7 +36,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -55,4 +55,4 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_1-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T20:18:56.042Z'
+updated_at: '2026-08-11T20:47:44.731Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -35,8 +35,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 1
-build_complete: true
+iteration: 2
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -86,5 +86,21 @@ history:
         verdict: REQUEST_CHANGES
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_3-iter2-claude.txt
+  - iteration: 1
+    plan_phase: phase_4
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_4-iter1-gemini.txt
+      - model: codex
+        verdict: REQUEST_CHANGES
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_4-iter1-codex.txt
+      - model: claude
+        verdict: REQUEST_CHANGES
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_4-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T22:46:40.932Z'
+updated_at: '2026-08-11T22:56:08.133Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -1,9 +1,27 @@
 id: '1401'
 title: artifact-canvas-remote-command
 protocol: spir
-phase: plan
-plan_phases: []
-current_plan_phase: null
+phase: implement
+plan_phases:
+  - id: phase_1
+    title: Command vocabulary wire contracts
+    status: in_progress
+  - id: phase_2
+    title: Canvas action registry extraction
+    status: pending
+  - id: phase_3
+    title: Canvas remote command seam
+    status: pending
+  - id: phase_4
+    title: Tower canvas view registry and command route
+    status: pending
+  - id: phase_5
+    title: sdk canvas command and view registration calls
+    status: pending
+  - id: phase_6
+    title: VS Code host wiring and end-to-end review loop
+    status: pending
+current_plan_phase: phase_1
 gates:
   spec-approval:
     status: approved
@@ -18,7 +36,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T11:52:27.580Z'
+updated_at: '2026-08-11T11:52:37.964Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -35,8 +35,24 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 1
-build_complete: true
-history: []
+iteration: 2
+build_complete: false
+history:
+  - iteration: 1
+    plan_phase: phase_1
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_1-iter1-gemini.txt
+      - model: codex
+        verdict: APPROVE
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_1-iter1-codex.txt
+      - model: claude
+        verdict: REQUEST_CHANGES
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_1-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T11:59:12.900Z'
+updated_at: '2026-08-11T18:58:21.191Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -35,8 +35,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 1
-build_complete: true
+iteration: 2
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -54,5 +54,21 @@ history:
         verdict: REQUEST_CHANGES
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_1-iter1-claude.txt
+  - iteration: 1
+    plan_phase: phase_3
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_3-iter1-gemini.txt
+      - model: codex
+        verdict: REQUEST_CHANGES
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_3-iter1-codex.txt
+      - model: claude
+        verdict: REQUEST_CHANGES
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_3-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T20:47:44.731Z'
+updated_at: '2026-08-11T22:18:56.022Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -150,10 +150,32 @@ history:
         verdict: APPROVE
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter2-claude.txt
+  - iteration: 3
+    plan_phase: phase_6
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter3-gemini.txt
+      - model: codex
+        verdict: REQUEST_CHANGES
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter3-codex.txt
+      - model: claude
+        verdict: APPROVE
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter3-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T23:45:31.074Z'
+updated_at: '2026-08-11T23:48:03.147Z'
 pr_history:
   - phase: implement
     pr_number: 1413
     branch: builder/spir-1401
     created_at: '2026-08-11T23:45:31.073Z'
+force_advanced:
+  phase: phase_6
+  iteration: 3
+  max_iterations: 3
+  rebuttal_file: 1401-phase_6-iter3-rebuttals.md
+  at: '2026-08-11T23:48:03.147Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -17,11 +17,11 @@ plan_phases:
     status: complete
   - id: phase_5
     title: sdk canvas command and view registration calls
-    status: in_progress
+    status: complete
   - id: phase_6
     title: VS Code host wiring and end-to-end review loop
-    status: pending
-current_plan_phase: phase_5
+    status: in_progress
+current_plan_phase: phase_6
 gates:
   spec-approval:
     status: approved
@@ -35,8 +35,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 2
-build_complete: true
+iteration: 1
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -119,4 +119,4 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_5-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T23:11:09.326Z'
+updated_at: '2026-08-11T23:13:25.293Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -14,14 +14,14 @@ plan_phases:
     status: complete
   - id: phase_4
     title: Tower canvas view registry and command route
-    status: in_progress
+    status: complete
   - id: phase_5
     title: sdk canvas command and view registration calls
-    status: pending
+    status: in_progress
   - id: phase_6
     title: VS Code host wiring and end-to-end review loop
     status: pending
-current_plan_phase: phase_4
+current_plan_phase: phase_5
 gates:
   spec-approval:
     status: approved
@@ -35,8 +35,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 2
-build_complete: true
+iteration: 1
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -103,4 +103,4 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_4-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T22:56:57.040Z'
+updated_at: '2026-08-11T23:00:28.289Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -151,4 +151,9 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter2-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T23:38:50.475Z'
+updated_at: '2026-08-11T23:45:31.074Z'
+pr_history:
+  - phase: implement
+    pr_number: 1413
+    branch: builder/spir-1401
+    created_at: '2026-08-11T23:45:31.073Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -35,8 +35,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 1
-build_complete: true
+iteration: 2
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -118,5 +118,21 @@ history:
         verdict: APPROVE
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_5-iter1-claude.txt
+  - iteration: 1
+    plan_phase: phase_6
+    build_output: ''
+    reviews:
+      - model: gemini
+        verdict: APPROVE
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter1-gemini.txt
+      - model: codex
+        verdict: REQUEST_CHANGES
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter1-codex.txt
+      - model: claude
+        verdict: COMMENT
+        file: >-
+          /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T23:18:32.074Z'
+updated_at: '2026-08-11T23:29:27.159Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -36,7 +36,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 2
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -119,4 +119,4 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_5-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T23:10:23.455Z'
+updated_at: '2026-08-11T23:11:09.326Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -8,10 +8,10 @@ plan_phases:
     status: complete
   - id: phase_2
     title: Canvas action registry extraction
-    status: in_progress
+    status: complete
   - id: phase_3
     title: Canvas remote command seam
-    status: pending
+    status: in_progress
   - id: phase_4
     title: Tower canvas view registry and command route
     status: pending
@@ -21,7 +21,7 @@ plan_phases:
   - id: phase_6
     title: VS Code host wiring and end-to-end review loop
     status: pending
-current_plan_phase: phase_2
+current_plan_phase: phase_3
 gates:
   spec-approval:
     status: approved
@@ -36,7 +36,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: true
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -55,4 +55,4 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_1-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T20:15:08.102Z'
+updated_at: '2026-08-11T20:18:56.042Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -1,7 +1,7 @@
 id: '1401'
 title: artifact-canvas-remote-command
 protocol: spir
-phase: implement
+phase: review
 plan_phases:
   - id: phase_1
     title: Command vocabulary wire contracts
@@ -20,8 +20,8 @@ plan_phases:
     status: complete
   - id: phase_6
     title: VS Code host wiring and end-to-end review loop
-    status: in_progress
-current_plan_phase: phase_6
+    status: complete
+current_plan_phase: null
 gates:
   spec-approval:
     status: approved
@@ -35,8 +35,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 3
-build_complete: true
+iteration: 1
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -167,7 +167,7 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter3-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T23:48:03.147Z'
+updated_at: '2026-08-11T23:48:04.915Z'
 pr_history:
   - phase: implement
     pr_number: 1413

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -36,7 +36,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 3
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -87,4 +87,4 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_3-iter2-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T22:34:14.936Z'
+updated_at: '2026-08-11T22:35:19.119Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -14,7 +14,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T10:57:41.093Z'
+updated_at: '2026-08-11T11:08:59.231Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -5,10 +5,10 @@ phase: implement
 plan_phases:
   - id: phase_1
     title: Command vocabulary wire contracts
-    status: in_progress
+    status: complete
   - id: phase_2
     title: Canvas action registry extraction
-    status: pending
+    status: in_progress
   - id: phase_3
     title: Canvas remote command seam
     status: pending
@@ -21,7 +21,7 @@ plan_phases:
   - id: phase_6
     title: VS Code host wiring and end-to-end review loop
     status: pending
-current_plan_phase: phase_1
+current_plan_phase: phase_2
 gates:
   spec-approval:
     status: approved
@@ -35,8 +35,8 @@ gates:
     status: pending
   verify-approval:
     status: pending
-iteration: 2
-build_complete: true
+iteration: 1
+build_complete: false
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -55,4 +55,4 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_1-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T20:04:46.669Z'
+updated_at: '2026-08-11T20:06:50.480Z'

--- a/codev/projects/1401-artifact-canvas-remote-command/status.yaml
+++ b/codev/projects/1401-artifact-canvas-remote-command/status.yaml
@@ -36,7 +36,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_1
@@ -55,4 +55,4 @@ history:
         file: >-
           /Users/amrmohamed/repos/cluesmith/codev/.builders/spir-1401/codev/projects/1401-artifact-canvas-remote-command/1401-phase_1-iter1-claude.txt
 started_at: '2026-08-11T10:57:41.092Z'
-updated_at: '2026-08-11T20:06:50.480Z'
+updated_at: '2026-08-11T20:15:08.102Z'

--- a/codev/resources/arch.md
+++ b/codev/resources/arch.md
@@ -1997,6 +1997,34 @@ All interactions with the repository hosting platform (GitHub by default) are ro
 
 **Environment variables**: Each concept receives `CODEV_*` env vars (e.g., `CODEV_ISSUE_NUMBER`, `CODEV_PR_NUMBER`) that the command uses to parameterize its output.
 
+### Two remote-command paths into an editor surface (Spec 1401)
+
+Tower has **two** ways for an external controller to drive an editor, and picking the wrong one
+is the mistake this note exists to prevent.
+
+| | `/api/command` (Spec 1189) | `/api/canvas/*` (Spec 1401) |
+|---|---|---|
+| Shape | Broadcast a canonical **verb** to every SSE subscriber | Resolve **one** registered canvas view and address it |
+| Answer | `{ok:true}` unconditionally, even with no provider listening | The resolved target, or `no-canvas` (404) / `invalid-request` (400) |
+| State | Stateless relay | In-memory registry of live views, heartbeat lease |
+| Use it when | Any provider may act; nobody needs to hear whether one did | The caller must know a target existed, or several could match |
+
+**Rule:** if a new remote feature needs to report that nothing was there to receive it, or to
+choose among several candidate surfaces, it belongs on the canvas-style path — the broadcast
+relay cannot express either, and bolting a reply onto it would change its contract for every
+existing verb.
+
+**Canvas channel specifics.** `packages/codev/src/agent-farm/servers/canvas-relay.ts` owns the
+route family; hosts register per **view** (a panel, not a document), heartbeat a lease, and
+filter the broadcast SSE by their Tower-minted `viewId`. Liveness and recency are tracked
+separately: any heartbeat extends the lease, but only focus or a delivered command advances the
+most-recently-active stamp used for targeting. Command delivery deliberately does **not** extend
+the lease — delivery is fire-and-forget and proves nothing about the host still being alive.
+
+The command vocabulary lives in `@cluesmith/codev-types` (`canvas-command.ts`) as a closed union;
+Tower, the sdk and the canvas package each keep a local `satisfies`-bound copy of any runtime list
+because codev-types is type-only for all three.
+
 ### Internal Dependencies
 - **Git**: Version control, worktrees for builder isolation
 - **Node.js**: Runtime for agent-farm TypeScript CLI

--- a/codev/resources/lessons-learned.md
+++ b/codev/resources/lessons-learned.md
@@ -257,6 +257,20 @@ Generalizable wisdom extracted from review documents, ordered by impact. Updated
 
 ## Testing
 
+- [From #1401] **A guard is not a guard until you have watched it fail.** Two variants bit in one
+  project. (a) A compile-time exhaustiveness check written as a bare conditional type alias
+  (`type _X = Cond extends never ? true : never`) constrains nothing — an omitted member resolves
+  to `never` and compiles happily. It must be a type that *fails to instantiate*:
+  `type Assert<T extends true> = T` wrapping a `… ? true : false`. I shipped the inert form,
+  had it caught, then reintroduced it two phases later under a comment claiming enforcement.
+  (b) The same project's type-test file lived outside `src/` so it would not be published, which
+  also meant `pnpm build` never compiled it and **no CI job invoked it** — it protected nothing
+  while looking like protection. Before trusting any guard, break the thing it guards and watch
+  the build go red; then check something in CI actually runs it.
+- [From #1401] Green signals can hide a red one. `check-types` was failing on a newly added
+  Playwright spec while the unit and browser suites both passed, because Playwright transpiles
+  per file with no project-wide type check. Run `check-types` after the last **file** is added,
+  not after the last logic change.
 - [From #1380] jsdom cannot express CSS layout (fragmentation, multicol, client rects) — for
   layout-dependent features, commit a real-browser (Playwright) fixture **alongside the first
   layout CSS**, and have it assert invariants (fragment-rect counts, reachability), not the

--- a/codev/reviews/1401-artifact-canvas-remote-command.md
+++ b/codev/reviews/1401-artifact-canvas-remote-command.md
@@ -107,7 +107,7 @@ architect authorization rather than worked around:
 | Tower relay e2e | 5 pass against a real booted Tower |
 | sdk | 98 pass, including 9 malformed-response cases |
 | streamdeck boundary | 63 pass, unchanged |
-| VS Code extension | 789 pass, including 12 new host-glue tests |
+| VS Code extension | 794 pass, including 17 new host-glue tests |
 | Repo | 4847 pass, build green, repo-wide `check-types` clean |
 
 **Human verification of the canvas half** (2026-08-12): the dev examples page was driven from the

--- a/codev/reviews/1401-artifact-canvas-remote-command.md
+++ b/codev/reviews/1401-artifact-canvas-remote-command.md
@@ -1,150 +1,184 @@
 # Review: Artifact-Canvas Remote Command Channel (Tower relay + sdk route)
 
-**Spec**: [codev/specs/1401-artifact-canvas-remote-command.md](../specs/1401-artifact-canvas-remote-command.md)
-**Plan**: [codev/plans/1401-artifact-canvas-remote-command.md](../plans/1401-artifact-canvas-remote-command.md)
-**Issue**: #1401 · **Branch**: `builder/spir-1401`
+**Spec**: [codev/specs/1401-artifact-canvas-remote-command.md](../specs/1401-artifact-canvas-remote-command.md) ·
+**Plan**: [codev/plans/1401-artifact-canvas-remote-command.md](../plans/1401-artifact-canvas-remote-command.md) ·
+**Issue**: #1401 · **PR**: #1413 · **Branch**: `builder/spir-1401`
 
-## What shipped
+## Summary
 
-A generic bridge that lets anything outside the canvas drive an open artifact-canvas view, built
-so the Stream Deck (#1400) is the first consumer rather than the only possible one.
+A generic remote-command channel for the artifact canvas, delivered in six phases: Tower keeps a
+registry of live canvas views, resolves exactly one target for a command, and answers explicitly
+when none is open. The Stream Deck (#1400) is the first consumer rather than the only possible
+one. 46 files, roughly +6000 lines; every layer green, with one human-only verification
+outstanding at the PR gate.
 
-| Layer | What it does |
-|---|---|
-| `codev-types` | The closed 14-command vocabulary, wire and client error unions, request/result/registry/event shapes, route and event names |
-| `artifact-canvas` | One named implementation per action, a `CommandAdapter` seam, and a focus-derived cursor giving remote commands a defined origin |
-| Tower | A registry of live canvas views plus a targeted `/api/canvas/*` route that resolves exactly one view and answers explicitly |
-| sdk | `sendCanvasCommand` on the controller subpath, and host-side register/heartbeat/unregister |
-| VS Code | Each canvas panel registers as a view, heartbeats, reports activity, and runs the commands addressed to it |
+## Spec Compliance
 
-53 commits, 46 files, roughly +5400 lines.
+- [x] AC1: All 14 commands produce their table-defined effect (Phase 3, verified by unit + Playwright)
+- [x] AC2: The remote origin is well-defined with no prior interaction — clean-state and scrolled-state both covered (Phase 3)
+- [x] AC3: No parallel vocabulary; keyboard and remote run the same per-action implementations (Phases 2-3)
+- [x] AC4: `count` multiplies the eight traversal commands and is rejected on the other six (Phases 3-4)
+- [x] AC5: Failure codes reach sdk callers as the closed union, never only prose (Phase 5)
+- [x] AC6: No matching view answers an explicit machine-readable `no-canvas` (Phase 4)
+- [x] AC7: Several matching views deliver to exactly one, most recently active, named in the response (Phase 4)
+- [x] AC8: File-qualified and file-less selectors route correctly (Phase 4)
+- [x] AC9: `composer-open` → typed body → `composer-submit` posts exactly one comment — **automated at the unit level (Phase 3); the live VS Code instance is the outstanding check below**
+- [x] AC10: The sdk call is available from `@cluesmith/codev-sdk/controller`; both boundary suites pass unchanged (Phase 5)
+- [x] AC11: In-page keyboard behavior unchanged — the pre-existing suite passes unmodified (Phase 2)
+- [x] AC12: Closing the last preview makes the next command return `no-canvas` (Phase 6, unit-verified; live pass outstanding)
 
-## Requirements traceability
+## Deviations from Plan
 
-| Issue requirement | Where it landed |
-|---|---|
-| 1. Canvas command channel over existing plumbing | `CommandAdapter` + delivery over Tower's existing SSE stream; no new transport |
-| 1a. Vocabulary mirrors the keyboard exactly | `Record<CanvasCommand, …>` registry; keyboard and remote run the same functions |
-| 1b. Composer open/submit/cancel in, text entry out | All three commands present; bodies are still typed on the keyboard |
-| 2. Tower surface accepting one command and relaying it | `POST /api/canvas/command`, addressed SSE delivery |
-| 3. sdk route, reviewed by the streamdeck architect | `sendCanvasCommand`, reviewed at design time and again at phase 5 |
-| 4. Target rule decided at spec time | Zero → `no-canvas` (404); many → single most-recently-active; never a silent no-op |
+- **Phase 2/3 split.** The plan's original phase 2 mixed a pure extraction with newly authored
+  actions. Since only 6 of 14 commands had a handler to extract, and the template requires one
+  atomic commit per phase, the phase was split so the extraction's "no behavior change" claim
+  could be proven by an unmodified test suite. Agreed during plan review, before implementation.
+- **Registration transport.** The plan left this open; per-view HTTP register/heartbeat/unregister
+  was chosen over binding registrations to the SSE connection, because one VS Code window holds a
+  single SSE connection but can host several canvas panels.
+- **Two spec/plan factual corrections**, both authorized rather than worked around: the spec's
+  "split editor" multi-view example was impossible under
+  `supportsMultipleEditorsPerDocument: false` (MRU requirement unchanged, verification venue moved
+  to the Tower registry), and the plan's claim that the webview has no `check-types` coverage was
+  wrong — `tsconfig.webview.json` covers it and the package script runs both configs.
 
-## What the reviews changed
+## Consultation Feedback
 
-Every phase went through a three-way consultation. Six findings were substantive enough to
-change the design rather than the wording, and they are the honest story of this project.
+Every phase ran a three-way consultation; several ran two or three rounds. Full per-round detail
+lives in `codev/projects/1401-*/1401-*-rebuttals.md`. Summarised by disposition:
 
-**A guard that could not fail (phase 1, then again in phase 3).** The exhaustiveness guard for
-the command vocabulary was written as a bare conditional type alias, which constrains nothing: an
-omitted member resolved to `never` and compiled. It was caught in phase 1, and I reintroduced the
-identical mistake in phase 3 while a comment claimed enforcement. Both are now
-`Assert<T extends true>` and both were verified by deliberately breaking them. A guard is not a
-guard until you have watched it fail.
+### Specify Phase (Round 1)
+- **Gemini**: No concerns → **N/A**
+- **Codex**: sdk error contract left open-ended (`…` in the union); parity not always literal; path/clock normalization unspecified; security posture absent → **Addressed** (closed error union, effect-parity rewrite, Tower-side canonicalization and timestamps, security paragraph)
+- **Claude**: (blocking) remote commands have no `e.target`, so literal parity would no-op 8 of 14 commands; `block-next/prev` cannot be Tab parity → **Addressed** (origin chain defined; block stepping defined against `[data-line]`, not Tab)
 
-**A test that never ran (phase 1).** The type-test guard lived outside `src/` so it would not be
-published, which also meant `pnpm build` never compiled it and no CI job invoked it. It protected
-nothing while looking like protection. Now wired into `test.yml`.
+### Plan Phase (Round 1)
+- **Gemini**: No concerns → **N/A**
+- **Codex**: runtime-vs-type-only classification; missing composer file; `supportsMultipleEditorsPerDocument: false`; reconnect undefined; canonicalization wording → **Addressed** (type-level classification; files added; scenario re-venued; re-registration specified)
+- **Claude**: (blocking) the shared runtime traversal list is unimportable by both consumers; "pure extraction" hid ~6 commands of new work; a type-test under `src/` would ship → **Addressed** (type-level with per-consumer `satisfies`; phase split; guard moved out of `src/`)
 
-**Literal keyboard parity would have been a no-op (spec phase).** The in-page handlers derive
-their origin from the DOM event, and a remote command has no event, so eight of fourteen commands
-would have done nothing in the feature's primary scenario. The spec was rewritten to *effect*
-parity with a defined origin: live focus, then the last focused block, then the topmost visible
-block, then the first block.
+### Phase 1 — Wire contracts (Rounds 1-2)
+- **Gemini / Codex**: APPROVE, no concerns → **N/A**
+- **Claude**: the exhaustiveness guard is never invoked by CI → **Addressed** (step added to `test.yml`; re-verified by the reviewer in round 2)
 
-**The lease renewed itself under traffic (phase 4).** Command delivery refreshed the liveness
-stamp as well as the recency stamp, so a dead host's view stayed alive exactly as long as a
-controller kept driving it. The guarantee the phase exists to provide silently inverted into
-"always reports success at a canvas nobody can see". Delivery now advances recency only.
+### Phase 2 — Action registry extraction (Round 1)
+- **Gemini**: lane skipped (`agy` produced no output) → **N/A** (`CONSULT_ERROR`-equivalent, non-blocking by design)
+- **Codex / Claude**: APPROVE. Three advisories for phase 3 (per-render registry needs ref dispatch; use `Extract<CanvasCommand,…>`; `pageColumn` edge untested) → **Addressed** in phase 3
 
-**A response shape accepted on faith (phase 5).** `sendCanvasCommand` checked only for an `ok`
-field, so a success without a target, or a failure with a code outside the union, passed through
-as a typed verdict. Now validated completely; anything unverifiable is reported as `unreachable`.
+### Phase 3 — Canvas remote seam (Rounds 1-3)
+- **Gemini**: APPROVE → **N/A**
+- **Codex**: column paging missing a mode check; counted traversal unbounded; coverage gaps → **Addressed** (mode check, progress-based break, browser suite driving the dev page). The stated vertical-mode scenario did not reproduce (`overflow-x` is mode-scoped) → **Rebutted** in part, with the guard kept as defence and the test rewritten to assert what is verifiable
+- **Claude**: (blocking) the drift guard is inert; unbounded `count` loop; quiet-focus not re-armed; `check-types` failing on the new spec → **Addressed** (all four; guard re-verified by deliberately breaking it)
 
-**`check-types` was red while everything I watched was green (phase 3).** I ran the typecheck
-before adding a Playwright spec, then re-ran only the unit and browser suites, which pass without
-project-wide type checking. The rule I now follow: run `check-types` after the last *file* is
-added, not after the last logic change.
+### Phase 4 — Tower registry and route (Rounds 1-2)
+- **Gemini**: APPROVE → **N/A**
+- **Codex / Claude**: (blocking) command delivery refreshed the liveness lease; a literal `null` body escaped as a 500 with no wire code; a malformed heartbeat renewed the lease; response literals untyped → **Addressed** (all four; the typing change exposed that the registration contract omitted `ok`)
 
-## Ground-truth corrections
+### Phase 5 — sdk calls (Rounds 1-2)
+- **Gemini / Claude**: APPROVE → **N/A**
+- **Codex**: (blocking) `sendCanvasCommand` accepted any object with `ok` → **Addressed** (full shape validation). Registration methods reachable via the exported class → **Rebutted**: the subpath exports `TowerClient` with 39 public methods; the three added here are no more reachable than the 36 that predate them. Streamdeck stakeholder accepted as-is; structural fix is #1411
 
-Two things the issue and spec assumed turned out to be false, and both were corrected with
-architect authorization rather than worked around:
+### Phase 6 — VS Code host wiring (Rounds 1-3)
+- **Gemini**: APPROVE → **N/A**
+- **Claude**: COMMENT then APPROVE. Re-registration race; deactivate-unregister missing; no reconnect handling; unvalidated command; lint warnings → **Addressed** (all five). Also corrected my own false premise about webview typechecking → **Addressed** (propagated to this document)
+- **Codex**: reconnect, runtime validation, malformed `count`, reconnect leaking the old id → **Addressed**. The live end-to-end pass → **Rebutted as unclosable by a builder**: it needs a real VS Code window, Tower, and an open panel driven by a person. Escalated to the PR gate with architect authorization (precedent: pir-1179, 1313 phase 7)
 
-- **`afx open` does not serve the canvas.** It serves the legacy `open.html` annotator; the canvas
-  migration is #1386. The bridge was therefore designed host-agnostic, and #1386's page becomes a
-  second registrant with no protocol change.
-- **VS Code cannot open two canvas panels for one document** (`supportsMultipleEditorsPerDocument:
-  false`), so the spec's "split editor" example was impossible. The MRU rule is unaffected and
-  still needed; only the verification venue moved to the Tower registry. The flag was deliberately
-  not flipped, since that would change user-visible editor behavior far outside this issue.
+## Lessons Learned
 
-## Dispositions for the PR gate
+### What Went Well
 
-- **Controller subpath exposure.** Codex asked that the new host-side registration methods be
-  unreachable through `@cluesmith/codev-sdk/controller`. They are not re-exported, but the subpath
-  exports the `TowerClient` class, which carries 39 public methods including `addArchitect`,
-  `killTerminal` and `sweepHusks`. The three added here are no more reachable than the
-  thirty-six that predate them, so this is a pre-existing property, not a regression.
-  **Streamdeck stakeholder verdict: accept as-is for #1401.** The structural fix is tracked as
-  **#1411** (restricted controller client), sequenced after this merge.
-- **The `file?` selector is not speculative.** #1400 was revised on 2026-08-11 to file-qualified
-  targeting: the deck will send both `workspace` and `file`, with MRU as the recorded fallback.
-  How the deck discovers the artifact path is a #1400 question.
-- **Playwright port collision (#1407).** The canvas browser config pins port 5199 and reuses any
-  existing server, so an orphaned vite process from a since-removed worktree silently served
-  deleted code to my first run. The orphan was cleared during this project and the suite now runs
-  against the committed config. The structural fix (per-worktree port) is #1407.
+The three-way consultation earned its cost. Six findings changed the design rather than the
+wording, and two of them — the self-renewing lease and the inert type guard — were defects that
+would have shipped looking correct.
 
-## Testing
+Splitting the canvas work into a pure extraction followed by new authorship made the
+"no behavior change" claim checkable by an untouched test suite, which is a much stronger
+guarantee than a careful diff read.
 
-| Suite | Result |
-|---|---|
-| `codev-types` compile-time guards | Pass, and verified to fail on an unclassified command |
-| artifact-canvas unit | 173 pass |
-| artifact-canvas Playwright | 39 pass, including 5 new remote-command specs |
-| Tower relay unit | 27 pass, lease expiry driven by an injected clock |
-| Tower relay e2e | 5 pass against a real booted Tower |
-| sdk | 98 pass, including 9 malformed-response cases |
-| streamdeck boundary | 63 pass, unchanged |
-| VS Code extension | 794 pass, including 17 new host-glue tests |
-| Repo | 4847 pass, build green, repo-wide `check-types` clean |
+Deciding the target rule at spec time, as the issue demanded, meant the multi-view and no-canvas
+cases were never open questions during implementation.
 
-**Human verification of the canvas half** (2026-08-12): the dev examples page was driven from the
-browser console through `window.__canvasCommand` and confirmed working by the user. Three things
-made it briefly look broken and are worth knowing: the call returns `undefined` because it is
-void, the only visible effect of navigation is the focus ring moving, and the sample document has
-exactly one commented block so a second `comment-next` is a correct no-op.
+### Challenges Encountered
 
-### Outstanding: the end-to-end VS Code pass
+**A non-convergent review loop.** Phase 6 ended 2-1 three rounds running, with the sole remaining
+objection being a check no code change can close. Escalating was correct, but it cost two extra
+consultation rounds to establish that the loop could not converge on its own.
 
-**This has not been performed, and it is the one criterion automation cannot cover here.** It
-needs a real VS Code window with the extension loaded, a running Tower, and an open canvas panel.
-Everything on either side of that seam is verified, but no automated test exercises the real
-extension registering with the real Tower and a real command reaching the real webview.
+**An hour lost to a wedged subprocess.** `porch next` appeared hung; it had spawned a `git push`
+that was itself stuck. Checking the parent said "still running" indefinitely; checking the *child*
+found it in one step.
 
-*Correction to the plan.* The plan's phase 6 test plan claims the webview has no `check-types`
-coverage, on the grounds that `apps/vscode/tsconfig.json` excludes
-`src/markdown-preview/webview`. That is wrong, and the phase 6 review caught it: a second config,
-`tsconfig.webview.json`, covers exactly that directory, and the package's `check-types` script
-runs both (`tsc --noEmit && tsc --noEmit -p tsconfig.webview.json`). The webview adapter *is*
-typechecked. The manual pass is still required, but for the ordinary reason — types do not prove
-runtime behavior across three processes — not because the code is unchecked.
+**Cross-worktree contamination.** The canvas Playwright suite reuses any server on port 5199, and
+an orphaned vite process from a since-removed worktree served deleted code to my first run. It
+failed loudly, which was lucky — the dangerous case is a compatible sibling making the suite pass
+against the wrong code.
 
-Suggested pass for the reviewer:
+### What Would Be Done Differently
 
-1. Open a spec in the Codev Markdown Preview with Tower running.
-2. `curl -X POST localhost:4100/api/canvas/command -H 'Content-Type: application/json' -d '{"workspace":"<abs path>","command":"comment-next"}'` and watch focus move.
-3. Close the panel, repeat, and confirm the response is `404 no-canvas` rather than a silent success.
-4. Drive `composer-open`, type a body on the keyboard, then `composer-submit`, and confirm exactly one comment is written.
+Prove a guard fails before trusting it, the first time. I wrote an inert exhaustiveness check,
+had it caught, and then wrote the identical inert form again two phases later underneath a comment
+asserting it worked.
+
+Run `check-types` after adding the last file rather than after the last logic change. A Playwright
+spec added post-typecheck left the criterion red while every suite I was watching stayed green.
+
+Check the keyboard equivalent before "fixing" a remote-path bug. Twice a failing new test looked
+like my regression and turned out to be long-standing behavior that the remote path was faithfully
+reproducing.
+
+### Methodology Improvements
+
+**Porch should recognise an unclosable finding.** When a reviewer's only remaining objection is a
+human-only verification, further rounds cannot change the verdict, and the loop currently relies
+on a human noticing and authorising a stop. A protocol-level "escalate to gate" disposition would
+make that path explicit instead of ad hoc.
+
+**Consultation prompts could ask for the reviewer's own verification method.** The most valuable
+findings this project came from reviewers who ran the code (probing the guard with `tsc`, running
+the CI step) rather than reading it. Asking for that explicitly would raise the floor.
+
+## Architecture Updates
+
+- Routed: **cold** — `codev/resources/arch.md`, Integration Points — "Two remote-command paths
+  into an editor surface (Spec 1401)": a comparison table of the broadcast verb relay versus the
+  targeted canvas channel, the rule for choosing between them, and the canvas channel's
+  registry/lease/liveness specifics.
+- **Not promoted to hot**, deliberately. `arch-critical.md` is at its 10-fact cap, and this is
+  subsystem detail a builder needs *when touching remote control*, not before every decision. The
+  hot map's existing "Integration Points — crossing a subsystem or process boundary" line already
+  routes a reader to it, so no displacement was warranted. Flagged for the architect in case they
+  judge the two-paths trap worth a hot slot at MAINTAIN.
+
+## Lessons Learned Updates
+
+- Routed: **cold** — `codev/resources/lessons-learned.md`, Testing — "A guard is not a guard until
+  you have watched it fail", covering both the inert conditional-type-alias form and the
+  guard-that-CI-never-runs variant, with the concrete fix.
+- Routed: **cold** — same section — green signals hiding a red one: run `check-types` after the
+  last file is added, not the last logic change.
+- **Hot candidate flagged, not taken unilaterally.** The guard lesson is cross-cutting and
+  behaviour-changing, which is hot-tier shape, but `lessons-critical.md` is at its 10-lesson cap
+  and promoting it requires demoting an existing entry. That displacement is the architect's call
+  at MAINTAIN, not a builder's mid-PR.
 
 ## Flaky Tests
 
-None encountered.
+No flaky tests encountered. One environmental failure is worth recording but is not flakiness:
+`pnpm --filter codev-vscode test` maps to `vscode-test` (the Electron harness), which fails in
+this worktree with `spawn Electron ENOENT`. It is pre-existing and unrelated; the unit tests run
+under `test:unit` → `vitest`, which is what CI invokes.
 
-## Follow-ups
+## Follow-up Items
 
-- **#1411** — restricted controller client / capability surface (streamdeck architect, after this merge).
+- **Outstanding at this PR gate — the live VS Code pass.** Needs a real VS Code window with the
+  extension loaded (built from this worktree), a running Tower, and an open canvas panel. Steps:
+  (1) drive `comment-next` by `curl` and watch focus move; (2) close the panel and confirm `404
+  no-canvas` rather than a silent success; (3) `block-next` with `count: 3`; (4) `composer-open`,
+  type a body, `composer-submit`, confirm **exactly one** comment written. Everything either side
+  of that seam is verified — Tower's route by 5 e2e tests against a real booted Tower, the canvas
+  by 173 unit and 39 Playwright tests plus a human dev-page session, the sdk by 98 tests, and the
+  host glue by 17 — so this closes the single untested join.
+- **#1411** — restricted controller client / capability surface (streamdeck architect, after merge).
 - **#1407** — per-worktree Playwright port for the canvas browser suite.
 - **#1400** — the deck actions themselves, unblocked by this bridge.
 - **#1386** — `afx open` onto the canvas; that page becomes a second registrant with no protocol change.

--- a/codev/reviews/1401-artifact-canvas-remote-command.md
+++ b/codev/reviews/1401-artifact-canvas-remote-command.md
@@ -1,0 +1,150 @@
+# Review: Artifact-Canvas Remote Command Channel (Tower relay + sdk route)
+
+**Spec**: [codev/specs/1401-artifact-canvas-remote-command.md](../specs/1401-artifact-canvas-remote-command.md)
+**Plan**: [codev/plans/1401-artifact-canvas-remote-command.md](../plans/1401-artifact-canvas-remote-command.md)
+**Issue**: #1401 · **Branch**: `builder/spir-1401`
+
+## What shipped
+
+A generic bridge that lets anything outside the canvas drive an open artifact-canvas view, built
+so the Stream Deck (#1400) is the first consumer rather than the only possible one.
+
+| Layer | What it does |
+|---|---|
+| `codev-types` | The closed 14-command vocabulary, wire and client error unions, request/result/registry/event shapes, route and event names |
+| `artifact-canvas` | One named implementation per action, a `CommandAdapter` seam, and a focus-derived cursor giving remote commands a defined origin |
+| Tower | A registry of live canvas views plus a targeted `/api/canvas/*` route that resolves exactly one view and answers explicitly |
+| sdk | `sendCanvasCommand` on the controller subpath, and host-side register/heartbeat/unregister |
+| VS Code | Each canvas panel registers as a view, heartbeats, reports activity, and runs the commands addressed to it |
+
+53 commits, 46 files, roughly +5400 lines.
+
+## Requirements traceability
+
+| Issue requirement | Where it landed |
+|---|---|
+| 1. Canvas command channel over existing plumbing | `CommandAdapter` + delivery over Tower's existing SSE stream; no new transport |
+| 1a. Vocabulary mirrors the keyboard exactly | `Record<CanvasCommand, …>` registry; keyboard and remote run the same functions |
+| 1b. Composer open/submit/cancel in, text entry out | All three commands present; bodies are still typed on the keyboard |
+| 2. Tower surface accepting one command and relaying it | `POST /api/canvas/command`, addressed SSE delivery |
+| 3. sdk route, reviewed by the streamdeck architect | `sendCanvasCommand`, reviewed at design time and again at phase 5 |
+| 4. Target rule decided at spec time | Zero → `no-canvas` (404); many → single most-recently-active; never a silent no-op |
+
+## What the reviews changed
+
+Every phase went through a three-way consultation. Six findings were substantive enough to
+change the design rather than the wording, and they are the honest story of this project.
+
+**A guard that could not fail (phase 1, then again in phase 3).** The exhaustiveness guard for
+the command vocabulary was written as a bare conditional type alias, which constrains nothing: an
+omitted member resolved to `never` and compiled. It was caught in phase 1, and I reintroduced the
+identical mistake in phase 3 while a comment claimed enforcement. Both are now
+`Assert<T extends true>` and both were verified by deliberately breaking them. A guard is not a
+guard until you have watched it fail.
+
+**A test that never ran (phase 1).** The type-test guard lived outside `src/` so it would not be
+published, which also meant `pnpm build` never compiled it and no CI job invoked it. It protected
+nothing while looking like protection. Now wired into `test.yml`.
+
+**Literal keyboard parity would have been a no-op (spec phase).** The in-page handlers derive
+their origin from the DOM event, and a remote command has no event, so eight of fourteen commands
+would have done nothing in the feature's primary scenario. The spec was rewritten to *effect*
+parity with a defined origin: live focus, then the last focused block, then the topmost visible
+block, then the first block.
+
+**The lease renewed itself under traffic (phase 4).** Command delivery refreshed the liveness
+stamp as well as the recency stamp, so a dead host's view stayed alive exactly as long as a
+controller kept driving it. The guarantee the phase exists to provide silently inverted into
+"always reports success at a canvas nobody can see". Delivery now advances recency only.
+
+**A response shape accepted on faith (phase 5).** `sendCanvasCommand` checked only for an `ok`
+field, so a success without a target, or a failure with a code outside the union, passed through
+as a typed verdict. Now validated completely; anything unverifiable is reported as `unreachable`.
+
+**`check-types` was red while everything I watched was green (phase 3).** I ran the typecheck
+before adding a Playwright spec, then re-ran only the unit and browser suites, which pass without
+project-wide type checking. The rule I now follow: run `check-types` after the last *file* is
+added, not after the last logic change.
+
+## Ground-truth corrections
+
+Two things the issue and spec assumed turned out to be false, and both were corrected with
+architect authorization rather than worked around:
+
+- **`afx open` does not serve the canvas.** It serves the legacy `open.html` annotator; the canvas
+  migration is #1386. The bridge was therefore designed host-agnostic, and #1386's page becomes a
+  second registrant with no protocol change.
+- **VS Code cannot open two canvas panels for one document** (`supportsMultipleEditorsPerDocument:
+  false`), so the spec's "split editor" example was impossible. The MRU rule is unaffected and
+  still needed; only the verification venue moved to the Tower registry. The flag was deliberately
+  not flipped, since that would change user-visible editor behavior far outside this issue.
+
+## Dispositions for the PR gate
+
+- **Controller subpath exposure.** Codex asked that the new host-side registration methods be
+  unreachable through `@cluesmith/codev-sdk/controller`. They are not re-exported, but the subpath
+  exports the `TowerClient` class, which carries 39 public methods including `addArchitect`,
+  `killTerminal` and `sweepHusks`. The three added here are no more reachable than the
+  thirty-six that predate them, so this is a pre-existing property, not a regression.
+  **Streamdeck stakeholder verdict: accept as-is for #1401.** The structural fix is tracked as
+  **#1411** (restricted controller client), sequenced after this merge.
+- **The `file?` selector is not speculative.** #1400 was revised on 2026-08-11 to file-qualified
+  targeting: the deck will send both `workspace` and `file`, with MRU as the recorded fallback.
+  How the deck discovers the artifact path is a #1400 question.
+- **Playwright port collision (#1407).** The canvas browser config pins port 5199 and reuses any
+  existing server, so an orphaned vite process from a since-removed worktree silently served
+  deleted code to my first run. The orphan was cleared during this project and the suite now runs
+  against the committed config. The structural fix (per-worktree port) is #1407.
+
+## Testing
+
+| Suite | Result |
+|---|---|
+| `codev-types` compile-time guards | Pass, and verified to fail on an unclassified command |
+| artifact-canvas unit | 173 pass |
+| artifact-canvas Playwright | 39 pass, including 5 new remote-command specs |
+| Tower relay unit | 27 pass, lease expiry driven by an injected clock |
+| Tower relay e2e | 5 pass against a real booted Tower |
+| sdk | 98 pass, including 9 malformed-response cases |
+| streamdeck boundary | 63 pass, unchanged |
+| VS Code extension | 789 pass, including 12 new host-glue tests |
+| Repo | 4847 pass, build green, repo-wide `check-types` clean |
+
+**Human verification of the canvas half** (2026-08-12): the dev examples page was driven from the
+browser console through `window.__canvasCommand` and confirmed working by the user. Three things
+made it briefly look broken and are worth knowing: the call returns `undefined` because it is
+void, the only visible effect of navigation is the focus ring moving, and the sample document has
+exactly one commented block so a second `comment-next` is a correct no-op.
+
+### Outstanding: the end-to-end VS Code pass
+
+**This has not been performed, and it is the one criterion automation cannot cover here.** It
+needs a real VS Code window with the extension loaded, a running Tower, and an open canvas panel.
+Everything on either side of that seam is verified, but no automated test exercises the real
+extension registering with the real Tower and a real command reaching the real webview.
+
+*Correction to the plan.* The plan's phase 6 test plan claims the webview has no `check-types`
+coverage, on the grounds that `apps/vscode/tsconfig.json` excludes
+`src/markdown-preview/webview`. That is wrong, and the phase 6 review caught it: a second config,
+`tsconfig.webview.json`, covers exactly that directory, and the package's `check-types` script
+runs both (`tsc --noEmit && tsc --noEmit -p tsconfig.webview.json`). The webview adapter *is*
+typechecked. The manual pass is still required, but for the ordinary reason — types do not prove
+runtime behavior across three processes — not because the code is unchecked.
+
+Suggested pass for the reviewer:
+
+1. Open a spec in the Codev Markdown Preview with Tower running.
+2. `curl -X POST localhost:4100/api/canvas/command -H 'Content-Type: application/json' -d '{"workspace":"<abs path>","command":"comment-next"}'` and watch focus move.
+3. Close the panel, repeat, and confirm the response is `404 no-canvas` rather than a silent success.
+4. Drive `composer-open`, type a body on the keyboard, then `composer-submit`, and confirm exactly one comment is written.
+
+## Flaky Tests
+
+None encountered.
+
+## Follow-ups
+
+- **#1411** — restricted controller client / capability surface (streamdeck architect, after this merge).
+- **#1407** — per-worktree Playwright port for the canvas browser suite.
+- **#1400** — the deck actions themselves, unblocked by this bridge.
+- **#1386** — `afx open` onto the canvas; that page becomes a second registrant with no protocol change.

--- a/codev/specs/1401-artifact-canvas-remote-command.md
+++ b/codev/specs/1401-artifact-canvas-remote-command.md
@@ -1,0 +1,352 @@
+# Specification: Artifact-Canvas Remote Command Channel (Tower relay + sdk route)
+
+<!--
+SPEC vs PLAN BOUNDARY:
+This spec defines WHAT and WHY. The plan defines HOW and WHEN.
+-->
+
+## Problem Statement
+
+The artifact canvas has a complete keyboard-first review vocabulary (#1237 / PR #1344,
+#1380 / PR #1398): step between blocks, jump between commented blocks and headings, go to
+document start/end, page columns in horizontal mode, open the comment composer on the focused
+block, submit or cancel it, and toggle reading mode. All of it is reachable only from the
+keyboard focused on the canvas itself.
+
+Nothing outside the page can drive that vocabulary. A remote controller — the Stream Deck
+(#1400), a test harness, an agent, or any future driver — has no way to tell an open canvas
+"next commented block" or "open the composer here". Issue #1400 (deck review-navigation
+actions) is blocked on exactly this bridge, and per the sequencing agreement it lands first,
+deck-free, so any remote driver of the viewer gets it for free.
+
+Affected parties: reviewers who want hardware-assisted review flow (#1400), the streamdeck
+architect as consumer and controller-surface stakeholder, and any future automation that wants
+to steer a review session.
+
+## Current State
+
+Ground truth (verified in-repo, 2026-08-11), including one correction to the issue's premise:
+
+- **The keyboard vocabulary exists but has no names.** Canvas keyboard handling is two inline
+  `e.key` handlers — `onBodyKeyDown` in
+  `packages/artifact-canvas/src/components/ArtifactCanvas.tsx` (navigation, composer-open,
+  help) and the composer's own `onKeyDown` in `src/overlays/CommentComposer.tsx`
+  (submit/cancel). There is no action enum, no dispatch table, no action-name strings; the
+  only place actions are named is the `?` help legend's display labels. "Focus next/previous
+  block" is not even a handler — it is native Tab/Shift+Tab over blocks stamped
+  `tabindex="0"` at render time. "Toggle reading mode" has no key at all; it is a toolbar
+  button (`ReadingModeToggle.tsx`).
+- **The canvas page holds no network channel.** The package's only production host is the
+  VS Code webview (`apps/vscode/src/markdown-preview/`), fed by extension-side
+  `postMessage({type:'update', …})`; `FileAdapter.watch` is a no-op there and refresh rides
+  the `refreshKey` prop. The Tower-served `afx open` page is **not** the canvas today — it is
+  the bespoke `templates/open.html` annotator (vendored `marked`, 1-second mtime polling).
+  Migrating it onto the canvas is separately tracked as #1386. So "the live-update channel
+  the page already holds" is, concretely: the webview's postMessage channel to the extension
+  host, which in turn holds an SSE connection to Tower (`apps/vscode/src/sse-client.ts`).
+- **Tower's push channel is broadcast-only SSE with no page identity.** `GET /api/events`
+  fans every event to every client; the client registry is a flat array keyed by random id —
+  no workspace, file, or page type per connection. Addressing is done client-side by
+  filtering (e.g. the VS Code command relay drops events for other workspaces and requires
+  window focus).
+- **A generic remote-command relay already exists end-to-end.** `POST /api/command`
+  (`CommandRequest {verb, args?, workspace?}` in `packages/types/src/command.ts`) →
+  Tower broadcasts an SSE `command` event → `apps/vscode/src/command-relay.ts` filters by
+  workspace + window focus and executes via a verb→VS Code-command allowlist
+  (`view-diff`, `diff-next-hunk`, `scroll`, …). It is fire-and-forget: Tower answers
+  `{ok:true}` whether or not any provider exists, and its own header comment flags provider
+  addressing as a deliberate later addition.
+- **The sdk side.** `TowerClient` (`packages/sdk/src/tower-client.ts`) has one method per
+  Tower call, all through a common `request()` with injected fetch/auth. The curated
+  controller surface is the `@cluesmith/codev-sdk/controller` subpath (`src/controller.ts`),
+  owned in review terms by the streamdeck architect (#1189 arrangement); the deck calls
+  `sendCommand(verb, args, workspace)` today. Hard constraints: sdk is environment-agnostic,
+  zero runtime deps, imports only `codev-types` as fully-erased `import type` — CI boundary
+  tests enforce all of this on both sides.
+- **Tower already knows which files are open as tabs** (`fileTabs`, deduped one tab per
+  path per workspace) but has no notion of which pages are *live* or focused.
+
+The pain: driving the review vocabulary remotely is impossible; the one existing relay can
+neither name a target view nor report that no target exists.
+
+## Desired State
+
+A generic, host-agnostic command bridge with three parts:
+
+### 1. Canvas command entry point (the package seam)
+
+The canvas package accepts remote commands through a new adapter interface alongside
+File/Marker/Theme — host-implemented, interface-only in the package, following the
+established D-series pattern:
+
+```ts
+/** Delivers remote review-navigation commands into the canvas. */
+export interface CommandAdapter {
+  /** Subscribe to inbound commands. Returns a Disposable synchronously. */
+  subscribe(onCommand: (command: CanvasCommand) => void): Disposable;
+}
+```
+
+`CanvasCommand` is a closed union naming the existing keyboard vocabulary — **exactly** the
+vocabulary, no parallel one. Canonical command set (14):
+
+| Command | Keyboard equivalent | Semantics |
+|---|---|---|
+| `block-next` / `block-prev` | Tab / Shift+Tab | Focus next/previous block in flow order |
+| `comment-next` / `comment-prev` | `n` / `p` | Focus next/previous commented block |
+| `heading-next` / `heading-prev` | `]` / `[` | Focus next/previous heading |
+| `doc-start` / `doc-end` | Home / End | Focus first/last block |
+| `column-forward` / `column-back` | PageDown / PageUp | Page one column (horizontal mode) |
+| `composer-open` | Enter / Space | Open composer on the focused block |
+| `composer-submit` | ⌘/Ctrl+Enter | Submit the open composer |
+| `composer-cancel` | Escape | Cancel the open composer |
+| `reading-mode-toggle` | (toolbar button) | Toggle vertical/horizontal reading mode |
+
+Semantics rule: **a command behaves exactly as its keyboard equivalent behaves today**, same
+guards, same edge behavior (no wrap-around at edges, column paging only meaningful in
+horizontal mode, composer-open requires a focused block, submit/cancel require an open
+composer). Where the equivalent would do nothing, the command does nothing — that is defined
+per-command applicability, not targeting ambiguity (Requirement 4 governs *targeting*, which
+is never silent; see §3). Text entry is out of scope: comment bodies are typed on the
+keyboard.
+
+Excluded from the set, deliberately: the `?` help legend (in-page discoverability chrome, not
+review navigation, and outside the issue's enumerated vocabulary) and card edit/delete
+(pointer-driven affordances, likewise outside it).
+
+Internally the package converges both input paths on one implementation: the inline key
+handlers and the adapter dispatch to the same per-action logic, so keyboard behavior cannot
+drift from remote behavior. In-page keyboard *behavior* does not change (non-goal).
+
+### 2. Tower surface: canvas view registry + command route
+
+Tower gains an authoritative registry of **live canvas views**: each open canvas view is
+registered by its host with `{viewId, workspace, file, lastActiveAt}`, kept fresh by the
+host (activity updates on focus), and removed on close or liveness expiry (lease/TTL — a
+dead host's views age out; exact transport is a plan decision).
+
+A new command endpoint accepts one command for a given target selector:
+
+```
+POST → { workspace, file?, command }   (selector: workspace required, file optional)
+```
+
+**Target rule (decided here, per Requirement 4 — never a silent ambiguous no-op):**
+
+1. Filter the registry to live views matching the selector (workspace, and file when given).
+2. **Zero matches → explicit error**: the route answers with a machine-readable
+   `no-canvas` error (the caller can render "no canvas open"). Never `{ok:true}`.
+3. **One match → deliver to it.**
+4. **Multiple matches → deliver to exactly one: the most recently active view**
+   (`lastActiveAt`; tie broken by most recent registration). Never broadcast to all
+   matches — `composer-submit` delivered to two views of the same file would double-post a
+   comment. MRU matches user intent ("the canvas I'm looking at") and gives the file-less
+   deck selector ("drive whatever I'm reviewing in this workspace") a well-defined answer.
+
+The success response names the resolved target (view id, file), so callers can verify what
+was driven. Delivery to the resolved view rides the existing SSE events channel as an
+addressed event (the target's host filters by its own view id — the established client-side
+filter pattern, made unambiguous by carrying the resolved `viewId` in the event). Delivery
+after resolution is best-effort (SSE has no ack); the explicit-answer guarantee covers
+target resolution.
+
+Hosts (VS Code extension now; the #1386 Tower-served page when it lands) are responsible for
+registering their canvas views, reporting activity, and forwarding delivered commands into
+the page's `CommandAdapter`. The bridge is host-agnostic by construction: any surface that
+can register a view and receive SSE gets remote drive for free.
+
+### 3. sdk route (streamdeck-architect review section)
+
+> This section is the design-time review surface for the streamdeck architect
+> (controller-subpath owner, #1189 arrangement).
+
+A new `TowerClient` method, re-exported through `@cluesmith/codev-sdk/controller`:
+
+```ts
+sendCanvasCommand(
+  command: CanvasCommand,
+  target: { workspace: string; file?: string }
+): Promise<CanvasCommandResult>
+// CanvasCommandResult: { ok: true, target: { viewId, file } }
+//                    | { ok: false, code: 'no-canvas' | …, error: string }
+```
+
+- Wire types (`CanvasCommand`, request/result shapes, route constant) live in
+  `codev-types`; the sdk imports them type-only and re-declares the route string literal,
+  matching the existing `COMMAND_ROUTE` pattern. Result types are re-exported as
+  `export type` from the controller subpath.
+- Distinct from `sendCommand` deliberately: the generic verb relay is fire-and-forget
+  broadcast; this call is targeted and reports resolution (`no-canvas` reaches the caller —
+  the deck can flash "no canvas open" on the key). Whether the canvas command set should
+  *additionally* be reachable as `canvas-*` verbs through the generic relay for controller
+  uniformity is explicitly deferred to this design review — the recommendation is no
+  (one path, one semantics).
+
+## Success Criteria
+
+- [ ] Every one of the 14 canonical commands, delivered remotely to an open canvas view,
+      produces exactly the effect of its keyboard equivalent (verified per command).
+- [ ] No parallel vocabulary exists: keyboard handlers and remote commands execute the same
+      per-action implementation in the package.
+- [ ] With no matching canvas view open, the Tower route and the sdk call return an explicit
+      machine-readable `no-canvas` error — observably not a success and not a silent no-op.
+- [ ] With two views open on the same file (e.g. split editor), a command is applied to
+      exactly one — the most recently active — and the response names it.
+- [ ] With views open on two different files in one workspace, a file-qualified command
+      reaches the view for that file; a file-less command reaches the most recently active.
+- [ ] `composer-open` → (human types) → `composer-submit` driven remotely posts exactly one
+      comment through the existing marker write path.
+- [ ] The sdk call is available from `@cluesmith/codev-sdk/controller`, and both existing
+      boundary-test suites (sdk import rules, streamdeck subpath rules) pass unchanged in CI.
+- [ ] In-page keyboard behavior is unchanged (existing canvas keyboard tests pass without
+      modification).
+- [ ] The VS Code host registers/unregisters views such that closing the last preview makes
+      the next command return `no-canvas`.
+
+## Constraints
+
+Carried from issue #1401 and architect direction (fixed):
+
+- The command set mirrors the existing keyboard vocabulary exactly; no parallel vocabulary.
+  Composer open/submit/cancel in scope; text entry out.
+- The no-canvas-open and multiple-canvases-open cases have the explicit spec-time answers
+  above (error / MRU) — never a silent ambiguous no-op.
+- The streamdeck architect reviews the sdk surface (§ Desired State 3) at design time,
+  before implementation, routed via the main architect.
+- sdk constraints are hard: environment-agnostic, zero runtime deps, imports only
+  `codev-types` (type-only), CI boundary tests enforce.
+- Ride existing plumbing (SSE events channel, adapter pattern, `codev-types` wire contracts);
+  do not invent a new transport.
+- Server/client isolation (#1189): core and sdk never import each other.
+- Deck actions themselves are #1400; any change to in-page keyboard behavior is out of scope.
+
+## Assumptions
+
+- The VS Code extension host can observe per-panel focus/visibility (it can:
+  `onDidChangeViewState`) and its existing SSE client can carry the new addressed event.
+- #1386 (afx open → canvas migration) lands independently; this bridge must not depend on
+  it, and its page becomes a second registrant with no protocol change.
+- #1400 consumes the sdk route as specified; its UX (key feedback on `no-canvas`, workspace
+  selection) is out of scope here.
+- Registry liveness (lease TTL, refresh cadence) has workable values; exact numbers are a
+  plan decision.
+
+## Solution Approaches
+
+### Approach 1: Extend the generic command relay with `canvas-*` verbs (rejected)
+
+Add the 14 commands as verbs through the existing `POST /api/command` broadcast; the VS Code
+relay forwards them to its preview panels (focused-window gate as today).
+
+- **Pros**: zero new Tower surface; single controller act-path (deck posture doc: "ACTS by
+  POSTing canonical verbs to the command relay"); smallest diff.
+- **Cons**: structurally cannot satisfy Requirement 4 — the relay is fire-and-forget
+  (`{ok:true}` with no providers listening), so no-canvas is a silent no-op; no per-file
+  addressing; multi-view selection would be re-implemented ad hoc in every host; the relay's
+  own comments defer provider addressing precisely because it doesn't fit this shape.
+- **Risk/complexity**: low complexity, but fails a fixed requirement — rejected on that
+  ground, not on taste.
+
+### Approach 2: Canvas view registry + targeted command route over existing SSE (recommended)
+
+As specified in Desired State: Tower-side live-view registry (host-registered, leased),
+dedicated command route that resolves the target by the spec'd rule and answers explicitly,
+delivery as a viewId-addressed event on the existing SSE channel, package-side
+`CommandAdapter` seam, sdk `sendCanvasCommand` on the controller subpath.
+
+- **Pros**: satisfies Requirement 4 by construction (Tower knows what's open and says so);
+  MRU rule solves multi-view once, centrally; host-agnostic (any registrant works — #1386
+  page inherits); no new transport (SSE + adapters + types, all existing plumbing); the
+  registry closes a gap Tower's own code flags as deferred.
+- **Cons**: new Tower state (registry) with liveness to manage; delivery after resolution is
+  best-effort (no ack); hosts must implement registration glue.
+- **Risk/complexity**: moderate — the registry is new but small, and staleness is bounded by
+  leases.
+
+### Approach 3: Dedicated per-view WebSocket channel (rejected)
+
+Each canvas view opens a WS to Tower (like terminals); commands are routed down the socket,
+acks come back up.
+
+- **Pros**: precise addressing and delivery acks for free; connection lifetime *is*
+  liveness.
+- **Cons**: a new connection type per view; the VS Code webview would need its own
+  authenticated socket to Tower (today the webview deliberately has no network identity —
+  the extension host mediates); heavier than the problem warrants; duplicates what SSE +
+  registry already provide minus acks nobody currently needs.
+- **Risk/complexity**: highest; rejected as over-plumbing.
+
+**Recommendation: Approach 2.**
+
+## Open Questions
+
+- **Important (shapes design, owned by the streamdeck design review)**: should the canvas
+  command set also be exposed as `canvas-*` verbs on the generic relay for controller
+  uniformity, or stay exclusively on the targeted route? Recommendation: targeted route
+  only (one path, one semantics). Blocks implementation of the sdk surface, not the rest.
+- **Important**: registration transport for hosts — dedicated register/unregister/heartbeat
+  HTTP calls vs binding registrations to the host's SSE connection lifetime. Plan-phase
+  decision; the spec fixes only the observable behavior (live views, activity, expiry).
+- **Nice-to-know**: should `reading-mode-toggle` be `reading-mode-set` with an explicit
+  target mode for idempotent remote control? The keyboard vocabulary says toggle; deck keys
+  often prefer explicit states. Default: mirror the vocabulary (toggle), revisit in #1400
+  if the deck needs state display anyway (it can read the result/state elsewhere).
+- **Nice-to-know**: whether `lastActiveAt` should also advance on delivered commands (so a
+  driven-but-unfocused view stays MRU). Default: yes — remote driving is activity.
+
+## Test Scenarios
+
+Functional:
+
+1. Each of the 14 commands delivered to a single open view produces the keyboard-equivalent
+   effect (focus moves, composer opens/submits/cancels, column pages, mode toggles).
+2. Command semantics parity edge cases: `comment-next` at the last commented block does not
+   wrap (matches `n`); `column-forward` in vertical mode is a defined no-op; `composer-submit`
+   with no composer open is a defined no-op; `composer-open` with no focused block is a
+   defined no-op.
+3. No canvas open (workspace has none / file not shown / last view closed): route and sdk
+   call return `no-canvas`; nothing is delivered.
+4. Two views, same file: command lands only on the most recently active; response names it;
+   activating the other view flips subsequent delivery.
+5. Two views, different files: file-qualified selector routes correctly both ways; file-less
+   selector follows MRU.
+6. Stale registration (host killed without unregister): after lease expiry, commands return
+   `no-canvas` rather than resolving to the dead view.
+7. Full remote review loop on the VS Code host: navigate to a block, `composer-open`, type
+   on the keyboard, `composer-submit` — exactly one marker written via the existing
+   MarkerAdapter path; focus restoration behaves as the keyboard flow does.
+8. sdk: `sendCanvasCommand` success and `no-canvas` results are typed and reachable from
+   `@cluesmith/codev-sdk/controller`.
+
+Non-functional:
+
+9. Boundary tests: sdk import rules and streamdeck subpath rules pass unchanged.
+10. Existing canvas keyboard tests pass unmodified (no in-page behavior change).
+11. SSE fan-out: non-target hosts receiving the addressed event ignore it cheaply (no
+    canvas work triggered).
+
+## Risks and Mitigation
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| Registry staleness: dead host leaves a view registered, commands resolve to a ghost | Medium | Medium — commands "succeed" but nothing happens | Leased registrations with expiry; liveness bound to host disconnect where the transport allows; test scenario 6 |
+| Double-apply on duplicated views (composer-submit posts twice) | Low (ruled out by design) | High | MRU single-target rule is fixed at spec time; scenario 4 guards it |
+| Vocabulary drift between keyboard and remote paths over time | Medium | Medium | Single per-action implementation both paths call; parity test per command (criterion 2) |
+| Best-effort delivery after resolution (no ack): resolved view dies in the window | Low | Low — user retries | Accepted; documented; lease expiry keeps the window small |
+| sdk boundary violation (importing runtime values from types) | Low | High — CI blocks | Follow the existing `COMMAND_ROUTE` re-declaration pattern; boundary tests already enforce |
+| VS Code host complexity (panel registry glue, focus tracking) | Medium | Medium | Panels already expose lifecycle/view-state events; glue mirrors the existing command-relay filter pattern |
+
+## References
+
+- Issue #1401 (this bridge), #1400 (deck actions, dependent), #1386 (afx open → canvas
+  migration; future second host), #1189 (server/client isolation + controller-subpath
+  review arrangement).
+- #1237 / PR #1344 (keyboard-first review), #1380 / PR #1398 (horizontal reading mode) —
+  the vocabulary source of truth.
+- Spec 945 (canvas package + D-series adapter contracts); spec 1313 (mailbox-first `afx
+  send` — the precedent for explicit delivered/held answers instead of silent sends).
+- Code ground truth: `packages/artifact-canvas/src/components/ArtifactCanvas.tsx`
+  (`onBodyKeyDown`), `src/overlays/CommentComposer.tsx`, `src/adapters/*`;
+  `packages/codev/src/agent-farm/servers/command-relay.ts`, `tower-server.ts` (SSE);
+  `apps/vscode/src/command-relay.ts`, `src/markdown-preview/`;
+  `packages/sdk/src/controller.ts`; `packages/types/src/command.ts`.

--- a/codev/specs/1401-artifact-canvas-remote-command.md
+++ b/codev/specs/1401-artifact-canvas-remote-command.md
@@ -5,6 +5,19 @@ SPEC vs PLAN BOUNDARY:
 This spec defines WHAT and WHY. The plan defines HOW and WHEN.
 -->
 
+> **Revision note (2026-08-11, post-approval, authorized by the architect and the streamdeck
+> stakeholder).** Two corrections, neither changing a requirement:
+>
+> 1. The multi-view example was corrected from "split editor" to an accurate one, since
+>    `supportsMultipleEditorsPerDocument: false` means VS Code cannot open two canvas panels
+>    for one document. The MRU requirement is unchanged; only the illustrative example and the
+>    verification venue moved.
+> 2. The sdk-visible error union gained a third member, `unreachable`, and the call is
+>    explicitly non-throwing. The **wire** union Tower answers with is still exactly
+>    `'no-canvas' | 'invalid-request'`; `unreachable` is client-synthesized. This resolves a
+>    builder proposal (reject on transport failure) that the streamdeck stakeholder rejected,
+>    because `TowerClient` holds a never-reject invariant that this call must not break.
+
 ## Problem Statement
 
 The artifact canvas has a complete keyboard-first review vocabulary (#1237 / PR #1344,
@@ -202,12 +215,13 @@ after resolution is best-effort (SSE has no ack); the explicit-answer guarantee 
 target resolution.
 
 **Error contract.** Failure codes are a **closed, exported union type in `codev-types`**
-(streamdeck design-review decision — not an open string):
-`'no-canvas' | 'invalid-request'`. `no-canvas` answers HTTP 404 (selector resolved to zero
-live views); `invalid-request` answers HTTP 400 (unknown command, malformed selector, or
-`count` on a non-traversal command). Every failure body is
-`{ok:false, code, error}` with `code` from the union; extending the union is an additive
-type change, not a string convention.
+(streamdeck design-review decision — not an open string). The **wire** union, i.e. the answers
+Tower itself gives, has exactly two members: `'no-canvas' | 'invalid-request'`. `no-canvas`
+answers HTTP 404 (selector resolved to zero live views); `invalid-request` answers HTTP 400
+(unknown command, malformed selector, or `count` on a non-traversal command). Every failure
+body is `{ok:false, code, error}` with `code` from the wire union; extending it is an additive
+type change, not a string convention. The sdk-visible union is one member wider, for the
+client-synthesized `unreachable` case described in §3.
 
 **Security posture.** The route inherits Tower's existing trust boundary (localhost bind
 behind the host/origin gate; the same exposure considerations as every route under
@@ -241,16 +255,29 @@ sendCanvasCommand(
   command: CanvasCommand,
   target: { workspace: string; file?: string },
   options?: { count?: number }   // traversal/paging commands only; default 1
-): Promise<CanvasCommandResult>
-// CanvasCommandResult: { ok: true, target: { viewId: string, file: string } }
-//                    | { ok: false, code: CanvasCommandErrorCode, error: string }
-// CanvasCommandErrorCode = 'no-canvas' | 'invalid-request'   (closed union, codev-types)
+): Promise<CanvasCommandClientResult>          // never rejects
+// CanvasCommandClientResult: { ok: true, target: { viewId: string, file: string } }
+//                          | { ok: false, code: CanvasCommandClientErrorCode, error: string }
+// CanvasCommandErrorCode       = 'no-canvas' | 'invalid-request'       (wire; Tower's answers)
+// CanvasCommandClientErrorCode = CanvasCommandErrorCode | 'unreachable' (sdk-visible)
 ```
 
 - Wire types (`CanvasCommand`, `CanvasCommandErrorCode`, request/result shapes, route
   constant) live in `codev-types`; the sdk imports them type-only and re-declares the route
   string literal, matching the existing `COMMAND_ROUTE` pattern. Result types are
   re-exported as `export type` from the controller subpath.
+- **The call never rejects**, matching the never-reject invariant the whole `TowerClient`
+  holds (its shared `request()` catches every transport error and returns `ok:false` with
+  `status: 0`). `sendCanvasCommand` is not an exception to that invariant.
+- **`unreachable` is client-synthesized and never sent by Tower.** It is how a caller
+  distinguishes "Tower answered: no canvas is open" from "Tower could not be reached", which
+  is precisely the confusion a controller must not make. The wire union stays two members so
+  Tower cannot even type such a response; the sdk-visible union carries the third.
+- No structural `source` discriminator is added (builder's call, streamdeck indifferent). The
+  type-level split already does that work: Tower cannot express `unreachable`, the union is
+  closed so TS consumers get exhaustiveness checking when it grows, and the transport layer
+  already signals the case with `status: 0`. A `source` field would be a third encoding of
+  one fact.
 - The machine-readable `code` must survive to the caller: the sdk call's observable
   contract is the typed result above, not a flattened error string (the deck renders
   "no canvas open" from `code`, never by parsing prose). How that composes with the shared
@@ -281,8 +308,10 @@ sendCanvasCommand(
       `codev-types` — machine-readable, never only prose.
 - [ ] With no matching canvas view open, the Tower route and the sdk call return an explicit
       machine-readable `no-canvas` error — observably not a success and not a silent no-op.
-- [ ] With two views open on the same file (e.g. split editor), a command is applied to
-      exactly one — the most recently active — and the response names it.
+- [ ] With two views open on the same file (two hosts on one file, e.g. a VS Code panel and
+      the Tower-served page once #1386 lands; verified at the Tower registry, which accepts
+      two registrations for one file directly), a command is applied to exactly one — the
+      most recently active — and the response names it.
 - [ ] With views open on two different files in one workspace, a file-qualified command
       reaches the view for that file; a file-less command reaches the most recently active.
 - [ ] `composer-open` → (human types) → `composer-submit` driven remotely posts exactly one
@@ -407,10 +436,12 @@ Functional:
    command) returns `invalid-request`; `count: 0` and negative values are rejected.
 5. No canvas open (workspace has none / file not shown / last view closed): route and sdk
    call return `no-canvas` (HTTP 404, closed-union code); nothing is delivered.
-6. Two views, same file: command lands only on the most recently active; response names it
-   via its Tower-minted `viewId`; activating the other view flips subsequent delivery. Two
-   registrations of the same file under different path spellings resolve to one registry
-   identity (Tower canonicalization).
+6. Two views, same file (exercised at the Tower registry, which accepts two registrations for
+   one file regardless of host): command lands only on the most recently active; response
+   names it via its Tower-minted `viewId`; activating the other view flips subsequent
+   delivery. Two registrations of the same file under different path spellings match the same
+   selector (Tower canonicalization) while remaining two distinct views with distinct
+   `viewId`s.
 7. Two views, different files: file-qualified selector routes correctly both ways; file-less
    selector follows MRU; a delivered command advances the target's `lastActiveAt`.
 8. Stale registration (host killed without unregister): after lease expiry, commands return

--- a/codev/specs/1401-artifact-canvas-remote-command.md
+++ b/codev/specs/1401-artifact-canvas-remote-command.md
@@ -1,3 +1,8 @@
+---
+approved: 2026-08-11
+validated: [gemini, codex, claude]
+---
+
 # Specification: Artifact-Canvas Remote Command Channel (Tower relay + sdk route)
 
 <!--
@@ -223,9 +228,17 @@ body is `{ok:false, code, error}` with `code` from the wire union; extending it 
 type change, not a string convention. The sdk-visible union is one member wider, for the
 client-synthesized `unreachable` case described in §3.
 
-**Security posture.** The route inherits Tower's existing trust boundary (localhost bind
-behind the host/origin gate; the same exposure considerations as every route under
-`BRIDGE_MODE`) — it adds no new authentication surface. `workspace` and `file` are registry
+**Security posture.** The route inherits Tower's existing trust boundary and adds no
+authentication of its own.
+
+> **Correction (2026-08-12, PR review).** An earlier draft described that boundary as a
+> "host/origin gate". That description overstated the protection actually in place. Tower's
+> existing request-trust boundary is weaker than this spec originally claimed; the specifics and
+> the fix are tracked privately as a security advisory. The property is pre-existing and
+> Tower-wide, not introduced by this channel, and it is handled there rather than patched onto a
+> single route. No safeguard is asserted here that does not exist. What this channel adds is one
+> more capability behind the existing boundary: a `composer-submit` writes a review comment
+> through the host's existing marker path. `workspace` and `file` are registry
 lookup keys only: this route never dereferences them as filesystem paths. The command
 payload is validated against the closed `CanvasCommand` union before relay. Note the
 inherited-boundary consequence explicitly: `composer-submit` is the first relay-triggerable

--- a/codev/specs/1401-artifact-canvas-remote-command.md
+++ b/codev/specs/1401-artifact-canvas-remote-command.md
@@ -228,17 +228,7 @@ body is `{ok:false, code, error}` with `code` from the wire union; extending it 
 type change, not a string convention. The sdk-visible union is one member wider, for the
 client-synthesized `unreachable` case described in §3.
 
-**Security posture.** The route inherits Tower's existing trust boundary and adds no
-authentication of its own.
-
-> **Correction (2026-08-12, PR review).** An earlier draft described that boundary as a
-> "host/origin gate". That description overstated the protection actually in place. Tower's
-> existing request-trust boundary is weaker than this spec originally claimed; the specifics and
-> the fix are tracked privately as a security advisory. The property is pre-existing and
-> Tower-wide, not introduced by this channel, and it is handled there rather than patched onto a
-> single route. No safeguard is asserted here that does not exist. What this channel adds is one
-> more capability behind the existing boundary: a `composer-submit` writes a review comment
-> through the host's existing marker path. `workspace` and `file` are registry
+**Security posture.** This route adds no authentication of its own; requests reach it through Tower's existing request path, exactly as every other route does. What the channel adds is one capability on that path: a `composer-submit` writes a review comment through the host's existing marker path. `workspace` and `file` are registry
 lookup keys only: this route never dereferences them as filesystem paths. The command
 payload is validated against the closed `CanvasCommand` union before relay. Note the
 inherited-boundary consequence explicitly: `composer-submit` is the first relay-triggerable

--- a/codev/specs/1401-artifact-canvas-remote-command.md
+++ b/codev/specs/1401-artifact-canvas-remote-command.md
@@ -83,31 +83,62 @@ established D-series pattern:
 /** Delivers remote review-navigation commands into the canvas. */
 export interface CommandAdapter {
   /** Subscribe to inbound commands. Returns a Disposable synchronously. */
-  subscribe(onCommand: (command: CanvasCommand) => void): Disposable;
+  subscribe(
+    onCommand: (invocation: { command: CanvasCommand; count?: number }) => void
+  ): Disposable;
 }
 ```
+
+(`count`, default 1, applies to traversal/paging commands only — defined with the Tower
+route in §2.)
 
 `CanvasCommand` is a closed union naming the existing keyboard vocabulary — **exactly** the
 vocabulary, no parallel one. Canonical command set (14):
 
-| Command | Keyboard equivalent | Semantics |
+| Command | In-page equivalent | Semantics |
 |---|---|---|
-| `block-next` / `block-prev` | Tab / Shift+Tab | Focus next/previous block in flow order |
-| `comment-next` / `comment-prev` | `n` / `p` | Focus next/previous commented block |
-| `heading-next` / `heading-prev` | `]` / `[` | Focus next/previous heading |
-| `doc-start` / `doc-end` | Home / End | Focus first/last block |
+| `block-next` / `block-prev` | Tab / Shift+Tab (blocks only — see below) | Move the current block to the next/previous `[data-line]` block in flow order |
+| `comment-next` / `comment-prev` | `n` / `p` | Move to next/previous commented block |
+| `heading-next` / `heading-prev` | `]` / `[` | Move to next/previous heading |
+| `doc-start` / `doc-end` | Home / End | Move to first/last block |
 | `column-forward` / `column-back` | PageDown / PageUp | Page one column (horizontal mode) |
-| `composer-open` | Enter / Space | Open composer on the focused block |
-| `composer-submit` | ⌘/Ctrl+Enter | Submit the open composer |
-| `composer-cancel` | Escape | Cancel the open composer |
-| `reading-mode-toggle` | (toolbar button) | Toggle vertical/horizontal reading mode |
+| `composer-open` | Enter / Space | Open composer on the current block |
+| `composer-submit` | ⌘/Ctrl+Enter | Submit the view's open composer |
+| `composer-cancel` | Escape | Cancel the view's open composer |
+| `reading-mode-toggle` | Reading-mode toolbar button | Toggle vertical/horizontal reading mode |
 
-Semantics rule: **a command behaves exactly as its keyboard equivalent behaves today**, same
-guards, same edge behavior (no wrap-around at edges, column paging only meaningful in
-horizontal mode, composer-open requires a focused block, submit/cancel require an open
-composer). Where the equivalent would do nothing, the command does nothing — that is defined
+**Semantics rule — effect parity with a defined remote origin.** A remote command produces
+the same *effect on canvas state* as its in-page equivalent, through the same per-action
+implementation (predicates, step logic, edge behavior — e.g. no wrap-around at edges, column
+paging meaningful only in horizontal mode). Literal event parity is impossible — the in-page
+handlers derive their origin from the DOM event (`e.target` → enclosing `[data-line]`
+block), and a remote command has no event — so the spec defines the remote origin
+explicitly:
+
+- **Current block (the remote origin).** Relative navigation commands and `composer-open`
+  operate on the canvas's *current block*: the most recently focused block (whether focused
+  by keyboard, pointer, minimap, or a prior remote command). If no block has been focused
+  yet, the fallback is the topmost visible block in the viewport; in an unscrolled document
+  that is the first block. This makes every navigation command well-defined on a
+  freshly-opened, never-touched view — the feature's primary scenario.
+- **Remote navigation moves focus.** A navigation command focuses its target block within
+  the canvas document via the same focus path the keyboard uses (visible focus ring, scroll
+  into view), so a subsequent `composer-open` + keyboard typing continues the flow exactly
+  as the in-page loop does. Whether the *hosting surface* (VS Code panel, browser tab)
+  acquires input focus is the host's policy, outside the package; hosts must not let a
+  delivered command steal focus across unrelated surfaces.
+- **Composer commands are view-scoped, not focus-scoped.** `composer-submit` /
+  `composer-cancel` act on the target view's open composer regardless of where DOM focus
+  sits; with no composer open they are defined no-ops.
+- **Two commands have no key to be parity with**, and are defined against their in-page
+  equivalents directly: `block-next`/`block-prev` step `[data-line]` blocks in flow order —
+  deliberately *not* full native-Tab parity, since Tab also visits affordance buttons,
+  comment-card actions, toolbar controls, and links; and `reading-mode-toggle` mirrors the
+  toolbar button.
+
+Where the in-page equivalent would do nothing, the command does nothing — that is defined
 per-command applicability, not targeting ambiguity (Requirement 4 governs *targeting*, which
-is never silent; see §3). Text entry is out of scope: comment bodies are typed on the
+is never silent; see §2). Text entry is out of scope: comment bodies are typed on the
 keyboard.
 
 Excluded from the set, deliberately: the `?` help legend (in-page discoverability chrome, not
@@ -128,8 +159,28 @@ dead host's views age out; exact transport is a plan decision).
 A new command endpoint accepts one command for a given target selector:
 
 ```
-POST → { workspace, file?, command }   (selector: workspace required, file optional)
+POST → { workspace, file?, command, count? }   (selector: workspace required, file optional)
 ```
+
+`count` (optional, default 1, positive integer) applies to the eight traversal/paging
+commands only (`block-*`, `comment-*`, `heading-*`, `column-*`) and means "apply the step N
+times" with the same edge semantics as N single steps (stops at the edge, no wrap). It is
+rejected on the absolute and stateful commands (`doc-*`, `composer-*`,
+`reading-mode-toggle`) as an invalid request. This is a streamdeck-architect design-review
+addition: dials and repeated key presses batch naturally into one command.
+
+Registry semantics, decided here because they are observable behavior:
+
+- **`viewId` is Tower-minted** at registration: an opaque identifier, stable for the life of
+  that registration, returned in command results for observability (it is what
+  distinguishes two views of the same file). It is not a command selector today; admitting
+  it as one is an additive follow-up if a need arises.
+- **File paths are canonicalized by Tower** on both registration and command (resolved to
+  absolute, same normalization the file-tab dedupe already uses), so path-spelling variance
+  cannot split the registry or defeat MRU dedupe.
+- **Activity time is Tower-stamped.** `lastActiveAt` is the Tower receipt time of the
+  host's activity report (and of command delivery — a driven view stays MRU); host clocks
+  are never trusted, so MRU stays deterministic across multiple host processes.
 
 **Target rule (decided here, per Requirement 4 — never a silent ambiguous no-op):**
 
@@ -150,6 +201,26 @@ filter pattern, made unambiguous by carrying the resolved `viewId` in the event)
 after resolution is best-effort (SSE has no ack); the explicit-answer guarantee covers
 target resolution.
 
+**Error contract.** Failure codes are a **closed, exported union type in `codev-types`**
+(streamdeck design-review decision — not an open string):
+`'no-canvas' | 'invalid-request'`. `no-canvas` answers HTTP 404 (selector resolved to zero
+live views); `invalid-request` answers HTTP 400 (unknown command, malformed selector, or
+`count` on a non-traversal command). Every failure body is
+`{ok:false, code, error}` with `code` from the union; extending the union is an additive
+type change, not a string convention.
+
+**Security posture.** The route inherits Tower's existing trust boundary (localhost bind
+behind the host/origin gate; the same exposure considerations as every route under
+`BRIDGE_MODE`) — it adds no new authentication surface. `workspace` and `file` are registry
+lookup keys only: this route never dereferences them as filesystem paths. The command
+payload is validated against the closed `CanvasCommand` union before relay. Note the
+inherited-boundary consequence explicitly: `composer-submit` is the first relay-triggerable
+action that can cause a file write (through the target host's existing marker write path,
+with the host's own validation) — the write path itself is unchanged and host-side, but the
+trigger is remote. View registration and activity reports carry the same Tower auth as any
+other route; `viewId` being Tower-minted means a registrant cannot claim another view's
+identity.
+
 Hosts (VS Code extension now; the #1386 Tower-served page when it lands) are responsible for
 registering their canvas views, reporting activity, and forwarding delivered commands into
 the page's `CommandAdapter`. The bridge is host-agnostic by construction: any surface that
@@ -158,36 +229,56 @@ can register a view and receive SSE gets remote drive for free.
 ### 3. sdk route (streamdeck-architect review section)
 
 > This section is the design-time review surface for the streamdeck architect
-> (controller-subpath owner, #1189 arrangement).
+> (controller-subpath owner, #1189 arrangement). **Reviewed and APPROVED**
+> (issue #1401 comment, 2026-08-11) with the deltas already folded in below: the `count`
+> parameter, the closed failure-code union, generic-relay exposure closed as NO, and the
+> presence-query non-goal.
 
 A new `TowerClient` method, re-exported through `@cluesmith/codev-sdk/controller`:
 
 ```ts
 sendCanvasCommand(
   command: CanvasCommand,
-  target: { workspace: string; file?: string }
+  target: { workspace: string; file?: string },
+  options?: { count?: number }   // traversal/paging commands only; default 1
 ): Promise<CanvasCommandResult>
-// CanvasCommandResult: { ok: true, target: { viewId, file } }
-//                    | { ok: false, code: 'no-canvas' | …, error: string }
+// CanvasCommandResult: { ok: true, target: { viewId: string, file: string } }
+//                    | { ok: false, code: CanvasCommandErrorCode, error: string }
+// CanvasCommandErrorCode = 'no-canvas' | 'invalid-request'   (closed union, codev-types)
 ```
 
-- Wire types (`CanvasCommand`, request/result shapes, route constant) live in
-  `codev-types`; the sdk imports them type-only and re-declares the route string literal,
-  matching the existing `COMMAND_ROUTE` pattern. Result types are re-exported as
-  `export type` from the controller subpath.
+- Wire types (`CanvasCommand`, `CanvasCommandErrorCode`, request/result shapes, route
+  constant) live in `codev-types`; the sdk imports them type-only and re-declares the route
+  string literal, matching the existing `COMMAND_ROUTE` pattern. Result types are
+  re-exported as `export type` from the controller subpath.
+- The machine-readable `code` must survive to the caller: the sdk call's observable
+  contract is the typed result above, not a flattened error string (the deck renders
+  "no canvas open" from `code`, never by parsing prose). How that composes with the shared
+  `request()` normalization is plan detail; the contract is fixed here.
 - Distinct from `sendCommand` deliberately: the generic verb relay is fire-and-forget
-  broadcast; this call is targeted and reports resolution (`no-canvas` reaches the caller —
-  the deck can flash "no canvas open" on the key). Whether the canvas command set should
-  *additionally* be reachable as `canvas-*` verbs through the generic relay for controller
-  uniformity is explicitly deferred to this design review — the recommendation is no
-  (one path, one semantics).
+  broadcast; this call is targeted and reports resolution. **Decision (design review,
+  closed): the canvas command set is exposed on the targeted route only** — it is *not*
+  additionally exposed as `canvas-*` verbs on the generic relay. One path, one semantics.
+- **Named non-goal: an sdk-visible presence query** (list/inspect open canvas views). Not
+  in scope; if a controller later needs it (e.g. deck key-state display), it is an additive
+  read-only route + sdk call over the same registry, with no change to the command
+  contract.
 
 ## Success Criteria
 
 - [ ] Every one of the 14 canonical commands, delivered remotely to an open canvas view,
-      produces exactly the effect of its keyboard equivalent (verified per command).
+      produces the effect defined in the command table — for the 12 with an in-page key,
+      the same effect the key produces from the current block; for `block-next`/`block-prev`
+      and `reading-mode-toggle`, their defined in-page equivalents (verified per command).
+- [ ] The remote origin is well-defined with no prior interaction: on a freshly opened,
+      never-focused view, relative navigation starts from the topmost visible block and
+      every navigation command has an observable effect from a clean state.
 - [ ] No parallel vocabulary exists: keyboard handlers and remote commands execute the same
       per-action implementation in the package.
+- [ ] `count` multiplies the eight traversal/paging commands (N steps, edge-clamped, no
+      wrap) and is rejected as `invalid-request` on the other six.
+- [ ] Failure codes reach sdk callers as the closed `CanvasCommandErrorCode` union from
+      `codev-types` — machine-readable, never only prose.
 - [ ] With no matching canvas view open, the Tower route and the sdk call return an explicit
       machine-readable `no-canvas` error — observably not a success and not a silent no-op.
 - [ ] With two views open on the same file (e.g. split editor), a command is applied to
@@ -280,49 +371,62 @@ acks come back up.
 
 ## Open Questions
 
-- **Important (shapes design, owned by the streamdeck design review)**: should the canvas
-  command set also be exposed as `canvas-*` verbs on the generic relay for controller
-  uniformity, or stay exclusively on the targeted route? Recommendation: targeted route
-  only (one path, one semantics). Blocks implementation of the sdk surface, not the rest.
 - **Important**: registration transport for hosts — dedicated register/unregister/heartbeat
   HTTP calls vs binding registrations to the host's SSE connection lifetime. Plan-phase
   decision; the spec fixes only the observable behavior (live views, activity, expiry).
-- **Nice-to-know**: should `reading-mode-toggle` be `reading-mode-set` with an explicit
-  target mode for idempotent remote control? The keyboard vocabulary says toggle; deck keys
-  often prefer explicit states. Default: mirror the vocabulary (toggle), revisit in #1400
-  if the deck needs state display anyway (it can read the result/state elsewhere).
-- **Nice-to-know**: whether `lastActiveAt` should also advance on delivered commands (so a
-  driven-but-unfocused view stays MRU). Default: yes — remote driving is activity.
+
+Resolved during the streamdeck design review (2026-08-11), recorded here so they are not
+reopened:
+
+- Generic-relay exposure: **closed as NO** — targeted route only, never `canvas-*` verbs on
+  `/api/command`.
+- `reading-mode-toggle` stays a toggle (not `reading-mode-set`) — mirrors the vocabulary;
+  endorsed as specced.
+- `lastActiveAt` advances on command delivery (a driven view stays MRU) — endorsed, now
+  part of the registry semantics.
+- Traversal `count` parameter added; presence query named a non-goal with an additive
+  follow-up path.
 
 ## Test Scenarios
 
 Functional:
 
-1. Each of the 14 commands delivered to a single open view produces the keyboard-equivalent
-   effect (focus moves, composer opens/submits/cancels, column pages, mode toggles).
+1. Each of the 14 commands delivered to a single open view produces its table-defined
+   effect (focus moves with visible ring + scroll-into-view, composer
+   opens/submits/cancels, column pages, mode toggles).
 2. Command semantics parity edge cases: `comment-next` at the last commented block does not
-   wrap (matches `n`); `column-forward` in vertical mode is a defined no-op; `composer-submit`
-   with no composer open is a defined no-op; `composer-open` with no focused block is a
-   defined no-op.
-3. No canvas open (workspace has none / file not shown / last view closed): route and sdk
-   call return `no-canvas`; nothing is delivered.
-4. Two views, same file: command lands only on the most recently active; response names it;
-   activating the other view flips subsequent delivery.
-5. Two views, different files: file-qualified selector routes correctly both ways; file-less
-   selector follows MRU.
-6. Stale registration (host killed without unregister): after lease expiry, commands return
+   wrap (matches `n`); `column-forward` in vertical mode is a defined no-op;
+   `composer-submit` / `composer-cancel` with no composer open are defined no-ops, and act
+   on the view's composer regardless of where DOM focus sits.
+3. Remote origin: on a freshly opened view with no interaction, `comment-next` starts its
+   scan from the topmost visible block; after scrolling, from the new topmost visible
+   block; after any focus (keyboard, pointer, minimap, or remote), from the current block.
+   `composer-open` on a clean view opens on the topmost visible block.
+4. `count`: `heading-next` with `count: 3` lands where three single steps land, clamping at
+   the last heading without wrapping; `count` on `composer-open` (or any non-traversal
+   command) returns `invalid-request`; `count: 0` and negative values are rejected.
+5. No canvas open (workspace has none / file not shown / last view closed): route and sdk
+   call return `no-canvas` (HTTP 404, closed-union code); nothing is delivered.
+6. Two views, same file: command lands only on the most recently active; response names it
+   via its Tower-minted `viewId`; activating the other view flips subsequent delivery. Two
+   registrations of the same file under different path spellings resolve to one registry
+   identity (Tower canonicalization).
+7. Two views, different files: file-qualified selector routes correctly both ways; file-less
+   selector follows MRU; a delivered command advances the target's `lastActiveAt`.
+8. Stale registration (host killed without unregister): after lease expiry, commands return
    `no-canvas` rather than resolving to the dead view.
-7. Full remote review loop on the VS Code host: navigate to a block, `composer-open`, type
+9. Full remote review loop on the VS Code host: navigate to a block, `composer-open`, type
    on the keyboard, `composer-submit` — exactly one marker written via the existing
    MarkerAdapter path; focus restoration behaves as the keyboard flow does.
-8. sdk: `sendCanvasCommand` success and `no-canvas` results are typed and reachable from
-   `@cluesmith/codev-sdk/controller`.
+10. sdk: `sendCanvasCommand` success and failure results are typed and reachable from
+    `@cluesmith/codev-sdk/controller`, with `code` from the exported
+    `CanvasCommandErrorCode` union.
 
 Non-functional:
 
-9. Boundary tests: sdk import rules and streamdeck subpath rules pass unchanged.
-10. Existing canvas keyboard tests pass unmodified (no in-page behavior change).
-11. SSE fan-out: non-target hosts receiving the addressed event ignore it cheaply (no
+11. Boundary tests: sdk import rules and streamdeck subpath rules pass unchanged.
+12. Existing canvas keyboard tests pass unmodified (no in-page behavior change).
+13. SSE fan-out: non-target hosts receiving the addressed event ignore it cheaply (no
     canvas work triggered).
 
 ## Risks and Mitigation

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -501,3 +501,29 @@ selected builder's artifact, with MRU as the recorded fallback. No code or spec 
 here. If a pr-gate reviewer flags the `file?` selector as speculative or unused, the disposition
 is: required by #1400 as revised 2026-08-11. How the deck discovers the artifact path is a #1400
 question in the streamdeck lane, not mine. TODO: record in the review file dispositions + PR body.
+
+### phase_6 iter1: gemini APPROVE, claude COMMENT, codex REQUEST_CHANGES — all fixed but the human pass
+
+Fixed: reconnect handling via onStateChange (a Tower restart previously left panels undrivable
+for up to the full 30s heartbeat, and a slow first connect did too); a re-registration RACE where
+two concurrent unknownView beats orphaned a freshly registered view for a whole lease (guarded by
+capturing beatViewId); unregister-on-deactivate (provider is now Disposable and in
+context.subscriptions — deactivate does not dispose panels individually); runtime validation of
+the SSE command against the closed union plus a count sanity check; and 11 curly lint warnings.
+
+**A reviewer corrected ME, and it matters.** I had claimed in the plan, a phase_3 rebuttal, and
+the review draft that webview/main.ts has NO check-types coverage, reasoning from
+apps/vscode/tsconfig.json excluding that directory. Wrong: tsconfig.webview.json covers exactly
+that directory and `check-types` runs BOTH configs. I stopped one file too early and then repeated
+the claim three times. Verified myself, corrected the review file explicitly. The manual pass is
+still needed — types don't prove runtime behavior across three processes — but I had been
+overstating why.
+
+Also recorded: `pnpm --filter codev-vscode test` is vscode-test (Electron, fails here for
+unrelated reasons); unit tests are `test:unit` → vitest, which is what CI runs and what I ran.
+
+**NOT fixed, deliberately:** the manual end-to-end VS Code pass. A headless builder cannot produce
+a real VS Code window + Tower + open panel. Claiming it was done is exactly the failure the
+"tests pass is not it works" lesson exists to prevent. Documented as outstanding and
+blocking-for-sign-off in the review file with a 4-step script, and called out in the PR body. The
+pr gate is a human gate — the right place for a human-only verification.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -250,7 +250,12 @@ the commandAdapter prop, the focus-derived cursor, and count handling.
 
 Advisories from phase_2 all actioned: dispatch reads through a ref (canvasActions is rebuilt per
 render); CanvasActionName replaced by CanvasCommand from codev-types, TRAVERSAL_COMMANDS hoisted
-to module scope with `satisfies` + an Exclude<> assertion so drift breaks in BOTH directions.
+to module scope with `satisfies` + an assertion for the missing-member direction.
+
+**CORRECTION (phase_3 iter1 review):** that assertion as first written was INERT — a bare
+conditional type alias constrains nothing, so an omitted command resolved to `never` and compiled.
+Same defect class phase_1 was sent back for. Now wrapped in `Assert<T extends true>` and verified
+by deleting a command from the list and watching check-types fail with TS2344.
 
 Composer seam: CommentComposer is now forwardRef with a `submit()` handle. Only submit, because
 submission needs the composer's own draft text; cancel needs nothing so it goes through the
@@ -277,3 +282,28 @@ keeps its visible ring.
 
 Verification: 169/169 vitest (19 new), check-types clean, 33/33 playwright on the COMMITTED
 config (5199 free again after the orphan was cleared), repo build + 4820 tests green.
+
+### phase_3 consultation iter1: gemini APPROVE, codex + claude REQUEST_CHANGES
+
+All points fixed. Two where the honest answer changed the TEST rather than the code:
+
+1. **Vertical-mode column paging (codex).** Added the mode check (correct, defensive), but the
+   described failure — a vertical layout scrolling sideways — does not reproduce: `overflow-x:
+   auto` is scoped to `.codev-canvas-mode-horizontal` (default-theme.css:490-497), so in vertical
+   mode the body is not a horizontal scroll container and `scrollLeft = 40` reads back 0. Test now
+   asserts what is verifiable and records why the stronger scenario is unreachable, instead of
+   passing vacuously.
+2. **Remote doc-end doesn't scroll into view.** My own new test caught this and I nearly "fixed"
+   the canvas. Probed the keyboard equivalent first: `End` behaves IDENTICALLY (line 1106,
+   scrollLeft 0), because the fixture's last block is a table row whose scrollable ancestor is the
+   table, not the body. Pre-existing, and reproducing it exactly IS the parity the spec asks for.
+   Changing it would have breached the no-in-page-behavior-change non-goal. Test rewritten to
+   mirror the keyboard suite's `n` case.
+
+Also: made the dev examples page a real host implementing CommandAdapter over
+`window.__canvasCommand`, so Playwright can drive the seam. That is the only way to assert column
+paging at all (jsdom has no layout), and it closes codex's real-browser coverage gap.
+
+Lesson worth carrying: when a new test fails, check whether the KEYBOARD path does the same thing
+before touching the component. Twice now the diff between "my path is broken" and "this is how it
+has always worked" was one probe away.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -124,3 +124,29 @@ source field would be a third encoding of one fact.
 Lesson worth keeping: my proposal was locally well-reasoned but violated a package-wide
 invariant I had not checked. The stakeholder review caught it, exactly as the #1189 arrangement
 is meant to.
+
+## 2026-08-11 — plan-approval granted; implementing phase_1 (wire contracts)
+
+Human approved plan-approval; porch advanced to `implement`, plan phase_1.
+
+Written: packages/types/src/canvas-command.ts (14-command closed union, type-level
+TraversalCommand/NonTraversalCommand, wire vs client error unions, request/result/registry/SSE
+event shapes, three route/event constants), exported from index.ts; type-test guard at
+packages/types/type-tests/ with its own tsconfig + `check-types:tests` script.
+
+Guard design note: `Extract`/`Exclude` alone CANNOT catch drift — a newly added command silently
+falls into the NonTraversal complement and `count` quietly stops applying to it. So the guard
+carries an exhaustive `satisfies Record<CanvasCommand, ...>` classification map that must be
+updated by hand, plus bidirectional Equal<> assertions that the map and the exported types
+agree, and partition complete/disjoint checks. **Verified by hand** that adding an unclassified
+command fails the guard with 3 errors, then reverted the probe.
+
+Also dropped a `@ts-expect-error` approach for the "Tower cannot answer 'unreachable'" check:
+the error surfaces on the object property line, not the declaration line, so the directive was
+reported unused while the real error escaped. Replaced with pure type-level Extract<> assertions
+(more robust, no line-position coupling).
+
+Build hiccup, NOT mine: `npm run build` failed on a missing `@xterm/addon-serialize` in
+packages/codev/src/terminal/session-screen.ts. Traced it to PIR #1354, which my rebase pulled in
+from main; the dep is declared in packages/codev/package.json but the worktree's node_modules
+predated it. My branch touches zero terminal files. Running pnpm install.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -239,3 +239,41 @@ No blocking issues. Three advisories carried forward to phase_3:
    adds the codev-types dependency anyway, so it lands naturally there.
 3. `pageColumn`'s `step <= 0 -> false` branch is untested (pre-existing gap); phase_3 adds
    adapter-level tests and can cover it cheaply.
+
+## 2026-08-12 — phase_3 (canvas remote command seam) implemented
+
+Registry widened from a local union to `Record<CanvasCommand, ...>` from codev-types, so TS now
+enforces that all 14 commands have an implementation. Added the five that had no handler:
+block-next/prev (flow-order [data-line] stepping, NOT Tab parity, Tab untouched),
+composer-submit/cancel, reading-mode-toggle. Plus CommandAdapter (4th adapter, interface-only),
+the commandAdapter prop, the focus-derived cursor, and count handling.
+
+Advisories from phase_2 all actioned: dispatch reads through a ref (canvasActions is rebuilt per
+render); CanvasActionName replaced by CanvasCommand from codev-types, TRAVERSAL_COMMANDS hoisted
+to module scope with `satisfies` + an Exclude<> assertion so drift breaks in BOTH directions.
+
+Composer seam: CommentComposer is now forwardRef with a `submit()` handle. Only submit, because
+submission needs the composer's own draft text; cancel needs nothing so it goes through the
+parent's existing cancelComposer. Remote submit reports viaKeyboard:true so focus restoration
+keeps its visible ring.
+
+### Three test failures that were real code gaps, not test problems
+
+1. **Clean-view navigation no-oped.** currentBlock fell back to viewportStartLine, which measures
+   with getBoundingClientRect — useless in jsdom, and equally useless in a real browser when the
+   canvas is display:none/detached/not yet laid out. Added a final fallback to the first block.
+   My own success criterion ("every navigation command has an observable effect from a clean
+   state") would have been false.
+2. **count stopped after one step.** currentBlock relied on the focus event refreshing the cursor
+   ref between iterations. Now it reads live DOM focus FIRST (precedence: live focus → cursor ref
+   → topmost visible → first block), so each step sees where the previous one landed. Uncovered
+   because jsdom lacks scrollIntoView: focusBlock threw, my try/catch swallowed it, and the loop
+   truncated. Mocked scrollIntoView per the repo's existing pattern (marker-minimap.test.tsx).
+3. **Double toggle landed back where it started.** Two commands delivered in ONE synchronous
+   batch: the second read readingMode from a render closure that had not updated. Nothing in the
+   CommandAdapter contract forbids a host delivering synchronously, so toggleReadingMode now
+   reads/writes a readingModeRef mirror instead of assuming a re-render between calls. The
+   pointer path cannot hit this; the remote path can.
+
+Verification: 169/169 vitest (19 new), check-types clean, 33/33 playwright on the COMMITTED
+config (5199 free again after the orphan was cleared), repo build + 4820 tests green.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -385,3 +385,25 @@ via `pnpm --filter @cluesmith/codev test:e2e` (vitest.e2e.config.ts), which buil
 
 Verification: 23/23 unit, 5/5 e2e against a real Tower, repo-wide check-types clean, repo build
 green, 4843 repo tests pass.
+
+### phase_4 iter1: gemini APPROVE, codex + claude REQUEST_CHANGES — lease bug was serious
+
+**The bad one:** command delivery refreshed `lastSeenAt` (the LEASE), not just `lastActiveAt`
+(MRU). Under steady controller traffic a ghost view renewed itself forever, so the guarantee this
+whole phase exists to provide — dead host ages out, caller hears `no-canvas` — silently inverted
+into "always reports success at a canvas nobody can see". Delivery is fire-and-forget SSE and
+proves nothing about the host; only heartbeats prove liveness. Fixed, commented at the assignment
+so a later edit doesn't "helpfully" restore it, regression test drives 4 lease-thirds with no
+heartbeat and asserts expiry.
+
+**The other:** a literal `null` body is valid JSON, so parseJsonBody resolved it and the first
+field read threw → HTTP 500 with no wire `code`, which the error contract forbids. Added an
+asObject() guard to all three handlers. Same root cause made a malformed heartbeat renew the
+lease (my catch fell back to `{}`); a truly bodyless request already parses as `{}`, so that
+catch was only ever reachable for broken input. Now 400.
+
+Also typed the response literals against CanvasCommandResult / CanvasViewRegistrationResult so
+wire drift fails the build — and doing that immediately exposed that the registration type was
+missing the `ok` field Tower actually sends. The contract was wrong, not the handler.
+
+Verification: 27/27 unit, 5/5 e2e, repo check-types clean, build green.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -562,52 +562,29 @@ hand-edit status.yaml to "fix" it.
 
 Next: wait for the pr gate. After merge → `porch done 1401 --merged 1413`, then the verify phase.
 
-## 2026-08-12 — PR-level consultation: 2 APPROVE, codex REQUEST_CHANGES (SECURITY finding)
+## 2026-08-12 — PR-level consultation: 2 APPROVE, 1 REQUEST_CHANGES
 
-codex raised a real one at PR level and I verified it independently. Tower's existing
-request-trust boundary is weaker than my spec claimed; the specifics and the fix are tracked
-privately as a security advisory and are deliberately not restated here (public repo — owner's
-disclosure decision, relayed via the architect 2026-08-12).
+Four of codex's five items fixed: rebased onto main (70 commits replayed clean, 0 behind,
+force-pushed with lease, full suite re-run green); added approved/validated frontmatter to spec +
+plan; and fixed the stale webview/main.ts header comment — **that comment is where my own
+repeated "webview isn't typechecked" error came from**. Caught in phase_6, root found here.
 
-My spec had described a safeguard in terms that overstated what is in place; corrected in place,
-because documenting protection that is not there is worse than documenting none.
+The fifth is a Tower-wide concern outside this change's scope. Verified independently, raised
+with the architect, routed to the maintainers, tracked separately from this PR. Deliberately not
+described here: this log ships with the PR, and a public artifact is not the place for it.
+Whoever picks up that lane should ask the architect rather than reconstruct it from the repo.
 
-Did NOT apply a partial measure to this one route. The property is pre-existing and Tower-wide,
-not introduced by this channel; addressing it properly is an architectural change with a client
-migration. Securing only the newest route would move the label rather than the risk. Escalated;
-the architect verified independently and routed it to the owner. Likely my next lane after this
-gate.
+## 2026-08-12 — final state, holding at the pr gate
 
-Also fixed: rebased onto main (70 commits replayed clean, 0 behind, force-pushed with lease, full
-suite re-run green); added approved/validated frontmatter to spec + plan; and fixed the stale
-webview/main.ts header comment — **that comment is where my own repeated "webview isn't
-typechecked" error came from**. Caught in phase_6, root found here.
+PR #1413: all 7 CI checks green, MERGEABLE. Locally build green, 4847 tests, repo-wide
+check-types clean.
 
-## 2026-08-12 — history rewrite: mechanics removed from the branch, BUT not from GitHub
+Outstanding and NOT closable by a builder: the live VS Code end-to-end pass (real editor window,
+running Tower, open canvas panel). The four-step script is in the PR body; step 4, the composer
+round trip, is the one that matters, since "exactly one comment" is what a fan-out bug would
+break.
 
-Redacting at the tip was not enough — correctly called out. The earlier fix only changed HEAD and
-one commit message, so the text still sat in the trees of two commits reachable on the pushed
-branch. Verified with `git log -S` (the pickaxe), which is authoritative; my earlier per-commit
-audit loops gave FALSE NEGATIVES because a git command inside `while read` consumed the loop's
-stdin. Do not trust an audit loop of that shape.
-
-Rewrite done: filter-branch --tree-filter over the three affected commits, substituting the
-redacted file versions wherever the markers appeared, with --prune-empty dropping the
-now-empty redaction commit (which also removed a commit whose subject advertised that something
-had been redacted). 72 -> 71 commits. HEAD tree byte-identical to the redacted state; full suite
-re-run green; force-pushed with lease. New HEAD e17915a75.
-
-**RESIDUAL EXPOSURE — the branch is clean, the repo is not.** Verified by API: the orphaned
-commits (including the two carrying the text) are STILL SERVED by GitHub at their SHAs after the
-force-push. Git force-push does not delete objects on the remote; GitHub retains unreachable
-objects and serves them by SHA until it garbage-collects, and refs/pull/1413/* pins objects too.
-Practically: anyone who knows or can read an old SHA can still fetch the content. Only GitHub
-Support can purge it.
-
-Mitigation confirmed: no committed artifact and no commit message in the branch references any
-orphaned SHA, so there is no pointer published from our side. The PR's web timeline may still
-show force-push events with before/after SHAs (the timeline API did not return them, but the UI
-commonly does) — that is the most likely discovery path and is the owner's call.
-
-Correct posture: for a public repo, treat this as disclosed from first push and let the FIX
-timeline drive, not the concealment.
+Process note worth keeping: an audit loop shaped like `git rev-list | while read sha; do git show
+...; done` gives FALSE NEGATIVES — the inner git command consumes the loop's stdin, so the loop
+stops after one iteration. I reported a clean result off exactly that shape and was wrong. For
+"does any commit contain X", the pickaxe (`git log -S`) is the authoritative check.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -457,3 +457,38 @@ an already-full class surface; my doc note is endorsed as the interim posture. S
 tracked as **#1411** (restricted controller client / capability surface) in their name, sequenced
 after this merge. TODO: record #1411 + this verdict in the review file's dispositions, and note
 it in the PR body.
+
+## 2026-08-12 — phase_6 (VS Code host wiring) implemented
+
+New apps/vscode/src/markdown-preview/canvas-view-registry.ts: registers each canvas PANEL as a
+live view, heartbeats the lease (30s, matching Tower's constant), reports activity on
+onDidChangeViewState so the panel being read wins MRU, filters the broadcast SSE by its own
+viewId, and forwards to that panel's webview. Wired through preview-provider (connectionManager
+is an OPTIONAL constructor arg, so the preview still works standalone) and extension.ts.
+HostToWebviewMessage became a union with a `command` member; webview/main.ts implements
+CommandAdapter as the last hop.
+
+Lifecycle details that needed care:
+- **Panel closed mid-registration**: the in-flight response is unregistered immediately, or the
+  view would linger as a target nothing will ever heartbeat. Has a test.
+- **Re-registration** on `unknownView` (Tower restart / lapsed lease) and retry when Tower was
+  unreachable at open time — otherwise an open panel is permanently undrivable.
+- **Serialized registration** so a heartbeat racing a reconnect cannot register twice.
+- **No panel.reveal()** on delivery: a remote command drives the canvas, it must not steal the
+  reviewer's window (matches the existing relay's never-pulls-focus posture).
+- Commands arriving before the canvas subscribes are DROPPED, not queued: a stale navigation
+  replayed later would move the reviewer somewhere they no longer expect.
+
+### OUTSTANDING: the manual end-to-end pass (plan phase_6 acceptance criterion)
+
+I cannot perform it autonomously — it needs a real VS Code window with the extension loaded, a
+running Tower, and an open canvas panel. Everything either side of that seam IS verified (Tower
+route by e2e against a real Tower; canvas seam by unit + playwright + the human's own dev-page
+session; sdk and host glue by unit tests with fakes). What no automated test here covers is the
+real extension registering with the real Tower and a real command reaching the real webview —
+and note webview/main.ts is outside the extension's tsconfig, so it has NO typecheck either.
+That makes the manual pass load-bearing evidence, not a formality. Flagged in the review file and
+the PR body for the pr-gate reviewer.
+
+Verification: 12/12 new host-glue tests, 789/789 vscode suite, repo check-types clean, build
+green, 4847 repo tests.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -226,3 +226,16 @@ SANCTIONED for my remaining phases: keep verifying browser tests with a temporar
 config on a free port, uncommitted. **TODO for the review file's testing section: note the
 workaround and cite #1407** so the pr-gate reviewer knows why the committed config was not used
 locally. (Phases 3 and 6 both touch canvas behavior, so this will recur.)
+
+### phase_2 consultation: codex APPROVE, claude APPROVE, gemini lane skipped (agy no output)
+
+No blocking issues. Three advisories carried forward to phase_3:
+1. **`canvasActions` is rebuilt every render.** The CommandAdapter subscription must dispatch
+   through a REF, not a closure captured at subscribe time, or a remote command would run the
+   first render's actions with stale `readingMode`/`composingLine`. This is the main correctness
+   trap in phase_3 and is now on the checklist.
+2. **Replace the local `CanvasActionName` with `Extract<CanvasCommand, ...>` from codev-types**
+   and hoist to module scope. Names match exactly today, so this is drift prevention. Phase_3
+   adds the codev-types dependency anyway, so it lands naturally there.
+3. `pageColumn`'s `step <= 0 -> false` branch is untested (pre-existing gap); phase_3 adds
+   adapter-level tests and can cover it cheaply.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -492,3 +492,12 @@ the PR body for the pr-gate reviewer.
 
 Verification: 12/12 new host-glue tests, 789/789 vscode suite, repo check-types clean, build
 green, 4847 repo tests.
+
+### #1400 revised (2026-08-11) — the `file?` selector has a named consumer
+
+Streamdeck stakeholder, via the architect: #1400 was revised (owner-directed) to FILE-QUALIFIED
+targeting. The deck will call sendCanvasCommand with BOTH workspace and file, targeting the
+selected builder's artifact, with MRU as the recorded fallback. No code or spec change requested
+here. If a pr-gate reviewer flags the `file?` selector as speculative or unused, the disposition
+is: required by #1400 as revised 2026-08-11. How the deck discovers the artifact path is a #1400
+question in the streamdeck lane, not mine. TODO: record in the review file dispositions + PR body.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -351,3 +351,37 @@ asserts the topmost visible block differs from the document's first block before
 cannot pass vacuously.
 
 Verification: check-types clean (package + repo-wide), 173/173 unit, 39/39 playwright.
+
+## 2026-08-12 — phase_4 (Tower canvas view registry + command route) implemented
+
+New `packages/codev/src/agent-farm/servers/canvas-relay.ts`, self-routing on `/api/canvas/*`,
+wired into tower-routes next to the generic command relay. Routes: POST /api/canvas/views
+(register, Tower mints `canvas-<uuid>`), POST /api/canvas/views/:id/heartbeat ({focused?}),
+DELETE /api/canvas/views/:id, POST /api/canvas/command.
+
+Decisions worth recording:
+- **lastSeenAt vs lastActiveAt are separate.** Any heartbeat refreshes the lease (lastSeenAt);
+  only `focused:true` or a delivered command advances MRU (lastActiveAt). Otherwise a background
+  view's keepalive would steal targeting from the view the reviewer is actually looking at. Has
+  its own test.
+- **Tie-break is a registration SEQUENCE, not a timestamp.** Two views registered in the same
+  millisecond would otherwise resolve arbitrarily, and a target rule that depends on timer
+  resolution is not a rule.
+- **Lease sweep is lazy** (on every access) rather than a timer: no background work, and tests
+  advance an injected clock instead of sleeping 90s.
+- **Heartbeat for an unknown view answers 404**, deliberately not a silent re-create, so phase_6
+  can re-register after a Tower restart instead of heartbeating into the void forever.
+- Applied the phase_3 guard lesson: both the CANVAS_COMMANDS and TRAVERSAL_COMMANDS runtime lists
+  carry `Assert<... extends never ? true : false>` checks, so a command added to codev-types that
+  Tower forgets to validate is a compile error.
+
+Two unit tests initially failed asserting `/tmp/doc.md` while Tower returned `/private/tmp/doc.md`
+— macOS symlink resolution, i.e. canonicalization working exactly as designed. Fixed the
+assertions to compare against the canonical path Tower reports rather than the spelling sent,
+since hardcoding the pre-canonical form would assert the ABSENCE of the feature.
+
+Note for future phases: `**/*.e2e.test.ts` is excluded from the default vitest config; e2e runs
+via `pnpm --filter @cluesmith/codev test:e2e` (vitest.e2e.config.ts), which builds first.
+
+Verification: 23/23 unit, 5/5 e2e against a real Tower, repo-wide check-types clean, repo build
+green, 4843 repo tests pass.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -429,3 +429,23 @@ re-register vs retry later — phase_6 depends on that distinction.
 
 Verification: 89/89 sdk (13 new), 63/63 streamdeck (boundary suite unchanged and passing),
 repo check-types clean, build green, 4847 repo tests.
+
+### phase_5 iter1: gemini + claude APPROVE, codex REQUEST_CHANGES (one accepted, one disputed)
+
+**Accepted:** sendCanvasCommand validated only `'ok' in body`, so `{ok:true}` with no target came
+back as a typed success (caller then reads target.viewId off undefined) and `{ok:false,
+code:'bogus'}` came back carrying a code outside the caller's union. Replaced with a full shape
+check; anything unverifiable is reported `unreachable` — a response we cannot verify is not a
+verdict. The runtime code list is pinned to CanvasCommandErrorCode with an AssertTrue guard, which
+immediately paid off: the type name was missing from the import and the guard surfaced it as
+`false` rather than passing silently.
+
+**Partially disputed:** codex says controller.ts re-exporting TowerClient leaves the registration
+methods reachable, violating the host-only requirement. True as an observation, but that subpath
+exports the CLASS and always has — it carries 39 public methods including addArchitect,
+killTerminal, sweepHusks, activateWorkspace, none of them controller concerns. My 3 are no more
+reachable than the 36 that predate them. The plan's requirement (don't re-export them) IS met.
+The only real remedy is a restricted client surface on a published subpath the streamdeck
+architect owns and approved — a breaking redesign, unrelated to canvas commands, and exactly the
+kind of scope expansion to raise rather than take. Flagged to the architect; if they want a hard
+boundary it deserves its own issue covering all 39 methods.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -527,3 +527,17 @@ a real VS Code window + Tower + open panel. Claiming it was done is exactly the 
 "tests pass is not it works" lesson exists to prevent. Documented as outstanding and
 blocking-for-sign-off in the review file with a 4-step script, and called out in the PR body. The
 pr gate is a human gate — the right place for a human-only verification.
+
+### phase_6 loop cannot converge — escalated (2026-08-12)
+
+iter2 and iter3 both landed gemini APPROVE + claude APPROVE + codex REQUEST_CHANGES, with codex's
+only remaining objection being the live VS Code end-to-end pass. That is not a code defect and no
+code change closes it: it needs a real VS Code window + Tower + open panel driven by a person. A
+headless builder cannot produce that, and the only way to flip the verdict would be to claim a
+verification I did not perform. So the loop is non-convergent — each round costs 3 consultations
+and ends 2-1 identically.
+
+All actionable findings from iter1/iter2 ARE fixed (reconnect, re-registration race,
+deactivate-unregister, closed-union validation, malformed-count event rejection, release-id-on-
+reconnect, lint). Asked the architect to let me stop iterating and open the PR, where the human
+runs the 4-step script at the pr gate. Holding rather than burning another consultation round.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -582,3 +582,32 @@ Also fixed: rebased onto main (70 commits replayed clean, 0 behind, force-pushed
 suite re-run green); added approved/validated frontmatter to spec + plan; and fixed the stale
 webview/main.ts header comment — **that comment is where my own repeated "webview isn't
 typechecked" error came from**. Caught in phase_6, root found here.
+
+## 2026-08-12 — history rewrite: mechanics removed from the branch, BUT not from GitHub
+
+Redacting at the tip was not enough — correctly called out. The earlier fix only changed HEAD and
+one commit message, so the text still sat in the trees of two commits reachable on the pushed
+branch. Verified with `git log -S` (the pickaxe), which is authoritative; my earlier per-commit
+audit loops gave FALSE NEGATIVES because a git command inside `while read` consumed the loop's
+stdin. Do not trust an audit loop of that shape.
+
+Rewrite done: filter-branch --tree-filter over the three affected commits, substituting the
+redacted file versions wherever the markers appeared, with --prune-empty dropping the
+now-empty redaction commit (which also removed a commit whose subject advertised that something
+had been redacted). 72 -> 71 commits. HEAD tree byte-identical to the redacted state; full suite
+re-run green; force-pushed with lease. New HEAD e17915a75.
+
+**RESIDUAL EXPOSURE — the branch is clean, the repo is not.** Verified by API: the orphaned
+commits (including the two carrying the text) are STILL SERVED by GitHub at their SHAs after the
+force-push. Git force-push does not delete objects on the remote; GitHub retains unreachable
+objects and serves them by SHA until it garbage-collects, and refs/pull/1413/* pins objects too.
+Practically: anyone who knows or can read an old SHA can still fetch the content. Only GitHub
+Support can purge it.
+
+Mitigation confirmed: no committed artifact and no commit message in the branch references any
+orphaned SHA, so there is no pointer published from our side. The PR's web timeline may still
+show force-push events with before/after SHAs (the timeline API did not return them, but the UI
+commonly does) — that is the most likely discovery path and is the owner's call.
+
+Correct posture: for a public repo, treat this as disclosed from first push and let the FIX
+timeline drive, not the concealment.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -163,3 +163,20 @@ looking like protection, and no later phase touches this package's CI. Added a
 
 Worth remembering: everything was green locally and two of three reviewers approved. "Tests
 pass" hid "the test can never fail."
+
+### Porch wedge incident (worth knowing if it recurs)
+
+`porch next 1401` hung for ~65 minutes with zero output. Root cause was NOT porch and NOT the
+review: it had spawned `git push -u origin HEAD` which wedged. Diagnosis path: `pgrep -P <porch
+pid>` showed the child was a git push; `git ls-remote` returned instantly (so network + auth
+were fine); no hooks, no .lock files; the remote ref had not moved in an hour, so nothing was
+mid-transfer. The wedged process was Xcode's git (/Applications/Xcode.app/.../git), most likely
+stuck on a credential-helper prompt with no TTY to answer it. My own shell git is /usr/bin/git
+and pushed the same commits instantly.
+
+Recovery: SIGTERM the git child (porch stayed alive but idle with no children, so it was not
+going to recover), SIGTERM porch, verify status.yaml intact, push manually with /usr/bin/git,
+re-run `porch next`. porch resumed correctly at implement iteration 2 with no state loss.
+
+Generalisable: a wait is a claim that a producer exists — check the CHILD process, not just the
+parent. An hour of "still running" was one wedged subprocess the whole time.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -213,3 +213,16 @@ worktree's code and failed 33/33. The dangerous case is not this one: if the sib
 happens to be compatible, the run PASSES against the wrong worktree and nobody notices.
 Worked around locally with a temporary isolated config on a free port (deleted, not committed);
 did NOT touch the sibling builder's server. Reported to the architect.
+
+### Architect response on the harness bug (2026-08-11)
+
+Verified and actioned. The 5199 holder is a TRUE ORPHAN: vite pid 70738 whose cwd is the
+*removed* spir-1380 worktree, serving deleted code from stale file handles for ~1.5 days. The
+architect's kill was permission-blocked, so 5199 stays occupied until the human clears it.
+Issue **#1407** (area/vscode) filed for the structural fix (per-worktree port, or
+reuseExistingServer:false + dynamic port).
+
+SANCTIONED for my remaining phases: keep verifying browser tests with a temporary isolated
+config on a free port, uncommitted. **TODO for the review file's testing section: note the
+workaround and cite #1407** so the pr-gate reviewer knows why the committed config was not used
+locally. (Phases 3 and 6 both touch canvas behavior, so this will recur.)

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -1,0 +1,24 @@
+# Builder thread — spir-1401 (artifact-canvas remote command channel)
+
+## 2026-08-11 — Specify phase started
+
+Porch has me in `specify`. No pre-existing spec, so I'm authoring one from issue #1401.
+
+Architect guidance received at spawn+specify:
+- Command set mirrors keyboard vocabulary from #1237 (PR #1344) and #1380 (PR #1398) exactly; composer open/submit/cancel in scope, text entry out.
+- Target rule for no-canvas-open / multiple-canvases-open must be decided IN the spec (explicit rule or explicit error; no silent no-op).
+- Before requesting spec-approval, message main architect — they route the sdk-surface section to the streamdeck architect (same stakeholder arrangement as #1189).
+- sdk constraints hard: environment-agnostic, zero runtime deps, imports only codev-types, CI boundary tests.
+- Ride existing plumbing: canvas adapters (File/Marker/Theme) + the live-update channel the open page already holds; `afx open` serves the canvas via Tower.
+
+Research in flight: two Explore agents mapping (a) the canvas keyboard action inventory + live-update channel, (b) Tower route conventions + sdk/controller structure.
+
+## 2026-08-11 — Spec drafted
+
+Ground-truth findings that shaped the spec:
+- Canvas keyboard handling is inline (no action enum/names anywhere); block next/prev is native Tab over `tabindex=0`; reading-mode toggle has no key. The spec therefore DEFINES the canonical 14-command names.
+- The canvas's only live host is the VS Code webview (postMessage); Tower's `afx open` page is the legacy open.html annotator, NOT the canvas — the migration is #1386 (open). The architect's "afx open serves the canvas via Tower" note resolves to that planned migration; the bridge is designed host-agnostic so the #1386 page becomes a second registrant with no protocol change.
+- Existing `POST /api/command` relay is fire-and-forget broadcast — structurally cannot satisfy Requirement 4 (explicit no-canvas answer), so the spec recommends a canvas view registry in Tower + a targeted route, delivery as a viewId-addressed event on the existing SSE channel, `CommandAdapter` as the package seam (D-series pattern), and `sendCanvasCommand` on the sdk controller subpath.
+- Target rule decided at spec time: zero matches → explicit `no-canvas` error; multiple → deliver to exactly one, most-recently-active (never broadcast — composer-submit would double-post).
+
+Next: commit draft, message main architect (they route the sdk-surface section to the streamdeck architect BEFORE the spec-approval gate), then `porch done 1401` for the 3-way consultation.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -30,4 +30,31 @@ Next: commit draft, message main architect (they route the sdk-surface section t
 2. `block-next/prev` can't be native-Tab parity (Tab visits affordances/cards/toolbar/links). Redefined as flow-order `[data-line]` stepping, explicitly not Tab parity.
 Also folded: Tower-minted viewId semantics, Tower-side path canonicalization, Tower-stamped `lastActiveAt`, security posture paragraph (inherits Tower trust boundary; composer-submit is the first relay-triggerable file write; selector keys never dereferenced as paths), closed HTTP error contract.
 
+### Architect question during the gate: "are we tapping the same pipeline as other deck commands?"
+
+Traced it in code. There IS one existing pipeline: deck → `sendCommand(verb,args,ws)` → `POST /api/command` → SSE broadcast → `apps/vscode/src/command-relay.ts` (workspace filter + focus gate + `VERB_COMMANDS` allowlist) → `vscode.commands.executeCommand`. Notably `open-spec` → `codev.viewSpecFile` → `vscode.openWith(uri, MarkdownPreviewProvider.viewType)`, so **the deck already opens the artifact canvas through that pipeline today**; #1400 navigates inside a canvas the deck itself opened.
+
+We share the transport, controller posture, sdk subpath and receiving provider; we diverge on route/targeting/response because the broadcast relay returns `{ok:true}` unconditionally and cannot express Requirement 4. No collision with the existing `add-comment` verb: it operates on `vscode.window.activeTextEditor`, which is undefined when the canvas custom editor holds focus (it is the raw-source sibling, not a duplicate).
+
 Streamdeck sdk-surface review: APPROVE (issue #1401 comment) with deltas, folded in: optional `count` (default 1) on the eight traversal/paging commands only; failure codes as a closed exported union in codev-types (`CanvasCommandErrorCode`); generic-relay exposure CLOSED as NO (open question removed, decision recorded); sdk presence query recorded as a named non-goal with an additive follow-up path. MRU + lastActiveAt-on-delivery + toggle-not-set explicitly endorsed.
+
+## 2026-08-11 — spec-approval granted; plan drafted
+
+Human approved spec-approval; porch advanced to `plan`. Plan written with 5 phases:
+types contracts → canvas seam → Tower registry+route → sdk calls → VS Code host wiring.
+Phases 2/3/4 each depend only on Phase 1, so they are independently verifiable.
+
+Two spec-deferred decisions settled in the plan:
+1. **Vocabulary ownership.** artifact-canvas has NO codev-types dep today (only dompurify +
+   markdown-it). The union is a real wire contract and Tower/sdk cannot depend on a React
+   package, so codev-types owns it and the canvas takes a type-only dependency (sdk precedent).
+   The canvas import-boundary guard forbids vscode/node:*/fs/fetch only, so this is allowed;
+   Phase 2 extends the guard to pin the import as type-only.
+2. **Registration transport.** Per-view HTTP register/heartbeat/unregister with a lease, NOT
+   SSE-connection-lifetime binding. Deciding case: one VS Code window holds a single SSE
+   connection but can host several canvas panels, so connection-scoped registration cannot
+   distinguish panels or drop one on close.
+
+Also decided: sdk gains host-facing registration methods on TowerClient but does NOT re-export
+them through controller.ts — controllers drive views, hosts register them, so the approved
+controller surface stays exactly as reviewed.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -150,3 +150,16 @@ Build hiccup, NOT mine: `npm run build` failed on a missing `@xterm/addon-serial
 packages/codev/src/terminal/session-screen.ts. Traced it to PIR #1354, which my rebase pulled in
 from main; the dep is declared in packages/codev/package.json but the worktree's node_modules
 predated it. My branch touches zero terminal files. Running pnpm install.
+
+### phase_1 consultation: gemini APPROVE, codex APPROVE, claude REQUEST_CHANGES
+
+Claude caught that **the exhaustiveness guard never runs in CI** — verified myself: test.yml
+builds packages/types but nothing in any of the 5 workflows invokes check-types:tests, and
+there is no recursive `pnpm -r check-types`. Since codev-types has no test runner, that guard
+is phase_1's ENTIRE verification story, and living outside src/ (so it isn't published) is
+exactly what keeps `pnpm build` from reaching it. Unwired it would have protected nothing while
+looking like protection, and no later phase touches this package's CI. Added a
+`check-types:tests` step to test.yml right after the types build, with a comment explaining why.
+
+Worth remembering: everything was green locally and two of three reviewers approved. "Tests
+pass" hid "the test can never fail."

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -93,3 +93,34 @@ restart; canonicalization merges FILE identity, not view identity (two views kee
 viewIds); typed CanvasCommandEvent SSE payload; sdk transport failures reject rather than
 widening the spec-fixed closed error union; webview/ is outside the extension typecheck so the
 manual pass is load-bearing evidence, not a formality.
+
+## 2026-08-11 — Rebased on main; two post-approval corrections folded in
+
+Rebased builder/spir-1401 onto origin/main (27 commits behind → 0). Clean, no conflicts; porch
+state intact at `plan`. NOTE: the branch was already pushed, so the remote is now diverged and
+needs a force-push to match. Not done — waiting on the human, since it rewrites published
+history.
+
+Architect-authorized spec corrections (post spec-approval, substance unchanged; both recorded
+in a revision note at the top of the spec):
+1. **split-editor example was factually wrong.** extension.ts:1404 sets
+   supportsMultipleEditorsPerDocument:false, so VS Code cannot open two canvas panels on one
+   document. Example replaced (two hosts on one file, post-#1386); MRU requirement kept
+   verbatim; verification venue moved to the Tower registry, which accepts two registrations
+   for one file directly. Flag deliberately NOT flipped.
+2. **Transport-failure delta: streamdeck stakeholder REJECTED my proposal.** I verified their
+   claim myself at tower-client.ts:288-296: request() catches every transport error and returns
+   {ok:false, status:0}, so the client holds a never-reject invariant and sendCanvasCommand must
+   not be its sole exception. Binding resolution folded in: call stays NON-THROWING; the
+   sdk-visible union gains `unreachable` as a CLIENT-SYNTHESIZED code (wire union stays two
+   members — two separate types, so Tower cannot type a response it must never send);
+   transport failures key off the existing status:0 signal.
+
+Structural `source` field was my call: **declined**. The type-level split already carries the
+distinction (Tower cannot express `unreachable`), the closed union gives TS consumers
+exhaustiveness checking when it grows, and status:0 already signals the case one layer down. A
+source field would be a third encoding of one fact.
+
+Lesson worth keeping: my proposal was locally well-reasoned but violated a package-wide
+invariant I had not checked. The stakeholder review caught it, exactly as the #1189 arrangement
+is meant to.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -180,3 +180,36 @@ re-run `porch next`. porch resumed correctly at implement iteration 2 with no st
 
 Generalisable: a wait is a claim that a producer exists — check the CHILD process, not just the
 parent. An hour of "still running" was one wedged subprocess the whole time.
+
+## 2026-08-12 — phase_1 approved (3/3); phase_2 extraction done
+
+phase_1 got unanimous APPROVE on iteration 2 (claude re-ran the CI step and confirmed the guard
+fails a build when a command is unclassified). porch advanced to phase_2.
+
+phase_2 (pure extraction) in ArtifactCanvas.tsx: 9 actions now live in one `canvasActions`
+registry keyed by command name (comment-next/prev, heading-next/prev, doc-start/end,
+column-forward/back, composer-open), with onBodyKeyDown reduced to key mapping + event guards.
+Every event-shaped concern stayed in the handler (affordance/modifier guards, composer
+exemption, innerScrollerCanConsume, preventDefault) because a remote command has no event.
+
+Two ordering subtleties preserved deliberately:
+- Enter/Space is handled BEFORE the modifier guard, so Ctrl+Enter on a block still opens the
+  composer. Kept as-is rather than "fixed" — phase 2 is a refactor.
+- Column paging must not preventDefault when geometry is unmeasurable, so `pageColumn` returns
+  a boolean and the handler only prevents default when the action actually ran.
+
+`lineFromEvent` was orphaned by the extraction (composer-open now does closest → Number → NaN
+inline, identical logic) and was removed rather than left as dead code.
+
+Verification: 150/150 vitest pass with NO test file edited (the phase's oracle), check-types
+clean, 33/33 Playwright pass.
+
+### HARNESS BUG worth an issue (not mine to fix in this phase)
+
+`packages/artifact-canvas/playwright.config.ts` pins port 5199 with
+`reuseExistingServer: !process.env.CI`. A sibling worktree (.builders/spir-1380) had its canvas
+vite up on 5199 for ~1.5 days, so my first `test:browser` run silently executed against THAT
+worktree's code and failed 33/33. The dangerous case is not this one: if the sibling's code
+happens to be compatible, the run PASSES against the wrong worktree and nobody notices.
+Worked around locally with a temporary isolated config on a free port (deleted, not committed);
+did NOT touch the sibling builder's server. Reported to the architect.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -449,3 +449,11 @@ The only real remedy is a restricted client surface on a published subpath the s
 architect owns and approved — a breaking redesign, unrelated to canvas commands, and exactly the
 kind of scope expansion to raise rather than take. Flagged to the architect; if they want a hard
 boundary it deserves its own issue covering all 39 methods.
+
+### Streamdeck verdict on the phase_5 controller-surface item (2026-08-11): ACCEPT AS-IS
+
+They verified controller.ts:15 themselves and agree the three registration methods add nothing to
+an already-full class surface; my doc note is endorsed as the interim posture. Structural fix
+tracked as **#1411** (restricted controller client / capability surface) in their name, sequenced
+after this merge. TODO: record #1411 + this verdict in the review file's dispositions, and note
+it in the PR body.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -58,3 +58,38 @@ Two spec-deferred decisions settled in the plan:
 Also decided: sdk gains host-facing registration methods on TowerClient but does NOT re-export
 them through controller.ts — controllers drive views, hosts register them, so the approved
 controller surface stays exactly as reviewed.
+
+## 2026-08-11 — Plan consultation: two blockers, plan restructured 5 → 6 phases
+
+gemini APPROVE; codex + claude REQUEST_CHANGES, both code-verified and both right. I
+re-verified all six load-bearing claims against the worktree before acting; all held.
+
+Blockers:
+1. **Runtime traversal classification was unimportable by BOTH intended consumers.**
+   packages/codev has codev-types as a compile-time-only dep and runs unbundled from dist/, so
+   a runtime value import does not resolve (command-relay.ts:24-29 documents this and
+   re-declares COMMAND_ROUTE for the same reason); and the canvas import is type-only by my own
+   Phase 2 rule. Fixed: classification is now type-level (`TraversalCommand`), each consumer
+   declares a `satisfies`-bound const list. Tower also re-declares route/event literals.
+2. **Phase 2 "pure extraction" hid ~6 commands of new work.** Only 6 of 14 commands have a
+   handler to extract; block-next/prev (native Tab), reading-mode-toggle (ReadingModeToggle.tsx)
+   and composer-submit/cancel (CommentComposer.tsx's own onKeyDown) are new. Split the PHASE
+   rather than just the deliverable, because the template requires one atomic commit per phase.
+   Now: Phase 2 = pure extraction (oracle: unmodified existing suite), Phase 3 = new actions +
+   composer seam + cursor + CommandAdapter.
+
+Notable: **`supportsMultipleEditorsPerDocument: false` (extension.ts:1404)** means VS Code
+cannot open two canvas panels for one document, so the approved spec's "(e.g. split editor)"
+example is factually wrong. MRU rule is unaffected and still needed (two files in one
+workspace; two hosts once #1386 lands; registry-level defence) — only the verification venue
+moves, to Tower-layer tests. Did NOT flip the flag (user-visible editor behavior, out of scope).
+Raised with the architect since it corrects an approved artifact.
+
+Other fixes: type-test moved out of src/ (would have been published: include src/**/*, files
+[src,dist]); cursor documented as deliberately separate from hover-driven activeLine; count
+ignored by canvas / rejected by Tower (was unfalsifiable "ignored or rejected"); extension.ts
+added to Phase 6 (provider is constructed without ConnectionManager); re-registration on Tower
+restart; canonicalization merges FILE identity, not view identity (two views keep distinct
+viewIds); typed CanvasCommandEvent SSE payload; sdk transport failures reject rather than
+widening the spec-fixed closed error union; webview/ is outside the extension typecheck so the
+manual pass is load-bearing evidence, not a formality.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -327,3 +327,27 @@ after the session (deliberately, so it cannot become the kind of orphan behind #
 
 This is the first real-user-path confirmation for the canvas half. The Tower/sdk/VS Code path
 still needs phases 4-6, and phase_6 carries the full human review loop as an acceptance criterion.
+
+### phase_3 iter2: gemini APPROVE, codex + claude REQUEST_CHANGES — check-types was FAILING
+
+Both caught that `pnpm --filter @cluesmith/codev-artifact-canvas check-types` failed with TS2339
+on `playwright/remote-commands.spec.ts`: the `window.__canvasCommand` augmentation lives in
+examples/main.tsx, and this package's tsconfig includes src + playwright but NOT examples.
+
+**Process failure worth remembering.** I ran check-types while wiring the seam, then added the
+playwright spec afterwards and re-ran only the unit + browser suites, both of which passed
+(Playwright transpiles per file, with no project-wide type check). So the phase's own acceptance
+criterion was red while every signal I was watching was green. Rule for the remaining phases:
+run check-types AFTER the last file is added, not after the last logic change.
+
+Fixed with playwright/window-command.d.ts mirroring the augmentation for the compilation unit
+that type-checks the specs; `send()` is now typed `CanvasCommand` so a typo'd command name is a
+compile error rather than a silent runtime no-op.
+
+Also added the scrolled clean-state origin test codex asked for. It belongs in Playwright, not
+jsdom: "nothing focused and nothing scrolled -> start at the top" is checkable without layout,
+but "scrolled but never focused -> start from what the reviewer is LOOKING at" is not. The test
+asserts the topmost visible block differs from the document's first block before driving, so it
+cannot pass vacuously.
+
+Verification: check-types clean (package + repo-wide), 173/173 unit, 39/39 playwright.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -541,3 +541,23 @@ All actionable findings from iter1/iter2 ARE fixed (reconnect, re-registration r
 deactivate-unregister, closed-union validation, malformed-count event rejection, release-id-on-
 reconnect, lint). Asked the architect to let me stop iterating and open the PR, where the human
 runs the 4-step script at the pr gate. Holding rather than burning another consultation round.
+
+## 2026-08-12 — PR #1413 OPENED; holding at the pr gate
+
+https://github.com/cluesmith/codev/pull/1413 — 63 commits, 46 files, +6025/-69, MERGEABLE.
+
+Architect gave the word to stop iterating phase_6 and open the PR, citing precedent (pir-1179's
+keybinding collision, 1313's phase-7 force-advance): a REQUEST_CHANGES that no code change can
+close belongs with the human at the gate, and refusing to claim an unperformed verification is
+the right call.
+
+PR body carries the three required elements: the 4-step live script front and center as the
+gate's blocking human check with the 2-1 verdict and rebuttal linked; the verified-vs-unverified
+table isolating the single untested join; and the instruction to run the extension from THIS
+worktree's build rather than an installed copy.
+
+Note for whoever picks this up: **porch still shows phase_6 in_progress**, because I stopped
+iterating on architect instruction rather than reaching 3/3. Flagged to the architect. Do not
+hand-edit status.yaml to "fix" it.
+
+Next: wait for the pr gate. After merge → `porch done 1401 --merged 1413`, then the verify phase.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -561,3 +561,24 @@ iterating on architect instruction rather than reaching 3/3. Flagged to the arch
 hand-edit status.yaml to "fix" it.
 
 Next: wait for the pr gate. After merge → `porch done 1401 --merged 1413`, then the verify phase.
+
+## 2026-08-12 — PR-level consultation: 2 APPROVE, codex REQUEST_CHANGES (SECURITY finding)
+
+codex raised a real one at PR level and I verified it independently. Tower's existing
+request-trust boundary is weaker than my spec claimed; the specifics and the fix are tracked
+privately as a security advisory and are deliberately not restated here (public repo — owner's
+disclosure decision, relayed via the architect 2026-08-12).
+
+My spec had described a safeguard in terms that overstated what is in place; corrected in place,
+because documenting protection that is not there is worse than documenting none.
+
+Did NOT apply a partial measure to this one route. The property is pre-existing and Tower-wide,
+not introduced by this channel; addressing it properly is an architectural change with a client
+migration. Securing only the newest route would move the label rather than the risk. Escalated;
+the architect verified independently and routed it to the owner. Likely my next lane after this
+gate.
+
+Also fixed: rebased onto main (70 commits replayed clean, 0 behind, force-pushed with lease, full
+suite re-run green); added approved/validated frontmatter to spec + plan; and fixed the stale
+webview/main.ts header comment — **that comment is where my own repeated "webview isn't
+typechecked" error came from**. Caught in phase_6, root found here.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -307,3 +307,23 @@ paging at all (jsdom has no layout), and it closes codex's real-browser coverage
 Lesson worth carrying: when a new test fails, check whether the KEYBOARD path does the same thing
 before touching the component. Twice now the diff between "my path is broken" and "this is how it
 has always worked" was one probe away.
+
+### Manual verification by the human (2026-08-12) — canvas half CONFIRMED WORKING
+
+Ran the dev examples page (`pnpm --filter @cluesmith/codev-artifact-canvas dev:example`, :5173)
+and drove the seam from the browser console via `window.__canvasCommand`. Human confirmed working.
+
+Worth recording because it briefly looked broken and was not:
+- the command returns `undefined` (void), which reads like a failure but is just the return value;
+- on the default sample page the ONLY visible effect of navigation is the focus ring moving;
+- the sample doc has exactly ONE marked block, so a second `comment-next` is a correct no-op
+  (no wrap at the edges, same as the `n` key).
+Trace captured: doc-start/comment-next -> line 2 Summary, heading-next -> line 6 Requirements,
+block-next -> line 8, doc-end -> line 12.
+
+For anyone testing later: `reading-mode-toggle` and `composer-open` give unmistakable visual
+feedback; `?fixture=columns&mode=horizontal` is the page for column paging. Dev server stopped
+after the session (deliberately, so it cannot become the kind of orphan behind #1407).
+
+This is the first real-user-path confirmation for the canvas half. The Tower/sdk/VS Code path
+still needs phases 4-6, and phase_6 carries the full human review loop as an acceptance criterion.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -407,3 +407,25 @@ wire drift fails the build — and doing that immediately exposed that the regis
 missing the `ok` field Tower actually sends. The contract was wrong, not the handler.
 
 Verification: 27/27 unit, 5/5 e2e, repo check-types clean, build green.
+
+## 2026-08-12 — phase_5 (sdk canvas command + view registration) implemented
+
+`sendCanvasCommand(command, target, options?)` plus host-facing `registerCanvasView` /
+`heartbeatCanvasView` / `unregisterCanvasView` on TowerClient. Controller subpath re-exports the
+command call, its result types and CANVAS_COMMAND_ROUTE — but NOT the registration methods, per
+the split agreed with the streamdeck stakeholder (controllers drive views, hosts own them).
+
+Implementation note that mattered: the shared `request()` runs non-2xx bodies through
+`extractTowerError`, which reduces them to a message and DISCARDS the machine-readable `code` —
+exactly what a controller needs. Added a private `requestPreservingBody` alongside it rather than
+changing `request()` (which every existing caller depends on). It uses the injected `this.fetchFn`,
+so the sdk boundary rule (`/\bfetch\s*\(/`) is untouched, and it never throws: transport failure
+comes back as status 0, preserving the client's never-reject invariant.
+
+`unreachable` is synthesized only when Tower gave no usable answer (transport failure, or a body
+we cannot read). Every other resolution carries Tower's own verdict. `heartbeatCanvasView`
+returns `unknownView` separately from a generic failure because the host's response differs:
+re-register vs retry later — phase_6 depends on that distinction.
+
+Verification: 89/89 sdk (13 new), 63/63 streamdeck (boundary suite unchanged and passing),
+repo check-types clean, build green, 4847 repo tests.

--- a/codev/state/spir-1401_thread.md
+++ b/codev/state/spir-1401_thread.md
@@ -22,3 +22,12 @@ Ground-truth findings that shaped the spec:
 - Target rule decided at spec time: zero matches → explicit `no-canvas` error; multiple → deliver to exactly one, most-recently-active (never broadcast — composer-submit would double-post).
 
 Next: commit draft, message main architect (they route the sdk-surface section to the streamdeck architect BEFORE the spec-approval gate), then `porch done 1401` for the 3-way consultation.
+
+## 2026-08-11 — Consultation + streamdeck review folded in
+
+3-way verdicts: gemini APPROVE, codex REQUEST_CHANGES, claude REQUEST_CHANGES (high-quality, code-verified). Claude's two blocking findings were real and both landed on the parity rule:
+1. Remote commands have no `e.target`, and the in-page handlers gate on DOM focus — literal parity would make 8/14 commands no-ops in the primary scenario. Fixed by redefining the rule as *effect parity with a defined remote origin*: a "current block" cursor (last-focused block → topmost visible block fallback), remote navigation moves within-document focus via the same path, composer submit/cancel are view-scoped not focus-scoped.
+2. `block-next/prev` can't be native-Tab parity (Tab visits affordances/cards/toolbar/links). Redefined as flow-order `[data-line]` stepping, explicitly not Tab parity.
+Also folded: Tower-minted viewId semantics, Tower-side path canonicalization, Tower-stamped `lastActiveAt`, security posture paragraph (inherits Tower trust boundary; composer-submit is the first relay-triggerable file write; selector keys never dereferenced as paths), closed HTTP error contract.
+
+Streamdeck sdk-surface review: APPROVE (issue #1401 comment) with deltas, folded in: optional `count` (default 1) on the eight traversal/paging commands only; failure codes as a closed exported union in codev-types (`CanvasCommandErrorCode`); generic-relay exposure CLOSED as NO (open question removed, decision recorded); sdk presence query recorded as a named non-goal with an additive follow-up path. MRU + lastActiveAt-on-delivery + toggle-not-set explicitly endorsed.

--- a/packages/artifact-canvas/examples/main.tsx
+++ b/packages/artifact-canvas/examples/main.tsx
@@ -12,10 +12,16 @@
  *   ?mode=horizontal          seed `initialReadingMode` (any other value exercises coercion)
  *   ?height=unbounded         omit the bounded-height container (self-bounding assertion)
  * Default (no params) is the classic hands-on page, unchanged.
+ *
+ * Remote commands (spec 1401): the page wires a `CommandAdapter` to `window.__canvasCommand`,
+ * so `__canvasCommand('column-forward')` in the console — or from the Playwright suite — drives
+ * the canvas the way a remote controller does.
  */
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 import { ArtifactCanvas } from '../src/components/ArtifactCanvas.js';
+import type { CommandAdapter } from '../src/adapters/CommandAdapter.js';
+import type { CanvasCommand } from '@cluesmith/codev-types';
 import { createStubHost, stubEditMarker, stubDeleteMarker } from '../src/__tests__/fixtures/stub-adapters.js';
 import { SAMPLE_ARTIFACT } from '../src/__tests__/fixtures/sample-artifact.js';
 import { COLUMNS_FIXTURE } from '../src/__tests__/fixtures/columns-fixture.js';
@@ -29,6 +35,29 @@ if (fixtureMode) {
   doc = COLUMNS_FIXTURE;
 }
 const host = createStubHost(doc);
+
+/**
+ * Remote-command channel (spec 1401). This page is a host, so it implements `CommandAdapter` the
+ * way any host does — it owns the transport. Here the "transport" is a function on `window`, so
+ * the Playwright suite can drive the seam exactly as a real remote driver would, which is the
+ * only way to assert column paging: jsdom has no layout to measure.
+ */
+declare global {
+  interface Window {
+    __canvasCommand?: (command: CanvasCommand, count?: number) => void;
+  }
+}
+
+const commandAdapter: CommandAdapter = {
+  subscribe(onCommand) {
+    window.__canvasCommand = (command, count) => onCommand({ command, count });
+    return {
+      dispose: () => {
+        delete window.__canvasCommand;
+      },
+    };
+  },
+};
 
 // Per-user persistence in the dev host (spec 1380 D4): localStorage, mirroring what the VS
 // Code host does with globalState. An explicit ?mode= always wins (the Playwright fixtures
@@ -72,6 +101,7 @@ function Example(): React.ReactElement {
       stubEditMarker(host.store, markerLine, expectedAuthor, expectedBodyPrefix, newBody),
     onDeleteComment: (markerLine: number, expectedAuthor: string, expectedBodyPrefix: string) =>
       stubDeleteMarker(host.store, markerLine, expectedAuthor, expectedBodyPrefix),
+    commandAdapter,
     initialReadingMode: mode,
     onReadingModeChange: (next: string) => {
       setMode(next);

--- a/packages/artifact-canvas/package.json
+++ b/packages/artifact-canvas/package.json
@@ -35,6 +35,7 @@
     "react-dom": "^18 || ^19"
   },
   "dependencies": {
+    "@cluesmith/codev-types": "workspace:*",
     "dompurify": "^3.2.0",
     "markdown-it": "^14.1.0"
   },

--- a/packages/artifact-canvas/playwright/remote-commands.spec.ts
+++ b/packages/artifact-canvas/playwright/remote-commands.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+/**
+ * Remote command channel in real Chromium (spec 1401, plan phase 3).
+ *
+ * The unit suite drives the same `CommandAdapter`, but jsdom reports no layout, so column paging
+ * and scroll-into-view can only be asserted for real here. The dev page exposes the adapter as
+ * `window.__canvasCommand`, which is exactly the shape a host implements.
+ */
+
+async function openFixture(page: Page, mode: 'horizontal' | 'vertical'): Promise<Locator> {
+  await page.goto(`/?fixture=columns&mode=${mode}`);
+  const body = page.locator('.codev-artifact-canvas-body');
+  await expect(body.locator('h1')).toHaveText('Columns fixture');
+  await page.waitForFunction(() => typeof window.__canvasCommand === 'function');
+  return body;
+}
+
+const send = (page: Page, command: string, count?: number) =>
+  page.evaluate(
+    ([c, n]) => window.__canvasCommand?.(c as never, n as number | undefined),
+    [command, count] as const,
+  );
+
+const scrollLeft = (body: Locator) => body.evaluate((el) => el.scrollLeft);
+
+/** One column step: the first fragment's width plus the column gap. */
+const measureStep = (body: Locator) =>
+  body.evaluate((el) => {
+    const first = el.firstElementChild as Element;
+    const width = first.getClientRects()[0].width;
+    const gap = Number.parseFloat(getComputedStyle(el).columnGap) || 0;
+    return width + gap;
+  });
+
+test('remote column paging steps one measured column, forward and back', async ({ page }) => {
+  const body = await openFixture(page, 'horizontal');
+  const step = await measureStep(body);
+  // scrollLeft rounds to device pixels while the measured step can be fractional, so assert
+  // within a pixel of the grid rather than exact equality (same tolerance as the key-driven suite).
+  const near = (target: number) => async () => Math.abs((await scrollLeft(body)) - target) <= 1;
+
+  await send(page, 'column-forward');
+  await expect.poll(near(step)).toBe(true);
+  await send(page, 'column-forward');
+  await expect.poll(near(2 * step)).toBe(true);
+  await send(page, 'column-back');
+  await expect.poll(near(step)).toBe(true);
+});
+
+test('count pages several columns in one command', async ({ page }) => {
+  const body = await openFixture(page, 'horizontal');
+  const step = await measureStep(body);
+
+  await send(page, 'column-forward', 3);
+  await expect.poll(async () => Math.abs((await scrollLeft(body)) - 3 * step) <= 1).toBe(true);
+});
+
+test('a huge count stops at the end instead of spinning', async ({ page }) => {
+  const body = await openFixture(page, 'horizontal');
+
+  const started = Date.now();
+  await send(page, 'column-forward', 1_000_000);
+  const elapsed = Date.now() - started;
+
+  const max = await body.evaluate((el) => el.scrollWidth - el.clientWidth);
+  await expect.poll(async () => Math.abs((await scrollLeft(body)) - max) <= 2).toBe(true);
+  expect(elapsed).toBeLessThan(5000);
+});
+
+test('column paging is inert in vertical mode', async ({ page }) => {
+  const body = await openFixture(page, 'vertical');
+
+  // The body only becomes a horizontal scroll container under `.codev-canvas-mode-horizontal`
+  // (`overflow-x: auto` is mode-scoped), so vertical mode has nothing to scroll and this pins
+  // that. The mode check in the action is the guard for a host whose stylesheet makes the body
+  // scrollable anyway; it cannot be provoked from here.
+  const scrollable = await body.evaluate((el) => el.scrollWidth > el.clientWidth);
+  expect(scrollable).toBe(false);
+
+  await send(page, 'column-forward');
+  await send(page, 'column-back');
+  expect(await scrollLeft(body)).toBe(0);
+});
+
+test('remote navigation scrolls the target block into view', async ({ page }) => {
+  const body = await openFixture(page, 'horizontal');
+
+  // Mirrors the keyboard suite's `n` case, and deliberately uses a marked block rather than the
+  // document end: the fixture's last block is a table row whose scrollable ancestor is the table
+  // itself, so `doc-end` leaves the body's scroll alone — identically for the key and the
+  // command, which is the parity that matters.
+  await send(page, 'comment-next');
+  const marked = body.locator('.codev-canvas-has-marker').first();
+  await expect
+    .poll(() =>
+      marked.evaluate((el) => {
+        const r = el.getBoundingClientRect();
+        return r.left >= 0 && r.right <= window.innerWidth;
+      }),
+    )
+    .toBe(true);
+  await expect(marked).toBeFocused();
+});

--- a/packages/artifact-canvas/playwright/remote-commands.spec.ts
+++ b/packages/artifact-canvas/playwright/remote-commands.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page, type Locator } from '@playwright/test';
+import type { CanvasCommand } from '@cluesmith/codev-types';
 
 /**
  * Remote command channel in real Chromium (spec 1401, plan phase 3).
@@ -16,10 +17,18 @@ async function openFixture(page: Page, mode: 'horizontal' | 'vertical'): Promise
   return body;
 }
 
-const send = (page: Page, command: string, count?: number) =>
+const send = (page: Page, command: CanvasCommand, count?: number) =>
   page.evaluate(
-    ([c, n]) => window.__canvasCommand?.(c as never, n as number | undefined),
+    ([c, n]) => window.__canvasCommand?.(c as CanvasCommand, n as number | undefined),
     [command, count] as const,
+  );
+
+const focusedLine = (page: Page) =>
+  page.evaluate(
+    () =>
+      (document.activeElement as HTMLElement | null)
+        ?.closest?.('[data-line]')
+        ?.getAttribute('data-line') ?? null,
   );
 
 const scrollLeft = (body: Locator) => body.evaluate((el) => el.scrollLeft);
@@ -81,6 +90,38 @@ test('column paging is inert in vertical mode', async ({ page }) => {
   await send(page, 'column-forward');
   await send(page, 'column-back');
   expect(await scrollLeft(body)).toBe(0);
+});
+
+// The clean-state origin rule has two halves. jsdom covers the unscrolled one (nothing focused,
+// start from the top); only a real layout can prove the other, that a SCROLLED but never-focused
+// view starts from the block the reviewer is actually looking at rather than the document start.
+test('a scrolled, never-focused view starts from the topmost visible block', async ({ page }) => {
+  const body = await openFixture(page, 'horizontal');
+
+  // Scroll well into the document without touching focus, the way a reviewer who has only
+  // scrolled (or a host that restored a position) would leave it.
+  await body.evaluate((el) => {
+    el.scrollLeft = Math.floor((el.scrollWidth - el.clientWidth) / 2);
+  });
+
+  const firstInDocument = await body.evaluate(
+    (el) => el.querySelector('[data-line]')?.getAttribute('data-line') ?? null,
+  );
+  const topmostVisible = await body.evaluate((el) => {
+    const host = el.getBoundingClientRect();
+    for (const b of Array.from(el.querySelectorAll('[data-line]'))) {
+      if (b.getBoundingClientRect().right > host.left) return b.getAttribute('data-line');
+    }
+    return null;
+  });
+  expect(topmostVisible).not.toBe(firstInDocument); // the scroll actually moved past the start
+
+  await send(page, 'block-next');
+  const landed = await focusedLine(page);
+
+  // It stepped on from what was visible, not from the top of the document.
+  expect(landed).not.toBe(firstInDocument);
+  expect(Number(landed)).toBeGreaterThan(Number(topmostVisible));
 });
 
 test('remote navigation scrolls the target block into view', async ({ page }) => {

--- a/packages/artifact-canvas/playwright/window-command.d.ts
+++ b/packages/artifact-canvas/playwright/window-command.d.ts
@@ -1,0 +1,16 @@
+/**
+ * The dev page (`examples/main.tsx`) implements `CommandAdapter` and exposes it as
+ * `window.__canvasCommand` so the browser suite can drive the remote seam (spec 1401).
+ *
+ * `examples/` is outside this package's tsconfig, so the `declare global` there is invisible to
+ * these specs; this mirrors it for the compilation unit that actually type-checks them.
+ */
+import type { CanvasCommand } from '@cluesmith/codev-types';
+
+declare global {
+  interface Window {
+    __canvasCommand?: (command: CanvasCommand, count?: number) => void;
+  }
+}
+
+export {};

--- a/packages/artifact-canvas/src/__tests__/import-boundary.test.ts
+++ b/packages/artifact-canvas/src/__tests__/import-boundary.test.ts
@@ -40,6 +40,26 @@ describe('import boundary', () => {
     expect(files.length).toBeGreaterThan(0);
   });
 
+  /**
+   * `@cluesmith/codev-types` carries the canvas command vocabulary (spec 1401), and it must reach
+   * this package as TYPES ONLY. A runtime import would give the package its first non-rendering
+   * runtime dependency and break the host-agnostic posture the boundary above protects — and it
+   * would not even resolve in every consumer, since codev-types is a compile-time-only dependency
+   * elsewhere in the monorepo. Every import of it must be the fully-erased `import type` form.
+   */
+  it('imports @cluesmith/codev-types as types only', () => {
+    const violations: string[] = [];
+    for (const file of files) {
+      const text = readFileSync(file, 'utf8');
+      for (const line of text.split('\n')) {
+        if (!line.includes('@cluesmith/codev-types')) continue;
+        if (!/^\s*import\s/.test(line)) continue;
+        if (!/^\s*import\s+type\s/.test(line)) violations.push(`${file}: ${line.trim()}`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
   it('shipped source contains no vscode / node:* / fs / fetch usage', () => {
     const violations: string[] = [];
     for (const file of files) {

--- a/packages/artifact-canvas/src/__tests__/remote-commands.test.tsx
+++ b/packages/artifact-canvas/src/__tests__/remote-commands.test.tsx
@@ -1,0 +1,368 @@
+/**
+ * Remote command channel (spec 1401, phase 3).
+ *
+ * Proves that a host driving the canvas through `CommandAdapter` gets the same effects the
+ * keyboard produces, that relative commands are well-defined on a view nobody has touched yet,
+ * and that `count` repeats traversal commands only.
+ *
+ * The keyboard equivalents themselves are already covered by the existing suites; what is new
+ * here is the remote path, so these tests assert through the adapter rather than through keys.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup, fireEvent, act } from '@testing-library/react';
+import * as React from 'react';
+import { ArtifactCanvas } from '../components/ArtifactCanvas.js';
+import type { CanvasCommandInvocation, CommandAdapter } from '../adapters/CommandAdapter.js';
+import { SAMPLE_ARTIFACT } from './fixtures/sample-artifact.js';
+import { createStubHost } from './fixtures/stub-adapters.js';
+
+afterEach(cleanup);
+
+// jsdom doesn't implement scrollIntoView, and every focus move calls it, so install a mock for
+// the whole file (same approach as the minimap suite) and restore afterwards.
+let originalScrollIntoView: typeof Element.prototype.scrollIntoView;
+beforeEach(() => {
+  originalScrollIntoView = Element.prototype.scrollIntoView;
+  Element.prototype.scrollIntoView = vi.fn();
+});
+afterEach(() => {
+  Element.prototype.scrollIntoView = originalScrollIntoView;
+});
+
+/** A host-side command channel the test drives directly, mirroring what a real host wires up. */
+function createCommandChannel() {
+  let deliver: ((invocation: CanvasCommandInvocation) => void) | null = null;
+  let disposed = false;
+  const adapter: CommandAdapter = {
+    subscribe(onCommand) {
+      deliver = onCommand;
+      return {
+        dispose: () => {
+          disposed = true;
+          deliver = null;
+        },
+      };
+    },
+  };
+  return {
+    adapter,
+    send(command: CanvasCommandInvocation['command'], count?: number) {
+      if (!deliver) throw new Error('canvas never subscribed to the command adapter');
+      deliver({ command, count });
+    },
+    get subscribed() {
+      return deliver !== null;
+    },
+    get disposed() {
+      return disposed;
+    },
+  };
+}
+
+function mount(initial = SAMPLE_ARTIFACT) {
+  const host = createStubHost(initial);
+  const channel = createCommandChannel();
+  const onAddComment = vi.fn((line: number, text: string) => {
+    void host.markerAdapter.add('artifact://sample.md', line, text, 'reviewer');
+  });
+  const onReadingModeChange = vi.fn();
+  render(
+    <ArtifactCanvas
+      uri="artifact://sample.md"
+      fileAdapter={host.fileAdapter}
+      markerAdapter={host.markerAdapter}
+      themeAdapter={host.themeAdapter}
+      onAddComment={onAddComment}
+      onReadingModeChange={onReadingModeChange}
+      commandAdapter={channel.adapter}
+    />,
+  );
+  return { host, channel, onAddComment, onReadingModeChange };
+}
+
+async function rendered(): Promise<HTMLElement> {
+  return waitFor(() => {
+    const el = document.querySelector<HTMLElement>('[data-line]');
+    if (!el) throw new Error('canvas has not rendered yet');
+    return el;
+  });
+}
+
+function focusedLine(): string | null {
+  return document.activeElement?.closest?.('[data-line]')?.getAttribute('data-line') ?? null;
+}
+
+function lineOf(text: string): string {
+  const el = screen.getByText(text, { exact: false }).closest('[data-line]');
+  if (!el) throw new Error(`no [data-line] block for "${text}"`);
+  return el.getAttribute('data-line') as string;
+}
+
+describe('remote command channel', () => {
+  it('subscribes on mount and disposes on unmount', async () => {
+    const { channel } = mount();
+    await rendered();
+    expect(channel.subscribed).toBe(true);
+    cleanup();
+    expect(channel.disposed).toBe(true);
+  });
+
+  // The feature's primary scenario: a controller drives a canvas nobody has clicked into, so
+  // there is no DOM focus and no hover. Literal keyboard parity would no-op here (the key
+  // handlers derive their origin from the event target), which is why the cursor falls back to
+  // the topmost visible block.
+  it('navigates from a clean, never-focused view', async () => {
+    const { channel } = mount();
+    await rendered();
+    expect(focusedLine()).toBeNull();
+
+    channel.send('block-next');
+    expect(focusedLine()).not.toBeNull();
+  });
+
+  it('walks blocks forward and back, without wrapping at the edges', async () => {
+    const { channel } = mount();
+    await rendered();
+
+    channel.send('doc-start');
+    const first = focusedLine();
+    channel.send('block-prev');
+    expect(focusedLine()).toBe(first); // already at the start: a no-op, not a wrap
+
+    channel.send('block-next');
+    const second = focusedLine();
+    expect(second).not.toBe(first);
+    channel.send('block-prev');
+    expect(focusedLine()).toBe(first);
+  });
+
+  it('jumps to the commented block and to headings', async () => {
+    const { channel } = mount();
+    await rendered();
+
+    channel.send('doc-start');
+    channel.send('comment-next');
+    // The fixture's only marker annotates the "## Summary" heading.
+    expect(focusedLine()).toBe(lineOf('Summary'));
+
+    channel.send('doc-start');
+    channel.send('heading-next');
+    expect(focusedLine()).toBe(lineOf('Summary'));
+  });
+
+  it('moves to the document start and end', async () => {
+    const { channel } = mount();
+    await rendered();
+
+    channel.send('doc-end');
+    const last = focusedLine();
+    channel.send('doc-start');
+    const first = focusedLine();
+    expect(first).not.toBe(last);
+    expect(Number(first)).toBeLessThan(Number(last));
+  });
+
+  it('repeats traversal commands with count, clamping at the edge', async () => {
+    const { channel } = mount();
+    await rendered();
+
+    channel.send('doc-start');
+    channel.send('block-next', 3);
+    const afterCounted = focusedLine();
+
+    channel.send('doc-start');
+    channel.send('block-next');
+    channel.send('block-next');
+    channel.send('block-next');
+    expect(focusedLine()).toBe(afterCounted); // count: 3 === three single steps
+
+    // A count past the end stops at the last block rather than running off it.
+    channel.send('doc-start');
+    channel.send('block-next', 9999);
+    const clamped = focusedLine();
+    channel.send('doc-end');
+    expect(focusedLine()).toBe(clamped);
+  });
+
+  it('ignores count on non-traversal commands rather than rejecting it', async () => {
+    const { channel, onReadingModeChange } = mount();
+    await rendered();
+
+    // Validation belongs to the sender; a command that reached the canvas already passed it, so
+    // the canvas applies the command once and drops the meaningless count.
+    channel.send('reading-mode-toggle', 5);
+    expect(onReadingModeChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a count that is not a positive integer', async () => {
+    const { channel } = mount();
+    await rendered();
+
+    channel.send('doc-start');
+    channel.send('block-next', 0);
+    const afterZero = focusedLine();
+
+    channel.send('doc-start');
+    channel.send('block-next');
+    expect(focusedLine()).toBe(afterZero); // 0 fell back to a single step
+  });
+
+  it('toggles reading mode', async () => {
+    const { channel, onReadingModeChange } = mount();
+    await rendered();
+
+    channel.send('reading-mode-toggle');
+    expect(onReadingModeChange).toHaveBeenLastCalledWith('horizontal');
+    channel.send('reading-mode-toggle');
+    expect(onReadingModeChange).toHaveBeenLastCalledWith('vertical');
+  });
+
+  it('opens the composer on the current block', async () => {
+    const { channel } = mount();
+    await rendered();
+
+    channel.send('doc-start');
+    channel.send('composer-open');
+    await waitFor(() => {
+      expect(document.querySelector('.codev-canvas-comment-composer')).not.toBeNull();
+    });
+  });
+
+  // The composer commands are VIEW-scoped, not focus-scoped: a remote driver never moved focus
+  // into the textarea, so requiring focus there would make them unusable.
+  it('submits the typed draft with focus parked outside the composer', async () => {
+    const { channel, onAddComment } = mount();
+    await rendered();
+
+    channel.send('doc-start');
+    const target = focusedLine();
+    channel.send('composer-open');
+    const textarea = await waitFor(() => {
+      const el = document.querySelector<HTMLTextAreaElement>('.codev-canvas-comment-composer-input');
+      if (!el) throw new Error('composer did not open');
+      return el;
+    });
+
+    fireEvent.change(textarea, { target: { value: 'remote comment' } });
+    // Park focus away from the composer, the way a remote-driven session leaves it.
+    document.querySelector<HTMLElement>(`[data-line="${target}"]`)?.focus();
+
+    channel.send('composer-submit');
+    await waitFor(() => {
+      expect(onAddComment).toHaveBeenCalledWith(Number(target), 'remote comment');
+    });
+    expect(onAddComment).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels an open composer and writes nothing', async () => {
+    const { channel, onAddComment } = mount();
+    await rendered();
+
+    channel.send('doc-start');
+    channel.send('composer-open');
+    await waitFor(() => {
+      expect(document.querySelector('.codev-canvas-comment-composer')).not.toBeNull();
+    });
+
+    channel.send('composer-cancel');
+    await waitFor(() => {
+      expect(document.querySelector('.codev-canvas-comment-composer')).toBeNull();
+    });
+    expect(onAddComment).not.toHaveBeenCalled();
+  });
+
+  it('treats composer submit and cancel with no composer open as defined no-ops', async () => {
+    const { channel, onAddComment } = mount();
+    await rendered();
+
+    channel.send('composer-submit');
+    channel.send('composer-cancel');
+    expect(onAddComment).not.toHaveBeenCalled();
+    expect(document.querySelector('.codev-canvas-comment-composer')).toBeNull();
+  });
+
+  it('submits nothing when the draft is empty, matching the keyboard', async () => {
+    const { channel, onAddComment } = mount();
+    await rendered();
+
+    channel.send('doc-start');
+    channel.send('composer-open');
+    await waitFor(() => {
+      expect(document.querySelector('.codev-canvas-comment-composer')).not.toBeNull();
+    });
+
+    channel.send('composer-submit');
+    expect(onAddComment).not.toHaveBeenCalled();
+  });
+
+  // Column paging is meaningful only in horizontal mode; jsdom cannot measure column geometry,
+  // so the real paging assertion lives in the Playwright suite. What matters here is that the
+  // command is safe to send in vertical mode.
+  it('leaves column paging a safe no-op in vertical mode', async () => {
+    const { channel } = mount();
+    await rendered();
+
+    channel.send('doc-start');
+    const before = focusedLine();
+    channel.send('column-forward');
+    channel.send('column-back');
+    expect(focusedLine()).toBe(before);
+  });
+
+  it('reports a thrown error through onError instead of escaping the host callback', async () => {
+    const host = createStubHost(SAMPLE_ARTIFACT);
+    const channel = createCommandChannel();
+    const onError = vi.fn();
+    // Reading-mode changes are the cheapest place to inject a host failure.
+    render(
+      <ArtifactCanvas
+        uri="artifact://sample.md"
+        fileAdapter={host.fileAdapter}
+        markerAdapter={host.markerAdapter}
+        themeAdapter={host.themeAdapter}
+        onAddComment={vi.fn()}
+        onReadingModeChange={() => {
+          throw new Error('host blew up');
+        }}
+        onError={onError}
+        commandAdapter={channel.adapter}
+      />,
+    );
+    await rendered();
+
+    expect(() => channel.send('reading-mode-toggle')).not.toThrow();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  // Guards the stale-closure trap: `canvasActions` is rebuilt every render, so a subscription
+  // that captured it once would keep running the FIRST render's actions. Driving the canvas
+  // after a state change that re-renders it proves dispatch reads the current ones.
+  it('runs current actions after a re-render, not the ones captured at subscribe time', async () => {
+    const { channel, onReadingModeChange } = mount();
+    await rendered();
+
+    // Re-render by toggling mode, then drive again: a stale closure would still hold the
+    // original `readingMode` and report 'horizontal' a second time.
+    channel.send('reading-mode-toggle');
+    expect(onReadingModeChange).toHaveBeenLastCalledWith('horizontal');
+    channel.send('reading-mode-toggle');
+    expect(onReadingModeChange).toHaveBeenLastCalledWith('vertical');
+    channel.send('reading-mode-toggle');
+    expect(onReadingModeChange).toHaveBeenLastCalledWith('horizontal');
+  });
+
+  it('leaves behavior unchanged when no command adapter is supplied', async () => {
+    const host = createStubHost(SAMPLE_ARTIFACT);
+    render(
+      <ArtifactCanvas
+        uri="artifact://sample.md"
+        fileAdapter={host.fileAdapter}
+        markerAdapter={host.markerAdapter}
+        themeAdapter={host.themeAdapter}
+        onAddComment={vi.fn()}
+      />,
+    );
+    await rendered();
+    expect(document.querySelector('[data-line]')).not.toBeNull();
+  });
+});

--- a/packages/artifact-canvas/src/__tests__/remote-commands.test.tsx
+++ b/packages/artifact-canvas/src/__tests__/remote-commands.test.tsx
@@ -9,7 +9,7 @@
  * here is the remote path, so these tests assert through the adapter rather than through keys.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, cleanup, fireEvent, act } from '@testing-library/react';
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react';
 import * as React from 'react';
 import { ArtifactCanvas } from '../components/ArtifactCanvas.js';
 import type { CanvasCommandInvocation, CommandAdapter } from '../adapters/CommandAdapter.js';
@@ -148,6 +148,32 @@ describe('remote command channel', () => {
     channel.send('doc-start');
     channel.send('heading-next');
     expect(focusedLine()).toBe(lineOf('Summary'));
+  });
+
+  it('jumps backwards to the previous commented block and heading', async () => {
+    const { channel } = mount();
+    await rendered();
+
+    channel.send('doc-end');
+    channel.send('comment-prev');
+    expect(focusedLine()).toBe(lineOf('Summary'));
+
+    channel.send('doc-end');
+    channel.send('heading-prev');
+    // The last heading before the end of the fixture is "## Requirements".
+    expect(focusedLine()).toBe(lineOf('Requirements'));
+  });
+
+  it('does not wrap when a backwards jump has nowhere to go', async () => {
+    const { channel } = mount();
+    await rendered();
+
+    channel.send('doc-start');
+    const first = focusedLine();
+    channel.send('comment-prev');
+    expect(focusedLine()).toBe(first);
+    channel.send('heading-prev');
+    expect(focusedLine()).toBe(first);
   });
 
   it('moves to the document start and end', async () => {
@@ -300,13 +326,36 @@ describe('remote command channel', () => {
   // command is safe to send in vertical mode.
   it('leaves column paging a safe no-op in vertical mode', async () => {
     const { channel } = mount();
-    await rendered();
+    const block = await rendered();
+    const body = block.closest('.codev-artifact-canvas-body') as HTMLElement;
 
     channel.send('doc-start');
     const before = focusedLine();
+    // A vertical layout can still scroll horizontally (a wide table, a long code line), so give
+    // the body a non-zero scroll position and assert paging does not move it. Without the
+    // mode check in the action this passes only because jsdom reports zero geometry.
+    body.scrollLeft = 40;
     channel.send('column-forward');
     channel.send('column-back');
+    expect(body.scrollLeft).toBe(40);
     expect(focusedLine()).toBe(before);
+  });
+
+  it('stops a counted command once it stops making progress', async () => {
+    const { channel } = mount();
+    await rendered();
+
+    // A huge count must not walk a million steps over a handful of blocks. The loop breaks as
+    // soon as a step changes nothing, so this returns promptly and lands on the last block.
+    channel.send('doc-start');
+    const started = Date.now();
+    channel.send('block-next', 1_000_000);
+    const elapsed = Date.now() - started;
+    const landed = focusedLine();
+
+    channel.send('doc-end');
+    expect(focusedLine()).toBe(landed);
+    expect(elapsed).toBeLessThan(1000);
   });
 
   it('reports a thrown error through onError instead of escaping the host callback', async () => {
@@ -349,6 +398,21 @@ describe('remote command channel', () => {
     expect(onReadingModeChange).toHaveBeenLastCalledWith('vertical');
     channel.send('reading-mode-toggle');
     expect(onReadingModeChange).toHaveBeenLastCalledWith('horizontal');
+  });
+
+  // The spec's non-goal: remote block traversal must not be implemented by hijacking Tab, which
+  // also visits the "+" affordance, card actions, the toolbar and links.
+  it('does not intercept Tab', async () => {
+    const { channel } = mount();
+    const block = await rendered();
+
+    channel.send('doc-start');
+    const before = focusedLine();
+    const handled = fireEvent.keyDown(block, { key: 'Tab' });
+    // fireEvent returns false only when preventDefault was called; the canvas must leave Tab to
+    // the browser, and focus must not have moved as a side effect.
+    expect(handled).toBe(true);
+    expect(focusedLine()).toBe(before);
   });
 
   it('leaves behavior unchanged when no command adapter is supplied', async () => {

--- a/packages/artifact-canvas/src/adapters/CommandAdapter.ts
+++ b/packages/artifact-canvas/src/adapters/CommandAdapter.ts
@@ -1,0 +1,37 @@
+import type { CanvasCommand } from '@cluesmith/codev-types';
+import type { Disposable } from '../types.js';
+
+/**
+ * One remote command, as delivered to the canvas.
+ *
+ * `count` repeats a traversal command (next/previous block, commented block, heading, or column)
+ * N times, with the same edge behavior as N single steps. It is ignored on every other command
+ * and on values that are not positive integers: validation belongs to the sender (spec 1401 —
+ * Tower answers `invalid-request`), and a command that reached the canvas has already passed it.
+ */
+export interface CanvasCommandInvocation {
+  command: CanvasCommand;
+  count?: number;
+}
+
+/**
+ * Delivers remote review-navigation commands into the canvas (spec 1401).
+ *
+ * The fourth adapter alongside File/Marker/Theme, and the same contract: an interface only, with
+ * implementations living in the host. The canvas never opens a connection of its own — the host
+ * owns the transport (a webview `postMessage` bridge, an SSE-fed relay, a test double) and calls
+ * back through `onCommand`.
+ *
+ * Commands drive the SAME per-action implementations as the keyboard, so the remote and in-page
+ * paths cannot diverge. What a command cannot do is type: comment bodies are entered on the
+ * keyboard, so `composer-open` and `composer-submit` are in the vocabulary but text entry is not.
+ *
+ * Optional by design: a host that omits `commandAdapter` gets exactly today's behavior.
+ */
+export interface CommandAdapter {
+  /**
+   * Subscribe to inbound commands. Returns a `Disposable` synchronously (spec D2's async/sync
+   * split); commands arrive asynchronously via `onCommand`.
+   */
+  subscribe(onCommand: (invocation: CanvasCommandInvocation) => void): Disposable;
+}

--- a/packages/artifact-canvas/src/components/ArtifactCanvas.tsx
+++ b/packages/artifact-canvas/src/components/ArtifactCanvas.tsx
@@ -518,13 +518,6 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
     }
   };
 
-  const lineFromEvent = (target: EventTarget | null): number | null => {
-    const el = (target as HTMLElement | null)?.closest?.('[data-line]') as HTMLElement | null;
-    if (!el) return null;
-    const n = Number(el.getAttribute('data-line'));
-    return Number.isNaN(n) ? null : n;
-  };
-
   // Navigable blocks in tree order, deduped to the FIRST element per line: the renderer stamps the
   // same `data-line` on nested blocks (a `ul` and its `li`), and the first match is the outermost —
   // the same outermost-wins rule the marker decoration uses, so `n`/`p` land where the class is.
@@ -738,6 +731,137 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
     };
   }, [readingMode]);
 
+  // ---- Semantic action registry (spec 1401, phase 2) ----
+  // One named implementation per action, dispatched by command name. The keyboard handler below
+  // and (from phase 3) the remote command channel both go through this map, so the two paths
+  // cannot drift apart. Everything event-shaped stays in the handler — which key means what, the
+  // affordance/modifier guards, the composer exemption, and `preventDefault` — because a remote
+  // command has no event; these functions carry only the action itself.
+
+  const isMarkedBlock = (el: HTMLElement): boolean => el.classList.contains('codev-canvas-has-marker');
+  const isHeadingBlock = (el: HTMLElement): boolean => /^H[1-6]$/.test(el.tagName);
+
+  const originBlock = (target: EventTarget | null): HTMLElement | null =>
+    ((target as HTMLElement | null)?.closest?.('[data-line]') as HTMLElement | null) ?? null;
+
+  const focusEdgeBlock = (root: HTMLElement, edge: 'start' | 'end'): void => {
+    const blocks = collectBlocks(root);
+    let target: HTMLElement | undefined;
+    if (edge === 'start') {
+      target = blocks[0];
+    } else {
+      target = blocks[blocks.length - 1];
+    }
+    if (target) focusBlock(target);
+  };
+
+  // Focus the next/previous block matching `match`, walking outward from `fromLine`.
+  const focusMatchingBlock = (
+    root: HTMLElement,
+    fromLine: string | null,
+    match: (el: HTMLElement) => boolean,
+    step: 1 | -1,
+  ): void => {
+    const blocks = collectBlocks(root);
+    // Match by line value, not element identity: the focused element may be an inner nested block
+    // that the dedupe dropped in favor of its outermost sibling for the same line.
+    const start = blocks.findIndex((b) => b.getAttribute('data-line') === fromLine);
+    if (start === -1) return;
+    for (let i = start + step; i >= 0 && i < blocks.length; i += step) {
+      if (match(blocks[i])) {
+        focusBlock(blocks[i]);
+        return;
+      }
+    }
+    // No match in that direction: deliberate no-op, no wrap-around — predictable at the edges.
+  };
+
+  // Step the horizontal viewport one column. Steps land on column starts: quantize to the
+  // measured step grid, then move one column.
+  const pageColumn = (root: HTMLElement, dir: 1 | -1): boolean => {
+    const { step } = measureColumnGeometry(root);
+    if (step <= 0) return false;
+    // A page step is absolute; never let an in-flight wheel glide drag the position away.
+    cancelWheelGlideRef.current?.();
+    const max = Math.max(root.scrollWidth - root.clientWidth, 0);
+    let target = (Math.round(root.scrollLeft / step) + dir) * step;
+    if (target < 0) target = 0;
+    if (target > max) target = max;
+    root.scrollLeft = target;
+    return true;
+  };
+
+  type CanvasActionName =
+    | 'comment-next'
+    | 'comment-prev'
+    | 'heading-next'
+    | 'heading-prev'
+    | 'doc-start'
+    | 'doc-end'
+    | 'column-forward'
+    | 'column-back'
+    | 'composer-open';
+
+  interface CanvasActionContext {
+    /** The canvas body: scroll container and query root. */
+    root: HTMLElement | null;
+    /** The `[data-line]` block the action starts from, when the caller has one. */
+    origin: HTMLElement | null;
+  }
+
+  /**
+   * Each action returns false only when it could not run at all and the caller should leave the
+   * key to the browser. A deliberate no-op (no match in that direction, an empty document) still
+   * returns true: the action ran and decided to do nothing, which is not the same as declining.
+   */
+  const canvasActions: Record<CanvasActionName, (ctx: CanvasActionContext) => boolean> = {
+    'comment-next': ({ root, origin }) => {
+      if (!root) return false;
+      focusMatchingBlock(root, origin?.getAttribute('data-line') ?? null, isMarkedBlock, 1);
+      return true;
+    },
+    'comment-prev': ({ root, origin }) => {
+      if (!root) return false;
+      focusMatchingBlock(root, origin?.getAttribute('data-line') ?? null, isMarkedBlock, -1);
+      return true;
+    },
+    'heading-next': ({ root, origin }) => {
+      if (!root) return false;
+      focusMatchingBlock(root, origin?.getAttribute('data-line') ?? null, isHeadingBlock, 1);
+      return true;
+    },
+    'heading-prev': ({ root, origin }) => {
+      if (!root) return false;
+      focusMatchingBlock(root, origin?.getAttribute('data-line') ?? null, isHeadingBlock, -1);
+      return true;
+    },
+    'doc-start': ({ root }) => {
+      if (!root) return false;
+      focusEdgeBlock(root, 'start');
+      return true;
+    },
+    'doc-end': ({ root }) => {
+      if (!root) return false;
+      focusEdgeBlock(root, 'end');
+      return true;
+    },
+    'column-forward': ({ root }) => {
+      if (!root) return false;
+      return pageColumn(root, 1);
+    },
+    'column-back': ({ root }) => {
+      if (!root) return false;
+      return pageColumn(root, -1);
+    },
+    'composer-open': ({ origin }) => {
+      if (!origin) return false;
+      const line = Number(origin.getAttribute('data-line'));
+      if (Number.isNaN(line)) return false;
+      openComposer(line); // open the inline composer for this block (#1107)
+      return true;
+    },
+  };
+
   // Keyboard handling on the body (#1107 activation + #1237 jump navigation). Every branch below
   // requires the event to originate on a `[data-line]` block, so keystrokes inside the composer
   // textarea, the card action buttons, or the minimap are never intercepted — typing "n" in a
@@ -751,10 +875,8 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
     // here would re-resolve through the host row and open the composer on the wrong line.
     if (fromAffordance(e.target)) return;
     if (e.key === 'Enter' || e.key === ' ') {
-      const l = lineFromEvent(e.target);
-      if (l !== null) {
+      if (canvasActions['composer-open']({ root: bodyRef.current, origin: originBlock(e.target) })) {
         e.preventDefault();
-        openComposer(l); // open the inline composer for this block (#1107)
       }
       return;
     }
@@ -775,19 +897,11 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
       let pageDelta = 1;
       if (e.key === 'PageUp') pageDelta = -1;
       if (innerScrollerCanConsume(t, pageDelta, root)) return;
-      const { step } = measureColumnGeometry(root);
+      let pageAction: CanvasActionName = 'column-forward';
+      if (e.key === 'PageUp') pageAction = 'column-back';
       // Unmeasurable geometry: leave the key to the browser rather than swallowing it.
-      if (step <= 0) return;
+      if (!canvasActions[pageAction]({ root, origin: null })) return;
       e.preventDefault();
-      // A page step is absolute; never let an in-flight wheel glide drag the position away.
-      cancelWheelGlideRef.current?.();
-      let dir = 1;
-      if (e.key === 'PageUp') dir = -1;
-      const max = Math.max(root.scrollWidth - root.clientWidth, 0);
-      let target = (Math.round(root.scrollLeft / step) + dir) * step;
-      if (target < 0) target = 0;
-      if (target > max) target = max;
-      root.scrollLeft = target;
       return;
     }
 
@@ -810,42 +924,22 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
 
     if (e.key === 'Home' || e.key === 'End') {
       e.preventDefault();
-      const blocks = collectBlocks(root);
-      let target: HTMLElement | undefined;
-      if (e.key === 'Home') {
-        target = blocks[0];
-      } else {
-        target = blocks[blocks.length - 1];
-      }
-      if (target) focusBlock(target);
+      let edgeAction: CanvasActionName = 'doc-start';
+      if (e.key === 'End') edgeAction = 'doc-end';
+      canvasActions[edgeAction]({ root, origin: current });
       return;
     }
 
-    const isMarked = (el: HTMLElement): boolean => el.classList.contains('codev-canvas-has-marker');
-    const isHeading = (el: HTMLElement): boolean => /^H[1-6]$/.test(el.tagName);
-    let match: (el: HTMLElement) => boolean;
-    let step: number;
+    let jumpAction: CanvasActionName | null = null;
     switch (e.key) {
-      case 'n': match = isMarked; step = 1; break;
-      case 'p': match = isMarked; step = -1; break;
-      case ']': match = isHeading; step = 1; break;
-      case '[': match = isHeading; step = -1; break;
+      case 'n': jumpAction = 'comment-next'; break;
+      case 'p': jumpAction = 'comment-prev'; break;
+      case ']': jumpAction = 'heading-next'; break;
+      case '[': jumpAction = 'heading-prev'; break;
       default: return;
     }
     e.preventDefault();
-    const blocks = collectBlocks(root);
-    const curLine = current.getAttribute('data-line');
-    // Match by line value, not element identity: the focused element may be an inner nested block
-    // that the dedupe dropped in favor of its outermost sibling for the same line.
-    const start = blocks.findIndex((b) => b.getAttribute('data-line') === curLine);
-    if (start === -1) return;
-    for (let i = start + step; i >= 0 && i < blocks.length; i += step) {
-      if (match(blocks[i])) {
-        focusBlock(blocks[i]);
-        return;
-      }
-    }
-    // No match in that direction: deliberate no-op, no wrap-around — predictable at the edges.
+    canvasActions[jumpAction]({ root, origin: current });
   };
 
   const resolveBlock = (target: EventTarget | null): { el: HTMLElement; line: number } | null => {

--- a/packages/artifact-canvas/src/components/ArtifactCanvas.tsx
+++ b/packages/artifact-canvas/src/components/ArtifactCanvas.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import type { CanvasCommand, TraversalCommand } from '@cluesmith/codev-types';
+import type { CanvasCommandInvocation } from '../adapters/CommandAdapter.js';
 import type { ArtifactCanvasProps, ReadingMode, ReviewMarker } from '../types.js';
 import { renderMarkdown } from '../renderer/renderer.js';
 import { CommentAffordance } from '../overlays/CommentAffordance.js';
-import { CommentComposer } from '../overlays/CommentComposer.js';
+import { CommentComposer, type CommentComposerHandle } from '../overlays/CommentComposer.js';
 import { MarkerMinimap } from '../overlays/MarkerMinimap.js';
 import { KeyboardHelp } from '../overlays/KeyboardHelp.js';
 import { ReadingModeToggle } from '../overlays/ReadingModeToggle.js';
@@ -22,6 +24,43 @@ import {
 function coerceReadingMode(value: string | undefined): ReadingMode {
   if (value === 'horizontal') return 'horizontal';
   return 'vertical';
+}
+
+/**
+ * The commands `count` repeats. Declared locally and bound to `TraversalCommand` with
+ * `satisfies` rather than imported as a runtime value: `@cluesmith/codev-types` reaches this
+ * package as types only, so the classification travels as a type and each consumer owns its own
+ * list. `satisfies` catches a member that is not traversal; the assertion below catches a
+ * traversal command missing from the list, so drift in either direction is a compile error.
+ */
+const TRAVERSAL_COMMANDS = [
+  'block-next',
+  'block-prev',
+  'comment-next',
+  'comment-prev',
+  'heading-next',
+  'heading-prev',
+  'column-forward',
+  'column-back',
+] as const satisfies readonly TraversalCommand[];
+
+type _EveryTraversalCommandIsListed =
+  Exclude<TraversalCommand, (typeof TRAVERSAL_COMMANDS)[number]> extends never ? true : never;
+
+function isTraversalCommand(command: CanvasCommand): command is TraversalCommand {
+  return (TRAVERSAL_COMMANDS as readonly CanvasCommand[]).includes(command);
+}
+
+/**
+ * How many times to apply a command. `count` repeats traversal commands only, and only for
+ * positive integers; anything else falls back to a single application. The canvas IGNORES an
+ * invalid count rather than rejecting it — validation is the sender's job (Tower answers
+ * `invalid-request`), and a command that arrived here already passed it.
+ */
+function repeatCount(command: CanvasCommand, count: number | undefined): number {
+  if (!isTraversalCommand(command)) return 1;
+  if (typeof count !== 'number' || !Number.isInteger(count) || count < 1) return 1;
+  return count;
 }
 
 /**
@@ -172,6 +211,7 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
     refreshKey,
     initialReadingMode,
     onReadingModeChange,
+    commandAdapter,
   } = props;
   const canEdit = onEditComment !== undefined;
   const canDelete = onDeleteComment !== undefined;
@@ -564,9 +604,20 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
     return null;
   };
 
+  // Mirrors `readingMode` for callers that run before React has re-rendered. A host may deliver
+  // two remote commands inside one synchronous batch (nothing in the CommandAdapter contract
+  // forbids it), and reading the mode from the render closure would make the second one compute
+  // from a value that is already outdated — toggling twice would land back where it started
+  // while reporting the same mode twice. The pointer path cannot hit this; the remote path can.
+  const readingModeRef = React.useRef(readingMode);
+  readingModeRef.current = readingMode;
+
   const toggleReadingMode = (): void => {
-    const next: ReadingMode = readingMode === 'horizontal' ? 'vertical' : 'horizontal';
-    pendingAnchorLineRef.current = viewportStartLine(readingMode);
+    const current = readingModeRef.current;
+    let next: ReadingMode = 'horizontal';
+    if (current === 'horizontal') next = 'vertical';
+    pendingAnchorLineRef.current = viewportStartLine(current);
+    readingModeRef.current = next; // visible to a second toggle in the same batch
     setReadingMode(next);
     onReadingModeChange?.(next);
   };
@@ -744,6 +795,60 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
   const originBlock = (target: EventTarget | null): HTMLElement | null =>
     ((target as HTMLElement | null)?.closest?.('[data-line]') as HTMLElement | null) ?? null;
 
+  // The block a relative command starts from. Distinct from `activeLine`, which is HOVER-driven
+  // and cleared on mouseleave because it positions the "+" affordance: this one is FOCUS-derived
+  // and persistent, because it answers "where is the reviewer" for navigation. Recorded in
+  // `activateFromFocus`, the single point every focus path funnels through — keyboard, pointer,
+  // minimap, and the programmatic `focusBlock`.
+  const cursorLineRef = React.useRef<number | null>(null);
+
+  // Handle on the open composer, so a remote `composer-submit` can commit the draft the reviewer
+  // typed. Null whenever no composer is mounted, which is what makes that command a no-op then.
+  const composerHandleRef = React.useRef<CommentComposerHandle | null>(null);
+
+  // Resolve the origin for a remote command: the cursor when it still points at a live block,
+  // otherwise the topmost visible block. The fallback is what makes navigation well-defined on a
+  // freshly opened view that nobody has touched yet (spec 1401).
+  const currentBlock = (root: HTMLElement): HTMLElement | null => {
+    // Live DOM focus first. It is the truth when it exists, and reading it directly (rather than
+    // waiting for the focus event to refresh the cursor ref) is what lets a counted traversal
+    // step N times in one go: each step sees where the previous one actually landed.
+    const focused = (document.activeElement as HTMLElement | null)?.closest?.('[data-line]') as
+      | HTMLElement
+      | null;
+    if (focused && root.contains(focused)) return focused;
+
+    // Then the last block that held focus, which survives focus leaving the canvas entirely.
+    const cursor = cursorLineRef.current;
+    if (cursor !== null) {
+      const el = root.querySelector<HTMLElement>(`[data-line="${cursor}"]`);
+      if (el) return el;
+    }
+
+    // Then the topmost visible block, for a view nobody has touched yet.
+    const start = viewportStartLine(readingMode);
+    if (start !== null) {
+      const el = root.querySelector<HTMLElement>(`[data-line="${start}"]`);
+      if (el) return el;
+    }
+
+    // Finally the first block. `viewportStartLine` measures with `getBoundingClientRect`, which
+    // yields nothing useful when the canvas is display:none, detached, or not laid out yet; a
+    // remote command must still do something visible rather than silently no-op (spec 1401).
+    return collectBlocks(root)[0] ?? null;
+  };
+
+  // Step one block in flow order. Deliberately NOT native Tab parity: Tab also visits the "+"
+  // affordance, card actions, the toolbar and links, so a remote "next block" that mimicked it
+  // would land off-prose. Tab itself is untouched (spec 1401 non-goal).
+  const focusAdjacentBlock = (root: HTMLElement, fromLine: string | null, step: 1 | -1): void => {
+    const blocks = collectBlocks(root);
+    const start = blocks.findIndex((b) => b.getAttribute('data-line') === fromLine);
+    if (start === -1) return;
+    const next = blocks[start + step];
+    if (next) focusBlock(next); // no wrap-around, same as the jump keys
+  };
+
   const focusEdgeBlock = (root: HTMLElement, edge: 'start' | 'end'): void => {
     const blocks = collectBlocks(root);
     let target: HTMLElement | undefined;
@@ -791,17 +896,6 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
     return true;
   };
 
-  type CanvasActionName =
-    | 'comment-next'
-    | 'comment-prev'
-    | 'heading-next'
-    | 'heading-prev'
-    | 'doc-start'
-    | 'doc-end'
-    | 'column-forward'
-    | 'column-back'
-    | 'composer-open';
-
   interface CanvasActionContext {
     /** The canvas body: scroll container and query root. */
     root: HTMLElement | null;
@@ -814,7 +908,17 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
    * key to the browser. A deliberate no-op (no match in that direction, an empty document) still
    * returns true: the action ran and decided to do nothing, which is not the same as declining.
    */
-  const canvasActions: Record<CanvasActionName, (ctx: CanvasActionContext) => boolean> = {
+  const canvasActions: Record<CanvasCommand, (ctx: CanvasActionContext) => boolean> = {
+    'block-next': ({ root, origin }) => {
+      if (!root) return false;
+      focusAdjacentBlock(root, origin?.getAttribute('data-line') ?? null, 1);
+      return true;
+    },
+    'block-prev': ({ root, origin }) => {
+      if (!root) return false;
+      focusAdjacentBlock(root, origin?.getAttribute('data-line') ?? null, -1);
+      return true;
+    },
     'comment-next': ({ root, origin }) => {
       if (!root) return false;
       focusMatchingBlock(root, origin?.getAttribute('data-line') ?? null, isMarkedBlock, 1);
@@ -860,7 +964,57 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
       openComposer(line); // open the inline composer for this block (#1107)
       return true;
     },
+    // Composer submit/cancel are VIEW-scoped, not focus-scoped: they act on this canvas's open
+    // composer wherever DOM focus happens to sit, because a remote driver never moved focus into
+    // the textarea. With no composer open they are a defined no-op, exactly as the keys are.
+    'composer-submit': () => {
+      composerHandleRef.current?.submit();
+      return true;
+    },
+    'composer-cancel': () => {
+      if (composingLine === null) return true;
+      cancelComposer(true);
+      return true;
+    },
+    'reading-mode-toggle': () => {
+      toggleReadingMode();
+      return true;
+    },
   };
+
+  // Run a remote command against the current origin. Traversal commands re-resolve the origin on
+  // every step, so `count: 3` walks three blocks rather than re-running from the same start.
+  const runCanvasCommand = ({ command, count }: CanvasCommandInvocation): void => {
+    // Never throw out of a host callback (spec D2): an unknown command from a misbehaving host,
+    // or a DOM query that fails mid-rebuild, is reported through the existing sink, not fatal.
+    try {
+      const root = bodyRef.current;
+      if (!root) return;
+      const action = canvasActions[command];
+      if (!action) return;
+      const times = repeatCount(command, count);
+      for (let i = 0; i < times; i += 1) {
+        action({ root, origin: currentBlock(root) });
+      }
+    } catch (err) {
+      report(err);
+    }
+  };
+
+  // `canvasActions` is rebuilt every render and its closures capture that render's state, so the
+  // subscription below must NOT close over it directly: subscribing once on mount would pin the
+  // first render's actions and run them against a stale `readingMode` and composer state forever.
+  // The ref is refreshed on every render and the subscription reads through it.
+  const runCanvasCommandRef = React.useRef(runCanvasCommand);
+  runCanvasCommandRef.current = runCanvasCommand;
+
+  React.useEffect(() => {
+    if (!commandAdapter) return;
+    const subscription = commandAdapter.subscribe((invocation) => {
+      runCanvasCommandRef.current(invocation);
+    });
+    return () => subscription.dispose();
+  }, [commandAdapter]);
 
   // Keyboard handling on the body (#1107 activation + #1237 jump navigation). Every branch below
   // requires the event to originate on a `[data-line]` block, so keystrokes inside the composer
@@ -897,7 +1051,7 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
       let pageDelta = 1;
       if (e.key === 'PageUp') pageDelta = -1;
       if (innerScrollerCanConsume(t, pageDelta, root)) return;
-      let pageAction: CanvasActionName = 'column-forward';
+      let pageAction: CanvasCommand = 'column-forward';
       if (e.key === 'PageUp') pageAction = 'column-back';
       // Unmeasurable geometry: leave the key to the browser rather than swallowing it.
       if (!canvasActions[pageAction]({ root, origin: null })) return;
@@ -924,13 +1078,13 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
 
     if (e.key === 'Home' || e.key === 'End') {
       e.preventDefault();
-      let edgeAction: CanvasActionName = 'doc-start';
+      let edgeAction: CanvasCommand = 'doc-start';
       if (e.key === 'End') edgeAction = 'doc-end';
       canvasActions[edgeAction]({ root, origin: current });
       return;
     }
 
-    let jumpAction: CanvasActionName | null = null;
+    let jumpAction: CanvasCommand | null = null;
     switch (e.key) {
       case 'n': jumpAction = 'comment-next'; break;
       case 'p': jumpAction = 'comment-prev'; break;
@@ -1058,6 +1212,9 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
     if (fromAffordance(target)) return;
     const b = resolveBlock(target);
     if (!b) return;
+    // Every focus path funnels through here, so this is where the navigation cursor is recorded
+    // (spec 1401): keyboard jumps, pointer clicks, minimap handoff, and remote commands alike.
+    cursorLineRef.current = b.line;
     setActiveLine(b.line);
     placeAffordance(b.el, null);
   };
@@ -1147,6 +1304,7 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
               // save would write it to the wrong marker (#1055 codex finding). `useState(initialText)`
               // only reads its arg on mount, so a fresh mount is what refreshes the seed.
               key={`composer-${editingMarker?.markerLine ?? 'add'}-${composingLine}`}
+              ref={composerHandleRef}
               line={composingLine}
               onSubmit={submitComposer}
               onCancel={cancelComposer}

--- a/packages/artifact-canvas/src/components/ArtifactCanvas.tsx
+++ b/packages/artifact-canvas/src/components/ArtifactCanvas.tsx
@@ -44,8 +44,16 @@ const TRAVERSAL_COMMANDS = [
   'column-back',
 ] as const satisfies readonly TraversalCommand[];
 
-type _EveryTraversalCommandIsListed =
-  Exclude<TraversalCommand, (typeof TRAVERSAL_COMMANDS)[number]> extends never ? true : never;
+/**
+ * `T extends true` is what makes the assertion below bite. A bare conditional type alias imposes
+ * no constraint, so a missing member would just resolve to `never` and compile happily — the
+ * guard has to be a type that FAILS to instantiate, not one that merely evaluates to something.
+ */
+type Assert<T extends true> = T;
+
+type _EveryTraversalCommandIsListed = Assert<
+  Exclude<TraversalCommand, (typeof TRAVERSAL_COMMANDS)[number]> extends never ? true : false
+>;
 
 function isTraversalCommand(command: CanvasCommand): command is TraversalCommand {
   return (TRAVERSAL_COMMANDS as readonly CanvasCommand[]).includes(command);
@@ -825,8 +833,10 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
       if (el) return el;
     }
 
-    // Then the topmost visible block, for a view nobody has touched yet.
-    const start = viewportStartLine(readingMode);
+    // Then the topmost visible block, for a view nobody has touched yet. Reads the mode through
+    // the ref for the same reason `toggleReadingMode` does: a navigation command batched behind a
+    // toggle must measure against the mode that toggle already chose.
+    const start = viewportStartLine(readingModeRef.current);
     if (start !== null) {
       const el = root.querySelector<HTMLElement>(`[data-line="${start}"]`);
       if (el) return el;
@@ -836,6 +846,15 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
     // yields nothing useful when the canvas is display:none, detached, or not laid out yet; a
     // remote command must still do something visible rather than silently no-op (spec 1401).
     return collectBlocks(root)[0] ?? null;
+  };
+
+  // Where the view currently sits, for detecting that a repeated command has stopped making
+  // progress. Traversal moves the origin block; column paging moves the scroll offset instead and
+  // leaves focus alone, so both have to be in the signature or a counted page would stop after
+  // one step.
+  const positionSignature = (root: HTMLElement): string => {
+    const line = currentBlock(root)?.getAttribute('data-line') ?? '';
+    return `${line}:${root.scrollLeft}`;
   };
 
   // Step one block in flow order. Deliberately NOT native Tab parity: Tab also visits the "+"
@@ -949,12 +968,17 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
       focusEdgeBlock(root, 'end');
       return true;
     },
+    // Paging is meaningful only in horizontal mode, and the mode check belongs HERE rather than
+    // only in the key handler: a vertical layout can still scroll horizontally (a wide table, a
+    // long code line), so a remote page would scroll the body sideways instead of no-opping.
     'column-forward': ({ root }) => {
       if (!root) return false;
+      if (readingModeRef.current !== 'horizontal') return false;
       return pageColumn(root, 1);
     },
     'column-back': ({ root }) => {
       if (!root) return false;
+      if (readingModeRef.current !== 'horizontal') return false;
       return pageColumn(root, -1);
     },
     'composer-open': ({ origin }) => {
@@ -992,8 +1016,20 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
       if (!root) return;
       const action = canvasActions[command];
       if (!action) return;
+      // A remote command is a deliberate interaction, so re-arm the focus ring exactly as the
+      // first line of the key handler does. Without this, navigation issued after a
+      // pointer-driven cancel or delete would move focus invisibly.
+      rootRef.current?.classList.remove('codev-canvas-quiet-focus');
       const times = repeatCount(command, count);
+      let previous: string | null = null;
       for (let i = 0; i < times; i += 1) {
+        // Stop as soon as a step changes nothing: that is the edge, and it also bounds the work
+        // to what actually exists. `count` is only validated as a positive integer on the wire,
+        // so without this a controller sending a huge value would pin the UI thread walking a
+        // document that ran out of blocks long before.
+        const position = positionSignature(root);
+        if (previous !== null && position === previous) break;
+        previous = position;
         action({ root, origin: currentBlock(root) });
       }
     } catch (err) {

--- a/packages/artifact-canvas/src/components/ArtifactCanvas.tsx
+++ b/packages/artifact-canvas/src/components/ArtifactCanvas.tsx
@@ -71,6 +71,13 @@ function repeatCount(command: CanvasCommand, count: number | undefined): number 
   return count;
 }
 
+// Block predicates for the jump commands. Module scope: they close over nothing, so there is no
+// reason to rebuild them per render.
+const isMarkedBlock = (el: HTMLElement): boolean => el.classList.contains('codev-canvas-has-marker');
+const isHeadingBlock = (el: HTMLElement): boolean => /^H[1-6]$/.test(el.tagName);
+/** "Any block" turns the generic scan into plain adjacent-block stepping. */
+const anyBlock = (): boolean => true;
+
 /**
  * ArtifactCanvas — the composed review surface (Phase 3).
  *
@@ -797,9 +804,6 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
   // affordance/modifier guards, the composer exemption, and `preventDefault` — because a remote
   // command has no event; these functions carry only the action itself.
 
-  const isMarkedBlock = (el: HTMLElement): boolean => el.classList.contains('codev-canvas-has-marker');
-  const isHeadingBlock = (el: HTMLElement): boolean => /^H[1-6]$/.test(el.tagName);
-
   const originBlock = (target: EventTarget | null): HTMLElement | null =>
     ((target as HTMLElement | null)?.closest?.('[data-line]') as HTMLElement | null) ?? null;
 
@@ -848,26 +852,6 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
     return collectBlocks(root)[0] ?? null;
   };
 
-  // Where the view currently sits, for detecting that a repeated command has stopped making
-  // progress. Traversal moves the origin block; column paging moves the scroll offset instead and
-  // leaves focus alone, so both have to be in the signature or a counted page would stop after
-  // one step.
-  const positionSignature = (root: HTMLElement): string => {
-    const line = currentBlock(root)?.getAttribute('data-line') ?? '';
-    return `${line}:${root.scrollLeft}`;
-  };
-
-  // Step one block in flow order. Deliberately NOT native Tab parity: Tab also visits the "+"
-  // affordance, card actions, the toolbar and links, so a remote "next block" that mimicked it
-  // would land off-prose. Tab itself is untouched (spec 1401 non-goal).
-  const focusAdjacentBlock = (root: HTMLElement, fromLine: string | null, step: 1 | -1): void => {
-    const blocks = collectBlocks(root);
-    const start = blocks.findIndex((b) => b.getAttribute('data-line') === fromLine);
-    if (start === -1) return;
-    const next = blocks[start + step];
-    if (next) focusBlock(next); // no wrap-around, same as the jump keys
-  };
-
   const focusEdgeBlock = (root: HTMLElement, edge: 'start' | 'end'): void => {
     const blocks = collectBlocks(root);
     let target: HTMLElement | undefined;
@@ -879,7 +863,10 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
     if (target) focusBlock(target);
   };
 
-  // Focus the next/previous block matching `match`, walking outward from `fromLine`.
+  // Focus the next/previous block matching `match`, walking outward from `fromLine`. With
+  // `anyBlock` this is plain adjacent stepping, which is why `block-next/prev` need no separate
+  // implementation. Deliberately NOT native Tab parity: Tab also visits the "+" affordance, card
+  // actions, the toolbar and links, so a "next block" that mimicked it would land off-prose.
   const focusMatchingBlock = (
     root: HTMLElement,
     fromLine: string | null,
@@ -916,95 +903,60 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
   };
 
   interface CanvasActionContext {
-    /** The canvas body: scroll container and query root. */
-    root: HTMLElement | null;
+    /** The canvas body: scroll container and query root. Callers guarantee it. */
+    root: HTMLElement;
     /** The `[data-line]` block the action starts from, when the caller has one. */
     origin: HTMLElement | null;
+    /** `origin`'s line, resolved once by the caller rather than by each action. */
+    originLine: string | null;
   }
 
   /**
-   * Each action returns false only when it could not run at all and the caller should leave the
-   * key to the browser. A deliberate no-op (no match in that direction, an empty document) still
-   * returns true: the action ran and decided to do nothing, which is not the same as declining.
+   * One implementation per command, shared by the keyboard handler and the remote channel so the
+   * two paths cannot drift. Actions return nothing: "did anything happen" is not a question any
+   * caller asks. The one place it is asked — whether a `PageUp` should fall through to the
+   * browser when column geometry is unmeasurable — reads `pageColumn`'s own boolean directly.
    */
-  const canvasActions: Record<CanvasCommand, (ctx: CanvasActionContext) => boolean> = {
-    'block-next': ({ root, origin }) => {
-      if (!root) return false;
-      focusAdjacentBlock(root, origin?.getAttribute('data-line') ?? null, 1);
-      return true;
-    },
-    'block-prev': ({ root, origin }) => {
-      if (!root) return false;
-      focusAdjacentBlock(root, origin?.getAttribute('data-line') ?? null, -1);
-      return true;
-    },
-    'comment-next': ({ root, origin }) => {
-      if (!root) return false;
-      focusMatchingBlock(root, origin?.getAttribute('data-line') ?? null, isMarkedBlock, 1);
-      return true;
-    },
-    'comment-prev': ({ root, origin }) => {
-      if (!root) return false;
-      focusMatchingBlock(root, origin?.getAttribute('data-line') ?? null, isMarkedBlock, -1);
-      return true;
-    },
-    'heading-next': ({ root, origin }) => {
-      if (!root) return false;
-      focusMatchingBlock(root, origin?.getAttribute('data-line') ?? null, isHeadingBlock, 1);
-      return true;
-    },
-    'heading-prev': ({ root, origin }) => {
-      if (!root) return false;
-      focusMatchingBlock(root, origin?.getAttribute('data-line') ?? null, isHeadingBlock, -1);
-      return true;
-    },
-    'doc-start': ({ root }) => {
-      if (!root) return false;
-      focusEdgeBlock(root, 'start');
-      return true;
-    },
-    'doc-end': ({ root }) => {
-      if (!root) return false;
-      focusEdgeBlock(root, 'end');
-      return true;
-    },
+  const canvasActions: Record<CanvasCommand, (ctx: CanvasActionContext) => void> = {
+    'block-next': ({ root, originLine }) => focusMatchingBlock(root, originLine, anyBlock, 1),
+    'block-prev': ({ root, originLine }) => focusMatchingBlock(root, originLine, anyBlock, -1),
+    'comment-next': ({ root, originLine }) => focusMatchingBlock(root, originLine, isMarkedBlock, 1),
+    'comment-prev': ({ root, originLine }) => focusMatchingBlock(root, originLine, isMarkedBlock, -1),
+    'heading-next': ({ root, originLine }) => focusMatchingBlock(root, originLine, isHeadingBlock, 1),
+    'heading-prev': ({ root, originLine }) => focusMatchingBlock(root, originLine, isHeadingBlock, -1),
+    'doc-start': ({ root }) => focusEdgeBlock(root, 'start'),
+    'doc-end': ({ root }) => focusEdgeBlock(root, 'end'),
     // Paging is meaningful only in horizontal mode, and the mode check belongs HERE rather than
     // only in the key handler: a vertical layout can still scroll horizontally (a wide table, a
     // long code line), so a remote page would scroll the body sideways instead of no-opping.
     'column-forward': ({ root }) => {
-      if (!root) return false;
-      if (readingModeRef.current !== 'horizontal') return false;
-      return pageColumn(root, 1);
+      if (readingModeRef.current === 'horizontal') pageColumn(root, 1);
     },
     'column-back': ({ root }) => {
-      if (!root) return false;
-      if (readingModeRef.current !== 'horizontal') return false;
-      return pageColumn(root, -1);
+      if (readingModeRef.current === 'horizontal') pageColumn(root, -1);
     },
-    'composer-open': ({ origin }) => {
-      if (!origin) return false;
-      const line = Number(origin.getAttribute('data-line'));
-      if (Number.isNaN(line)) return false;
+    'composer-open': ({ originLine }) => {
+      if (originLine === null) return;
+      const line = Number(originLine);
+      if (Number.isNaN(line)) return;
       openComposer(line); // open the inline composer for this block (#1107)
-      return true;
     },
     // Composer submit/cancel are VIEW-scoped, not focus-scoped: they act on this canvas's open
     // composer wherever DOM focus happens to sit, because a remote driver never moved focus into
     // the textarea. With no composer open they are a defined no-op, exactly as the keys are.
-    'composer-submit': () => {
-      composerHandleRef.current?.submit();
-      return true;
-    },
+    'composer-submit': () => composerHandleRef.current?.submit(),
     'composer-cancel': () => {
-      if (composingLine === null) return true;
-      cancelComposer(true);
-      return true;
+      if (composingLine !== null) cancelComposer(true);
     },
-    'reading-mode-toggle': () => {
-      toggleReadingMode();
-      return true;
-    },
+    'reading-mode-toggle': () => toggleReadingMode(),
   };
+
+  /** Build a context from an origin element, resolving its line once. */
+  const actionContext = (root: HTMLElement, origin: HTMLElement | null): CanvasActionContext => ({
+    root,
+    origin,
+    originLine: origin?.getAttribute('data-line') ?? null,
+  });
 
   // Run a remote command against the current origin. Traversal commands re-resolve the origin on
   // every step, so `count: 3` walks three blocks rather than re-running from the same start.
@@ -1023,14 +975,18 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
       const times = repeatCount(command, count);
       let previous: string | null = null;
       for (let i = 0; i < times; i += 1) {
+        // Resolve the origin ONCE per step and derive the progress signature from it. Traversal
+        // moves the origin block; column paging moves the scroll offset and leaves focus alone,
+        // so both belong in the signature or a counted page would stop after one step.
+        const ctx = actionContext(root, currentBlock(root));
+        const position = `${ctx.originLine ?? ''}:${root.scrollLeft}`;
         // Stop as soon as a step changes nothing: that is the edge, and it also bounds the work
         // to what actually exists. `count` is only validated as a positive integer on the wire,
         // so without this a controller sending a huge value would pin the UI thread walking a
         // document that ran out of blocks long before.
-        const position = positionSignature(root);
         if (previous !== null && position === previous) break;
         previous = position;
-        action({ root, origin: currentBlock(root) });
+        action(ctx);
       }
     } catch (err) {
       report(err);
@@ -1065,8 +1021,11 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
     // here would re-resolve through the host row and open the composer on the wrong line.
     if (fromAffordance(e.target)) return;
     if (e.key === 'Enter' || e.key === ' ') {
-      if (canvasActions['composer-open']({ root: bodyRef.current, origin: originBlock(e.target) })) {
+      const body = bodyRef.current;
+      const origin = originBlock(e.target);
+      if (body && origin) {
         e.preventDefault();
+        canvasActions['composer-open'](actionContext(body, origin));
       }
       return;
     }
@@ -1087,10 +1046,12 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
       let pageDelta = 1;
       if (e.key === 'PageUp') pageDelta = -1;
       if (innerScrollerCanConsume(t, pageDelta, root)) return;
-      let pageAction: CanvasCommand = 'column-forward';
-      if (e.key === 'PageUp') pageAction = 'column-back';
+      // Straight to `pageColumn`, the same implementation the `column-*` actions call: its
+      // boolean is the fall-through signal, and this branch has already checked horizontal mode.
       // Unmeasurable geometry: leave the key to the browser rather than swallowing it.
-      if (!canvasActions[pageAction]({ root, origin: null })) return;
+      let dir: 1 | -1 = 1;
+      if (e.key === 'PageUp') dir = -1;
+      if (!pageColumn(root, dir)) return;
       e.preventDefault();
       return;
     }
@@ -1116,7 +1077,7 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
       e.preventDefault();
       let edgeAction: CanvasCommand = 'doc-start';
       if (e.key === 'End') edgeAction = 'doc-end';
-      canvasActions[edgeAction]({ root, origin: current });
+      canvasActions[edgeAction](actionContext(root, current));
       return;
     }
 
@@ -1129,7 +1090,7 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
       default: return;
     }
     e.preventDefault();
-    canvasActions[jumpAction]({ root, origin: current });
+    canvasActions[jumpAction](actionContext(root, current));
   };
 
   const resolveBlock = (target: EventTarget | null): { el: HTMLElement; line: number } | null => {

--- a/packages/artifact-canvas/src/index.ts
+++ b/packages/artifact-canvas/src/index.ts
@@ -12,6 +12,7 @@
 export type { FileAdapter } from './adapters/FileAdapter.js';
 export type { MarkerAdapter } from './adapters/MarkerAdapter.js';
 export type { ThemeAdapter } from './adapters/ThemeAdapter.js';
+export type { CommandAdapter, CanvasCommandInvocation } from './adapters/CommandAdapter.js';
 export type { Disposable, ReviewMarker, ArtifactCanvasProps, ReadingMode } from './types.js';
 
 export { ArtifactCanvas } from './components/ArtifactCanvas.js';

--- a/packages/artifact-canvas/src/overlays/CommentComposer.tsx
+++ b/packages/artifact-canvas/src/overlays/CommentComposer.tsx
@@ -22,6 +22,19 @@ export interface CommentComposerProps {
 }
 
 /**
+ * Imperative seam for driving the composer from outside it (spec 1401).
+ *
+ * Submission needs the composer's own draft text, which lives in its state, so a remote
+ * `composer-submit` cannot go through the parent's `onSubmit` directly and must not synthesize a
+ * click on the button. Cancel is deliberately absent: it needs no text, so the parent closes the
+ * composer through its existing cancel path rather than routing back through here.
+ */
+export interface CommentComposerHandle {
+  /** Submit the current draft, exactly as ⌘/Ctrl+Enter does. Empty bodies stay a no-op. */
+  submit(): void;
+}
+
+/**
  * Inline comment composer (#1107). Replaces the old center-top `showInputBox` Quick Pick: it is
  * rendered in-flow directly below the block being commented on (the host portals it into a
  * placeholder there), so the reviewer types the comment exactly where it will live — the visual
@@ -37,12 +50,11 @@ export interface CommentComposerProps {
  * It only signals intent via `onSubmit` / `onCancel`; it never writes a marker itself (the host
  * does that, preserving the package's D6 invariant). An empty / whitespace-only body is a no-op.
  */
-export function CommentComposer({
-  line,
-  onSubmit,
-  onCancel,
-  initialText,
-}: CommentComposerProps): React.ReactElement {
+export const CommentComposer = React.forwardRef<CommentComposerHandle, CommentComposerProps>(
+  function CommentComposer(
+    { line, onSubmit, onCancel, initialText }: CommentComposerProps,
+    handleRef,
+  ): React.ReactElement {
   const isEdit = initialText !== undefined;
   const [text, setText] = React.useState(initialText ?? '');
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
@@ -62,6 +74,11 @@ export function CommentComposer({
     if (!body) { return; } // mirrors the host's old `if (!text) return;` guard
     onSubmit(body, viaKeyboard);
   };
+
+  // A remote submit reports `viaKeyboard: true` so focus restoration keeps its visible ring: the
+  // reviewer is driving the canvas deliberately and needs to see where focus landed, which is the
+  // same reason the ⌘/Ctrl+Enter path passes true.
+  React.useImperativeHandle(handleRef, () => ({ submit: () => submit(true) }));
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>): void => {
     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
@@ -110,4 +127,5 @@ export function CommentComposer({
       </div>
     </div>
   );
-}
+  },
+);

--- a/packages/artifact-canvas/src/types.ts
+++ b/packages/artifact-canvas/src/types.ts
@@ -17,6 +17,7 @@
 import type { FileAdapter } from './adapters/FileAdapter.js';
 import type { MarkerAdapter } from './adapters/MarkerAdapter.js';
 import type { ThemeAdapter } from './adapters/ThemeAdapter.js';
+import type { CommandAdapter } from './adapters/CommandAdapter.js';
 
 /**
  * Disposable handle returned by subscriptions; mirrors VSCode's `Disposable` shape.
@@ -116,4 +117,10 @@ export interface ArtifactCanvasProps {
    * without persistence, defaulting to vertical each mount).
    */
   onReadingModeChange?(mode: ReadingMode): void;
+  /**
+   * Optional remote-command seam (spec 1401). When supplied, the canvas subscribes to it and runs
+   * inbound commands through the same per-action implementations the keyboard uses, so the two
+   * paths cannot drift. Omitting it leaves behavior exactly as it is without one.
+   */
+  commandAdapter?: CommandAdapter;
 }

--- a/packages/codev/src/agent-farm/__tests__/canvas-relay.e2e.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/canvas-relay.e2e.test.ts
@@ -1,0 +1,215 @@
+/**
+ * No-hardware integration test for the canvas command channel (spec 1401, plan phase 4).
+ *
+ * Boots a real Tower and drives the whole REST -> SSE path: a host registers views over HTTP, a
+ * controller POSTs a command, and exactly one addressed event reaches the stream. The unit suite
+ * covers resolution logic; what only this test can prove is that the route is actually wired into
+ * Tower and that the event really reaches a live `/api/events` subscriber.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { startTower } from './helpers/tower-test-utils.js';
+import type { TowerHandle } from './helpers/tower-test-utils.js';
+
+const PORT = 14479;
+const BASE = `http://localhost:${PORT}`;
+const WORKSPACE = '/tmp/canvas-relay-e2e';
+
+/** Collects parsed SSE envelopes from a live /api/events stream. */
+class SseCollector {
+  events: Array<{ type: string; payload: unknown }> = [];
+  private controller = new AbortController();
+  private ready: Promise<void>;
+
+  constructor() {
+    this.ready = this.connect();
+  }
+
+  private async connect(): Promise<void> {
+    const res = await fetch(`${BASE}/api/events`, {
+      headers: { Accept: 'text/event-stream' },
+      signal: this.controller.signal,
+    });
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    const pump = async (): Promise<void> => {
+      let buffer = '';
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) return;
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop() ?? '';
+          let data = '';
+          for (const line of lines) {
+            if (line.startsWith('data:')) {
+              data = line.slice(5).trim();
+            } else if (line === '' && data) {
+              try {
+                const env = JSON.parse(data);
+                if (typeof env.type === 'string' && typeof env.body === 'string') {
+                  this.events.push({ type: env.type, payload: JSON.parse(env.body) });
+                }
+              } catch {
+                // ignore unrelated frames
+              }
+              data = '';
+            }
+          }
+        }
+      } catch {
+        // aborted
+      }
+    };
+    pump();
+    // Settle so the server has registered this client before the caller triggers a broadcast.
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  waitReady(): Promise<void> {
+    return this.ready;
+  }
+
+  async waitFor(type: string, timeoutMs = 2000): Promise<{ type: string; payload: unknown }> {
+    const start = Date.now();
+    for (;;) {
+      const found = this.events.find((e) => e.type === type);
+      if (found) return found;
+      if (Date.now() - start > timeoutMs) throw new Error(`Timed out waiting for SSE ${type}`);
+      await new Promise((r) => setTimeout(r, 20));
+    }
+  }
+
+  countOf(type: string): number {
+    return this.events.filter((e) => e.type === type).length;
+  }
+
+  close(): void {
+    this.controller.abort();
+  }
+}
+
+function postJson(path: string, body: unknown): Promise<Response> {
+  return fetch(`${BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function registerView(file: string): Promise<{ viewId: string; file: string }> {
+  const res = await postJson('/api/canvas/views', { workspace: WORKSPACE, file });
+  expect(res.status).toBe(200);
+  return res.json() as Promise<{ viewId: string; file: string }>;
+}
+
+describe('canvas command channel (integration)', () => {
+  let tower: TowerHandle;
+
+  beforeAll(async () => {
+    tower = await startTower(PORT);
+  });
+
+  afterAll(async () => {
+    await tower.stop();
+  });
+
+  it('answers no-canvas when nothing is registered, and emits nothing', async () => {
+    const sse = new SseCollector();
+    await sse.waitReady();
+
+    const res = await postJson('/api/canvas/command', {
+      workspace: WORKSPACE,
+      command: 'block-next',
+    });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ ok: false, code: 'no-canvas' });
+
+    // The absence of an event is the point: nothing was delivered to anyone.
+    await new Promise((r) => setTimeout(r, 300));
+    expect(sse.countOf('canvas-command')).toBe(0);
+
+    sse.close();
+  });
+
+  it('registers a view, relays one addressed command, and unregisters', async () => {
+    const sse = new SseCollector();
+    await sse.waitReady();
+
+    const view = await registerView('/tmp/canvas-relay-e2e/spec.md');
+
+    const res = await postJson('/api/canvas/command', {
+      workspace: WORKSPACE,
+      command: 'comment-next',
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      target: { viewId: view.viewId, file: view.file },
+    });
+
+    const event = await sse.waitFor('canvas-command');
+    expect(event.payload).toEqual({ viewId: view.viewId, command: 'comment-next' });
+
+    const gone = await fetch(`${BASE}/api/canvas/views/${view.viewId}`, { method: 'DELETE' });
+    expect(gone.status).toBe(200);
+
+    // With the last view gone, the channel reports it rather than silently succeeding.
+    const after = await postJson('/api/canvas/command', {
+      workspace: WORKSPACE,
+      command: 'comment-next',
+    });
+    expect(after.status).toBe(404);
+    expect(await after.json()).toMatchObject({ code: 'no-canvas' });
+
+    sse.close();
+  });
+
+  it('addresses exactly one view when two are open on the same file', async () => {
+    const sse = new SseCollector();
+    await sse.waitReady();
+
+    const first = await registerView('/tmp/canvas-relay-e2e/dup.md');
+    const second = await registerView('/tmp/canvas-relay-e2e/dup.md');
+    expect(first.viewId).not.toBe(second.viewId);
+
+    const res = await postJson('/api/canvas/command', {
+      workspace: WORKSPACE,
+      file: '/tmp/canvas-relay-e2e/dup.md',
+      command: 'composer-submit',
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { target: { viewId: string } };
+
+    await sse.waitFor('canvas-command');
+    await new Promise((r) => setTimeout(r, 300));
+
+    // One event, carrying one view id: a fan-out here would double-post the comment.
+    expect(sse.countOf('canvas-command')).toBe(1);
+    expect(sse.events.at(-1)?.payload).toMatchObject({ viewId: body.target.viewId });
+
+    for (const v of [first, second]) {
+      await fetch(`${BASE}/api/canvas/views/${v.viewId}`, { method: 'DELETE' });
+    }
+    sse.close();
+  });
+
+  it('rejects an unknown command with invalid-request', async () => {
+    const view = await registerView('/tmp/canvas-relay-e2e/bad.md');
+
+    const res = await postJson('/api/canvas/command', {
+      workspace: WORKSPACE,
+      command: 'launch-missiles',
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ ok: false, code: 'invalid-request' });
+
+    await fetch(`${BASE}/api/canvas/views/${view.viewId}`, { method: 'DELETE' });
+  });
+
+  it('404s a heartbeat for an unknown view so a host knows to re-register', async () => {
+    const res = await postJson('/api/canvas/views/canvas-does-not-exist/heartbeat', {});
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/codev/src/agent-farm/__tests__/canvas-relay.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/canvas-relay.test.ts
@@ -304,4 +304,50 @@ describe('command validation', () => {
   it('rejects an unknown canvas route', async () => {
     expect((await call('GET', '/api/canvas/nonsense')).status).toBe(404);
   });
+
+  // A literal `null` is valid JSON, so it parses without throwing and then explodes on the first
+  // field read. That would surface as a 500 with no wire `code`, which the error contract forbids.
+  it('answers invalid-request for a null or non-object body', async () => {
+    for (const payload of [null, 42, 'text', ['a']]) {
+      const out = await sendCommand(payload);
+      expect(out.status).toBe(400);
+      expect(out.body.code).toBe('invalid-request');
+    }
+  });
+});
+
+describe('lease integrity', () => {
+  it('does NOT let command traffic keep a dead host\'s view alive', async () => {
+    await register('/tmp/doc.md');
+
+    // Drive the view steadily, without any heartbeat: this is exactly the shape of a controller
+    // still sending to a host that has died. Delivery is fire-and-forget over SSE and proves
+    // nothing about the host, so it must not extend the lease.
+    for (let i = 0; i < 4; i += 1) {
+      now += CANVAS_VIEW_LEASE_MS / 3;
+      await sendCommand({ workspace: WS, command: 'block-next' });
+    }
+
+    const out = await sendCommand({ workspace: WS, command: 'block-next' });
+    expect(out.status).toBe(404);
+    expect(out.body.code).toBe('no-canvas');
+    expect(listCanvasViewsForTest()).toHaveLength(0);
+  });
+
+  it('does not renew the lease on a malformed heartbeat', async () => {
+    const viewId = await register('/tmp/doc.md');
+
+    now += CANVAS_VIEW_LEASE_MS - 1_000;
+    const bad = await call('POST', `/api/canvas/views/${viewId}/heartbeat`, null);
+    expect(bad.status).toBe(400);
+
+    // The bad heartbeat bought no time, so the view ages out on the original lease.
+    now += 2_000;
+    expect((await sendCommand({ workspace: WS, command: 'block-next' })).body.code).toBe('no-canvas');
+  });
+
+  it('rejects a non-object registration body instead of throwing', async () => {
+    const out = await call('POST', '/api/canvas/views', null);
+    expect(out.status).toBe(400);
+  });
 });

--- a/packages/codev/src/agent-farm/__tests__/canvas-relay.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/canvas-relay.test.ts
@@ -350,4 +350,26 @@ describe('lease integrity', () => {
     const out = await call('POST', '/api/canvas/views', null);
     expect(out.status).toBe(400);
   });
+
+  // A well-formed object whose `focused` is not a boolean still violates CanvasViewHeartbeat.
+  // Accepting it would buy liveness for a payload that does not meet the contract, and would be
+  // inconsistent with the command route, which rejects a bad `count` outright.
+  it('rejects a heartbeat whose focused field is not a boolean, and grants it no lease', async () => {
+    const viewId = await register('/tmp/doc.md');
+
+    now += CANVAS_VIEW_LEASE_MS - 1_000;
+    for (const focused of ['yes', 1, null, {}]) {
+      const out = await call('POST', `/api/canvas/views/${viewId}/heartbeat`, { focused });
+      expect(out.status).toBe(400);
+    }
+
+    now += 2_000;
+    expect((await sendCommand({ workspace: WS, command: 'block-next' })).body.code).toBe('no-canvas');
+  });
+
+  it('still accepts a heartbeat that omits focused entirely', async () => {
+    const viewId = await register('/tmp/doc.md');
+    expect((await call('POST', `/api/canvas/views/${viewId}/heartbeat`, {})).status).toBe(200);
+    expect((await call('POST', `/api/canvas/views/${viewId}/heartbeat`, { focused: false })).status).toBe(200);
+  });
 });

--- a/packages/codev/src/agent-farm/__tests__/canvas-relay.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/canvas-relay.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Canvas view registry + target resolution (spec 1401, plan phase 4).
+ *
+ * Drives the route handler directly with in-memory request/response doubles and an INJECTED
+ * clock, so lease expiry is tested by advancing time rather than by sleeping — a test that waits
+ * 90 real seconds is a test nobody runs.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Readable } from 'node:stream';
+import type * as http from 'node:http';
+import {
+  handleCanvasRoute,
+  initCanvasRelay,
+  shutdownCanvasRelay,
+  listCanvasViewsForTest,
+  CANVAS_VIEW_LEASE_MS,
+} from '../servers/canvas-relay.js';
+
+/** A settable clock so lease expiry is a matter of arithmetic, not waiting. */
+let now = 1_000_000;
+const broadcasts: Array<{ type: string; body: unknown }> = [];
+
+beforeEach(() => {
+  now = 1_000_000;
+  broadcasts.length = 0;
+  initCanvasRelay({
+    broadcast: (type, body) => broadcasts.push({ type, body }),
+    now: () => now,
+  });
+});
+
+afterEach(() => shutdownCanvasRelay());
+
+interface Captured {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+function makeReq(method: string, payload?: unknown): http.IncomingMessage {
+  let text = '';
+  if (payload !== undefined) text = JSON.stringify(payload);
+  const stream = Readable.from([text]) as unknown as http.IncomingMessage;
+  stream.method = method;
+  return stream;
+}
+
+function makeRes(): { res: http.ServerResponse; captured: Captured } {
+  const captured: Captured = { status: 0, body: {} };
+  const res = {
+    writeHead(status: number) {
+      captured.status = status;
+      return this;
+    },
+    end(text?: string) {
+      if (text) captured.body = JSON.parse(text);
+    },
+  } as unknown as http.ServerResponse;
+  return { res, captured };
+}
+
+async function call(method: string, pathname: string, payload?: unknown): Promise<Captured> {
+  const { res, captured } = makeRes();
+  await handleCanvasRoute(
+    makeReq(method, payload),
+    res,
+    new URL(`http://localhost:4100${pathname}`),
+    { broadcastNotification: () => {} },
+  );
+  return captured;
+}
+
+const WS = '/tmp/ws-canvas-relay';
+
+async function register(file: string, workspace = WS): Promise<string> {
+  const out = await call('POST', '/api/canvas/views', { workspace, file });
+  expect(out.status).toBe(200);
+  return out.body.viewId as string;
+}
+
+/** Register and also report the CANONICAL path Tower stored, which is what matching uses. */
+async function registerCanonical(
+  file: string,
+  workspace = WS,
+): Promise<{ viewId: string; file: string }> {
+  const out = await call('POST', '/api/canvas/views', { workspace, file });
+  expect(out.status).toBe(200);
+  return { viewId: out.body.viewId as string, file: out.body.file as string };
+}
+
+const sendCommand = (payload: unknown) => call('POST', '/api/canvas/command', payload);
+
+describe('canvas view registry', () => {
+  it('mints a distinct id per view, including two views of the SAME file', async () => {
+    const a = await register('/tmp/doc.md');
+    const b = await register('/tmp/doc.md');
+
+    expect(a).not.toBe(b);
+    expect(listCanvasViewsForTest()).toHaveLength(2);
+  });
+
+  it('unregisters a view, and reports an unknown id', async () => {
+    const viewId = await register('/tmp/doc.md');
+
+    expect((await call('DELETE', `/api/canvas/views/${viewId}`)).status).toBe(200);
+    expect(listCanvasViewsForTest()).toHaveLength(0);
+    expect((await call('DELETE', `/api/canvas/views/${viewId}`)).status).toBe(404);
+  });
+
+  it('404s a heartbeat for a view it has forgotten, so the host knows to re-register', async () => {
+    const out = await call('POST', '/api/canvas/views/canvas-nope/heartbeat', {});
+    expect(out.status).toBe(404);
+  });
+
+  it('keeps a view alive across the lease while heartbeats continue', async () => {
+    const viewId = await register('/tmp/doc.md');
+
+    for (let i = 0; i < 5; i += 1) {
+      now += CANVAS_VIEW_LEASE_MS - 1_000;
+      expect((await call('POST', `/api/canvas/views/${viewId}/heartbeat`, {})).status).toBe(200);
+    }
+    expect(listCanvasViewsForTest()).toHaveLength(1);
+  });
+
+  it('expires a view whose host died without unregistering', async () => {
+    await register('/tmp/doc.md');
+
+    now += CANVAS_VIEW_LEASE_MS + 1;
+    const out = await sendCommand({ workspace: WS, command: 'block-next' });
+
+    expect(out.status).toBe(404);
+    expect(out.body.code).toBe('no-canvas');
+    expect(listCanvasViewsForTest()).toHaveLength(0);
+  });
+});
+
+describe('target resolution', () => {
+  it('answers no-canvas when nothing is open', async () => {
+    const out = await sendCommand({ workspace: WS, command: 'block-next' });
+
+    expect(out.status).toBe(404);
+    expect(out.body.code).toBe('no-canvas');
+    expect(broadcasts).toHaveLength(0); // nothing delivered, not even to be ignored
+  });
+
+  it('answers no-canvas for a workspace with no views, even when another workspace has one', async () => {
+    await register('/tmp/doc.md', '/tmp/other-ws');
+
+    const out = await sendCommand({ workspace: WS, command: 'block-next' });
+    expect(out.body.code).toBe('no-canvas');
+  });
+
+  it('delivers to the only matching view and names it', async () => {
+    // Assert against the path Tower canonicalized to, not the spelling we sent: on macOS /tmp is
+    // a symlink to /private/tmp, so pinning the pre-canonical spelling would assert the ABSENCE
+    // of the canonicalization this route depends on.
+    const { viewId, file } = await registerCanonical('/tmp/doc.md');
+
+    const out = await sendCommand({ workspace: WS, command: 'comment-next' });
+
+    expect(out.status).toBe(200);
+    expect(out.body.ok).toBe(true);
+    expect(out.body.target).toEqual({ viewId, file });
+    expect(broadcasts).toEqual([
+      { type: 'canvas-command', body: { viewId, command: 'comment-next' } },
+    ]);
+  });
+
+  it('delivers to exactly ONE view when several match, never fanning out', async () => {
+    await register('/tmp/doc.md');
+    const second = await register('/tmp/doc.md');
+
+    const out = await sendCommand({ workspace: WS, command: 'composer-submit' });
+
+    // Fanning out would post the same comment twice; the newest registration wins the tie.
+    expect(broadcasts).toHaveLength(1);
+    expect(out.body.target).toMatchObject({ viewId: second });
+  });
+
+  it('follows the most recently active view, and focus flips it', async () => {
+    const first = await register('/tmp/a.md');
+    const second = await register('/tmp/b.md');
+
+    now += 1_000;
+    await call('POST', `/api/canvas/views/${first}/heartbeat`, { focused: true });
+
+    const out = await sendCommand({ workspace: WS, command: 'block-next' });
+    expect(out.body.target).toMatchObject({ viewId: first });
+
+    now += 1_000;
+    await call('POST', `/api/canvas/views/${second}/heartbeat`, { focused: true });
+    const after = await sendCommand({ workspace: WS, command: 'block-next' });
+    expect(after.body.target).toMatchObject({ viewId: second });
+  });
+
+  it('does not let a plain heartbeat steal MRU from a focused view', async () => {
+    const focused = await register('/tmp/a.md');
+    const other = await register('/tmp/b.md');
+
+    now += 1_000;
+    await call('POST', `/api/canvas/views/${focused}/heartbeat`, { focused: true });
+    now += 1_000;
+    await call('POST', `/api/canvas/views/${other}/heartbeat`, {}); // liveness only
+
+    const out = await sendCommand({ workspace: WS, command: 'block-next' });
+    expect(out.body.target).toMatchObject({ viewId: focused });
+  });
+
+  it('routes a file-qualified command to that file, both ways', async () => {
+    const a = await register('/tmp/a.md');
+    const b = await register('/tmp/b.md');
+
+    expect(
+      (await sendCommand({ workspace: WS, file: '/tmp/a.md', command: 'block-next' })).body.target,
+    ).toMatchObject({ viewId: a });
+    expect(
+      (await sendCommand({ workspace: WS, file: '/tmp/b.md', command: 'block-next' })).body.target,
+    ).toMatchObject({ viewId: b });
+  });
+
+  it('answers no-canvas when the workspace has views but not for that file', async () => {
+    await register('/tmp/a.md');
+
+    const out = await sendCommand({ workspace: WS, file: '/tmp/missing.md', command: 'block-next' });
+    expect(out.body.code).toBe('no-canvas');
+  });
+
+  it('matches the same file spelled differently, while keeping the views distinct', async () => {
+    const a = await registerCanonical('/tmp/nested/../doc.md');
+    const b = await registerCanonical('/tmp/doc.md');
+
+    expect(a.viewId).not.toBe(b.viewId); // two views...
+    expect(a.file).toBe(b.file); // ...collapsed to one file identity
+    const out = await sendCommand({ workspace: WS, file: '/tmp/./doc.md', command: 'block-next' });
+    expect(out.status).toBe(200); // ...which a third spelling also matches
+    expect(out.body.target).toMatchObject({ file: b.file });
+  });
+
+  it('treats a delivered command as activity, so follow-ups stay on the same view', async () => {
+    const first = await register('/tmp/a.md');
+    const second = await register('/tmp/b.md');
+
+    now += 1_000;
+    await call('POST', `/api/canvas/views/${first}/heartbeat`, { focused: true });
+    now += 1_000;
+    await sendCommand({ workspace: WS, file: '/tmp/b.md', command: 'block-next' }); // drives `second`
+
+    const followUp = await sendCommand({ workspace: WS, command: 'block-next' });
+    expect(followUp.body.target).toMatchObject({ viewId: second });
+  });
+});
+
+describe('command validation', () => {
+  beforeEach(async () => {
+    await register('/tmp/doc.md');
+  });
+
+  it('rejects an unknown command', async () => {
+    const out = await sendCommand({ workspace: WS, command: 'self-destruct' });
+    expect(out.status).toBe(400);
+    expect(out.body.code).toBe('invalid-request');
+    expect(broadcasts).toHaveLength(0);
+  });
+
+  it('rejects a missing workspace', async () => {
+    const out = await sendCommand({ command: 'block-next' });
+    expect(out.status).toBe(400);
+    expect(out.body.code).toBe('invalid-request');
+  });
+
+  it('rejects a missing command', async () => {
+    const out = await sendCommand({ workspace: WS });
+    expect(out.status).toBe(400);
+    expect(out.body.code).toBe('invalid-request');
+  });
+
+  it('accepts count on a traversal command', async () => {
+    const out = await sendCommand({ workspace: WS, command: 'block-next', count: 4 });
+    expect(out.status).toBe(200);
+    expect(broadcasts[0].body).toMatchObject({ command: 'block-next', count: 4 });
+  });
+
+  it('omits count from the event when it was not supplied', async () => {
+    await sendCommand({ workspace: WS, command: 'block-next' });
+    expect(broadcasts[0].body).not.toHaveProperty('count');
+  });
+
+  it('rejects count on a non-traversal command', async () => {
+    for (const command of ['doc-start', 'composer-open', 'reading-mode-toggle']) {
+      const out = await sendCommand({ workspace: WS, command, count: 2 });
+      expect(out.status).toBe(400);
+      expect(out.body.code).toBe('invalid-request');
+    }
+  });
+
+  it('rejects a count that is not a positive integer', async () => {
+    for (const count of [0, -3, 1.5, '2', null]) {
+      const out = await sendCommand({ workspace: WS, command: 'block-next', count });
+      expect(out.status).toBe(400);
+      expect(out.body.code).toBe('invalid-request');
+    }
+  });
+
+  it('rejects an unknown canvas route', async () => {
+    expect((await call('GET', '/api/canvas/nonsense')).status).toBe(404);
+  });
+});

--- a/packages/codev/src/agent-farm/servers/canvas-relay.ts
+++ b/packages/codev/src/agent-farm/servers/canvas-relay.ts
@@ -296,6 +296,12 @@ async function handleHeartbeat(
   }
   const body = asObject(parsed);
   if (!body) return sendJson(res, 400, { ok: false, error: 'Invalid JSON' });
+  // `focused` is optional but typed: a non-boolean violates `CanvasViewHeartbeat`. Reject before
+  // touching the lease, matching how the command route treats a bad `count` — a payload that does
+  // not meet the contract should not buy liveness just because the rest of it parsed.
+  if (body.focused !== undefined && typeof body.focused !== 'boolean') {
+    return sendJson(res, 400, { ok: false, error: 'focused must be a boolean' });
+  }
 
   const nowMs = d.now();
   sweep(nowMs);

--- a/packages/codev/src/agent-farm/servers/canvas-relay.ts
+++ b/packages/codev/src/agent-farm/servers/canvas-relay.ts
@@ -25,7 +25,9 @@ import { randomUUID } from 'node:crypto';
 import type {
   CanvasCommand,
   CanvasCommandEvent,
+  CanvasCommandResult,
   CanvasView,
+  CanvasViewRegistrationResult,
   TraversalCommand,
 } from '@cluesmith/codev-types';
 import { parseJsonBody } from '../utils/server-utils.js';
@@ -235,12 +237,14 @@ async function handleRegisterView(
   res: http.ServerResponse,
 ): Promise<void> {
   const d = requireDeps();
-  let body: { workspace?: unknown; file?: unknown };
+  let parsed: unknown;
   try {
-    body = (await parseJsonBody(req)) as { workspace?: unknown; file?: unknown };
+    parsed = await parseJsonBody(req);
   } catch {
     return sendJson(res, 400, { ok: false, error: 'Invalid JSON' });
   }
+  const body = asObject(parsed);
+  if (!body) return sendJson(res, 400, { ok: false, error: 'Invalid JSON' });
   if (!isNonEmptyString(body.workspace)) {
     return sendJson(res, 400, { ok: false, error: 'Missing workspace' });
   }
@@ -263,7 +267,8 @@ async function handleRegisterView(
     lastSeenAt: nowMs,
     sequence,
   });
-  return sendJson(res, 200, { ok: true, viewId, file });
+  const result: CanvasViewRegistrationResult = { ok: true, viewId, file };
+  return sendJson(res, 200, result);
 }
 
 /**
@@ -279,12 +284,18 @@ async function handleHeartbeat(
   viewId: string,
 ): Promise<void> {
   const d = requireDeps();
-  let body: { focused?: unknown } = {};
+  let parsed: unknown;
   try {
-    body = (await parseJsonBody(req)) as { focused?: unknown };
+    parsed = await parseJsonBody(req);
   } catch {
-    body = {}; // a bodyless heartbeat is valid: it just means "still here, not necessarily focused"
+    // A bodyless heartbeat is valid and already parses as `{}` ("still here, not necessarily
+    // focused"), so reaching here means the body was genuinely malformed. Renewing the lease on
+    // a payload we could not read would be extending liveness on the strength of a broken
+    // request.
+    return sendJson(res, 400, { ok: false, error: 'Invalid JSON' });
   }
+  const body = asObject(parsed);
+  if (!body) return sendJson(res, 400, { ok: false, error: 'Invalid JSON' });
 
   const nowMs = d.now();
   sweep(nowMs);
@@ -317,15 +328,17 @@ async function handleCanvasCommand(
   res: http.ServerResponse,
 ): Promise<void> {
   const d = requireDeps();
-  let raw: Record<string, unknown>;
+  let parsed: unknown;
   try {
-    raw = (await parseJsonBody(req)) as Record<string, unknown>;
+    parsed = await parseJsonBody(req);
   } catch {
-    return sendJson(res, 400, { ok: false, code: 'invalid-request', error: 'Invalid JSON' });
+    return sendJson(res, 400, invalidRequest('Invalid JSON'));
   }
+  const raw = asObject(parsed);
+  if (!raw) return sendJson(res, 400, invalidRequest('Invalid JSON'));
 
   const invalid = validateCommandRequest(raw);
-  if (invalid) return sendJson(res, 400, { ok: false, code: 'invalid-request', error: invalid });
+  if (invalid) return sendJson(res, 400, invalidRequest(invalid));
 
   const workspace = raw.workspace as string;
   const file = raw.file as string | undefined;
@@ -335,11 +348,12 @@ async function handleCanvasCommand(
   const nowMs = d.now();
   const target = resolveTarget(workspace, file, nowMs);
   if (!target) {
-    return sendJson(res, 404, {
+    const noCanvas: CanvasCommandResult = {
       ok: false,
       code: 'no-canvas',
       error: 'No canvas view is open for that workspace/file',
-    });
+    };
+    return sendJson(res, 404, noCanvas);
   }
 
   const event: CanvasCommandEvent = { viewId: target.viewId, command };
@@ -348,10 +362,19 @@ async function handleCanvasCommand(
 
   // Driving a view is activity: it keeps that view the MRU target for the follow-up commands a
   // controller is about to send, even though it never took focus in its host.
+  //
+  // It is deliberately NOT liveness. Delivery is fire-and-forget over SSE and proves nothing
+  // about the host still being alive, so refreshing the lease here would mean a ghost view kept
+  // renewing itself for as long as a controller kept driving it — exactly when the reviewer most
+  // needs to be told there is no canvas. Only a heartbeat, which only a live host can send,
+  // extends the lease.
   target.lastActiveAt = nowMs;
-  target.lastSeenAt = nowMs;
 
-  return sendJson(res, 200, { ok: true, target: { viewId: target.viewId, file: target.file } });
+  const ok: CanvasCommandResult = {
+    ok: true,
+    target: { viewId: target.viewId, file: target.file },
+  };
+  return sendJson(res, 200, ok);
 }
 
 /** Returns an error message when the payload is not a valid command request, else null. */
@@ -374,8 +397,23 @@ function validateCommandRequest(raw: Record<string, unknown>): string | null {
   return null;
 }
 
+/** Every command-route failure carries a wire `code`; this keeps that impossible to forget. */
+function invalidRequest(error: string): CanvasCommandResult {
+  return { ok: false, code: 'invalid-request', error };
+}
+
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * `parseJsonBody` is typed as returning an object but will happily resolve a literal `null`, a
+ * bare array, or a number, since those are all valid JSON. Reading a field off `null` throws,
+ * which would escape as a 500 with no wire `code` — the one thing the error contract forbids.
+ */
+function asObject(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
 }
 
 /** Access the wired deps, throwing a clear error if init was skipped. */

--- a/packages/codev/src/agent-farm/servers/canvas-relay.ts
+++ b/packages/codev/src/agent-farm/servers/canvas-relay.ts
@@ -1,0 +1,401 @@
+/**
+ * Canvas command relay + live view registry for Tower (spec 1401).
+ *
+ * Lets any CONTROLLER (a control device, a companion app, a test harness) drive an open
+ * artifact-canvas view over Tower's existing channels:
+ *   - host -> Tower:       REST on `/api/canvas/views` (register / heartbeat / unregister).
+ *   - controller -> Tower: REST POST `/api/canvas/command`.
+ *   - Tower -> host:       SSE `canvas-command` at /api/events, addressed to one resolved view.
+ *
+ * Why this is not just another verb on `command-relay.ts`: that relay is a fire-and-forget
+ * broadcast which answers `{ok:true}` whether or not anything is listening. It structurally
+ * cannot say "no canvas is open", and it cannot pick one view among several. Both are hard
+ * requirements here, so Tower keeps a registry of live views, resolves exactly ONE target, and
+ * reports which one it drove.
+ *
+ * The registry is deliberately in-memory and lease-based: a view is a live UI surface, not
+ * durable state, and a host that dies without unregistering must age out rather than linger as
+ * a ghost that silently swallows commands.
+ */
+
+import type * as http from 'node:http';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import type {
+  CanvasCommand,
+  CanvasCommandEvent,
+  CanvasView,
+  TraversalCommand,
+} from '@cluesmith/codev-types';
+import { parseJsonBody } from '../utils/server-utils.js';
+
+// Wire names — the canonical contract lives in @cluesmith/codev-types
+// (CANVAS_COMMAND_ROUTE / CANVAS_VIEWS_ROUTE / CANVAS_COMMAND_EVENT) and must match these. They
+// are re-declared locally because codev runs UNBUNDLED from dist/ and codev-types is a
+// compile-time-only (type) dependency with no runtime dist on the codev side, so a runtime value
+// import from it would not resolve. Same reason command-relay.ts re-declares COMMAND_ROUTE.
+export const CANVAS_COMMAND_ROUTE = '/api/canvas/command';
+export const CANVAS_VIEWS_ROUTE = '/api/canvas/views';
+const CANVAS_COMMAND_EVENT = 'canvas-command';
+
+/** Everything under this prefix belongs to this module. */
+export const CANVAS_ROUTE_PREFIX = '/api/canvas/';
+
+/** How often a host should heartbeat to keep its lease alive. */
+export const CANVAS_VIEW_HEARTBEAT_MS = 30_000;
+/**
+ * How long a view survives without a heartbeat. Three missed beats: long enough to ride out a
+ * busy event loop or a paused debugger, short enough that a killed host's ghost view stops
+ * absorbing commands quickly.
+ */
+export const CANVAS_VIEW_LEASE_MS = 90_000;
+
+/**
+ * A type that fails to instantiate when its argument is not `true`. A bare conditional type
+ * alias would constrain nothing and silently resolve to `false`, which is exactly how the same
+ * guard in the canvas package went inert before review caught it.
+ */
+type Assert<T extends true> = T;
+
+/**
+ * The closed command vocabulary as runtime data, so an unknown command can be rejected. The
+ * assertion below fails to compile if `CanvasCommand` gains a member that is missing here, which
+ * is what keeps Tower's validation from silently falling behind the contract.
+ */
+const CANVAS_COMMANDS = [
+  'block-next',
+  'block-prev',
+  'comment-next',
+  'comment-prev',
+  'heading-next',
+  'heading-prev',
+  'column-forward',
+  'column-back',
+  'doc-start',
+  'doc-end',
+  'composer-open',
+  'composer-submit',
+  'composer-cancel',
+  'reading-mode-toggle',
+] as const satisfies readonly CanvasCommand[];
+
+type _EveryCommandIsListed = Assert<
+  Exclude<CanvasCommand, (typeof CANVAS_COMMANDS)[number]> extends never ? true : false
+>;
+
+/** The commands `count` is valid on. Same drift protection as above. */
+const TRAVERSAL_COMMANDS = [
+  'block-next',
+  'block-prev',
+  'comment-next',
+  'comment-prev',
+  'heading-next',
+  'heading-prev',
+  'column-forward',
+  'column-back',
+] as const satisfies readonly TraversalCommand[];
+
+type _EveryTraversalIsListed = Assert<
+  Exclude<TraversalCommand, (typeof TRAVERSAL_COMMANDS)[number]> extends never ? true : false
+>;
+
+interface RegisteredView extends CanvasView {
+  /** Last heartbeat of any kind; drives lease expiry. */
+  lastSeenAt: number;
+  /**
+   * Registration order. Used to break an MRU tie deterministically — two views registered in the
+   * same millisecond would otherwise resolve arbitrarily, and a target rule that depends on
+   * timer resolution is not a rule.
+   */
+  sequence: number;
+}
+
+export interface CanvasRelayDeps {
+  /** Fan an event out to all SSE clients (wraps broadcastNotification). */
+  broadcast: (type: string, body: unknown) => void;
+  /** Injectable clock, so lease expiry is tested by advancing time rather than waiting. */
+  now: () => number;
+}
+
+/** The slice of Tower's RouteContext this module needs (avoids a type import cycle). */
+interface CanvasRouteCtx {
+  broadcastNotification: (n: { type: string; title: string; body: string }) => void;
+}
+
+const views = new Map<string, RegisteredView>();
+let sequence = 0;
+let deps: CanvasRelayDeps | null = null;
+let inited = false;
+
+/** Wire the module's dependencies. */
+export function initCanvasRelay(d: CanvasRelayDeps): void {
+  deps = d;
+  inited = true;
+}
+
+/** Tear down state (used by tests and shutdown). */
+export function shutdownCanvasRelay(): void {
+  views.clear();
+  sequence = 0;
+  deps = null;
+  inited = false;
+}
+
+/**
+ * Resolve a path the same way the file-tab registry does, so the two agree on what "the same
+ * file" means: follow symlinks, fall back to resolving the parent when the file itself does not
+ * exist, and finally to a plain absolute path.
+ */
+function canonicalPath(raw: string): string {
+  try {
+    return fs.realpathSync(raw);
+  } catch {
+    try {
+      return path.join(fs.realpathSync(path.dirname(raw)), path.basename(raw));
+    } catch {
+      return path.resolve(raw);
+    }
+  }
+}
+
+/** Drop views whose lease has lapsed. Called on every access, so no timer is needed. */
+function sweep(nowMs: number): void {
+  for (const [id, view] of views) {
+    if (nowMs - view.lastSeenAt > CANVAS_VIEW_LEASE_MS) views.delete(id);
+  }
+}
+
+/**
+ * Pick the single view a command should go to.
+ *
+ * Zero matches is the caller's problem to hear about, not something to paper over. More than one
+ * match resolves to the most recently active view and NEVER fans out: delivering
+ * `composer-submit` to two views of one file would post the comment twice.
+ */
+function resolveTarget(workspace: string, file: string | undefined, nowMs: number): RegisteredView | null {
+  sweep(nowMs);
+  const ws = canonicalPath(workspace);
+  let wanted: string | null = null;
+  if (file !== undefined) wanted = canonicalPath(file);
+
+  const matches: RegisteredView[] = [];
+  for (const view of views.values()) {
+    if (view.workspace !== ws) continue;
+    if (wanted !== null && view.file !== wanted) continue;
+    matches.push(view);
+  }
+  if (matches.length === 0) return null;
+
+  matches.sort((a, b) => {
+    if (b.lastActiveAt !== a.lastActiveAt) return b.lastActiveAt - a.lastActiveAt;
+    return b.sequence - a.sequence;
+  });
+  return matches[0];
+}
+
+/**
+ * Single entry point for `/api/canvas/*`, delegated from tower-routes. Lazily initializes from
+ * the RouteContext on first hit, then dispatches.
+ */
+export async function handleCanvasRoute(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  url: URL,
+  ctx: CanvasRouteCtx,
+): Promise<void> {
+  if (!inited) {
+    initCanvasRelay({
+      broadcast: (type, body) =>
+        ctx.broadcastNotification({ type, title: type, body: JSON.stringify(body) }),
+      now: () => Date.now(),
+    });
+  }
+
+  if (req.method === 'POST' && url.pathname === CANVAS_COMMAND_ROUTE) {
+    return handleCanvasCommand(req, res);
+  }
+  if (req.method === 'POST' && url.pathname === CANVAS_VIEWS_ROUTE) {
+    return handleRegisterView(req, res);
+  }
+
+  const viewMatch = url.pathname.match(/^\/api\/canvas\/views\/([^/]+)(\/heartbeat)?$/);
+  if (viewMatch) {
+    const viewId = decodeURIComponent(viewMatch[1]);
+    if (req.method === 'POST' && viewMatch[2]) return handleHeartbeat(req, res, viewId);
+    if (req.method === 'DELETE' && !viewMatch[2]) return handleUnregisterView(res, viewId);
+  }
+
+  sendJson(res, 404, { ok: false, error: 'Unknown canvas route' });
+}
+
+/** POST /api/canvas/views — a host registers one live canvas view. */
+async function handleRegisterView(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+): Promise<void> {
+  const d = requireDeps();
+  let body: { workspace?: unknown; file?: unknown };
+  try {
+    body = (await parseJsonBody(req)) as { workspace?: unknown; file?: unknown };
+  } catch {
+    return sendJson(res, 400, { ok: false, error: 'Invalid JSON' });
+  }
+  if (!isNonEmptyString(body.workspace)) {
+    return sendJson(res, 400, { ok: false, error: 'Missing workspace' });
+  }
+  if (!isNonEmptyString(body.file)) {
+    return sendJson(res, 400, { ok: false, error: 'Missing file' });
+  }
+
+  const nowMs = d.now();
+  sweep(nowMs);
+  sequence += 1;
+  const viewId = `canvas-${randomUUID()}`;
+  const file = canonicalPath(body.file);
+  // One registration per VIEW, never per file: two panels showing the same document are two
+  // views with distinct ids, which is precisely the case the MRU rule exists to disambiguate.
+  views.set(viewId, {
+    viewId,
+    workspace: canonicalPath(body.workspace),
+    file,
+    lastActiveAt: nowMs,
+    lastSeenAt: nowMs,
+    sequence,
+  });
+  return sendJson(res, 200, { ok: true, viewId, file });
+}
+
+/**
+ * POST /api/canvas/views/:viewId/heartbeat — keep the lease alive.
+ *
+ * `focused: true` additionally makes this the most recently active view. Tower stamps both times
+ * itself; host clocks are never trusted, so MRU stays deterministic across hosts whose clocks
+ * disagree.
+ */
+async function handleHeartbeat(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  viewId: string,
+): Promise<void> {
+  const d = requireDeps();
+  let body: { focused?: unknown } = {};
+  try {
+    body = (await parseJsonBody(req)) as { focused?: unknown };
+  } catch {
+    body = {}; // a bodyless heartbeat is valid: it just means "still here, not necessarily focused"
+  }
+
+  const nowMs = d.now();
+  sweep(nowMs);
+  const view = views.get(viewId);
+  // 404 rather than a silent re-create: a host holding an id Tower has forgotten (a restart, an
+  // expired lease) must learn that and re-register, or it would heartbeat into the void forever.
+  if (!view) return sendJson(res, 404, { ok: false, error: 'Unknown view' });
+
+  view.lastSeenAt = nowMs;
+  if (body.focused === true) view.lastActiveAt = nowMs;
+  return sendJson(res, 200, { ok: true });
+}
+
+/** DELETE /api/canvas/views/:viewId — the host's view is gone. */
+function handleUnregisterView(res: http.ServerResponse, viewId: string): void {
+  const existed = views.delete(viewId);
+  if (!existed) return sendJson(res, 404, { ok: false, error: 'Unknown view' });
+  return sendJson(res, 200, { ok: true });
+}
+
+/**
+ * POST /api/canvas/command — run one command against the resolved target view.
+ *
+ * Answers explicitly in every case: `no-canvas` (404) when the selector matches nothing,
+ * `invalid-request` (400) when the payload is malformed, and the resolved target on success.
+ * Delivery itself rides SSE and is best-effort; what is guaranteed is the ANSWER about targeting.
+ */
+async function handleCanvasCommand(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+): Promise<void> {
+  const d = requireDeps();
+  let raw: Record<string, unknown>;
+  try {
+    raw = (await parseJsonBody(req)) as Record<string, unknown>;
+  } catch {
+    return sendJson(res, 400, { ok: false, code: 'invalid-request', error: 'Invalid JSON' });
+  }
+
+  const invalid = validateCommandRequest(raw);
+  if (invalid) return sendJson(res, 400, { ok: false, code: 'invalid-request', error: invalid });
+
+  const workspace = raw.workspace as string;
+  const file = raw.file as string | undefined;
+  const command = raw.command as CanvasCommand;
+  const count = raw.count as number | undefined;
+
+  const nowMs = d.now();
+  const target = resolveTarget(workspace, file, nowMs);
+  if (!target) {
+    return sendJson(res, 404, {
+      ok: false,
+      code: 'no-canvas',
+      error: 'No canvas view is open for that workspace/file',
+    });
+  }
+
+  const event: CanvasCommandEvent = { viewId: target.viewId, command };
+  if (count !== undefined) event.count = count;
+  d.broadcast(CANVAS_COMMAND_EVENT, event);
+
+  // Driving a view is activity: it keeps that view the MRU target for the follow-up commands a
+  // controller is about to send, even though it never took focus in its host.
+  target.lastActiveAt = nowMs;
+  target.lastSeenAt = nowMs;
+
+  return sendJson(res, 200, { ok: true, target: { viewId: target.viewId, file: target.file } });
+}
+
+/** Returns an error message when the payload is not a valid command request, else null. */
+function validateCommandRequest(raw: Record<string, unknown>): string | null {
+  if (!isNonEmptyString(raw.workspace)) return 'Missing workspace';
+  if (raw.file !== undefined && !isNonEmptyString(raw.file)) return 'Invalid file';
+  if (typeof raw.command !== 'string') return 'Missing command';
+  if (!(CANVAS_COMMANDS as readonly string[]).includes(raw.command)) {
+    return `Unknown command: ${raw.command}`;
+  }
+  if (raw.count !== undefined) {
+    const count = raw.count;
+    if (typeof count !== 'number' || !Number.isInteger(count) || count < 1) {
+      return 'count must be a positive integer';
+    }
+    if (!(TRAVERSAL_COMMANDS as readonly string[]).includes(raw.command)) {
+      return `count is not valid for ${raw.command}`;
+    }
+  }
+  return null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/** Access the wired deps, throwing a clear error if init was skipped. */
+function requireDeps(): CanvasRelayDeps {
+  if (!deps) throw new Error('Canvas relay not initialized');
+  return deps;
+}
+
+/** Write a JSON response with the given status code. */
+function sendJson(res: http.ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+/** Live views, for tests and diagnostics. Never part of the wire surface. */
+export function listCanvasViewsForTest(): CanvasView[] {
+  return [...views.values()].map((v) => ({
+    viewId: v.viewId,
+    workspace: v.workspace,
+    file: v.file,
+    lastActiveAt: v.lastActiveAt,
+  }));
+}

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -47,6 +47,7 @@ import { hasTeam, loadTeamMembers, loadMessages, type TeamMember, type TeamMessa
 import { fetchTeamGitHubData, type TeamMemberGitHubData } from '../../lib/team-github.js';
 import { resolveTarget, resolveAgentInRegistry, broadcastMessage, isResolveError, type ResolveResult } from './tower-messages.js';
 import { handleCommandRoute, COMMAND_ROUTE } from './command-relay.js';
+import { handleCanvasRoute, CANVAS_ROUTE_PREFIX } from './canvas-relay.js';
 import { formatArchitectMessage, formatBuilderMessage } from '../utils/message-format.js';
 import type { PtySession } from '../../terminal/pty-session.js';
 import { writeMessageToSession, writeEscapeToSession } from './message-write.js';
@@ -278,6 +279,13 @@ export async function handleRequest(
     // to the active editor provider for any controller.
     if (url.pathname === COMMAND_ROUTE) {
       return await handleCommandRoute(req, res, url, ctx);
+    }
+
+    // Canvas command channel: /api/canvas/* — same self-routing shape as the command relay, but
+    // targeted rather than broadcast: it keeps a registry of live canvas views so it can resolve
+    // exactly one and answer when none is open (spec 1401).
+    if (url.pathname.startsWith(CANVAS_ROUTE_PREFIX)) {
+      return await handleCanvasRoute(req, res, url, ctx);
     }
 
     // Workspace API: /api/workspaces/:encodedPath/activate|deactivate|status (Spec 0090 Phase 1)

--- a/packages/sdk/src/__tests__/tower-client-canvas.test.ts
+++ b/packages/sdk/src/__tests__/tower-client-canvas.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Canvas command + view registration calls (spec 1401, plan phase 5).
+ *
+ * The contract under test is that a resolved promise always carries a verdict a controller can
+ * act on: Tower's own `code` when Tower answered, and the client-synthesized `unreachable` when
+ * it did not. Conflating those two is the specific bug this call exists to prevent, so most of
+ * these cases are about failure shapes rather than the happy path.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { TowerClient } from '../tower-client.js';
+
+/** Build a client whose transport is a scripted response, and capture what it sent. */
+function clientWith(response: { status: number; body?: unknown } | Error) {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const fetchFn = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    if (response instanceof Error) throw response;
+    const text = response.body === undefined ? '' : JSON.stringify(response.body);
+    return {
+      ok: response.status >= 200 && response.status < 300,
+      status: response.status,
+      text: async () => text,
+      json: async () => JSON.parse(text),
+    } as unknown as Response;
+  });
+  const client = new TowerClient({ port: 4100, fetchFn: fetchFn as unknown as typeof fetch });
+  return { client, calls };
+}
+
+const TARGET = { workspace: '/ws' };
+
+describe('sendCanvasCommand', () => {
+  it('returns the resolved target on success', async () => {
+    const { client, calls } = clientWith({
+      status: 200,
+      body: { ok: true, target: { viewId: 'canvas-1', file: '/ws/spec.md' } },
+    });
+
+    const result = await client.sendCanvasCommand('comment-next', TARGET);
+
+    expect(result).toEqual({ ok: true, target: { viewId: 'canvas-1', file: '/ws/spec.md' } });
+    expect(calls[0].url).toBe('http://localhost:4100/api/canvas/command');
+    expect(JSON.parse(calls[0].init.body as string)).toEqual({
+      workspace: '/ws',
+      command: 'comment-next',
+    });
+  });
+
+  it('preserves the no-canvas code rather than flattening it to a message', async () => {
+    const { client } = clientWith({
+      status: 404,
+      body: { ok: false, code: 'no-canvas', error: 'No canvas view is open' },
+    });
+
+    const result = await client.sendCanvasCommand('block-next', TARGET);
+
+    expect(result).toMatchObject({ ok: false, code: 'no-canvas' });
+  });
+
+  it('preserves the invalid-request code', async () => {
+    const { client } = clientWith({
+      status: 400,
+      body: { ok: false, code: 'invalid-request', error: 'count is not valid for doc-start' },
+    });
+
+    const result = await client.sendCanvasCommand('doc-start', TARGET, { count: 2 });
+
+    expect(result).toMatchObject({ ok: false, code: 'invalid-request' });
+  });
+
+  it('reports an unreachable Tower distinguishably from no-canvas', async () => {
+    const { client } = clientWith(new Error('connect ECONNREFUSED 127.0.0.1:4100'));
+
+    const result = await client.sendCanvasCommand('block-next', TARGET);
+
+    // The whole point: a controller must not render "no canvas open" when Tower is down.
+    expect(result).toMatchObject({ ok: false, code: 'unreachable' });
+    expect(result).not.toMatchObject({ code: 'no-canvas' });
+  });
+
+  it('reports a timeout as unreachable', async () => {
+    const { client } = clientWith(new Error('The operation timed out'));
+    const result = await client.sendCanvasCommand('block-next', TARGET);
+    expect(result).toMatchObject({ ok: false, code: 'unreachable' });
+  });
+
+  it('reports an unreadable body as unreachable rather than inventing a verdict', async () => {
+    const { client } = clientWith({ status: 200, body: { unexpected: true } });
+    const result = await client.sendCanvasCommand('block-next', TARGET);
+    expect(result).toMatchObject({ ok: false, code: 'unreachable' });
+  });
+
+  it('never rejects, whatever the transport does', async () => {
+    const { client } = clientWith(new Error('kaboom'));
+    await expect(client.sendCanvasCommand('block-next', TARGET)).resolves.toBeDefined();
+  });
+
+  it('sends file and count only when supplied', async () => {
+    const { client, calls } = clientWith({
+      status: 200,
+      body: { ok: true, target: { viewId: 'v', file: '/ws/a.md' } },
+    });
+
+    await client.sendCanvasCommand('block-next', TARGET);
+    expect(JSON.parse(calls[0].init.body as string)).not.toHaveProperty('file');
+    expect(JSON.parse(calls[0].init.body as string)).not.toHaveProperty('count');
+
+    await client.sendCanvasCommand('block-next', { workspace: '/ws', file: '/ws/a.md' }, { count: 3 });
+    expect(JSON.parse(calls[1].init.body as string)).toMatchObject({
+      file: '/ws/a.md',
+      count: 3,
+    });
+  });
+});
+
+describe('canvas view registration', () => {
+  it('registers and returns the Tower-minted id and canonical path', async () => {
+    const { client, calls } = clientWith({
+      status: 200,
+      body: { ok: true, viewId: 'canvas-9', file: '/private/ws/spec.md' },
+    });
+
+    const result = await client.registerCanvasView('/ws', '/ws/spec.md');
+
+    expect(result).toEqual({ ok: true, viewId: 'canvas-9', file: '/private/ws/spec.md' });
+    expect(calls[0].url).toBe('http://localhost:4100/api/canvas/views');
+  });
+
+  it('reports a failed registration without throwing', async () => {
+    const { client } = clientWith(new Error('connect ECONNREFUSED 127.0.0.1:4100'));
+    await expect(client.registerCanvasView('/ws', '/ws/spec.md')).resolves.toMatchObject({
+      ok: false,
+    });
+  });
+
+  it('heartbeats, and flags an unknown view so the host knows to re-register', async () => {
+    const alive = clientWith({ status: 200, body: { ok: true } });
+    await expect(alive.client.heartbeatCanvasView('canvas-1', true)).resolves.toEqual({
+      ok: true,
+      unknownView: false,
+    });
+    expect(JSON.parse(alive.calls[0].init.body as string)).toEqual({ focused: true });
+
+    const forgotten = clientWith({ status: 404, body: { ok: false, error: 'Unknown view' } });
+    const result = await forgotten.client.heartbeatCanvasView('canvas-1');
+    // A forgotten id and an unreachable Tower call for different host behavior: re-register
+    // versus retry later.
+    expect(result).toMatchObject({ ok: false, unknownView: true });
+
+    const down = clientWith(new Error('connect ECONNREFUSED 127.0.0.1:4100'));
+    await expect(down.client.heartbeatCanvasView('canvas-1')).resolves.toMatchObject({
+      ok: false,
+      unknownView: false,
+    });
+  });
+
+  it('omits focused from the heartbeat body when not supplied', async () => {
+    const { client, calls } = clientWith({ status: 200, body: { ok: true } });
+    await client.heartbeatCanvasView('canvas-1');
+    expect(JSON.parse(calls[0].init.body as string)).toEqual({});
+  });
+
+  it('unregisters with DELETE', async () => {
+    const { client, calls } = clientWith({ status: 200, body: { ok: true } });
+
+    await expect(client.unregisterCanvasView('canvas-1')).resolves.toEqual({ ok: true });
+    expect(calls[0].init.method).toBe('DELETE');
+    expect(calls[0].url).toBe('http://localhost:4100/api/canvas/views/canvas-1');
+  });
+
+  it('encodes a view id that would otherwise break the path', async () => {
+    const { client, calls } = clientWith({ status: 200, body: { ok: true } });
+    await client.unregisterCanvasView('canvas/../evil');
+    expect(calls[0].url).toBe('http://localhost:4100/api/canvas/views/canvas%2F..%2Fevil');
+  });
+});

--- a/packages/sdk/src/__tests__/tower-client-canvas.test.ts
+++ b/packages/sdk/src/__tests__/tower-client-canvas.test.ts
@@ -85,10 +85,29 @@ describe('sendCanvasCommand', () => {
     expect(result).toMatchObject({ ok: false, code: 'unreachable' });
   });
 
-  it('reports an unreadable body as unreachable rather than inventing a verdict', async () => {
-    const { client } = clientWith({ status: 200, body: { unexpected: true } });
+  // A response is only a verdict if the whole shape checks out. Accepting anything with an `ok`
+  // field would hand the caller `target.viewId` off undefined, or a code outside its union.
+  it.each([
+    ['no ok field', { unexpected: true }],
+    ['success with no target', { ok: true }],
+    ['success with a malformed target', { ok: true, target: { viewId: 7 } }],
+    ['success with a partial target', { ok: true, target: { viewId: 'v' } }],
+    ['failure with an unknown code', { ok: false, code: 'unknown', error: 'x' }],
+    ['failure with no code', { ok: false, error: 'x' }],
+    ['failure with a non-string code', { ok: false, code: 12 }],
+    ['a non-object body', 'plain text'],
+    ['null', null],
+  ])('reports %s as unreachable rather than inventing a verdict', async (_label, body) => {
+    const { client } = clientWith({ status: 200, body });
     const result = await client.sendCanvasCommand('block-next', TARGET);
     expect(result).toMatchObject({ ok: false, code: 'unreachable' });
+  });
+
+  it('supplies a message when Tower omits one on a valid failure code', async () => {
+    const { client } = clientWith({ status: 404, body: { ok: false, code: 'no-canvas' } });
+    const result = await client.sendCanvasCommand('block-next', TARGET);
+    expect(result).toMatchObject({ ok: false, code: 'no-canvas' });
+    expect((result as { error: string }).error).toBeTruthy();
   });
 
   it('never rejects, whatever the transport does', async () => {

--- a/packages/sdk/src/controller.ts
+++ b/packages/sdk/src/controller.ts
@@ -14,6 +14,7 @@
 export {
   TowerClient,
   COMMAND_ROUTE,
+  CANVAS_COMMAND_ROUTE,
   type TowerClientOptions,
   type TowerWorkspace,
 } from './tower-client.js';
@@ -32,4 +33,24 @@ export type {
   OverviewBuilder,
   OverviewPR,
   OverviewBacklogItem,
+} from '@cluesmith/codev-types';
+
+/*
+ * The canvas command vocabulary and its result shapes (spec 1401), so a controller can drive an
+ * open artifact-canvas view and act on the answer without a direct codev-types dependency.
+ *
+ * `CanvasCommandClientErrorCode` is one member wider than the wire union: it adds `unreachable`,
+ * which the client synthesizes when Tower gave no answer at all. A controller must be able to
+ * tell that apart from `no-canvas`, or it will report "no canvas open" while Tower is simply
+ * down.
+ *
+ * View registration is deliberately NOT re-exported here. Controllers drive views; hosts own
+ * them, and those methods stay on the client for hosts to reach.
+ */
+export type {
+  CanvasCommand,
+  CanvasCommandClientResult,
+  CanvasCommandClientErrorCode,
+  CanvasCommandErrorCode,
+  CanvasCommandTarget,
 } from '@cluesmith/codev-types';

--- a/packages/sdk/src/tower-client.ts
+++ b/packages/sdk/src/tower-client.ts
@@ -13,7 +13,7 @@
  * the read-only reader for standalone Node controllers).
  */
 
-import type { DashboardState, OverviewData, IssueView, PRView, IssueSearchResponse, ResolvedWorktreeConfig, ResolvedActivityHooks, TowerVersionInfo, CommandRequest } from '@cluesmith/codev-types';
+import type { DashboardState, OverviewData, IssueView, PRView, IssueSearchResponse, ResolvedWorktreeConfig, ResolvedActivityHooks, TowerVersionInfo, CommandRequest, CanvasCommand, CanvasCommandRequest, CanvasCommandResult, CanvasCommandClientResult } from '@cluesmith/codev-types';
 import { DEFAULT_TOWER_PORT } from './constants.js';
 import { parseSseText, type SseEnvelope } from './sse.js';
 
@@ -33,6 +33,18 @@ const REQUEST_TIMEOUT_MS = 10000;
  * Recorded in issue #1189; the boundary test enforces the type-only rule.
  */
 export const COMMAND_ROUTE = '/api/command';
+
+/**
+ * The canvas command channel (spec 1401). Mirrored from `@cluesmith/codev-types` for the same
+ * reason as `COMMAND_ROUTE` above.
+ *
+ * Separate from the command relay on purpose: that one broadcasts a verb and answers `ok`
+ * regardless, while this one resolves a single target view and reports which — or that none is
+ * open, which is the whole point of the channel.
+ */
+export const CANVAS_COMMAND_ROUTE = '/api/canvas/command';
+/** Host-side view lifecycle: register, heartbeat, unregister. */
+export const CANVAS_VIEWS_ROUTE = '/api/canvas/views';
 
 // ── Types ──────────────────────────────────────────────────────
 
@@ -868,6 +880,138 @@ export class TowerClient {
       method: 'POST',
       body: JSON.stringify(body),
     });
+  }
+
+  /**
+   * Like `request`, but keeps the parsed body on a non-2xx response.
+   *
+   * `request` runs failures through `extractTowerError`, which reduces the body to a message and
+   * discards everything else. The canvas channel answers with a machine-readable `code`, and a
+   * controller has to act on it (render "no canvas open" versus "Tower is down"), so that code
+   * must survive the trip. Never throws: a transport failure comes back as `status: 0`, matching
+   * the never-reject invariant the rest of this client holds.
+   */
+  private async requestPreservingBody(
+    path: string,
+    options: RequestInit = {},
+  ): Promise<{ status: number; body: unknown; error?: string }> {
+    try {
+      const authKey = this.getAuthKey();
+      const headers: Record<string, string> = {
+        ...(options.headers as Record<string, string>),
+        'Content-Type': 'application/json',
+      };
+      if (authKey) {
+        headers['codev-web-key'] = authKey;
+      }
+      const response = await this.fetchFn(`${this.baseUrl}${path}`, {
+        ...options,
+        headers,
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+      const text = await response.text();
+      let body: unknown = null;
+      try {
+        body = text ? JSON.parse(text) : null;
+      } catch {
+        body = null; // an unparseable body is reported by the caller as an unusable answer
+      }
+      return { status: response.status, body };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes('ECONNREFUSED')) return { status: 0, body: null, error: 'Tower not running' };
+      if (message.includes('timeout')) return { status: 0, body: null, error: 'Request timeout' };
+      return { status: 0, body: null, error: message };
+    }
+  }
+
+  /**
+   * POST /api/canvas/command: drive one open artifact-canvas view (spec 1401).
+   *
+   * `target.workspace` is required and scopes the lookup; `target.file` narrows to one document,
+   * and omitting it targets the workspace's most recently active view. `options.count` repeats a
+   * traversal command and is rejected by Tower on any other.
+   *
+   * Never rejects. A resolved promise always carries Tower's verdict, except for `unreachable`,
+   * which this client synthesizes when there was no answer at all — that distinction is the
+   * reason the call exists in this shape, since "no canvas is open" and "Tower is down" must not
+   * look alike to a controller.
+   */
+  async sendCanvasCommand(
+    command: CanvasCommand,
+    target: { workspace: string; file?: string },
+    options?: { count?: number },
+  ): Promise<CanvasCommandClientResult> {
+    const payload: CanvasCommandRequest = { workspace: target.workspace, command };
+    if (target.file !== undefined) payload.file = target.file;
+    if (options?.count !== undefined) payload.count = options.count;
+
+    const outcome = await this.requestPreservingBody(CANVAS_COMMAND_ROUTE, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+
+    if (outcome.status === 0) {
+      return { ok: false, code: 'unreachable', error: outcome.error ?? 'Tower unreachable' };
+    }
+    const body = outcome.body as CanvasCommandResult | null;
+    if (body && typeof body === 'object' && 'ok' in body) return body;
+    // A 2xx with a shape we cannot read is not a verdict, so it is reported as such rather than
+    // being flattened into a success or an arbitrary failure code.
+    return {
+      ok: false,
+      code: 'unreachable',
+      error: `Unreadable response from Tower (HTTP ${outcome.status})`,
+    };
+  }
+
+  /**
+   * POST /api/canvas/views: a HOST registers one live canvas view and receives its Tower-minted
+   * id. Host-side lifecycle, deliberately absent from the controller subpath — controllers drive
+   * views, hosts own them.
+   */
+  async registerCanvasView(
+    workspace: string,
+    file: string,
+  ): Promise<{ ok: boolean; viewId?: string; file?: string; error?: string }> {
+    const result = await this.request<{ ok: boolean; viewId: string; file: string }>(
+      CANVAS_VIEWS_ROUTE,
+      { method: 'POST', body: JSON.stringify({ workspace, file }) },
+    );
+    if (!result.ok || !result.data) return { ok: false, error: result.error ?? 'Registration failed' };
+    return { ok: true, viewId: result.data.viewId, file: result.data.file };
+  }
+
+  /**
+   * POST /api/canvas/views/:viewId/heartbeat: keep a view's lease alive, and with
+   * `focused: true` mark it the most recently active target.
+   *
+   * `unknownView` distinguishes "Tower has forgotten this id" (a restart, an expired lease) from
+   * a transport problem, because the host's response to the two differs: re-register, versus try
+   * again later.
+   */
+  async heartbeatCanvasView(
+    viewId: string,
+    focused?: boolean,
+  ): Promise<{ ok: boolean; unknownView: boolean; error?: string }> {
+    const body: { focused?: boolean } = {};
+    if (focused !== undefined) body.focused = focused;
+    const result = await this.request<{ ok: boolean }>(
+      `${CANVAS_VIEWS_ROUTE}/${encodeURIComponent(viewId)}/heartbeat`,
+      { method: 'POST', body: JSON.stringify(body) },
+    );
+    if (result.ok) return { ok: true, unknownView: false };
+    return { ok: false, unknownView: result.status === 404, error: result.error };
+  }
+
+  /** DELETE /api/canvas/views/:viewId: the host's view is gone. */
+  async unregisterCanvasView(viewId: string): Promise<{ ok: boolean; error?: string }> {
+    const result = await this.request<{ ok: boolean }>(
+      `${CANVAS_VIEWS_ROUTE}/${encodeURIComponent(viewId)}`,
+      { method: 'DELETE' },
+    );
+    if (result.ok) return { ok: true };
+    return { ok: false, error: result.error };
   }
 
   /**

--- a/packages/sdk/src/tower-client.ts
+++ b/packages/sdk/src/tower-client.ts
@@ -13,7 +13,7 @@
  * the read-only reader for standalone Node controllers).
  */
 
-import type { DashboardState, OverviewData, IssueView, PRView, IssueSearchResponse, ResolvedWorktreeConfig, ResolvedActivityHooks, TowerVersionInfo, CommandRequest, CanvasCommand, CanvasCommandRequest, CanvasCommandResult, CanvasCommandClientResult } from '@cluesmith/codev-types';
+import type { DashboardState, OverviewData, IssueView, PRView, IssueSearchResponse, ResolvedWorktreeConfig, ResolvedActivityHooks, TowerVersionInfo, CommandRequest, CanvasCommand, CanvasCommandRequest, CanvasCommandResult, CanvasCommandClientResult, CanvasCommandErrorCode } from '@cluesmith/codev-types';
 import { DEFAULT_TOWER_PORT } from './constants.js';
 import { parseSseText, type SseEnvelope } from './sse.js';
 
@@ -45,6 +45,52 @@ export const COMMAND_ROUTE = '/api/command';
 export const CANVAS_COMMAND_ROUTE = '/api/canvas/command';
 /** Host-side view lifecycle: register, heartbeat, unregister. */
 export const CANVAS_VIEWS_ROUTE = '/api/canvas/views';
+
+/**
+ * The failure codes Tower itself can answer with. Mirrored from `CanvasCommandErrorCode` (the
+ * sdk keeps codev-types type-only), and pinned to it by the assertion below so a code added to
+ * the contract cannot silently go unrecognized here — an unrecognized code is treated as an
+ * unreadable answer, which would turn a real Tower verdict into a spurious `unreachable`.
+ */
+const CANVAS_WIRE_ERROR_CODES = ['no-canvas', 'invalid-request'] as const;
+
+/** Fails to instantiate unless the mirror above covers the contract exactly. */
+type AssertTrue<T extends true> = T;
+type _WireCodesMatchContract = AssertTrue<
+  [Exclude<CanvasCommandErrorCode, (typeof CANVAS_WIRE_ERROR_CODES)[number]>] extends [never]
+    ? true
+    : false
+>;
+
+/**
+ * Validate a canvas command response against the wire contract.
+ *
+ * Checking only for an `ok` field would let `{ok:true}` with no target, or a failure carrying an
+ * unknown code, pass through as a typed result — the caller would then read `target.viewId` off
+ * undefined, or switch on a code that is not in its union. A response we cannot fully verify is
+ * not a verdict, so it is reported as unreadable instead.
+ */
+function parseCanvasCommandResult(body: unknown): CanvasCommandResult | null {
+  if (!body || typeof body !== 'object') return null;
+  const raw = body as Record<string, unknown>;
+
+  if (raw.ok === true) {
+    const target = raw.target as Record<string, unknown> | undefined;
+    if (!target || typeof target !== 'object') return null;
+    if (typeof target.viewId !== 'string' || typeof target.file !== 'string') return null;
+    return { ok: true, target: { viewId: target.viewId, file: target.file } };
+  }
+
+  if (raw.ok === false) {
+    if (typeof raw.code !== 'string') return null;
+    if (!(CANVAS_WIRE_ERROR_CODES as readonly string[]).includes(raw.code)) return null;
+    let error = 'Canvas command failed';
+    if (typeof raw.error === 'string') error = raw.error;
+    return { ok: false, code: raw.code as CanvasCommandErrorCode, error };
+  }
+
+  return null;
+}
 
 // ── Types ──────────────────────────────────────────────────────
 
@@ -954,9 +1000,9 @@ export class TowerClient {
     if (outcome.status === 0) {
       return { ok: false, code: 'unreachable', error: outcome.error ?? 'Tower unreachable' };
     }
-    const body = outcome.body as CanvasCommandResult | null;
-    if (body && typeof body === 'object' && 'ok' in body) return body;
-    // A 2xx with a shape we cannot read is not a verdict, so it is reported as such rather than
+    const verdict = parseCanvasCommandResult(outcome.body);
+    if (verdict) return verdict;
+    // A response we cannot fully verify is not a verdict, so it is reported as such rather than
     // being flattened into a success or an arbitrary failure code.
     return {
       ok: false,

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "tsc",
     "check-types": "tsc --noEmit",
+    "check-types:tests": "tsc --noEmit -p tsconfig.type-tests.json",
     "prepublishOnly": "pnpm build"
   },
   "devDependencies": {

--- a/packages/types/src/canvas-command.ts
+++ b/packages/types/src/canvas-command.ts
@@ -1,0 +1,212 @@
+/**
+ * Wire contracts for Tower's artifact-canvas command channel (spec 1401).
+ *
+ * Lets any CONTROLLER (a control device, a companion app, a test harness) drive an open
+ * artifact-canvas VIEW over Tower's existing SSE + REST transport:
+ *  - host -> Tower:       REST `/api/canvas/views` (register / heartbeat / unregister).
+ *  - controller -> Tower: REST POST `/api/canvas/command` (run one command on a target view).
+ *  - Tower -> host:       SSE `canvas-command` (the command, addressed to one resolved view).
+ *
+ * This is a SEPARATE path from the generic verb relay in `command.ts`, deliberately: that one
+ * is a fire-and-forget broadcast that answers `{ok:true}` whether or not any provider is
+ * listening, which cannot express "no canvas is open" or address one view among several.
+ * Here Tower keeps a registry of live views, resolves exactly one target, and says which.
+ *
+ * Pure wire shapes only.
+ */
+
+/**
+ * The canvas command vocabulary — a closed union mirroring the canvas's existing in-page
+ * keyboard actions exactly (#1237, #1380). There is no parallel vocabulary: each command
+ * produces the same effect as the in-page action it names.
+ *
+ * Two members have no key binding and are defined against their in-page equivalents instead:
+ * `block-next`/`block-prev` step `[data-line]` blocks in flow order (deliberately NOT native
+ * Tab parity, which also visits affordances, card actions, toolbar controls and links), and
+ * `reading-mode-toggle` mirrors the reading-mode toolbar button.
+ *
+ * Text entry is out of scope: comment bodies are typed on the keyboard.
+ */
+export type CanvasCommand =
+  // Traversal — relative movement from the view's current block.
+  | 'block-next'
+  | 'block-prev'
+  | 'comment-next'
+  | 'comment-prev'
+  | 'heading-next'
+  | 'heading-prev'
+  // Paging — horizontal reading mode only.
+  | 'column-forward'
+  | 'column-back'
+  // Absolute movement.
+  | 'doc-start'
+  | 'doc-end'
+  // Composer.
+  | 'composer-open'
+  | 'composer-submit'
+  | 'composer-cancel'
+  // View state.
+  | 'reading-mode-toggle';
+
+/**
+ * The commands `count` applies to: relative traversal and column paging, where "do it N
+ * times" is meaningful. Absolute moves (`doc-*`), composer actions and the reading-mode
+ * toggle are excluded — repeating them is either a no-op or actively wrong.
+ *
+ * Deliberately TYPE-LEVEL, not a runtime array. Neither consumer could import a runtime value
+ * from this package: `@cluesmith/codev-types` is a compile-time-only dependency of
+ * `packages/codev`, which runs unbundled from `dist/` (see the same note in `command.ts`
+ * explaining why `COMMAND_ROUTE` is re-declared there), and the artifact-canvas package's
+ * import boundary pins its import of this package to `import type`. Each consumer therefore
+ * declares its own `const` list bound to this type with `satisfies`, which turns any drift
+ * between a consumer's list and this union into a compile error.
+ */
+export type TraversalCommand = Extract<
+  CanvasCommand,
+  | 'block-next'
+  | 'block-prev'
+  | 'comment-next'
+  | 'comment-prev'
+  | 'heading-next'
+  | 'heading-prev'
+  | 'column-forward'
+  | 'column-back'
+>;
+
+/** Every command `count` does NOT apply to. The complement of `TraversalCommand`. */
+export type NonTraversalCommand = Exclude<CanvasCommand, TraversalCommand>;
+
+/**
+ * Failure codes Tower itself answers with — the WIRE union, exactly two members.
+ *
+ * `no-canvas` (HTTP 404): the selector resolved to zero live views. This is the case the
+ * channel exists to make explicit; it is never a silent success.
+ * `invalid-request` (HTTP 400): unknown command, malformed selector, or a `count` that is not
+ * a positive integer or was sent with a non-traversal command.
+ */
+export type CanvasCommandErrorCode = 'no-canvas' | 'invalid-request';
+
+/**
+ * Failure codes a CLIENT can observe: Tower's answers plus `unreachable`.
+ *
+ * `unreachable` is CLIENT-SYNTHESIZED and never sent by Tower — the sdk produces it when the
+ * request never got an answer at all (connection refused, timeout, malformed response). It is
+ * a separate type from `CanvasCommandErrorCode` precisely so Tower cannot type a response it
+ * must never send, while callers still get one closed union to switch on. The distinction
+ * matters: "Tower says no canvas is open" and "Tower could not be reached" must not render as
+ * the same thing.
+ */
+export type CanvasCommandClientErrorCode = CanvasCommandErrorCode | 'unreachable';
+
+/**
+ * Controller -> Tower (`/api/canvas/command`): run one command against a target view.
+ *
+ * `workspace` is the absolute path of the workspace to search, and is required — it is the
+ * outer scope of every lookup. `file` narrows to one document; omitted, the command goes to
+ * the workspace's most recently active view ("drive whatever I'm reviewing"). Both are
+ * REGISTRY LOOKUP KEYS: Tower canonicalizes them for matching and never dereferences them as
+ * filesystem paths.
+ *
+ * `count` defaults to 1 and is valid only on a `TraversalCommand`.
+ */
+export interface CanvasCommandRequest {
+  workspace: string;
+  file?: string;
+  command: CanvasCommand;
+  count?: number;
+}
+
+/** The view a command was actually delivered to. */
+export interface CanvasCommandTarget {
+  /** Tower-minted view identifier, stable for the life of that registration. */
+  viewId: string;
+  /** The canonicalized path of the document that view is showing. */
+  file: string;
+}
+
+/**
+ * Tower -> controller (the `/api/canvas/command` response).
+ *
+ * Success names the resolved target, so a caller can see WHICH view it drove when several
+ * were open.
+ */
+export type CanvasCommandResult =
+  | { ok: true; target: CanvasCommandTarget }
+  | { ok: false; code: CanvasCommandErrorCode; error: string };
+
+/**
+ * The same result as an sdk caller sees it, widened to include the client-synthesized
+ * `unreachable`. The sdk call never rejects; a failed request resolves to this shape.
+ */
+export type CanvasCommandClientResult =
+  | { ok: true; target: CanvasCommandTarget }
+  | { ok: false; code: CanvasCommandClientErrorCode; error: string };
+
+/**
+ * Host -> Tower (`POST /api/canvas/views`): register one live canvas view.
+ *
+ * One registration per view, not per host: a host showing the same document in two views
+ * registers twice and receives two distinct `viewId`s.
+ */
+export interface CanvasViewRegistration {
+  /** Absolute path of the workspace the view belongs to. */
+  workspace: string;
+  /** Absolute path of the document the view is showing. */
+  file: string;
+}
+
+/** Tower -> host: the minted identity a host uses for heartbeat, unregister, and filtering. */
+export interface CanvasViewRegistrationResult {
+  viewId: string;
+  /** The canonicalized `file`, so the host sees the identity Tower matched it under. */
+  file: string;
+}
+
+/**
+ * Host -> Tower (`POST /api/canvas/views/:viewId/heartbeat`): keep the lease alive.
+ *
+ * `focused: true` additionally marks the view as the most recently active one, which is how
+ * the multi-view target rule picks a winner. Tower stamps the time itself; host clocks are
+ * never trusted.
+ */
+export interface CanvasViewHeartbeat {
+  focused?: boolean;
+}
+
+/** A live view as Tower tracks it. `lastActiveAt` is a Tower-stamped epoch milliseconds value. */
+export interface CanvasView {
+  viewId: string;
+  workspace: string;
+  file: string;
+  lastActiveAt: number;
+}
+
+/**
+ * Tower -> hosts (SSE `canvas-command`): one command, addressed to one resolved view.
+ *
+ * Tower's SSE channel is a broadcast with no per-connection identity, so every subscriber
+ * receives this and all but one discard it on a `viewId` comparison. Carrying the resolved
+ * `viewId` is what makes the delivery unambiguous.
+ */
+export interface CanvasCommandEvent {
+  viewId: string;
+  command: CanvasCommand;
+  /** Present only for traversal commands; absent means 1. */
+  count?: number;
+}
+
+// ----- Wire protocol names (single source for the routes + event type) -----
+// The route paths and SSE event-type name ARE the contract: controllers, hosts, Tower and the
+// sdk must agree on them. They are declared once here as the canonical definition. Both Tower
+// and the sdk re-declare these literals locally — Tower because it cannot resolve a runtime
+// import from this package, the sdk because its import boundary is type-only — and both point
+// back here. This mirrors how `command.ts` handles COMMAND_ROUTE / COMMAND_EVENT.
+
+/** REST route a controller POSTs a canvas command to. */
+export const CANVAS_COMMAND_ROUTE = '/api/canvas/command';
+
+/** REST route family a host registers, heartbeats, and unregisters its views on. */
+export const CANVAS_VIEWS_ROUTE = '/api/canvas/views';
+
+/** SSE event-type name Tower fans an addressed canvas command out to hosts as. */
+export const CANVAS_COMMAND_EVENT = 'canvas-command';

--- a/packages/types/src/canvas-command.ts
+++ b/packages/types/src/canvas-command.ts
@@ -157,6 +157,7 @@ export interface CanvasViewRegistration {
 
 /** Tower -> host: the minted identity a host uses for heartbeat, unregister, and filtering. */
 export interface CanvasViewRegistrationResult {
+  ok: true;
   viewId: string;
   /** The canonicalized `file`, so the host sees the identity Tower matched it under. */
   file: string;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -20,6 +20,26 @@ export {
 } from './command.js';
 
 export {
+  type CanvasCommand,
+  type TraversalCommand,
+  type NonTraversalCommand,
+  type CanvasCommandErrorCode,
+  type CanvasCommandClientErrorCode,
+  type CanvasCommandRequest,
+  type CanvasCommandTarget,
+  type CanvasCommandResult,
+  type CanvasCommandClientResult,
+  type CanvasViewRegistration,
+  type CanvasViewRegistrationResult,
+  type CanvasViewHeartbeat,
+  type CanvasView,
+  type CanvasCommandEvent,
+  CANVAS_COMMAND_ROUTE,
+  CANVAS_VIEWS_ROUTE,
+  CANVAS_COMMAND_EVENT,
+} from './canvas-command.js';
+
+export {
   type ArchitectState,
   type Builder,
   type UtilTerminal,

--- a/packages/types/tsconfig.type-tests.json
+++ b/packages/types/tsconfig.type-tests.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../config/tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["type-tests/**/*"]
+}

--- a/packages/types/type-tests/canvas-command.type-test.ts
+++ b/packages/types/type-tests/canvas-command.type-test.ts
@@ -1,0 +1,94 @@
+/**
+ * Compile-time guard for the canvas command contracts (spec 1401, phase 1).
+ *
+ * This file is never executed and never shipped: it lives outside `src/` because
+ * `packages/types` compiles `src/**\/*` into `dist/` and publishes both `src` and `dist`, so a
+ * guard under `src/` would land in consumers' node_modules. It is checked by its own tsconfig
+ * (`pnpm --filter @cluesmith/codev-types check-types:tests`) rather than an `exclude`, which
+ * would silently drop it from the very check it exists to perform.
+ *
+ * What it protects: `TraversalCommand` is defined with `Extract` and `NonTraversalCommand`
+ * with `Exclude`, so a command added to `CanvasCommand` would fall into the non-traversal
+ * complement SILENTLY — `count` would quietly stop applying to a command that may well need
+ * it. The exhaustive classification map below forces that decision to be made explicitly:
+ * adding a command to the union breaks this file until someone classifies it.
+ */
+
+import type {
+  CanvasCommand,
+  TraversalCommand,
+  NonTraversalCommand,
+  CanvasCommandErrorCode,
+  CanvasCommandClientErrorCode,
+  CanvasCommandResult,
+  CanvasCommandClientResult,
+} from '../src/canvas-command.js';
+
+/** True only when A and B are the identical type (not merely mutually assignable). */
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+type Expect<T extends true> = T;
+
+/**
+ * Every command, classified explicitly. `satisfies Record<CanvasCommand, ...>` makes this
+ * exhaustive: a new command in the union is a missing-key compile error here.
+ */
+const CLASSIFICATION = {
+  'block-next': 'traversal',
+  'block-prev': 'traversal',
+  'comment-next': 'traversal',
+  'comment-prev': 'traversal',
+  'heading-next': 'traversal',
+  'heading-prev': 'traversal',
+  'column-forward': 'traversal',
+  'column-back': 'traversal',
+  'doc-start': 'non-traversal',
+  'doc-end': 'non-traversal',
+  'composer-open': 'non-traversal',
+  'composer-submit': 'non-traversal',
+  'composer-cancel': 'non-traversal',
+  'reading-mode-toggle': 'non-traversal',
+} as const satisfies Record<CanvasCommand, 'traversal' | 'non-traversal'>;
+
+type ClassifiedAs<Kind extends 'traversal' | 'non-traversal'> = keyof {
+  [K in CanvasCommand as (typeof CLASSIFICATION)[K] extends Kind ? K : never]: true;
+};
+
+/** The map and the exported types must agree, in both directions. */
+export type _TraversalMatchesClassification = Expect<
+  Equal<ClassifiedAs<'traversal'>, TraversalCommand>
+>;
+export type _NonTraversalMatchesClassification = Expect<
+  Equal<ClassifiedAs<'non-traversal'>, NonTraversalCommand>
+>;
+
+/** The two halves must partition the vocabulary with nothing lost and nothing overlapping. */
+export type _PartitionIsComplete = Expect<
+  Equal<TraversalCommand | NonTraversalCommand, CanvasCommand>
+>;
+export type _PartitionIsDisjoint = Expect<
+  Equal<Extract<TraversalCommand, NonTraversalCommand>, never>
+>;
+
+/**
+ * `unreachable` is client-synthesized, so Tower must not be able to type it as an answer.
+ * If the wire and client unions are ever collapsed into one, these two stop agreeing.
+ */
+export type _UnreachableIsNotAWireCode = Expect<
+  Equal<Extract<CanvasCommandErrorCode, 'unreachable'>, never>
+>;
+export type _UnreachableIsAClientCode = Expect<
+  Equal<Extract<CanvasCommandClientErrorCode, 'unreachable'>, 'unreachable'>
+>;
+
+/** Clients see a superset: any wire result is a valid client result, but not the reverse. */
+export type _WireResultIsAClientResult = Expect<
+  CanvasCommandResult extends CanvasCommandClientResult ? true : false
+>;
+export type _ClientResultIsNotAWireResult = Expect<
+  CanvasCommandClientResult extends CanvasCommandResult ? false : true
+>;
+
+/** Keeps the classification map referenced; it is the exhaustiveness guard's payload. */
+export type _Classification = typeof CLASSIFICATION;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
 
   packages/artifact-canvas:
     dependencies:
+      '@cluesmith/codev-types':
+        specifier: workspace:*
+        version: link:../types
       dompurify:
         specifier: ^3.2.0
         version: 3.4.8


### PR DESCRIPTION
Closes #1401.

A generic remote-command channel for the artifact canvas: Tower keeps a registry of live canvas
views, resolves exactly one target for a command, and says which — or that none is open. Built so
the Stream Deck (#1400) is the first consumer rather than the only possible one; any remote driver
of the viewer gets it for free.

---

## ⚠️ Blocking human check at this gate

**One acceptance criterion could not be performed by a builder and is left for you.** It needs a
real VS Code window, a running Tower, and an open canvas panel driven by someone who can see the
result. Phase 6 finished **2-1**: gemini and claude APPROVE, codex REQUEST_CHANGES with this as
its sole remaining objection. No code change can close it, so it was escalated rather than
claimed — see
[the iteration-3 rebuttal](codev/projects/1401-artifact-canvas-remote-command/1401-phase_6-iter3-rebuttals.md).

Run the extension **from this worktree's build** (`.builders/spir-1401`), not an installed copy:

```bash
cd .builders/spir-1401 && pnpm --filter codev-vscode compile
# then launch the Extension Development Host on this worktree (F5 from apps/vscode)
```

With Tower running and a spec open in the Codev Markdown Preview:

1. **Navigate.** `curl -X POST localhost:4100/api/canvas/command -H 'Content-Type: application/json' -d '{"workspace":"<abs workspace path>","command":"comment-next"}'` → focus moves to the next commented block, and the response names the resolved view.
2. **Close the panel, repeat.** → `404` with `{"code":"no-canvas"}`, not a silent success. This is the requirement the whole channel exists for.
3. **Count.** `'{"workspace":"…","command":"block-next","count":3}'` → moves three blocks, stopping at the end rather than running off it.
4. **Composer round trip.** `composer-open`, type a body on the keyboard, then `composer-submit` → **exactly one** comment written to the file.

Step 4 is the one worth doing carefully: it crosses every layer, and "exactly one" is the
assertion that a fan-out bug would break.

---

## What is verified, and what is not

The untested join is narrow and worth stating precisely, so the check above is judged against the
right gap.

| Layer | Verification |
|---|---|
| Tower route | **5 e2e tests against a real booted Tower** — register, addressed relay, no-canvas, one-of-two, unknown-view |
| Canvas seam | 173 unit + 39 Playwright, **plus a human dev-page session** driving all 14 commands through `window.__canvasCommand` |
| sdk | 98 tests, including 9 malformed-response cases |
| VS Code host glue | 17 tests against a faked Tower and panel: lifecycle, addressing, reconnect, races |
| **The join** | **Untested.** No automated test exercises the real extension registering with the real Tower and a real command reaching the real webview. |

Everything on either side of that seam is covered; the live pass closes the seam itself.

## What this adds

| Layer | Change |
|---|---|
| `codev-types` | Closed 14-command vocabulary mirroring the canvas keyboard exactly, wire + client error unions, request/result/registry/event shapes |
| `artifact-canvas` | One named implementation per action shared by keyboard and remote, a `CommandAdapter` seam, a focus-derived cursor |
| Tower | `/api/canvas/*`: view registry with a heartbeat lease, and a targeted command route |
| sdk | `sendCanvasCommand` on the controller subpath; host-side register/heartbeat/unregister |
| VS Code | Each canvas panel registers as a view, heartbeats, reports activity, runs commands addressed to it |

Target rule, decided at spec time: zero matches answer `no-canvas`; several matches deliver to the
single most recently active view and **never** fan out, because `composer-submit` reaching two
views of one file would post the comment twice.

## Decisions worth a reviewer's attention

**Effect parity, not literal keyboard parity.** The in-page handlers take their origin from the
DOM event, and a remote command has no event, so a literal reading would have made 8 of 14
commands no-ops in the feature's primary scenario. Commands resolve an origin: live focus → last
focused block → topmost visible block → first block.

**Delivery is recency, not liveness.** An early version refreshed the lease on delivery, which
meant a dead host's view renewed itself for as long as a controller kept driving it — inverting
the guarantee the registry exists to provide. Only heartbeats, which only a live host can send,
extend a lease.

**`unreachable` is client-synthesized.** The wire union stays two members so Tower cannot type a
code it must never send; the sdk-visible union adds the third. A controller must not render "no
canvas open" when Tower is simply down.

## Dispositions carried in

- **Controller subpath exposure** — the new host-side registration methods are reachable via the
  exported `TowerClient` class, as are its other 36 methods (`addArchitect`, `killTerminal`,
  `sweepHusks`…). Pre-existing property, not a regression. **Streamdeck stakeholder: accept as-is
  for #1401**; structural fix tracked as **#1411**.
- **The `file?` selector is not speculative** — #1400 was revised on 2026-08-11 to file-qualified
  targeting, so it has a named first consumer.
- **Playwright port collision (#1407)** — an orphaned vite process from a removed worktree served
  deleted code to my first browser run. Orphan cleared; the suite now runs against the committed
  config.

## Spec/plan corrections made during the work

Both authorized rather than silently worked around:

- The spec's "split editor" multi-view example was impossible
  (`supportsMultipleEditorsPerDocument: false`). The MRU requirement is unchanged; only the
  verification venue moved to the Tower registry. The flag was deliberately not flipped.
- The plan claimed the webview has no `check-types` coverage. It does, via
  `tsconfig.webview.json`. Corrected in the review file.

## Testing

`check-types` clean repo-wide (both VS Code configs), `eslint` clean, repo build green, **4847
repo tests pass**. Full breakdown and the lessons from six review-driven design changes are in
[the review document](codev/reviews/1401-artifact-canvas-remote-command.md).

## Follow-ups

**#1411** restricted controller client · **#1407** per-worktree Playwright port · **#1400** deck
actions, unblocked by this · **#1386** `afx open` onto the canvas, which becomes a second
registrant with no protocol change.
