### PR TITLE
Stream Deck: map canvas review dial presses to composer-open-or-submit / composer-cancel (#1425)

### DIFF
--- a/apps/streamdeck/src/__tests__/actions.test.ts
+++ b/apps/streamdeck/src/__tests__/actions.test.ts
@@ -195,31 +195,31 @@ describe('encoders', () => {
     expect(ctx.sent.map((s) => s.verb)).toEqual(['forward-file', 'forward-hunk']);
   });
 
-  it('canvas mode: coarse dial rotates headings (count = |ticks|), press opens composer, tap resets to doc start', async () => {
+  it('canvas mode: coarse dial rotates headings (count = |ticks|), press cancels composer, tap resets to doc start', async () => {
     const ctx = makeStore(); // default selection pir-1 is blocked at plan-approval → canvas mode
     const nav = new DiffFileNav(ctx.store);
     await nav.onDialRotate(dial(3) as never);   // heading-next, count 3
     await nav.onDialRotate(dial(-1) as never);  // heading-prev, count 1
-    await nav.onDialDown();                      // composer-open
+    await nav.onDialDown();                      // composer-cancel (#1425)
     await nav.onTouchTap();                       // doc-start
     expect(ctx.canvasSent).toEqual([
       { command: 'heading-next', target: { workspace: '/work/alpha' }, count: 3 },
       { command: 'heading-prev', target: { workspace: '/work/alpha' }, count: 1 },
-      { command: 'composer-open', target: { workspace: '/work/alpha' }, count: undefined },
+      { command: 'composer-cancel', target: { workspace: '/work/alpha' }, count: undefined },
       { command: 'doc-start', target: { workspace: '/work/alpha' }, count: undefined },
     ]);
     expect(ctx.sent).toHaveLength(0); // canvas mode never touches the generic verb relay
   });
 
-  it('canvas mode: fine dial rotates blocks, tap walks forward through comments', async () => {
+  it('canvas mode: fine dial rotates blocks, press submits/opens composer, tap walks forward through comments', async () => {
     const ctx = makeStore(); // pir-1 → canvas mode
     const nav = new DiffHunkNav(ctx.store);
     await nav.onDialRotate(dial(2) as never);   // block-next, count 2
-    await nav.onDialDown();                      // composer-open
+    await nav.onDialDown();                      // composer-open-or-submit (#1425)
     await nav.onTouchTap();                       // comment-next
     expect(ctx.canvasSent).toEqual([
       { command: 'block-next', target: { workspace: '/work/alpha' }, count: 2 },
-      { command: 'composer-open', target: { workspace: '/work/alpha' }, count: undefined },
+      { command: 'composer-open-or-submit', target: { workspace: '/work/alpha' }, count: undefined },
       { command: 'comment-next', target: { workspace: '/work/alpha' }, count: undefined },
     ]);
   });
@@ -239,7 +239,7 @@ describe('encoders', () => {
     nav.onWillAppear({ action, payload: {} } as never);
     await nav.onDialRotate({ action, payload: { ticks: 1, settings: {} } } as never);
     const last = action.setFeedback.mock.calls.at(-1)?.[0];
-    expect(last).toMatchObject({ title: 'Headings', value: 'Open artifact' });
+    expect(last).toMatchObject({ title: 'Headings · Cancel', value: 'Open artifact' });
 
     ctx.canvasResult.value = { ok: false, code: 'unreachable', error: 'Tower down' };
     await nav.onDialDown();
@@ -605,14 +605,15 @@ describe('ZoomNav zoom gesture', () => {
     expect(fb.bar).toBe(45);                       // builder progress
   });
 
-  it('legibility: canvas-phase builder titles the dials Headings/Blocks', () => {
+  it('legibility: canvas-phase dials pair the rotate axis with the press meaning (#1425)', () => {
     const ctx = makeStore(); // selected builder (cursor 0) → pir-1, blocked at plan-approval → canvas
     const fileAction = { isDial: () => true, setFeedback: vi.fn() };
     const hunkAction = { isDial: () => true, setFeedback: vi.fn() };
     new DiffFileNav(ctx.store).onWillAppear({ action: fileAction, payload: {} } as never);
     new DiffHunkNav(ctx.store).onWillAppear({ action: hunkAction, payload: {} } as never);
-    expect(fileAction.setFeedback).toHaveBeenCalledWith({ title: 'Headings', value: '#101 Add the relay', bar: 45 });
-    expect(hunkAction.setFeedback).toHaveBeenCalledWith({ title: 'Blocks', value: '#101 Add the relay', bar: 45 });
+    // Coarse dial cancels; fine dial opens/submits. Line 2 stays the builder under review.
+    expect(fileAction.setFeedback).toHaveBeenCalledWith({ title: 'Headings · Cancel', value: '#101 Add the relay', bar: 45 });
+    expect(hunkAction.setFeedback).toHaveBeenCalledWith({ title: 'Blocks · Open/Submit', value: '#101 Add the relay', bar: 45 });
   });
 
   it('legibility: diff-phase builder titles the dials Files/Changes', () => {
@@ -631,7 +632,7 @@ describe('ZoomNav zoom gesture', () => {
     const action = { isDial: () => true, setFeedback: vi.fn() };
     const nav = new DiffFileNav(ctx.store);
     nav.onWillAppear({ action, payload: {} } as never); // pir-1 → canvas
-    expect(action.setFeedback.mock.calls.at(-1)?.[0]).toMatchObject({ title: 'Headings' });
+    expect(action.setFeedback.mock.calls.at(-1)?.[0]).toMatchObject({ title: 'Headings · Cancel' });
     ctx.store.syncToBuilder('pir-2'); // → diff; onChange re-renders
     expect(action.setFeedback.mock.calls.at(-1)?.[0]).toMatchObject({ title: 'Files' });
   });

--- a/apps/streamdeck/src/actions.ts
+++ b/apps/streamdeck/src/actions.ts
@@ -503,8 +503,9 @@ interface DiffSpec {
 
 /**
  * Canvas-mode gesture spec: canvas commands driven over `sendCanvasCommand` (#1401).
- * Press is always `composer-open` (feedback at the focused block), so it is shared
- * across dials rather than a field here.
+ * Press differs per dial (#1425): the fine dial submits (`composer-open-or-submit`), the
+ * coarse dial cancels (`composer-cancel`), so each dial carries its own press verb and a
+ * short touchstrip hint naming it.
  */
 interface CanvasSpec {
   /** Line-1 label in canvas mode (Headings / Blocks). */
@@ -513,6 +514,11 @@ interface CanvasSpec {
   prev: CanvasCommand;
   /** Tap. */
   jump: CanvasCommand;
+  /** Press: the composer command sent on dial down. */
+  press: CanvasCommand;
+  /** Short line-1 hint naming the press (e.g. Open/Submit, Cancel) so a reviewer can tell
+   *  the two dials' presses apart at a glance. */
+  pressLabel: string;
 }
 
 /** Touchstrip line for a failed canvas command, per client error code (plan §4). */
@@ -576,7 +582,10 @@ abstract class ReviewNav extends SingletonAction {
   /** Line 1 = the live semantic (mode-dependent); line 2 = builder under review
    *  (id + title); bar = its progress. A pending canvas error takes line 2 for one cycle. */
   private renderTo(action: DialAction): void {
-    const label = this.mode() === 'canvas' ? this.canvas.label : this.diff.label;
+    // Canvas line 1 pairs the rotate axis with the press meaning (`Blocks · Open/Submit`,
+    // `Headings · Cancel`); diff mode shows only its axis label.
+    const label =
+      this.mode() === 'canvas' ? `${this.canvas.label} · ${this.canvas.pressLabel}` : this.diff.label;
     const b = this.store.selectedBuilder();
     const id = b ? (b.issueId ? `#${b.issueId}` : b.id) : '';
     const details = b ? (b.issueTitle ? `${id} ${b.issueTitle}` : id) : 'No builder';
@@ -602,7 +611,7 @@ abstract class ReviewNav extends SingletonAction {
   override async onDialDown(): Promise<void> {
     const mode = this.mode();
     if (mode === 'canvas') {
-      await this.runCanvas('composer-open');
+      await this.runCanvas(this.canvas.press);
       return;
     }
     if (mode === 'diff') {
@@ -648,12 +657,14 @@ export class DiffFileNav extends ReviewNav {
     forward: 'forward-file',
   };
   // Coarse dial in canvas mode: step headings; tap resets to the document start
-  // (role-consistent with diff-mode jump-to-first-file).
+  // (role-consistent with diff-mode jump-to-first-file); press cancels an open composer.
   protected readonly canvas: CanvasSpec = {
     label: 'Headings',
     next: 'heading-next',
     prev: 'heading-prev',
     jump: 'doc-start',
+    press: 'composer-cancel',
+    pressLabel: 'Cancel',
   };
 }
 
@@ -668,12 +679,15 @@ export class DiffHunkNav extends ReviewNav {
   };
   // Fine dial in canvas mode: step blocks; tap walks forward through commented blocks
   // (the "next place needing attention" capability). Keyboard parity means no wrap, so
-  // it stops at the last comment.
+  // it stops at the last comment. Press is context-aware: opens the composer at the
+  // focused block, or submits an already-open draft (#1420).
   protected readonly canvas: CanvasSpec = {
     label: 'Blocks',
     next: 'block-next',
     prev: 'block-prev',
     jump: 'comment-next',
+    press: 'composer-open-or-submit',
+    pressLabel: 'Open/Submit',
   };
 }
 

--- a/apps/streamdeck/src/actions.ts
+++ b/apps/streamdeck/src/actions.ts
@@ -535,8 +535,9 @@ function canvasErrorLine(code: CanvasCommandClientErrorCode): string {
  *     the diff axis (files / hunks), press forwards that axis to the builder, tap
  *     jumps to the first — over the generic command relay.
  *   - canvas mode (specify / plan, or blocked at spec-approval / plan-approval): rotate
- *     steps the artifact-canvas (headings / blocks), press opens the composer at the
- *     focused block, tap resets (doc start) or walks comments — over `sendCanvasCommand`.
+ *     steps the artifact-canvas (headings / blocks), press drives the composer per dial
+ *     (fine: open-or-submit; coarse: cancel — #1425), tap resets (doc start) or walks
+ *     comments — over `sendCanvasCommand`.
  *
  * The dials drive the workspace's most-recently-active canvas (MRU targeting): the
  * phase picks the mode, the dials drive what you are looking at, and #1404's press

--- a/codev/plans/1425-stream-deck-map-review-dials-t.md
+++ b/codev/plans/1425-stream-deck-map-review-dials-t.md
@@ -130,14 +130,20 @@ Scope is `apps/streamdeck` only (requirement 4).
 **Hardware (dev-approval gate — a physical Stream Deck+ session):**
 
 Sideload swap (current Elgato Plugins symlink points at the **pir-1400** worktree —
-verified `…/Plugins/com.cluesmith.codev.sdPlugin -> …/.builders/pir-1400/…`):
+verified `…/Plugins/com.cluesmith.codev.sdPlugin -> …/.builders/pir-1400/…`). Amr runs
+these at the gate session:
 
 ```bash
-# from the monorepo root (main checkout)
+# Build THIS lane's bundle — MUST run from the pir-1425 WORKTREE root. `pnpm --filter`
+# resolves against the nearest workspace, so from the main checkout it would build MAIN's
+# apps/streamdeck and you would sideload a stale/missing bin/plugin.js and test the wrong code.
+cd /Users/amrmohamed/repos/cluesmith/codev/.builders/pir-1425
 pnpm --filter @cluesmith/codev-sdk build
-pnpm --filter @cluesmith/codev-streamdeck build   # builds pir-1425/.../bin/plugin.js
+pnpm --filter @cluesmith/codev-streamdeck build   # -> .builders/pir-1425/apps/streamdeck/com.cluesmith.codev.sdPlugin/bin/plugin.js
+
+# Link that bundle (absolute path; streamdeck link/unlink/restart are cwd-independent).
 streamdeck unlink com.cluesmith.codev
-streamdeck link .builders/pir-1425/apps/streamdeck/com.cluesmith.codev.sdPlugin
+streamdeck link /Users/amrmohamed/repos/cluesmith/codev/.builders/pir-1425/apps/streamdeck/com.cluesmith.codev.sdPlugin
 streamdeck restart com.cluesmith.codev
 streamdeck list                                   # confirm it points at pir-1425
 ```
@@ -154,15 +160,20 @@ Verify the flow from the issue:
 7. Touchstrip on the coarse dial reads `Headings · Cancel`; confirm neither line-1 string
    truncates unacceptably.
 
-Restore the sideload after the gate (return the deck to the prior build):
+Restore the sideload after the gate. Per the architect's ruling, the permanent stable
+target is a **fresh build of `apps/streamdeck` from the MAIN checkout** (behaviorally
+identical to pir-1400's merged code) — not the pir-1400 worktree. This main-checkout link
+becomes the deck's lasting target and frees the pir-1400 worktree for the pending orphan
+sweep (#1176):
 
 ```bash
-# from the monorepo root
-streamdeck unlink com.cluesmith.codev
-streamdeck link .builders/pir-1400/apps/streamdeck/com.cluesmith.codev.sdPlugin
-streamdeck restart com.cluesmith.codev
-streamdeck list                                   # confirm restored to pir-1400
-```
+# Build apps/streamdeck from the MAIN checkout (run from the main checkout root).
+cd /Users/amrmohamed/repos/cluesmith/codev
+pnpm --filter @cluesmith/codev-sdk build
+pnpm --filter @cluesmith/codev-streamdeck build   # -> apps/streamdeck/com.cluesmith.codev.sdPlugin/bin/plugin.js
 
-(If pir-1400's worktree is gone by then, relink whatever build the architect designates —
-the restore target is "the deck's prior state," confirmed with the architect at the gate.)
+streamdeck unlink com.cluesmith.codev
+streamdeck link /Users/amrmohamed/repos/cluesmith/codev/apps/streamdeck/com.cluesmith.codev.sdPlugin
+streamdeck restart com.cluesmith.codev
+streamdeck list                                   # confirm it points at the MAIN checkout — the deck's permanent stable target
+```

--- a/codev/plans/1425-stream-deck-map-review-dials-t.md
+++ b/codev/plans/1425-stream-deck-map-review-dials-t.md
@@ -1,0 +1,168 @@
+# PIR Plan: Map review dials to composer-open-or-submit / composer-cancel
+
+## Understanding
+
+The bridge command `composer-open-or-submit` landed on main in PR #1424 (the #1420
+bridge lane) and is wired through all four allowlists, but nothing on the deck sends it
+yet, so the hands-free review flow does not exist on hardware. This lane is the deck half:
+wire the two canvas-mode review dial presses to the new command pair and make the
+touchstrip say which press does what.
+
+Today both review dials share one press handler. In canvas mode (`ReviewNav.onDialDown`,
+`apps/streamdeck/src/actions.ts:602-612`) both presses send `composer-open` — the #1400
+decision this issue supersedes. The two concrete dials are:
+
+- `DiffFileNav` — the **coarse** dial; canvas rotate steps `Headings`
+  (`actions.ts:641-658`).
+- `DiffHunkNav` — the **fine** dial; canvas rotate steps `Blocks`
+  (`actions.ts:660-678`).
+
+`CanvasSpec` (`actions.ts:509-516`) has no press field precisely because the press was
+identical across dials (see its doc comment at `actions.ts:504-508`). Both target
+`CanvasCommand` members that already exist in the type and the canvas-relay allowlist:
+`composer-open-or-submit` and `composer-cancel` (`packages/types/src/canvas-command.ts:54,56`;
+`packages/codev/src/agent-farm/servers/canvas-relay.ts:81-82`). The canvas already
+implements both semantics (`packages/artifact-canvas/src/components/ArtifactCanvas.tsx:948,957`):
+open-or-submit opens at the focused block when none is open, submits (trim, no-op on empty)
+when one is; cancel is a no-op when nothing is open. So the deck change is purely a client
+remap plus label — no bridge, canvas, types, or host changes (issue requirement 4).
+
+## Proposed Change
+
+**1. Per-dial press command.** Give `CanvasSpec` a `press: CanvasCommand` field and have
+`onDialDown` send `this.canvas.press` in canvas mode instead of the hardcoded
+`composer-open`. Set:
+
+- `DiffHunkNav` (fine): `press: 'composer-open-or-submit'`
+- `DiffFileNav` (coarse): `press: 'composer-cancel'`
+
+This is the natural extension of the existing spec pattern — the reason the field did not
+exist is stated in the current doc comment, and that reason no longer holds. Update the
+`CanvasSpec` doc comment accordingly.
+
+**2. Touchstrip legibility.** Add a `pressLabel: string` to `CanvasSpec` (a short human
+hint) and render it in canvas mode so a reviewer can tell the two presses apart at a
+glance. The dial feedback today is `{ title: label, value: details, bar }`
+(`actions.ts:583`), where line 1 (`title`) names the rotate axis and line 2 (`value`)
+identifies the builder under review. In canvas mode, make line 1 read
+`` `${label} · ${pressLabel}` `` so the rotate axis and the press meaning sit together
+while line 2 keeps the builder identity. Proposed labels:
+
+- Fine / `Blocks`: `pressLabel: 'Open/Submit'` → line 1 `Blocks · Open/Submit`
+- Coarse / `Headings`: `pressLabel: 'Cancel'` → line 1 `Headings · Cancel`
+
+`Open/Submit` (not just `Submit`) is honest about the contextual command: the first fine
+press opens the composer, the second submits. Diff mode is untouched — its `title` stays
+the bare `diff.label`.
+
+Width note: the Stream Deck+ touchstrip title is narrow. `Headings · Cancel` is short;
+`Blocks · Open/Submit` (~20 chars) is the one to watch. This is the single item to confirm
+on hardware at dev-approval — if it truncates, the fallback is to shorten the fine label to
+`Blocks · Submit` (the submit is the action a reviewer waits on). I will surface the
+rendered strip to the architect at the gate before deciding.
+
+**3. Submit/cancel only, no text entry** (issue requirement 5, unchanged): the deck only
+sends the command verbs; dictation happens in the composer textarea via the OS, exactly as
+today. No text ever crosses the deck.
+
+### Dial-semantics summary (routed to architect before the gate)
+
+| Dial | Canvas rotate | Canvas press → command | Touchstrip line 1 |
+|---|---|---|---|
+| Fine (`DiffHunkNav`) | Blocks | `composer-open-or-submit` | `Blocks · Open/Submit` |
+| Coarse (`DiffFileNav`) | Headings | `composer-cancel` | `Headings · Cancel` |
+
+Tap and rotate are unchanged. Diff mode (implement/review phases) is unchanged.
+
+## Files to Change
+
+- `apps/streamdeck/src/actions.ts:509-516` — add `press: CanvasCommand` and
+  `pressLabel: string` to `CanvasSpec`; rewrite its doc comment (the "press is always
+  composer-open, so it is shared" rationale is now obsolete).
+- `apps/streamdeck/src/actions.ts:604-606` — `onDialDown` canvas branch sends
+  `this.canvas.press` instead of `'composer-open'`.
+- `apps/streamdeck/src/actions.ts:578-584` — `renderTo` composes line 1 as
+  `` `${label} · ${this.canvas.pressLabel}` `` in canvas mode; diff mode unchanged.
+- `apps/streamdeck/src/actions.ts:652-657` (`DiffFileNav.canvas`) — add
+  `press: 'composer-cancel'`, `pressLabel: 'Cancel'`.
+- `apps/streamdeck/src/actions.ts:672-677` (`DiffHunkNav.canvas`) — add
+  `press: 'composer-open-or-submit'`, `pressLabel: 'Open/Submit'`.
+- `apps/streamdeck/src/__tests__/actions.test.ts:198-227` — update the two canvas-mode
+  press assertions (`composer-open` → per-dial command); add a coarse-press-cancel
+  assertion; add a `renderTo`/`setFeedback` assertion that line 1 carries the pressLabel in
+  canvas mode. No new test file.
+
+Scope is `apps/streamdeck` only (requirement 4).
+
+## Risks & Alternatives Considered
+
+- **Risk: touchstrip truncation** of `Blocks · Open/Submit`. Mitigation: confirm on
+  hardware at dev-approval; documented fallback is `Blocks · Submit`. Low blast radius
+  (cosmetic, one string).
+- **Risk: mislabeling the fine press as one action** when it is contextual (open then
+  submit). Mitigation: `Open/Submit` names both states; the canvas is the sole owner of
+  open/closed state and already branches correctly (`ArtifactCanvas.tsx:957`), so the deck
+  stays stateless.
+- **Alternative: encode press meaning on line 2 (`value`) instead of line 1.** Rejected —
+  line 2 identifies the builder under review (id + title + progress bar), which a reviewer
+  needs; press meaning is a property of the dial, so it belongs with the axis label on
+  line 1.
+- **Alternative: keep one shared press and branch on `manifestId` inside `onDialDown`.**
+  Rejected — the spec-per-dial pattern already exists for rotate/tap; a `manifestId` switch
+  would be a second, inconsistent dispatch mechanism.
+- **Alternative: a dynamic touchstrip that flips the label to `Submit` once a composer is
+  open.** Rejected — the deck has no composer-open signal (canvas owns that state, #1420),
+  and adding a back-channel is out of scope (requirement 4). A static per-dial label is
+  legible enough.
+
+## Test Plan
+
+**Unit (`apps/streamdeck`, `pnpm --filter @cluesmith/codev-streamdeck test`):**
+
+- Fine dial in canvas mode: `onDialDown` sends `composer-open-or-submit` (workspace target,
+  `count: undefined`).
+- Coarse dial in canvas mode: `onDialDown` sends `composer-cancel`.
+- Diff mode press unchanged (still forwards `forward-file` / `forward-hunk`).
+- `renderTo` in canvas mode: `setFeedback` line 1 includes the dial's `pressLabel`
+  (`Open/Submit` for fine, `Cancel` for coarse); diff mode line 1 is the bare `diff.label`.
+- `check-types` + `test` green in the worktree.
+
+**Hardware (dev-approval gate — a physical Stream Deck+ session):**
+
+Sideload swap (current Elgato Plugins symlink points at the **pir-1400** worktree —
+verified `…/Plugins/com.cluesmith.codev.sdPlugin -> …/.builders/pir-1400/…`):
+
+```bash
+# from the monorepo root (main checkout)
+pnpm --filter @cluesmith/codev-sdk build
+pnpm --filter @cluesmith/codev-streamdeck build   # builds pir-1425/.../bin/plugin.js
+streamdeck unlink com.cluesmith.codev
+streamdeck link .builders/pir-1425/apps/streamdeck/com.cluesmith.codev.sdPlugin
+streamdeck restart com.cluesmith.codev
+streamdeck list                                   # confirm it points at pir-1425
+```
+
+Verify the flow from the issue:
+
+1. Navigate to a block (fine dial rotate) → touchstrip reads `Blocks · Open/Submit`.
+2. Fine press → composer opens at the focused block.
+3. Dictate into the composer (OS dictation).
+4. Fine press again → draft submits as a comment.
+5. Coarse press with a composer open → composer cancels (draft discarded).
+6. Fine press on an open-but-empty composer → nothing happens, draft/composer preserved
+   (open-or-submit trims and no-ops on empty).
+7. Touchstrip on the coarse dial reads `Headings · Cancel`; confirm neither line-1 string
+   truncates unacceptably.
+
+Restore the sideload after the gate (return the deck to the prior build):
+
+```bash
+# from the monorepo root
+streamdeck unlink com.cluesmith.codev
+streamdeck link .builders/pir-1400/apps/streamdeck/com.cluesmith.codev.sdPlugin
+streamdeck restart com.cluesmith.codev
+streamdeck list                                   # confirm restored to pir-1400
+```
+
+(If pir-1400's worktree is gone by then, relink whatever build the architect designates —
+the restore target is "the deck's prior state," confirmed with the architect at the gate.)

--- a/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
+++ b/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-08-12T10:42:45.824Z'
     approved_at: '2026-08-12T11:06:38.136Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-08-12T11:10:24.507Z'
+    approved_at: '2026-08-12T11:19:36.214Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T10:21:33.851Z'
-updated_at: '2026-08-12T11:10:24.508Z'
+updated_at: '2026-08-12T11:19:36.216Z'
 pr_history:
   - phase: review
     pr_number: 1426
     branch: builder/pir-1425
     created_at: '2026-08-12T11:07:57.075Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
+++ b/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-08-12T10:39:23.123Z'
   dev-approval:
     status: pending
+    requested_at: '2026-08-12T10:42:45.824Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T10:21:33.851Z'
-updated_at: '2026-08-12T10:39:27.964Z'
+updated_at: '2026-08-12T10:42:45.825Z'

--- a/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
+++ b/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
@@ -1,7 +1,7 @@
 id: '1425'
 title: stream-deck-map-review-dials-t
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T10:21:33.851Z'
-updated_at: '2026-08-12T11:06:38.137Z'
+updated_at: '2026-08-12T11:06:43.299Z'

--- a/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
+++ b/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T10:21:33.851Z'
-updated_at: '2026-08-12T11:06:43.299Z'
+updated_at: '2026-08-12T11:07:57.076Z'
+pr_history:
+  - phase: review
+    pr_number: 1426
+    branch: builder/pir-1425
+    created_at: '2026-08-12T11:07:57.075Z'

--- a/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
+++ b/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-08-12T10:24:36.601Z'
     approved_at: '2026-08-12T10:39:23.123Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-08-12T10:42:45.824Z'
+    approved_at: '2026-08-12T11:06:38.136Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T10:21:33.851Z'
-updated_at: '2026-08-12T10:42:45.825Z'
+updated_at: '2026-08-12T11:06:38.137Z'

--- a/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
+++ b/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
@@ -1,0 +1,18 @@
+id: '1425'
+title: stream-deck-map-review-dials-t
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-12T10:21:33.851Z'
+updated_at: '2026-08-12T10:21:33.852Z'

--- a/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
+++ b/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-08-12T10:21:33.851Z'
-updated_at: '2026-08-12T11:07:57.076Z'
+updated_at: '2026-08-12T11:08:03.699Z'
 pr_history:
   - phase: review
     pr_number: 1426

--- a/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
+++ b/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-08-12T11:06:38.136Z'
   pr:
     status: pending
+    requested_at: '2026-08-12T11:10:24.507Z'
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-08-12T10:21:33.851Z'
-updated_at: '2026-08-12T11:08:03.699Z'
+updated_at: '2026-08-12T11:10:24.508Z'
 pr_history:
   - phase: review
     pr_number: 1426
     branch: builder/pir-1425
     created_at: '2026-08-12T11:07:57.075Z'
+pr_ready_for_human: true

--- a/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
+++ b/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
@@ -1,7 +1,7 @@
 id: '1425'
 title: stream-deck-map-review-dials-t
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T10:21:33.851Z'
-updated_at: '2026-08-12T10:39:23.123Z'
+updated_at: '2026-08-12T10:39:27.964Z'

--- a/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
+++ b/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-08-12T10:24:36.601Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T10:21:33.851Z'
-updated_at: '2026-08-12T10:21:33.852Z'
+updated_at: '2026-08-12T10:24:36.602Z'

--- a/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
+++ b/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-08-12T10:24:36.601Z'
+    approved_at: '2026-08-12T10:39:23.123Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T10:21:33.851Z'
-updated_at: '2026-08-12T10:24:36.602Z'
+updated_at: '2026-08-12T10:39:23.123Z'

--- a/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
+++ b/codev/projects/1425-stream-deck-map-review-dials-t/status.yaml
@@ -1,7 +1,7 @@
 id: '1425'
 title: stream-deck-map-review-dials-t
 protocol: pir
-phase: review
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -21,7 +21,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T10:21:33.851Z'
-updated_at: '2026-08-12T11:19:36.216Z'
+updated_at: '2026-08-12T11:19:38.132Z'
 pr_history:
   - phase: review
     pr_number: 1426

--- a/codev/reviews/1425-stream-deck-map-review-dials-t.md
+++ b/codev/reviews/1425-stream-deck-map-review-dials-t.md
@@ -65,6 +65,11 @@ documented, so they stay in this review rather than in `lessons-learned.md`:
 
 ## Things to Look At During PR Review
 
+- **Consultation dispositions** (review-phase 3-way, iter 1): gemini APPROVE, claude APPROVE,
+  codex COMMENT. Codex flagged one stale source comment — the `ReviewNav` class doc still said
+  canvas presses "open the composer at the focused block," which no longer holds after the
+  per-dial remap. Fixed the comment to describe fine=open-or-submit / coarse=cancel (no
+  behavior change). No REQUEST_CHANGES from any reviewer.
 - **`renderTo` title composition** (`actions.ts`): canvas mode now emits
   `` `${label} · ${pressLabel}` ``; diff mode still emits the bare `diff.label`. Confirm the
   diff-mode path is untouched (the mode-transition test covers `Headings · Cancel` → `Files`).

--- a/codev/reviews/1425-stream-deck-map-review-dials-t.md
+++ b/codev/reviews/1425-stream-deck-map-review-dials-t.md
@@ -1,0 +1,89 @@
+# PIR Review: Map canvas review dial presses to composer-open-or-submit / composer-cancel
+
+Fixes #1425
+
+## Summary
+
+The bridge command `composer-open-or-submit` shipped on main in PR #1424 (the #1420 bridge
+lane) but nothing on the Stream Deck sent it, so the hands-free review flow did not exist on
+hardware. This PR is the deck half: in canvas/review mode the **fine** review dial press now
+sends `composer-open-or-submit` (open the composer, or submit the open draft) and the
+**coarse** dial press sends `composer-cancel`, superseding #1400's shared `composer-open`.
+The touchstrip line 1 now pairs each dial's rotate axis with its press meaning
+(`Blocks · Open/Submit`, `Headings · Cancel`) so a reviewer can tell submit from cancel at a
+glance. Changes are confined to `apps/streamdeck`.
+
+## Files Changed
+
+- `apps/streamdeck/src/actions.ts` (+21 / -5)
+- `apps/streamdeck/src/__tests__/actions.test.ts` (+13 / -10)
+
+(Plan, thread, and porch status files also travel on the branch but are not part of the
+runtime change.)
+
+## Commits
+
+- `fe813cbe3` [PIR #1425] Remap canvas review dial presses: fine open/submit, coarse cancel
+- `561123043` [PIR #1425] thread: implement phase done, at dev-approval
+
+## Test Results
+
+- `pnpm --filter @cluesmith/codev-streamdeck check-types`: ✓ pass
+- `pnpm --filter @cluesmith/codev-streamdeck test`: ✓ pass (84 tests; press/title assertions
+  updated, no net new test files — the new behavior folded into the existing canvas-press and
+  canvas-legibility tests)
+- `pnpm --filter @cluesmith/codev-streamdeck build`: ✓ pass (esbuild → `bin/plugin.js`)
+- porch `build` + `tests` checks: ✓ pass
+- Manual verification (dev-approval, physical Stream Deck+): the deck was sideloaded from
+  this lane's worktree build and the issue flow was exercised — navigate to a block, fine
+  press opens the composer, dictate, fine press submits; coarse press cancels an open
+  composer; a fine press on an open-but-empty composer is a no-op (draft preserved). Approved
+  at the dev-approval gate. Restore target after the session is a fresh main-checkout build
+  (per the plan), which frees the pir-1400 worktree for the #1176 orphan sweep.
+
+## Architecture Updates
+
+No arch changes. This is a client-side dial remap inside an existing pattern: `CanvasSpec`
+already parameterised the canvas-mode rotate/tap verbs per dial; this PR adds a `press` verb +
+`pressLabel` to the same spec. No module boundary, process boundary, or system-shape fact
+changed — nothing rises to `arch-critical.md` or `arch.md`.
+
+## Lessons Learned Updates
+
+No governance-doc edit. The two gotchas here are streamdeck-sideload-local and already
+documented, so they stay in this review rather than in `lessons-learned.md`:
+
+- **Sideload builds must run from the worktree root, not the main checkout.** `pnpm --filter
+  @cluesmith/codev-streamdeck build` resolves against the nearest pnpm workspace, so running
+  it from the main checkout builds *main's* `apps/streamdeck` and you sideload the wrong
+  `bin/plugin.js`. The plan's swap commands `cd` into the worktree first. (Consistent with the
+  existing "run tests/build from the worktree" rule.)
+- **Build the sdk dist before type-checking the plugin.** `apps/streamdeck` imports
+  `@cluesmith/codev-sdk/*`; a fresh worktree has no sdk `dist/`, so `check-types` fails to
+  resolve the module until `pnpm --filter @cluesmith/codev-sdk build` runs once. (Already in
+  `apps/streamdeck/README.md`.)
+
+## Things to Look At During PR Review
+
+- **`renderTo` title composition** (`actions.ts`): canvas mode now emits
+  `` `${label} · ${pressLabel}` ``; diff mode still emits the bare `diff.label`. Confirm the
+  diff-mode path is untouched (the mode-transition test covers `Headings · Cancel` → `Files`).
+- **Contextual label wording**: the fine dial press is `composer-open-or-submit` (open, then
+  submit), labelled `Open/Submit` rather than `Submit` to stay honest about the first press.
+- **Touchstrip width**: `Blocks · Open/Submit` (~20 chars) is the widest line-1 string. It was
+  checked on hardware at dev-approval; the pre-approved fallback if it ever clips on a
+  different layout is `Blocks · Submit`.
+- **Verb validity**: both `composer-open-or-submit` and `composer-cancel` are existing
+  `CanvasCommand` members, in the canvas-relay allowlist, and implemented in the
+  `ArtifactCanvas` action map — this PR only routes the deck to them, no bridge/canvas/types
+  change.
+
+## How to Test Locally
+
+- **View diff**: VSCode sidebar → right-click builder pir-1425 → **Review Diff**
+- **Unit**: from the worktree root, `pnpm --filter @cluesmith/codev-sdk build` then
+  `pnpm --filter @cluesmith/codev-streamdeck test`
+- **Hardware** (optional re-verify): build from the worktree root, `streamdeck unlink
+  com.cluesmith.codev`, `streamdeck link <abs path>/.builders/pir-1425/apps/streamdeck/com.cluesmith.codev.sdPlugin`,
+  `streamdeck restart com.cluesmith.codev`; then in canvas mode: fine press opens → dictate →
+  fine press submits; coarse press cancels; fine press on an empty open composer is a no-op.

--- a/codev/state/pir-1425_thread.md
+++ b/codev/state/pir-1425_thread.md
@@ -24,3 +24,18 @@ Per architect instruction (2026-08-12T10:22Z), routing dial-semantics + hardware
 sections to the architect BEFORE the plan-approval gate.
 
 Plan written to `codev/plans/1425-stream-deck-map-review-dials-t.md`. Awaiting plan-approval.
+
+### Plan review revisions (2026-08-12T10:26Z, architect)
+
+Approved with two hardware-section fixes (semantics/press-field/pressLabel/tests all
+approved as written; `Blocks · Submit` truncation fallback pre-approved):
+
+1. BUG: swap-build commands must run from the **pir-1425 worktree root**, not main —
+   `pnpm --filter` from main builds main's apps/streamdeck, sideloading stale/missing
+   `bin/plugin.js`. Rewrote with `cd` to worktree root + absolute link path.
+2. RULING: restore target is a **fresh build from the MAIN checkout** (behaviorally
+   identical to pir-1400's merged code), which becomes the deck's permanent stable link
+   and frees pir-1400 for the #1176 orphan sweep. No longer restoring to pir-1400.
+
+Both applied. Amr runs swap/restore at the gate session. Re-committed; still at
+plan-approval.

--- a/codev/state/pir-1425_thread.md
+++ b/codev/state/pir-1425_thread.md
@@ -60,3 +60,12 @@ canvas-legibility test. `check-types` clean, 84/84 tests pass, plugin builds
 
 At dev-approval — hardware session. Amr runs the sideload swap (worktree build) → verify →
 restore to main-checkout build.
+
+## REVIEW phase (2026-08-12)
+
+dev-approval approved (hardware verified). Wrote
+`codev/reviews/1425-stream-deck-map-review-dials-t.md`: no arch change (client dial remap
+inside the existing CanvasSpec pattern); no lessons-doc edit (the two sideload gotchas —
+build from worktree root, sdk dist first — are streamdeck-local and already documented, kept
+in the review). Opening PR next, recording with porch, then `porch done` triggers the single
+3-way consult pass → pr gate.

--- a/codev/state/pir-1425_thread.md
+++ b/codev/state/pir-1425_thread.md
@@ -69,3 +69,9 @@ inside the existing CanvasSpec pattern); no lessons-doc edit (the two sideload g
 build from worktree root, sdk dist first — are streamdeck-local and already documented, kept
 in the review). Opening PR next, recording with porch, then `porch done` triggers the single
 3-way consult pass → pr gate.
+
+PR #1426 opened (Fixes #1425), recorded via porch. 3-way consult (iter1): gemini APPROVE,
+claude APPROVE, codex COMMENT. Codex's one COMMENT = stale ReviewNav class doc comment
+("press opens the composer") no longer true after the remap; fixed the comment in 3d7765ec7
+(no behavior change), noted in review "Things to Look At". No REQUEST_CHANGES. At the pr gate
+awaiting human merge.

--- a/codev/state/pir-1425_thread.md
+++ b/codev/state/pir-1425_thread.md
@@ -1,0 +1,26 @@
+# Builder thread — pir-1425
+
+**Issue #1425**: Stream Deck — map review dials to composer-open-or-submit /
+composer-cancel (deck half of #1420). Protocol: PIR (hardware verification before PR).
+Refs #1420, PR #1424 (bridge lane, merged).
+
+## PLAN phase (2026-08-12)
+
+Investigated `apps/streamdeck/src/actions.ts`. The two canvas-mode review dials share one
+press handler (`ReviewNav.onDialDown`) that hardcodes `composer-open` — the #1400 decision
+this issue supersedes. `CanvasSpec` has no press field on purpose (press was identical).
+
+Plan: add `press: CanvasCommand` + `pressLabel: string` to `CanvasSpec`; fine dial
+(`DiffHunkNav`, Blocks) → `composer-open-or-submit`, coarse dial (`DiffFileNav`, Headings)
+→ `composer-cancel`. Touchstrip line 1 becomes `${label} · ${pressLabel}` in canvas mode
+(`Blocks · Open/Submit`, `Headings · Cancel`); line 2 keeps builder identity. Both commands
+already exist in `CanvasCommand`, the canvas-relay allowlist, and `ArtifactCanvas` action
+map — deck-only remap, no bridge/canvas/types/host change (requirement 4).
+
+Verified the Elgato Plugins symlink currently points at the **pir-1400** worktree, so the
+plan covers the sideload swap to pir-1425 for dev-approval and restoring the link after.
+
+Per architect instruction (2026-08-12T10:22Z), routing dial-semantics + hardware-verification
+sections to the architect BEFORE the plan-approval gate.
+
+Plan written to `codev/plans/1425-stream-deck-map-review-dials-t.md`. Awaiting plan-approval.

--- a/codev/state/pir-1425_thread.md
+++ b/codev/state/pir-1425_thread.md
@@ -39,3 +39,24 @@ approved as written; `Blocks · Submit` truncation fallback pre-approved):
 
 Both applied. Amr runs swap/restore at the gate session. Re-committed; still at
 plan-approval.
+
+## IMPLEMENT phase (2026-08-12)
+
+Plan approved. Implemented in `apps/streamdeck/src/actions.ts` (commit fe813cbe3):
+- `CanvasSpec` gained `press: CanvasCommand` + `pressLabel: string` (doc comment rewritten;
+  the "press is always composer-open, shared" rationale is gone).
+- `onDialDown` canvas branch sends `this.canvas.press`.
+- `renderTo` canvas-mode line 1 = `${label} · ${pressLabel}`; diff mode unchanged.
+- Fine (`DiffHunkNav`): `composer-open-or-submit` / `Open/Submit`. Coarse (`DiffFileNav`):
+  `composer-cancel` / `Cancel`.
+
+Tests: updated the two canvas-press assertions + both legibility/title tests to the new
+`Headings · Cancel` / `Blocks · Open/Submit` titles (three pre-existing tests asserted the
+bare titles). Did NOT add a redundant new title test — folded it into the existing
+canvas-legibility test. `check-types` clean, 84/84 tests pass, plugin builds
+(`bin/plugin.js` is gitignored, rebuilt at sideload). Note: had to build the sdk dist first
+(`pnpm --filter @cluesmith/codev-sdk build`) or the streamdeck check-types can't resolve
+`@cluesmith/codev-sdk/*`.
+
+At dev-approval — hardware session. Amr runs the sideload swap (worktree build) → verify →
+restore to main-checkout build.


### PR DESCRIPTION
# PIR Review: Map canvas review dial presses to composer-open-or-submit / composer-cancel

Fixes #1425

## Summary

The bridge command `composer-open-or-submit` shipped on main in PR #1424 (the #1420 bridge
lane) but nothing on the Stream Deck sent it, so the hands-free review flow did not exist on
hardware. This PR is the deck half: in canvas/review mode the **fine** review dial press now
sends `composer-open-or-submit` (open the composer, or submit the open draft) and the
**coarse** dial press sends `composer-cancel`, superseding #1400's shared `composer-open`.
The touchstrip line 1 now pairs each dial's rotate axis with its press meaning
(`Blocks · Open/Submit`, `Headings · Cancel`) so a reviewer can tell submit from cancel at a
glance. Changes are confined to `apps/streamdeck`.

## Files Changed

- `apps/streamdeck/src/actions.ts` (+21 / -5)
- `apps/streamdeck/src/__tests__/actions.test.ts` (+13 / -10)

(Plan, thread, and porch status files also travel on the branch but are not part of the
runtime change.)

## Commits

- `fe813cbe3` [PIR #1425] Remap canvas review dial presses: fine open/submit, coarse cancel
- `561123043` [PIR #1425] thread: implement phase done, at dev-approval

## Test Results

- `pnpm --filter @cluesmith/codev-streamdeck check-types`: ✓ pass
- `pnpm --filter @cluesmith/codev-streamdeck test`: ✓ pass (84 tests; press/title assertions
  updated, no net new test files — the new behavior folded into the existing canvas-press and
  canvas-legibility tests)
- `pnpm --filter @cluesmith/codev-streamdeck build`: ✓ pass (esbuild → `bin/plugin.js`)
- porch `build` + `tests` checks: ✓ pass
- Manual verification (dev-approval, physical Stream Deck+): the deck was sideloaded from
  this lane's worktree build and the issue flow was exercised — navigate to a block, fine
  press opens the composer, dictate, fine press submits; coarse press cancels an open
  composer; a fine press on an open-but-empty composer is a no-op (draft preserved). Approved
  at the dev-approval gate. Restore target after the session is a fresh main-checkout build
  (per the plan), which frees the pir-1400 worktree for the #1176 orphan sweep.

## Architecture Updates

No arch changes. This is a client-side dial remap inside an existing pattern: `CanvasSpec`
already parameterised the canvas-mode rotate/tap verbs per dial; this PR adds a `press` verb +
`pressLabel` to the same spec. No module boundary, process boundary, or system-shape fact
changed — nothing rises to `arch-critical.md` or `arch.md`.

## Lessons Learned Updates

No governance-doc edit. The two gotchas here are streamdeck-sideload-local and already
documented, so they stay in this review rather than in `lessons-learned.md`:

- **Sideload builds must run from the worktree root, not the main checkout.** `pnpm --filter
  @cluesmith/codev-streamdeck build` resolves against the nearest pnpm workspace, so running
  it from the main checkout builds *main's* `apps/streamdeck` and you sideload the wrong
  `bin/plugin.js`. The plan's swap commands `cd` into the worktree first. (Consistent with the
  existing "run tests/build from the worktree" rule.)
- **Build the sdk dist before type-checking the plugin.** `apps/streamdeck` imports
  `@cluesmith/codev-sdk/*`; a fresh worktree has no sdk `dist/`, so `check-types` fails to
  resolve the module until `pnpm --filter @cluesmith/codev-sdk build` runs once. (Already in
  `apps/streamdeck/README.md`.)

## Things to Look At During PR Review

- **`renderTo` title composition** (`actions.ts`): canvas mode now emits
  `` `${label} · ${pressLabel}` ``; diff mode still emits the bare `diff.label`. Confirm the
  diff-mode path is untouched (the mode-transition test covers `Headings · Cancel` → `Files`).
- **Contextual label wording**: the fine dial press is `composer-open-or-submit` (open, then
  submit), labelled `Open/Submit` rather than `Submit` to stay honest about the first press.
- **Touchstrip width**: `Blocks · Open/Submit` (~20 chars) is the widest line-1 string. It was
  checked on hardware at dev-approval; the pre-approved fallback if it ever clips on a
  different layout is `Blocks · Submit`.
- **Verb validity**: both `composer-open-or-submit` and `composer-cancel` are existing
  `CanvasCommand` members, in the canvas-relay allowlist, and implemented in the
  `ArtifactCanvas` action map — this PR only routes the deck to them, no bridge/canvas/types
  change.

## How to Test Locally

- **View diff**: VSCode sidebar → right-click builder pir-1425 → **Review Diff**
- **Unit**: from the worktree root, `pnpm --filter @cluesmith/codev-sdk build` then
  `pnpm --filter @cluesmith/codev-streamdeck test`
- **Hardware** (optional re-verify): build from the worktree root, `streamdeck unlink
  com.cluesmith.codev`, `streamdeck link <abs path>/.builders/pir-1425/apps/streamdeck/com.cluesmith.codev.sdPlugin`,
  `streamdeck restart com.cluesmith.codev`; then in canvas mode: fine press opens → dictate →
  fine press submits; coarse press cancels; fine press on an empty open composer is a no-op.
