### PR TITLE
Stream Deck: composer-open-or-submit context-aware canvas command (#1420)

### DIFF
--- a/apps/vscode/src/markdown-preview/canvas-view-registry.ts
+++ b/apps/vscode/src/markdown-preview/canvas-view-registry.ts
@@ -45,6 +45,7 @@ const CANVAS_COMMANDS = [
   'composer-open',
   'composer-submit',
   'composer-cancel',
+  'composer-open-or-submit',
   'reading-mode-toggle',
 ] as const satisfies readonly CanvasCommand[];
 

--- a/codev/plans/1420-stream-deck-hands-free-comment.md
+++ b/codev/plans/1420-stream-deck-hands-free-comment.md
@@ -1,0 +1,177 @@
+# PIR Plan: `composer-open-or-submit` — one context-aware canvas command
+
+## Scope of this lane
+
+This project is the **bridge-extension half** of the agreed cross-lane split (main + streamdeck
+architects, recorded on issue #1420):
+
+- **In scope** — requirement 1 (new `composer-open-or-submit` command, resolved **canvas-side**
+  from `composingLine`, which never discards a draft) and requirement 2 (add it to the closed
+  `CanvasCommand` union in `packages/types`, the host allowlist, and the canvas action map).
+- **Out of scope, streamdeck's follow-on lane** — requirement 3 (deck dial remapping in
+  `apps/streamdeck/.../actions.ts`) and requirement 4 (touchstrip legibility). Those sequence
+  **after** this command merges, mirroring the #1401 → #1400 pattern.
+- Requirement 5 stands: submit/cancel only, no text entry.
+
+Nothing in `apps/streamdeck/` changes here. The deck stays stateless; the canvas owns composer
+state.
+
+## Understanding
+
+In canvas/review mode a controller (the Stream Deck) drives an open artifact-canvas view over
+Tower's `sendCanvasCommand` bridge (#1401). Today it can `composer-open` at the focused block, but
+committing the comment still needs the keyboard (`Cmd+Enter` submit / `Esc` cancel), which breaks
+the hands-free dictation flow.
+
+The controller cannot own the open-vs-submit decision: the bridge result carries only
+`{ok, target}`, so the deck never learns composer state back. A deck that *guessed* the state would
+desync the moment the composer is submitted/cancelled via the keyboard, and a wrong guess is not
+harmless — `composer-open` re-anchors the composer and unmounts the in-progress draft
+(`ArtifactCanvas.tsx` `openComposer` → `setComposingLine`), so a mis-fire discards a dictated
+comment.
+
+Only the **canvas** knows whether a composer is open — it tracks `composingLine`
+(`ArtifactCanvas.tsx:246`). So the fix is a single context-aware command the canvas resolves against
+its own state.
+
+### Why the empty-draft ruling is already satisfied
+
+The deck-stakeholder ruling requires that a press on an **open but empty** composer must NOT submit
+an empty comment and must NOT discard the draft. The existing composer already delivers this:
+`CommentComposer.submit()` trims and returns early on an empty body
+(`CommentComposer.tsx:72-76`), leaving the composer mounted with its draft intact. Routing the
+"open" case through `submit()` therefore inherits the guard for free — no empty comment is written,
+and nothing re-anchors the composer.
+
+### Why reading `composingLine` in the action is correct
+
+`canvasActions` is rebuilt on every render and `runCanvasCommandRef.current` is refreshed on every
+render (`ArtifactCanvas.tsx:996-1001`), so an action body reads that render's `composingLine`. The
+existing `composer-cancel` action already reads `composingLine` directly
+(`ArtifactCanvas.tsx:948-950`); the new command follows the identical, proven pattern.
+
+## Proposed Change
+
+Add **one** new command, `composer-open-or-submit`, to the closed `CanvasCommand` vocabulary and
+resolve it canvas-side:
+
+- **Composer closed (`composingLine === null`)** → open at the focused block (the exact
+  `composer-open` guard: `originLine` present and numeric, then `openComposer(line)`).
+- **Composer open (`composingLine !== null`)** → `composerHandleRef.current?.submit()`. A non-empty
+  draft submits; an empty draft is a no-op that leaves the composer and its draft untouched.
+
+The command is remote-only (no key binding), exactly like `block-next`/`block-prev`, so the keyboard
+path is unchanged. It is a `NonTraversalCommand` automatically (excluded from `TraversalCommand`),
+so `count` is rejected on it by the existing relay and host validation — no wiring needed.
+
+Failure verdicts need no new channel: the command travels the existing relay + SSE path, so failures
+stay inside the closed `CanvasCommandClientErrorCode` union (`no-canvas` / `invalid-request` /
+`unreachable`) the dial already renders.
+
+## Files to Change
+
+The union is guarded by `satisfies readonly CanvasCommand[]` / `satisfies Record<CanvasCommand, …>`
+assertions in **four** independent locations, so adding the union member without updating each is a
+compile error. **Note: the issue's requirement 2 lists only three of these; the fourth
+(`canvas-relay.ts`, Tower's own relay validation) is required too — without it Tower answers
+`invalid-request` and the command never reaches the canvas.**
+
+1. `packages/types/src/canvas-command.ts:44-49` — add `| 'composer-open-or-submit'` under the
+   `// Composer.` group, and extend the type doc-comment to describe the context-aware resolution.
+   (No `TraversalCommand` change — it lands in `NonTraversalCommand` automatically.)
+2. `packages/types/type-tests/canvas-command.type-test.ts:48-52` — add
+   `'composer-open-or-submit': 'non-traversal'` to the `CLASSIFICATION` map (the `satisfies
+   Record<CanvasCommand, …>` fails to compile otherwise).
+3. `packages/codev/src/agent-farm/servers/canvas-relay.ts:68-83` — add `'composer-open-or-submit'`
+   to Tower's `CANVAS_COMMANDS` relay allowlist.
+4. `apps/vscode/src/markdown-preview/canvas-view-registry.ts:34-49` — add `'composer-open-or-submit'`
+   to the host `CANVAS_COMMANDS` allowlist.
+5. `packages/artifact-canvas/src/components/ArtifactCanvas.tsx:920-952` — add the
+   `'composer-open-or-submit'` entry to the `canvasActions` map:
+
+   ```ts
+   // Context-aware composer control (#1420): the canvas — the only party that knows whether a
+   // composer is open — decides. Closed → open at the focused block; open → submit the draft
+   // (an empty draft is CommentComposer's own no-op, so this never writes an empty comment and
+   // never re-anchors/discards the draft). Reads composingLine like composer-cancel does; the
+   // action map is rebuilt each render, so the read is current.
+   'composer-open-or-submit': ({ originLine }) => {
+     if (composingLine !== null) {
+       composerHandleRef.current?.submit();
+       return;
+     }
+     if (originLine === null) return;
+     const line = Number(originLine);
+     if (Number.isNaN(line)) return;
+     openComposer(line);
+   },
+   ```
+
+Optional doc touch-up (no behavior): `packages/artifact-canvas/src/adapters/CommandAdapter.ts:27`
+mentions `composer-open`/`composer-submit` in prose; I will leave it unless review wants it noted.
+
+## Command semantics — for streamdeck-architect review before the plan gate
+
+Per the agreed process, this section routes to the streamdeck architect before `plan-approval`.
+Exact behavior per composer state:
+
+| Composer state | `composer-open-or-submit` does | Draft safety |
+|---|---|---|
+| Closed | Opens the inline composer at the focused block | n/a |
+| Open, non-empty draft | Submits the draft (`onAddComment` / edit path) | Committed |
+| Open, empty/whitespace draft | No-op; composer stays open, draft preserved | **Never** written, **never** discarded |
+| No focused block resolvable (closed case) | No-op | n/a |
+
+Rulings honored: (1) closed → open, open+content → submit; (2) empty-draft press never submits and
+never discards; (3) failures stay in the existing closed `CanvasCommandClientErrorCode` union — no
+new error channel; (4) `composer-cancel` is reused unchanged (the coarse-dial mapping lands in the
+streamdeck lane).
+
+## Risks & Alternatives Considered
+
+- **Risk — the fourth allowlist is missed and the command silently 400s.** Mitigated: all four
+  enumerations carry a `satisfies` + `Assert`/`AssertTrue` guard, so a missing update fails the
+  build, not production. The file list above names all four explicitly.
+- **Risk — stale `composingLine` closure resolves the branch wrong.** Mitigated: proven not stale —
+  `canvasActions` and `runCanvasCommandRef.current` are rebuilt every render and `composer-cancel`
+  already relies on this; a test asserts open→submit and closed→open on one control.
+- **Alternative — deck remembers it sent `composer-open` and sends `composer-submit` itself.**
+  Rejected in the issue's design constraint: the deck never learns composer state back, so a guess
+  desyncs on any keyboard/self-close and a wrong `composer-open` re-fire discards the draft.
+- **Alternative — name `composer-toggle`.** Rejected: "toggle" implies open↔close symmetry; this is
+  open→**submit**, and cancel is a separate command. `composer-open-or-submit` names the two real
+  outcomes.
+- **Alternative — make the empty-open case cancel instead of no-op.** Rejected: cancel discards the
+  (empty) composer the reviewer just opened to dictate into; a no-op that leaves it open is the safe
+  reading of the ruling and matches the keyboard, where `Cmd+Enter` on an empty draft also does
+  nothing.
+
+## Test Plan
+
+- **Unit (`packages/artifact-canvas/src/__tests__/remote-commands.test.tsx`)** — extend the existing
+  remote-command suite (harness at line 246+):
+  - Closed composer: `composer-open-or-submit` opens the composer at the focused block.
+  - Open composer with typed draft, focus parked outside: `composer-open-or-submit` submits — one
+    control opened then committed (`onAddComment` called once with the draft).
+  - Open composer with **empty** draft: `composer-open-or-submit` writes nothing **and** the
+    composer stays mounted (draft not discarded, no re-anchor).
+- **Relay (`packages/codev/src/agent-farm/__tests__/canvas-relay.test.ts`)** — the new command
+  round-trips through `/api/canvas/command` (accepted, not `invalid-request`); and it rejects a
+  `count` (add it to the non-traversal list at line 288-292).
+- **Type-tests** — `packages/types/type-tests/canvas-command.type-test.ts` compiles with the new
+  classification entry; the four `satisfies` guards compile.
+- **Build/lint** — `pnpm -w build` and the package test suites from the worktree.
+- **Manual (dev-approval gate, in the worktree)** — with a canvas view open and Tower running, drive
+  `composer-open-or-submit` via `sendCanvasCommand` (curl to `/api/canvas/command` or the sdk):
+  first press opens the composer at the focused block; type a comment; second press submits it;
+  confirm a keyboard `Esc` between presses is handled correctly (next press re-opens rather than
+  submitting a discarded draft). Deck hardware verification of the dial mapping itself is the
+  streamdeck follow-on lane, not this gate.
+- **Cross-platform** — n/a (VS Code extension host + web canvas only; no mobile).
+
+## Follow-on (not this lane)
+
+`apps/streamdeck/src/actions.ts:605` currently sends `composer-open` on the review-dial press. The
+remap (fine dial → `composer-open-or-submit`, coarse dial → `composer-cancel`) and touchstrip
+legibility land in streamdeck's lane after this command merges, coordinated with #1410's layout
+work.

--- a/codev/projects/1420-stream-deck-hands-free-comment/1420-review-iter1-rebuttals.md
+++ b/codev/projects/1420-stream-deck-hands-free-comment/1420-review-iter1-rebuttals.md
@@ -1,0 +1,39 @@
+# PIR #1420 — Review iteration 1 rebuttals
+
+Verdicts: **Gemini APPROVE, Claude APPROVE, Codex REQUEST_CHANGES**. PIR consultation is a single
+advisory pass (`max_iterations: 1`); there is no automated re-review, so the Codex finding and this
+response are escalated to the human at the `pr` gate.
+
+## Codex (REQUEST_CHANGES) — ACCEPTED and fixed
+
+**Finding:** Replace `Fixes #1420` with `Refs #1420`; requirements 3–4 (deck dial remap, touchstrip
+legibility) remain for the Stream Deck follow-on lane, so merging this PR must not auto-close the
+issue.
+
+**Assessment:** Correct. This PR is the bridge-extension lane and lands requirements 1, 2, and 5;
+requirements 3 and 4 are explicitly out of scope for this lane (per main's scoping comment on the
+issue) and belong to streamdeck's follow-on. `Fixes #1420` would close the issue on merge and drop
+that remaining work. The PIR review-phase prompt itself prescribes `Refs` for a partial PR.
+
+**What changed:** Review file `Fixes #1420` → `Refs #1420` (commit `1c14cb651`), PR #1424 body updated
+to match (verified: body now reads `Refs #1420`). Documented in the review's "Things to Look At"
+section, including the explicit **human decision at the `pr` gate**: if the follow-on is tracked under
+its own issue / #1410 and #1420 should close with this merge, switch back to `Fixes` or close the
+issue manually.
+
+## Claude (APPROVE) — non-blocking notes, no code change
+
+1. **Duplicated open-branch body could be a shared helper.** Acknowledged; left as-is. The five-line
+   body mirrors the existing `composer-open` action verbatim and matches the approved plan; extracting
+   a helper for one reused branch adds indirection without removing a real maintenance hazard.
+2. **No test for the edit-composer press path.** The edit path shares `composingLine`, so
+   `composer-open-or-submit` while editing routes to `submit()` (submit-the-edit) through the same
+   branch the "submits on second press" test already exercises; the routing is state-driven, not
+   path-specific. Flagged in the review as a spot for the human to exercise at the gate rather than
+   adding a redundant unit test.
+3. **`composerHandleRef` null-while-open is a pre-existing silent no-op shared with `composer-submit`.**
+   Correct, and pre-existing — not introduced here. Out of scope for this lane.
+
+## Gemini (APPROVE)
+
+No issues raised.

--- a/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
+++ b/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
@@ -1,7 +1,7 @@
 id: '1420'
 title: stream-deck-hands-free-comment
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T08:46:00.888Z'
-updated_at: '2026-08-12T08:51:11.352Z'
+updated_at: '2026-08-12T08:51:17.921Z'

--- a/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
+++ b/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-08-12T09:50:03.471Z'
   pr:
     status: pending
+    requested_at: '2026-08-12T09:55:56.026Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-08-12T08:46:00.888Z'
-updated_at: '2026-08-12T09:52:15.817Z'
+updated_at: '2026-08-12T09:55:56.028Z'
 pr_history:
   - phase: review
     pr_number: 1424
     branch: builder/pir-1420
     created_at: '2026-08-12T09:52:06.220Z'
+pr_ready_for_human: true

--- a/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
+++ b/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
@@ -1,0 +1,18 @@
+id: '1420'
+title: stream-deck-hands-free-comment
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-12T08:46:00.888Z'
+updated_at: '2026-08-12T08:46:00.889Z'

--- a/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
+++ b/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-08-12T08:59:54.442Z'
     approved_at: '2026-08-12T09:50:03.471Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-08-12T09:55:56.026Z'
+    approved_at: '2026-08-12T10:01:56.479Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-08-12T08:46:00.888Z'
-updated_at: '2026-08-12T09:55:56.028Z'
+updated_at: '2026-08-12T10:01:56.481Z'
 pr_history:
   - phase: review
     pr_number: 1424
     branch: builder/pir-1420
     created_at: '2026-08-12T09:52:06.220Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
+++ b/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
@@ -1,7 +1,7 @@
 id: '1420'
 title: stream-deck-hands-free-comment
 protocol: pir
-phase: review
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -21,7 +21,7 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-08-12T08:46:00.888Z'
-updated_at: '2026-08-12T10:01:56.481Z'
+updated_at: '2026-08-12T10:02:10.868Z'
 pr_history:
   - phase: review
     pr_number: 1424

--- a/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
+++ b/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-08-12T08:49:35.815Z'
     approved_at: '2026-08-12T08:51:11.352Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-08-12T08:59:54.442Z'
+    approved_at: '2026-08-12T09:50:03.471Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T08:46:00.888Z'
-updated_at: '2026-08-12T08:59:54.443Z'
+updated_at: '2026-08-12T09:50:03.471Z'

--- a/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
+++ b/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-08-12T08:51:11.352Z'
   dev-approval:
     status: pending
+    requested_at: '2026-08-12T08:59:54.442Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T08:46:00.888Z'
-updated_at: '2026-08-12T08:51:17.921Z'
+updated_at: '2026-08-12T08:59:54.443Z'

--- a/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
+++ b/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-08-12T08:49:35.815Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T08:46:00.888Z'
-updated_at: '2026-08-12T08:46:00.889Z'
+updated_at: '2026-08-12T08:49:35.816Z'

--- a/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
+++ b/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-08-12T08:46:00.888Z'
-updated_at: '2026-08-12T09:52:06.221Z'
+updated_at: '2026-08-12T09:52:15.817Z'
 pr_history:
   - phase: review
     pr_number: 1424

--- a/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
+++ b/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-08-12T08:49:35.815Z'
+    approved_at: '2026-08-12T08:51:11.352Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T08:46:00.888Z'
-updated_at: '2026-08-12T08:49:35.816Z'
+updated_at: '2026-08-12T08:51:11.352Z'

--- a/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
+++ b/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T08:46:00.888Z'
-updated_at: '2026-08-12T09:50:13.066Z'
+updated_at: '2026-08-12T09:52:06.221Z'
+pr_history:
+  - phase: review
+    pr_number: 1424
+    branch: builder/pir-1420
+    created_at: '2026-08-12T09:52:06.220Z'

--- a/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
+++ b/codev/projects/1420-stream-deck-hands-free-comment/status.yaml
@@ -1,7 +1,7 @@
 id: '1420'
 title: stream-deck-hands-free-comment
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T08:46:00.888Z'
-updated_at: '2026-08-12T09:50:03.471Z'
+updated_at: '2026-08-12T09:50:13.066Z'

--- a/codev/reviews/1420-stream-deck-hands-free-comment.md
+++ b/codev/reviews/1420-stream-deck-hands-free-comment.md
@@ -1,0 +1,104 @@
+# PIR Review: `composer-open-or-submit` — context-aware canvas command
+
+Fixes #1420
+
+## Summary
+
+Adds a single context-aware canvas command, `composer-open-or-submit`, to the artifact-canvas
+remote-command vocabulary (spec 1401). The canvas — the only party that knows whether a composer is
+open — resolves it against its own `composingLine` state: open the composer at the focused block when
+none is open, submit the draft when one is. This lets a stateless controller (the Stream Deck) drive
+open-then-submit from one gesture without guessing composer state, which if wrong would re-anchor the
+composer and discard an in-progress dictated comment. This is the **bridge-extension half** of the
+agreed cross-lane split; the deck dial remapping and touchstrip legibility (issue requirements 3–4)
+are streamdeck's follow-on lane, sequenced after this command merges.
+
+## Files Changed
+
+Scoped to this branch (`git diff --stat` at the merge-base), code + tests:
+
+- `packages/types/src/canvas-command.ts` (+9 / -0) — new union member + type doc-comment
+- `packages/types/type-tests/canvas-command.type-test.ts` (+1 / -0) — CLASSIFICATION map entry
+- `packages/codev/src/agent-farm/servers/canvas-relay.ts` (+1 / -0) — Tower relay allowlist
+- `packages/codev/src/agent-farm/__tests__/canvas-relay.test.ts` (+16 / -1) — relay round-trip + count-rejection
+- `apps/vscode/src/markdown-preview/canvas-view-registry.ts` (+1 / -0) — host allowlist
+- `packages/artifact-canvas/src/components/ArtifactCanvas.tsx` (+16 / -0) — `canvasActions` entry
+- `packages/artifact-canvas/src/adapters/CommandAdapter.ts` (+6 / -1) — doc-comment refresh
+- `packages/artifact-canvas/src/__tests__/remote-commands.test.tsx` (+71 / -0) — open/submit/empty-no-op coverage
+
+Non-code (protocol artifacts): `codev/plans/1420-*.md`, `codev/state/pir-1420_thread.md`, `status.yaml`.
+
+## Commits
+
+`git log main..HEAD --oneline` (implementation commits only):
+
+- `3c719dac6` [PIR #1420] feat: add composer-open-or-submit canvas command
+- `22cafa2fa` [PIR #1420] test: assert no-re-anchor; refresh CommandAdapter prose
+
+## Test Results
+
+- `pnpm build` (types + artifact-canvas + codev): ✓ pass
+- `pnpm --filter @cluesmith/codev-artifact-canvas test`: ✓ 176 passed (3 new)
+- `pnpm --filter @cluesmith/codev test`: ✓ 4850 passed, 48 skipped (2 new, incl. relay round-trip)
+- `codev-types` `check-types` + `check-types:tests`: ✓ clean
+- `codev-vscode` `check-types` (src + webview): ✓ clean
+- Manual verification: exercised at the `dev-approval` gate — open-then-submit via `sendCanvasCommand`
+  against a running canvas view, `Esc`-between-presses re-opens rather than submitting a discarded
+  draft.
+
+## Architecture Updates
+
+No arch-doc changes. This adds one member to the already-documented, closed `CanvasCommand` vocabulary
+(spec 1401); it changes no module boundary, transport, or invariant. The one structural fact worth a
+future contributor knowing — that a new `CanvasCommand` member must be added to **four**
+`satisfies`-guarded enumerations (the union, the type-test CLASSIFICATION map, Tower's relay allowlist
+in `canvas-relay.ts`, and the host allowlist in `canvas-view-registry.ts`) plus the `canvasActions`
+map — is already enforced by those compile-time guards themselves: omitting any one fails the build,
+so it needs no prose in the hot-capped `arch-critical.md`.
+
+## Lessons Learned Updates
+
+No new hot-tier lesson. The design principle here — a context-dependent decision belongs to the party
+that owns the state (the canvas), never to a stateless client that would have to guess — is an
+application of the existing `lessons-critical.md` entry "Single source of truth beats distributed
+state." One spec-narrow observation, recorded here rather than promoted: the issue's requirement list
+enumerated three allowlists to update but there were four (Tower's own relay validation was the
+omitted one); the `satisfies readonly CanvasCommand[]` + `Assert` guards on every list are what turned
+that undercount from a latent production 400 into a compile error caught before the first test run.
+
+## Things to Look At During PR Review
+
+- **The open-vs-submit branch reads `composingLine` live.** `canvasActions` is rebuilt every render
+  and `runCanvasCommandRef.current` is refreshed every render (`ArtifactCanvas.tsx:996-1001`), so the
+  action body sees the current `composingLine`. `composer-cancel` already relies on this exact
+  pattern. If that render-freshness assumption were wrong, the command would resolve against a stale
+  state — the "submits on second press" test is what pins it.
+- **Draft-safety rests on `CommentComposer.submit()`'s empty guard** (`overlays/CommentComposer.tsx`),
+  which trims and returns early on an empty body. The open+empty press routes to `submit()`, so it is
+  a no-op that leaves the composer mounted — it never writes an empty comment and never re-anchors.
+  The empty-draft test asserts the composer's line-scoped `aria-label` is unchanged after moving the
+  cursor and pressing again, so a wrong branch resolution (which would re-open at the new line) fails
+  it directly.
+- **Edit composer shares `composingLine`.** A press while editing an existing comment (the pencil
+  path) routes to submit-the-edit, not a re-anchor that would discard it — correct, and worth
+  exercising.
+
+## How to Test Locally
+
+For reviewers pulling the branch:
+
+- **View diff**: VSCode sidebar → right-click builder `pir-1420` → **Review Diff**
+- **Run dev**: VSCode sidebar → **Run Dev**, or `afx dev pir-1420`
+- **What to verify** (maps to the plan's Test Plan):
+  - With a canvas view open and Tower running, POST `composer-open-or-submit` to
+    `/api/canvas/command` (or via the sdk): first call opens the composer at the focused block.
+  - Type a comment, POST again: it submits (a marker is written).
+  - Press `Esc` to cancel between the two POSTs, then POST again: it re-opens rather than submitting a
+    discarded draft.
+  - Send `count` with the command: Tower answers `invalid-request` (400) — it is non-traversal.
+
+## Follow-on (not this lane)
+
+`apps/streamdeck/src/actions.ts` still sends `composer-open` on the review-dial press. The deck remap
+(fine dial → `composer-open-or-submit`, coarse dial → `composer-cancel`) and touchstrip legibility are
+streamdeck's follow-on lane, coordinated with #1410's layout work.

--- a/codev/reviews/1420-stream-deck-hands-free-comment.md
+++ b/codev/reviews/1420-stream-deck-hands-free-comment.md
@@ -1,6 +1,6 @@
 # PIR Review: `composer-open-or-submit` — context-aware canvas command
 
-Fixes #1420
+Refs #1420
 
 ## Summary
 
@@ -68,6 +68,14 @@ that undercount from a latent production 400 into a compile error caught before 
 
 ## Things to Look At During PR Review
 
+- **`Refs #1420`, not `Fixes` — deliberate (raised by Codex at the PR consultation, REQUEST_CHANGES).**
+  Issue #1420 enumerates requirements 1–5; this PR is the bridge-extension lane and lands 1, 2, and 5,
+  but requirements 3 (deck dial remap) and 4 (touchstrip legibility) remain for streamdeck's follow-on
+  lane. Auto-closing #1420 on merge would drop that remaining work on the floor, so the PR body
+  references the issue rather than closing it. **Human decision at the `pr` gate:** if the follow-on
+  work is (or will be) tracked under its own issue / #1410 and #1420 should close with this merge,
+  switch back to `Fixes #1420` or close the issue manually. This finding gets no automated
+  re-review (PIR consultation is single-pass), so it is surfaced here and to the architect.
 - **The open-vs-submit branch reads `composingLine` live.** `canvasActions` is rebuilt every render
   and `runCanvasCommandRef.current` is refreshed every render (`ArtifactCanvas.tsx:996-1001`), so the
   action body sees the current `composingLine`. `composer-cancel` already relies on this exact

--- a/codev/state/pir-1420_thread.md
+++ b/codev/state/pir-1420_thread.md
@@ -30,3 +30,27 @@ Plan has a dedicated "Command semantics" section to route to the streamdeck arch
 before the plan gate (per the process ruling in the issue comments).
 
 Next: notify architect + streamdeck architect; wait at plan-approval gate.
+
+## Implement phase (iter 1) — done, verifying
+plan-approval approved by human. Implemented all five code locations + tests (commit 3c719dac6):
+- types union + doc, type-test CLASSIFICATION map, Tower relay allowlist, host allowlist, canvas
+  action map (`composer-open-or-submit`).
+- Tests: canvas open/submit/empty-no-op via remote channel; relay round-trip + count-rejection.
+
+Green: codev 4850 passed / 48 skipped; artifact-canvas 176; types build + type-tests; vscode
+check-types. All exit 0.
+
+CMAP (impl, pir): codex APPROVE, claude APPROVE, gemini REQUEST_CHANGES. Gemini's only blocker is
+"missing review artifact" — a FALSE POSITIVE: PIR implement.md forbids writing the review file this
+phase (it's the review phase's job). Claude flagged the same and confirmed it's not a defect.
+
+Applied two non-blocking CMAP nits from claude:
+- Strengthened the empty-draft test to assert NO re-anchor (block-next between presses, assert the
+  composer aria-label still names the original line — the prior test would pass even under wrong
+  branch resolution).
+- Updated stale CommandAdapter.ts prose to mention the context-aware member (plan flagged optional).
+
+Also confirmed (claude): the edit composer shares composingLine, so a press mid-edit routes to
+submit-the-edit, never a draft-discarding re-anchor. Worth exercising at the dev gate.
+
+Next: re-run canvas tests after nits, commit, `porch done`, wait at dev-approval gate.

--- a/codev/state/pir-1420_thread.md
+++ b/codev/state/pir-1420_thread.md
@@ -62,3 +62,15 @@ the four satisfies-guards already enforce the invariant — nothing rises to hot
 explain why, per protocol.
 Next: commit review, push, open PR, `porch done --pr`, then `porch done` (porch runs 3-way consult
 once), notify architect, wait at pr gate.
+
+PR #1424 opened (branch builder/pir-1420). Porch ran the single 3-way consult pass.
+Verdicts: gemini APPROVE, claude APPROVE, codex REQUEST_CHANGES.
+
+Codex (REAL, accepted): `Fixes #1420` would auto-close the issue on merge, but this PR is only the
+bridge lane (reqs 1,2,5) — reqs 3-4 (deck remap, touchstrip) remain for streamdeck's follow-on. Fixed:
+review + PR body now `Refs #1420` (commit 1c14cb651). Escalated to human at pr gate: they decide
+whether #1420 should close with this merge (if follow-on rides its own issue/#1410) or stay open.
+Rebuttal written (1420-review-iter1-rebuttals.md, committed 2939886d8). Claude's non-blocking notes
+addressed in rebuttal, no code change.
+
+Now at PR GATE — waiting for human to merge on GitHub. Do NOT self-merge or self-approve.

--- a/codev/state/pir-1420_thread.md
+++ b/codev/state/pir-1420_thread.md
@@ -1,0 +1,32 @@
+# Builder thread — pir-1420
+
+Issue #1420: Stream Deck hands-free comment submit/cancel (dictation). PIR protocol, strict mode.
+
+## Scope (bridge-extension lane only)
+This lane is the bridge half of the agreed main+streamdeck split: requirements 1 & 2 only —
+add the `composer-open-or-submit` canvas command (canvas-side resolution from `composingLine`,
+never discards a draft) to the closed vocabulary, allowlists, and action map. Deck remapping
+(req 3) and touchstrip (req 4) are streamdeck's follow-on lane, after this merges. No
+`apps/streamdeck/` change here.
+
+## Plan phase (iter 1) — done, awaiting plan-approval gate
+Wrote `codev/plans/1420-stream-deck-hands-free-comment.md`.
+
+Key findings from codebase investigation:
+- The empty-draft ruling is ALREADY satisfied: `CommentComposer.submit()` trims + returns early on
+  empty (`CommentComposer.tsx:72-76`), leaving the composer mounted with draft intact. So routing
+  the open case through `submit()` inherits the guard — never writes empty, never discards.
+- Reading `composingLine` in the action is safe: `canvasActions` + `runCanvasCommandRef.current`
+  rebuilt every render (`ArtifactCanvas.tsx:996-1001`); `composer-cancel` already reads it directly.
+- **FOUR** allowlists guard the union, not the three the issue's req 2 names. The extra one is
+  Tower's own relay validation `packages/codev/src/agent-farm/servers/canvas-relay.ts:68-83` —
+  without it Tower answers `invalid-request` and the command never reaches the canvas. Flagged in
+  the plan. All four are `satisfies`-guarded, so a miss is a compile error.
+- Fifth touch: `packages/types/type-tests/canvas-command.type-test.ts` CLASSIFICATION map
+  (`satisfies Record<CanvasCommand,…>`) needs the new member as 'non-traversal'.
+- No codev-skeleton mirror (this is product code under packages/apps, not framework template).
+
+Plan has a dedicated "Command semantics" section to route to the streamdeck architect for review
+before the plan gate (per the process ruling in the issue comments).
+
+Next: notify architect + streamdeck architect; wait at plan-approval gate.

--- a/codev/state/pir-1420_thread.md
+++ b/codev/state/pir-1420_thread.md
@@ -54,3 +54,11 @@ Also confirmed (claude): the edit composer shares composingLine, so a press mid-
 submit-the-edit, never a draft-discarding re-anchor. Worth exercising at the dev gate.
 
 Next: re-run canvas tests after nits, commit, `porch done`, wait at dev-approval gate.
+
+## Review phase (iter 1) — writing retrospective, opening PR
+dev-approval approved by human. Wrote codev/reviews/1420-stream-deck-hands-free-comment.md.
+No arch/lessons governance-file changes (one member added to an already-guarded closed vocabulary;
+the four satisfies-guards already enforce the invariant — nothing rises to hot-tier). Sections
+explain why, per protocol.
+Next: commit review, push, open PR, `porch done --pr`, then `porch done` (porch runs 3-way consult
+once), notify architect, wait at pr gate.

--- a/packages/artifact-canvas/src/__tests__/remote-commands.test.tsx
+++ b/packages/artifact-canvas/src/__tests__/remote-commands.test.tsx
@@ -362,21 +362,34 @@ describe('remote command channel', () => {
 
   // The draft-safety ruling: a press on an open-but-empty composer must neither submit nor discard
   // the draft. Submit is CommentComposer's own no-op on empty, and the open branch is never taken
-  // while the composer is open, so the composer stays mounted.
-  it('leaves an empty open composer mounted and writes nothing (composer-open-or-submit)', async () => {
+  // while the composer is open, so the composer stays mounted AND anchored to its original line.
+  // Moving the cursor with `block-next` between presses is what makes this assert "never
+  // re-anchors": if the branch resolved wrongly it would re-open at the NEW focused line, changing
+  // the composer's line-scoped aria-label. Asserting the label is unchanged catches that directly.
+  it('leaves an empty open composer mounted and anchored, writing nothing (composer-open-or-submit)', async () => {
     const { channel, onAddComment } = mount();
     await rendered();
 
     channel.send('doc-start');
+    const originalLine = focusedLine();
     channel.send('composer-open-or-submit');
+    const label = `Add comment on line ${Number(originalLine) + 1}`;
     await waitFor(() => {
-      expect(document.querySelector('.codev-canvas-comment-composer')).not.toBeNull();
+      const el = document.querySelector('.codev-canvas-comment-composer-input');
+      if (!el) throw new Error('composer did not open');
+      expect(el.getAttribute('aria-label')).toBe(label);
     });
 
-    // Composer open, draft empty: the press is a no-op that keeps the composer (and its draft) alive.
+    // Move the cursor off the composer's line, then press again with the draft still empty.
+    channel.send('block-next');
+    expect(focusedLine()).not.toBe(originalLine);
     channel.send('composer-open-or-submit');
+
+    // No write, composer still mounted, and still anchored to the ORIGINAL line — no re-anchor.
     expect(onAddComment).not.toHaveBeenCalled();
-    expect(document.querySelector('.codev-canvas-comment-composer')).not.toBeNull();
+    const composer = document.querySelector('.codev-canvas-comment-composer-input');
+    expect(composer).not.toBeNull();
+    expect(composer?.getAttribute('aria-label')).toBe(label);
   });
 
   // Column paging is meaningful only in horizontal mode; jsdom cannot measure column geometry,

--- a/packages/artifact-canvas/src/__tests__/remote-commands.test.tsx
+++ b/packages/artifact-canvas/src/__tests__/remote-commands.test.tsx
@@ -321,6 +321,64 @@ describe('remote command channel', () => {
     expect(onAddComment).not.toHaveBeenCalled();
   });
 
+  // Context-aware composer control (#1420). The canvas resolves open-vs-submit against its own
+  // composer state, so one gesture opens then submits without the controller tracking anything.
+  it('opens the composer when none is open (composer-open-or-submit)', async () => {
+    const { channel } = mount();
+    await rendered();
+
+    channel.send('doc-start');
+    channel.send('composer-open-or-submit');
+    await waitFor(() => {
+      expect(document.querySelector('.codev-canvas-comment-composer')).not.toBeNull();
+    });
+  });
+
+  it('submits the open composer on a second composer-open-or-submit', async () => {
+    const { channel, onAddComment } = mount();
+    await rendered();
+
+    channel.send('doc-start');
+    const target = focusedLine();
+    // First press opens at the focused block.
+    channel.send('composer-open-or-submit');
+    const textarea = await waitFor(() => {
+      const el = document.querySelector<HTMLTextAreaElement>('.codev-canvas-comment-composer-input');
+      if (!el) throw new Error('composer did not open');
+      return el;
+    });
+
+    fireEvent.change(textarea, { target: { value: 'dictated comment' } });
+    // Park focus away from the composer, the way a remote-driven session leaves it.
+    document.querySelector<HTMLElement>(`[data-line="${target}"]`)?.focus();
+
+    // Second press submits — the canvas saw the composer open and routed to submit, not re-open.
+    channel.send('composer-open-or-submit');
+    await waitFor(() => {
+      expect(onAddComment).toHaveBeenCalledWith(Number(target), 'dictated comment');
+    });
+    expect(onAddComment).toHaveBeenCalledTimes(1);
+  });
+
+  // The draft-safety ruling: a press on an open-but-empty composer must neither submit nor discard
+  // the draft. Submit is CommentComposer's own no-op on empty, and the open branch is never taken
+  // while the composer is open, so the composer stays mounted.
+  it('leaves an empty open composer mounted and writes nothing (composer-open-or-submit)', async () => {
+    const { channel, onAddComment } = mount();
+    await rendered();
+
+    channel.send('doc-start');
+    channel.send('composer-open-or-submit');
+    await waitFor(() => {
+      expect(document.querySelector('.codev-canvas-comment-composer')).not.toBeNull();
+    });
+
+    // Composer open, draft empty: the press is a no-op that keeps the composer (and its draft) alive.
+    channel.send('composer-open-or-submit');
+    expect(onAddComment).not.toHaveBeenCalled();
+    expect(document.querySelector('.codev-canvas-comment-composer')).not.toBeNull();
+  });
+
   // Column paging is meaningful only in horizontal mode; jsdom cannot measure column geometry,
   // so the real paging assertion lives in the Playwright suite. What matters here is that the
   // command is safe to send in vertical mode.

--- a/packages/artifact-canvas/src/adapters/CommandAdapter.ts
+++ b/packages/artifact-canvas/src/adapters/CommandAdapter.ts
@@ -23,8 +23,11 @@ export interface CanvasCommandInvocation {
  * back through `onCommand`.
  *
  * Commands drive the SAME per-action implementations as the keyboard, so the remote and in-page
- * paths cannot diverge. What a command cannot do is type: comment bodies are entered on the
- * keyboard, so `composer-open` and `composer-submit` are in the vocabulary but text entry is not.
+ * paths cannot diverge. One member has no keyboard twin: `composer-open-or-submit` (#1420) is
+ * resolved canvas-side against composer state (open when none is open, else submit) so a stateless
+ * controller can drive open-then-submit from one gesture. What a command cannot do is type: comment
+ * bodies are entered on the keyboard, so `composer-open` and `composer-submit` are in the vocabulary
+ * but text entry is not.
  *
  * Optional by design: a host that omits `commandAdapter` gets exactly today's behavior.
  */

--- a/packages/artifact-canvas/src/components/ArtifactCanvas.tsx
+++ b/packages/artifact-canvas/src/components/ArtifactCanvas.tsx
@@ -948,6 +948,22 @@ export function ArtifactCanvas(props: ArtifactCanvasProps): React.ReactElement {
     'composer-cancel': () => {
       if (composingLine !== null) cancelComposer(true);
     },
+    // Context-aware composer control (#1420): the canvas — the only party that knows whether a
+    // composer is open — decides, so a stateless controller can drive open-then-submit from one
+    // gesture. Closed → open at the focused block; open → submit the current draft. Submit trims
+    // and no-ops on an empty body (CommentComposer.submit), so this never writes an empty comment
+    // and never re-anchors/discards the draft. Reads `composingLine` like `composer-cancel`; the
+    // action map is rebuilt each render, so the read is current.
+    'composer-open-or-submit': ({ originLine }) => {
+      if (composingLine !== null) {
+        composerHandleRef.current?.submit();
+        return;
+      }
+      if (originLine === null) return;
+      const line = Number(originLine);
+      if (Number.isNaN(line)) return;
+      openComposer(line);
+    },
     'reading-mode-toggle': () => toggleReadingMode(),
   };
 

--- a/packages/codev/src/agent-farm/__tests__/canvas-relay.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/canvas-relay.test.ts
@@ -166,6 +166,21 @@ describe('target resolution', () => {
     ]);
   });
 
+  // The context-aware composer command (#1420) must clear Tower's own allowlist and relay like any
+  // other member; without the entry in canvas-relay's CANVAS_COMMANDS it would 400 before the
+  // canvas ever saw it.
+  it('relays the context-aware composer command (#1420)', async () => {
+    const { viewId } = await registerCanonical('/tmp/doc.md');
+
+    const out = await sendCommand({ workspace: WS, command: 'composer-open-or-submit' });
+
+    expect(out.status).toBe(200);
+    expect(out.body.ok).toBe(true);
+    expect(broadcasts).toEqual([
+      { type: 'canvas-command', body: { viewId, command: 'composer-open-or-submit' } },
+    ]);
+  });
+
   it('delivers to exactly ONE view when several match, never fanning out', async () => {
     await register('/tmp/doc.md');
     const second = await register('/tmp/doc.md');
@@ -286,7 +301,7 @@ describe('command validation', () => {
   });
 
   it('rejects count on a non-traversal command', async () => {
-    for (const command of ['doc-start', 'composer-open', 'reading-mode-toggle']) {
+    for (const command of ['doc-start', 'composer-open', 'composer-open-or-submit', 'reading-mode-toggle']) {
       const out = await sendCommand({ workspace: WS, command, count: 2 });
       expect(out.status).toBe(400);
       expect(out.body.code).toBe('invalid-request');

--- a/packages/codev/src/agent-farm/servers/canvas-relay.ts
+++ b/packages/codev/src/agent-farm/servers/canvas-relay.ts
@@ -79,6 +79,7 @@ const CANVAS_COMMANDS = [
   'composer-open',
   'composer-submit',
   'composer-cancel',
+  'composer-open-or-submit',
   'reading-mode-toggle',
 ] as const satisfies readonly CanvasCommand[];
 

--- a/packages/types/src/canvas-command.ts
+++ b/packages/types/src/canvas-command.ts
@@ -25,6 +25,13 @@
  * Tab parity, which also visits affordances, card actions, toolbar controls and links), and
  * `reading-mode-toggle` mirrors the reading-mode toolbar button.
  *
+ * One member is context-aware rather than mirroring a single in-page action: `composer-open-or-submit`
+ * (#1420) resolves canvas-side against the view's composer state — no composer open means open one at
+ * the focused block, an open composer means submit it. It exists so a stateless controller (a control
+ * device that never learns composer state back) can drive open-then-submit from one gesture without
+ * guessing, which — if wrong — would re-anchor the composer and discard an in-progress draft. The
+ * canvas makes the call, so it is always correct; an empty draft stays the composer's own no-op.
+ *
  * Text entry is out of scope: comment bodies are typed on the keyboard.
  */
 export type CanvasCommand =
@@ -45,6 +52,8 @@ export type CanvasCommand =
   | 'composer-open'
   | 'composer-submit'
   | 'composer-cancel'
+  // Composer, context-aware: open when none is open, else submit (#1420).
+  | 'composer-open-or-submit'
   // View state.
   | 'reading-mode-toggle';
 

--- a/packages/types/type-tests/canvas-command.type-test.ts
+++ b/packages/types/type-tests/canvas-command.type-test.ts
@@ -48,6 +48,7 @@ const CLASSIFICATION = {
   'composer-open': 'non-traversal',
   'composer-submit': 'non-traversal',
   'composer-cancel': 'non-traversal',
+  'composer-open-or-submit': 'non-traversal',
   'reading-mode-toggle': 'non-traversal',
 } as const satisfies Record<CanvasCommand, 'traversal' | 'non-traversal'>;
 


### PR DESCRIPTION
# PIR Review: `composer-open-or-submit` — context-aware canvas command

Refs #1420

## Summary

Adds a single context-aware canvas command, `composer-open-or-submit`, to the artifact-canvas
remote-command vocabulary (spec 1401). The canvas — the only party that knows whether a composer is
open — resolves it against its own `composingLine` state: open the composer at the focused block when
none is open, submit the draft when one is. This lets a stateless controller (the Stream Deck) drive
open-then-submit from one gesture without guessing composer state, which if wrong would re-anchor the
composer and discard an in-progress dictated comment. This is the **bridge-extension half** of the
agreed cross-lane split; the deck dial remapping and touchstrip legibility (issue requirements 3–4)
are streamdeck's follow-on lane, sequenced after this command merges.

## Files Changed

Scoped to this branch (`git diff --stat` at the merge-base), code + tests:

- `packages/types/src/canvas-command.ts` (+9 / -0) — new union member + type doc-comment
- `packages/types/type-tests/canvas-command.type-test.ts` (+1 / -0) — CLASSIFICATION map entry
- `packages/codev/src/agent-farm/servers/canvas-relay.ts` (+1 / -0) — Tower relay allowlist
- `packages/codev/src/agent-farm/__tests__/canvas-relay.test.ts` (+16 / -1) — relay round-trip + count-rejection
- `apps/vscode/src/markdown-preview/canvas-view-registry.ts` (+1 / -0) — host allowlist
- `packages/artifact-canvas/src/components/ArtifactCanvas.tsx` (+16 / -0) — `canvasActions` entry
- `packages/artifact-canvas/src/adapters/CommandAdapter.ts` (+6 / -1) — doc-comment refresh
- `packages/artifact-canvas/src/__tests__/remote-commands.test.tsx` (+71 / -0) — open/submit/empty-no-op coverage

Non-code (protocol artifacts): `codev/plans/1420-*.md`, `codev/state/pir-1420_thread.md`, `status.yaml`.

## Commits

`git log main..HEAD --oneline` (implementation commits only):

- `3c719dac6` [PIR #1420] feat: add composer-open-or-submit canvas command
- `22cafa2fa` [PIR #1420] test: assert no-re-anchor; refresh CommandAdapter prose

## Test Results

- `pnpm build` (types + artifact-canvas + codev): ✓ pass
- `pnpm --filter @cluesmith/codev-artifact-canvas test`: ✓ 176 passed (3 new)
- `pnpm --filter @cluesmith/codev test`: ✓ 4850 passed, 48 skipped (2 new, incl. relay round-trip)
- `codev-types` `check-types` + `check-types:tests`: ✓ clean
- `codev-vscode` `check-types` (src + webview): ✓ clean
- Manual verification: exercised at the `dev-approval` gate — open-then-submit via `sendCanvasCommand`
  against a running canvas view, `Esc`-between-presses re-opens rather than submitting a discarded
  draft.

## Architecture Updates

No arch-doc changes. This adds one member to the already-documented, closed `CanvasCommand` vocabulary
(spec 1401); it changes no module boundary, transport, or invariant. The one structural fact worth a
future contributor knowing — that a new `CanvasCommand` member must be added to **four**
`satisfies`-guarded enumerations (the union, the type-test CLASSIFICATION map, Tower's relay allowlist
in `canvas-relay.ts`, and the host allowlist in `canvas-view-registry.ts`) plus the `canvasActions`
map — is already enforced by those compile-time guards themselves: omitting any one fails the build,
so it needs no prose in the hot-capped `arch-critical.md`.

## Lessons Learned Updates

No new hot-tier lesson. The design principle here — a context-dependent decision belongs to the party
that owns the state (the canvas), never to a stateless client that would have to guess — is an
application of the existing `lessons-critical.md` entry "Single source of truth beats distributed
state." One spec-narrow observation, recorded here rather than promoted: the issue's requirement list
enumerated three allowlists to update but there were four (Tower's own relay validation was the
omitted one); the `satisfies readonly CanvasCommand[]` + `Assert` guards on every list are what turned
that undercount from a latent production 400 into a compile error caught before the first test run.

## Things to Look At During PR Review

- **`Refs #1420`, not `Fixes` — deliberate (raised by Codex at the PR consultation, REQUEST_CHANGES).**
  Issue #1420 enumerates requirements 1–5; this PR is the bridge-extension lane and lands 1, 2, and 5,
  but requirements 3 (deck dial remap) and 4 (touchstrip legibility) remain for streamdeck's follow-on
  lane. Auto-closing #1420 on merge would drop that remaining work on the floor, so the PR body
  references the issue rather than closing it. **Human decision at the `pr` gate:** if the follow-on
  work is (or will be) tracked under its own issue / #1410 and #1420 should close with this merge,
  switch back to `Fixes #1420` or close the issue manually. This finding gets no automated
  re-review (PIR consultation is single-pass), so it is surfaced here and to the architect.
- **The open-vs-submit branch reads `composingLine` live.** `canvasActions` is rebuilt every render
  and `runCanvasCommandRef.current` is refreshed every render (`ArtifactCanvas.tsx:996-1001`), so the
  action body sees the current `composingLine`. `composer-cancel` already relies on this exact
  pattern. If that render-freshness assumption were wrong, the command would resolve against a stale
  state — the "submits on second press" test is what pins it.
- **Draft-safety rests on `CommentComposer.submit()`'s empty guard** (`overlays/CommentComposer.tsx`),
  which trims and returns early on an empty body. The open+empty press routes to `submit()`, so it is
  a no-op that leaves the composer mounted — it never writes an empty comment and never re-anchors.
  The empty-draft test asserts the composer's line-scoped `aria-label` is unchanged after moving the
  cursor and pressing again, so a wrong branch resolution (which would re-open at the new line) fails
  it directly.
- **Edit composer shares `composingLine`.** A press while editing an existing comment (the pencil
  path) routes to submit-the-edit, not a re-anchor that would discard it — correct, and worth
  exercising.

## How to Test Locally

For reviewers pulling the branch:

- **View diff**: VSCode sidebar → right-click builder `pir-1420` → **Review Diff**
- **Run dev**: VSCode sidebar → **Run Dev**, or `afx dev pir-1420`
- **What to verify** (maps to the plan's Test Plan):
  - With a canvas view open and Tower running, POST `composer-open-or-submit` to
    `/api/canvas/command` (or via the sdk): first call opens the composer at the focused block.
  - Type a comment, POST again: it submits (a marker is written).
  - Press `Esc` to cancel between the two POSTs, then POST again: it re-opens rather than submitting a
    discarded draft.
  - Send `count` with the command: Tower answers `invalid-request` (400) — it is non-traversal.

## Follow-on (not this lane)

`apps/streamdeck/src/actions.ts` still sends `composer-open` on the review-dial press. The deck remap
(fine dial → `composer-open-or-submit`, coarse dial → `composer-cancel`) and touchstrip legibility are
streamdeck's follow-on lane, coordinated with #1410's layout work.
