### PR TITLE
Sort Recently Closed sidebar section by closedAt descending (#1191)

### DIFF
--- a/codev/plans/1191-recently-closed-sidebar-sectio.md
+++ b/codev/plans/1191-recently-closed-sidebar-sectio.md
@@ -1,0 +1,85 @@
+# PIR Plan: Sort Recently Closed by closedAt descending
+
+## Understanding
+
+The **Recently Closed** section in the Codev sidebar lists items in whatever order the
+forge returns them. For GitHub that order is the search API's default relevance ("best
+match") ranking, not closure time — verified empirically in the issue: an item closed at
+08:00Z today renders *below* items closed the previous day.
+
+**Root cause.** No layer in the chain imposes an ordering:
+
+- `packages/codev/scripts/forge/github/recently-closed.sh` runs
+  `gh issue list --state closed --search "closed:>$SINCE"`; `--search` delegates to
+  GitHub's search API, whose default sort is relevance.
+- `fetchRecentlyClosed` (`packages/codev/src/lib/github.ts:210-218`) filters to the 24h
+  window but does not reorder.
+- `overview.ts` (`packages/codev/src/agent-farm/servers/overview.ts:963-985`) maps the
+  fetched list into `OverviewRecentlyClosed[]` **in fetched order**, preserving it.
+- `apps/vscode/src/views/recently-closed.ts` renders `data.recentlyClosed` as-is.
+
+`closedAt` is already an ISO-8601 string on every closed item
+(`ClosedIssue.closedAt: string` — `packages/codev/src/lib/github.ts:266`; and on the
+output type `OverviewRecentlyClosed.closedAt: string` —
+`packages/types/src/api.ts:282`), for every forge. So a single sort at the assembly point
+fixes ordering for all forges at once.
+
+## Proposed Change
+
+Sort the assembled `recentlyClosed` array by `closedAt` **descending** (most recently
+closed first) in `overview.ts`, immediately after the `.map()` that builds it and before
+it is placed on the `OverviewData` result.
+
+Sort using parsed timestamps (`new Date(x.closedAt).getTime()`) rather than lexicographic
+string comparison. ISO-8601 UTC strings do sort correctly lexicographically, but the forge
+scripts are provider-specific and not guaranteed to emit a normalized `Z`-suffixed form for
+every forge (gitlab/gitea/linear); parsing to epoch millis is unambiguous and matches how
+the 24h-window filter already interprets `closedAt`
+(`github.ts:216` uses `new Date(i.closedAt).getTime()`).
+
+This is product code in `packages/codev` (the server that assembles the overview), not a
+framework template file, so there is **no** `codev-skeleton/` twin to mirror.
+
+## Files to Change
+
+- `packages/codev/src/agent-farm/servers/overview.ts:985` — after the
+  `recentlyClosed = closed.map(...)` block (inside `if (closed !== null)`), append
+  `recentlyClosed.sort((a, b) => new Date(b.closedAt).getTime() - new Date(a.closedAt).getTime());`
+  with a short comment explaining the forge search APIs return relevance order, not
+  closure order (issue #1191).
+- `packages/codev/src/agent-farm/__tests__/overview.test.ts` — add a test that mocks
+  `fetchRecentlyClosed` with items whose `closedAt` values are deliberately out of order
+  and asserts `data.recentlyClosed` comes back in descending `closedAt` order.
+
+## Risks & Alternatives Considered
+
+- **Risk:** an item with a malformed/absent `closedAt` would parse to `NaN` and sort
+  unpredictably. Mitigation: `fetchRecentlyClosed` already filters on
+  `i.closedAt && new Date(i.closedAt).getTime() >= cutoff`, so any item reaching this
+  point has a valid, parseable `closedAt`. No extra guarding needed.
+- **Alternative — patch each forge script with a `sort:` qualifier
+  (`--search "... sort:updated"` etc.):** rejected. It multiplies the fix across four
+  provider scripts (github/gitlab/gitea/linear), each with different sort grammar, and
+  GitHub's search `sort:` options don't include a true `closed`-time sort anyway (only
+  created/updated/comments). Sorting on the already-present `closedAt` field in the shared
+  assembly layer is one change that is correct for every forge.
+- **Alternative — sort in the VS Code view (`recently-closed.ts`):** rejected. The view is
+  a presentation layer; ordering the data at the server keeps every consumer (view, any
+  future API client) consistent and matches where the data is shaped.
+
+## Test Plan
+
+- **Unit test** (`overview.test.ts`): mock `fetchRecentlyClosed` to return three items with
+  `closedAt` timestamps in non-descending order (e.g. yesterday, today-08:00Z,
+  two-days-ago). Assert `data.recentlyClosed.map(i => i.id)` equals the ids in
+  most-recent-first order. Run:
+  `pnpm --filter @cluesmith/codev test overview` (from the worktree).
+- **Regression:** existing `overview.test.ts` recentlyClosed cases must still pass (they
+  use single-item or find-by-id assertions, so order-agnostic).
+- **Manual (dev-approval gate):** run the worktree, open the Codev sidebar → Recently
+  Closed section, confirm items are ordered most-recently-closed first (the item closed
+  earliest today appears above yesterday's). The reviewer can compare against
+  `gh issue list --state closed --search "closed:>$(date -u -v-1d +%Y-%m-%dT%H:%M:%SZ)"`
+  sorted by `closedAt`.
+- **Cross-forge:** logic is forge-agnostic (operates on the normalized `closedAt` field);
+  no per-forge manual verification required.

--- a/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
+++ b/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-08-12T11:08:32.823Z'
   dev-approval:
     status: pending
+    requested_at: '2026-08-12T11:10:48.472Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T11:03:50.931Z'
-updated_at: '2026-08-12T11:08:37.509Z'
+updated_at: '2026-08-12T11:10:48.472Z'

--- a/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
+++ b/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
@@ -1,7 +1,7 @@
 id: '1191'
 title: recently-closed-sidebar-sectio
 protocol: pir
-phase: review
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -21,7 +21,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T11:03:50.931Z'
-updated_at: '2026-08-12T11:19:54.134Z'
+updated_at: '2026-08-12T11:20:20.093Z'
 pr_history:
   - phase: review
     pr_number: 1427

--- a/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
+++ b/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-08-12T11:05:25.127Z'
     approved_at: '2026-08-12T11:08:32.823Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-08-12T11:10:48.472Z'
+    approved_at: '2026-08-12T11:14:14.432Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T11:03:50.931Z'
-updated_at: '2026-08-12T11:10:48.472Z'
+updated_at: '2026-08-12T11:14:14.432Z'

--- a/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
+++ b/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
@@ -1,0 +1,18 @@
+id: '1191'
+title: recently-closed-sidebar-sectio
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-12T11:03:50.931Z'
+updated_at: '2026-08-12T11:03:50.932Z'

--- a/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
+++ b/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
@@ -1,7 +1,7 @@
 id: '1191'
 title: recently-closed-sidebar-sectio
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T11:03:50.931Z'
-updated_at: '2026-08-12T11:14:14.432Z'
+updated_at: '2026-08-12T11:14:19.092Z'

--- a/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
+++ b/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-08-12T11:10:48.472Z'
     approved_at: '2026-08-12T11:14:14.432Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-08-12T11:17:47.062Z'
+    approved_at: '2026-08-12T11:19:54.133Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T11:03:50.931Z'
-updated_at: '2026-08-12T11:17:47.063Z'
+updated_at: '2026-08-12T11:19:54.134Z'
 pr_history:
   - phase: review
     pr_number: 1427
     branch: builder/pir-1191
     created_at: '2026-08-12T11:15:06.405Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
+++ b/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T11:03:50.931Z'
-updated_at: '2026-08-12T11:14:19.092Z'
+updated_at: '2026-08-12T11:15:06.406Z'
+pr_history:
+  - phase: review
+    pr_number: 1427
+    branch: builder/pir-1191
+    created_at: '2026-08-12T11:15:06.405Z'

--- a/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
+++ b/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-08-12T11:03:50.931Z'
-updated_at: '2026-08-12T11:15:06.406Z'
+updated_at: '2026-08-12T11:15:12.207Z'
 pr_history:
   - phase: review
     pr_number: 1427

--- a/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
+++ b/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-08-12T11:14:14.432Z'
   pr:
     status: pending
+    requested_at: '2026-08-12T11:17:47.062Z'
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-08-12T11:03:50.931Z'
-updated_at: '2026-08-12T11:15:12.207Z'
+updated_at: '2026-08-12T11:17:47.063Z'
 pr_history:
   - phase: review
     pr_number: 1427
     branch: builder/pir-1191
     created_at: '2026-08-12T11:15:06.405Z'
+pr_ready_for_human: true

--- a/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
+++ b/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
@@ -1,7 +1,7 @@
 id: '1191'
 title: recently-closed-sidebar-sectio
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T11:03:50.931Z'
-updated_at: '2026-08-12T11:08:32.824Z'
+updated_at: '2026-08-12T11:08:37.509Z'

--- a/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
+++ b/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-08-12T11:05:25.127Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T11:03:50.931Z'
-updated_at: '2026-08-12T11:03:50.932Z'
+updated_at: '2026-08-12T11:05:25.127Z'

--- a/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
+++ b/codev/projects/1191-recently-closed-sidebar-sectio/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-08-12T11:05:25.127Z'
+    approved_at: '2026-08-12T11:08:32.823Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T11:03:50.931Z'
-updated_at: '2026-08-12T11:05:25.127Z'
+updated_at: '2026-08-12T11:08:32.824Z'

--- a/codev/reviews/1191-recently-closed-sidebar-sectio.md
+++ b/codev/reviews/1191-recently-closed-sidebar-sectio.md
@@ -1,0 +1,58 @@
+# PIR Review: Sort Recently Closed by closedAt descending
+
+Fixes #1191
+
+## Summary
+
+The Codev sidebar's **Recently Closed** section listed items in the forge search API's
+relevance ("best match") order, so an item closed this morning could render below one closed
+the previous day. This PR sorts the assembled `recentlyClosed` list by `closedAt` descending
+in the shared overview-assembly layer (`overview.ts`), fixing ordering for every forge at
+once since `closedAt` is present on every item.
+
+## Files Changed
+
+- `packages/codev/src/agent-farm/servers/overview.ts` (+9 / -0) — sort `recentlyClosed` by `closedAt` descending after assembly
+- `packages/codev/src/agent-farm/__tests__/overview.test.ts` (+17 / -0) — regression test asserting descending order from an out-of-order fixture
+
+## Commits
+
+- `da7a44f86` [PIR #1191] Sort Recently Closed by closedAt descending
+- `b33ac8f4c` [PIR #1191] thread: implement phase
+
+## Test Results
+
+- `pnpm --filter @cluesmith/codev build`: ✓ pass
+- `pnpm --filter @cluesmith/codev test`: ✓ pass (4851 passed, 48 pre-existing skips; 1 new test)
+- Manual verification: reviewer approved at the `dev-approval` gate.
+
+## Architecture Updates
+
+No arch changes — this is a localized ordering fix at an existing assembly point. It does not
+change module boundaries, the forge abstraction, or any invariant. The fact that ordering
+belongs in the shared assembly layer (not per-forge scripts) is already implied by the
+existing single-assembly design.
+
+## Lessons Learned Updates
+
+No lessons captured — the change was a mechanical, well-scoped fix. The one reusable insight
+(sort shared, forge-normalized fields in the assembly layer rather than patching each
+provider script) is a narrow recipe, not a cross-cutting rule worth a hot/cold entry.
+
+## Things to Look At During PR Review
+
+- The sort parses `closedAt` to epoch millis (`new Date(x.closedAt).getTime()`) rather than
+  comparing ISO strings lexicographically. Deliberate: provider scripts
+  (github/gitlab/gitea/linear) aren't guaranteed to emit a normalized `Z`-suffixed form, and
+  this matches how the existing 24h-window filter (`github.ts:216`) interprets `closedAt`.
+- No `NaN` guarding: every item reaching the sort has already passed
+  `fetchRecentlyClosed`'s `i.closedAt && new Date(i.closedAt).getTime() >= cutoff` filter, so
+  `closedAt` is always present and parseable here.
+
+## How to Test Locally
+
+- **View diff**: VSCode sidebar → right-click builder pir-1191 → **Review Diff**
+- **Run dev**: VSCode sidebar → **Run Dev**, or `afx dev pir-1191`
+- **What to verify**: open the Codev sidebar → **Recently Closed**; items appear
+  most-recently-closed first (an item closed this morning sits above yesterday's). Compare
+  against `gh issue list --state closed --search "closed:>$(date -u -v-1d +%Y-%m-%dT%H:%M:%SZ)"`.

--- a/codev/reviews/1191-recently-closed-sidebar-sectio.md
+++ b/codev/reviews/1191-recently-closed-sidebar-sectio.md
@@ -12,8 +12,8 @@ once since `closedAt` is present on every item.
 
 ## Files Changed
 
-- `packages/codev/src/agent-farm/servers/overview.ts` (+9 / -0) — sort `recentlyClosed` by `closedAt` descending after assembly
-- `packages/codev/src/agent-farm/__tests__/overview.test.ts` (+17 / -0) — regression test asserting descending order from an out-of-order fixture
+- `packages/codev/src/agent-farm/servers/overview.ts` (+9 / -0): sort `recentlyClosed` by `closedAt` descending after assembly
+- `packages/codev/src/agent-farm/__tests__/overview.test.ts` (+17 / -0): regression test asserting descending order from an out-of-order fixture
 
 ## Commits
 
@@ -24,18 +24,18 @@ once since `closedAt` is present on every item.
 
 - `pnpm --filter @cluesmith/codev build`: ✓ pass
 - `pnpm --filter @cluesmith/codev test`: ✓ pass (4851 passed, 48 pre-existing skips; 1 new test)
-- Manual verification: reviewer approved at the `dev-approval` gate.
+- Manual verification: the running worktree was reviewed and the `dev-approval` gate was granted.
 
 ## Architecture Updates
 
-No arch changes — this is a localized ordering fix at an existing assembly point. It does not
+No arch changes: this is a localized ordering fix at an existing assembly point. It does not
 change module boundaries, the forge abstraction, or any invariant. The fact that ordering
 belongs in the shared assembly layer (not per-forge scripts) is already implied by the
 existing single-assembly design.
 
 ## Lessons Learned Updates
 
-No lessons captured — the change was a mechanical, well-scoped fix. The one reusable insight
+No lessons captured: the change was a mechanical, well-scoped fix. The one reusable insight
 (sort shared, forge-normalized fields in the assembly layer rather than patching each
 provider script) is a narrow recipe, not a cross-cutting rule worth a hot/cold entry.
 

--- a/codev/state/pir-1191_thread.md
+++ b/codev/state/pir-1191_thread.md
@@ -32,5 +32,9 @@ skips). Committed da7a44f86. dev-approval gate reached.
 ## Review phase (2026-08-12)
 
 dev-approval granted. Wrote retrospective `codev/reviews/1191-recently-closed-sidebar-sectio.md`.
-No arch/lessons updates (mechanical localized fix). Opening PR next, then porch runs the
-single 3-way consultation pass and fires the pr gate.
+No arch/lessons updates (mechanical localized fix). Opened PR #1427, recorded with porch.
+
+3-way consultation (single pass): gemini APPROVE, codex APPROVE, claude APPROVE (all HIGH).
+Claude flagged two non-blocking nits: em dashes (standing project preference) and a
+pre-emptive "reviewer approved" line. Fixed both in e31765f15 (did NOT re-run porch done, so
+no re-consult). pr gate now pending — awaiting human merge.

--- a/codev/state/pir-1191_thread.md
+++ b/codev/state/pir-1191_thread.md
@@ -18,3 +18,13 @@ Existing test harness in `overview.test.ts` mocks `fetchRecentlyClosed` — will
 an out-of-order fixture asserting descending order.
 
 Plan written and committed. Awaiting plan-approval gate.
+
+## Implement phase (2026-08-12)
+
+Plan-approval granted. Applied the one-line sort in `overview.ts` (after the
+`recentlyClosed.map`, inside `if (closed !== null)`): epoch-millis descending sort with a
+comment tying it to #1191. Added test `sorts recently closed items by closedAt descending
+(#1191)` in `overview.test.ts` feeding items out of order and asserting `['2','3','1']`.
+
+Build ✓. overview suite ✓ (165 tests). Running full package suite before committing.
+Awaiting dev-approval gate next.

--- a/codev/state/pir-1191_thread.md
+++ b/codev/state/pir-1191_thread.md
@@ -1,0 +1,20 @@
+# Builder pir-1191 — Recently Closed sorted by recency (Issue #1191)
+
+## Plan phase (2026-08-12)
+
+Investigated the chain: forge script `gh issue list --search` returns relevance order →
+`fetchRecentlyClosed` filters the 24h window but doesn't reorder → `overview.ts` maps in
+fetched order → VS Code view renders as-is. Confirmed `closedAt` is an ISO string on both
+`ClosedIssue` (github.ts:266) and the output `OverviewRecentlyClosed` (api.ts:282), present
+on every forge's items.
+
+Decision: sort by `closedAt` descending once, at the assembly point in `overview.ts`
+(after the `.map`, ~line 985). One change, correct for all forges, no `codev-skeleton/`
+twin (product code, not framework template). Chose epoch-millis sort (`new Date().getTime()`)
+over lexicographic to stay robust to non-normalized forge timestamps, matching the existing
+24h-filter comparison.
+
+Existing test harness in `overview.test.ts` mocks `fetchRecentlyClosed` — will extend with
+an out-of-order fixture asserting descending order.
+
+Plan written and committed. Awaiting plan-approval gate.

--- a/codev/state/pir-1191_thread.md
+++ b/codev/state/pir-1191_thread.md
@@ -26,5 +26,11 @@ Plan-approval granted. Applied the one-line sort in `overview.ts` (after the
 comment tying it to #1191. Added test `sorts recently closed items by closedAt descending
 (#1191)` in `overview.test.ts` feeding items out of order and asserting `['2','3','1']`.
 
-Build ✓. overview suite ✓ (165 tests). Running full package suite before committing.
-Awaiting dev-approval gate next.
+Build ✓. overview suite ✓ (165 tests). Full package suite ✓ (4851 passed, 48 pre-existing
+skips). Committed da7a44f86. dev-approval gate reached.
+
+## Review phase (2026-08-12)
+
+dev-approval granted. Wrote retrospective `codev/reviews/1191-recently-closed-sidebar-sectio.md`.
+No arch/lessons updates (mechanical localized fix). Opening PR next, then porch runs the
+single 3-way consultation pass and fires the pr gate.

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -2169,6 +2169,23 @@ describe('overview', () => {
       expect(item200.prUrl).toBeUndefined();
     });
 
+    it('sorts recently closed items by closedAt descending (#1191)', async () => {
+      // Forge search APIs return relevance order, not closure order. Feed the
+      // items deliberately out of order and assert they come back most-recent-first.
+      const now = Date.now();
+      const hour = 60 * 60 * 1000;
+      mockFetchRecentlyClosed.mockResolvedValue([
+        { number: 1, title: 'Closed yesterday', url: 'https://github.com/org/repo/issues/1', labels: [], createdAt: '2026-01-01T00:00:00Z', closedAt: new Date(now - 20 * hour).toISOString() },
+        { number: 2, title: 'Closed this morning', url: 'https://github.com/org/repo/issues/2', labels: [], createdAt: '2026-01-01T00:00:00Z', closedAt: new Date(now - 1 * hour).toISOString() },
+        { number: 3, title: 'Closed midday', url: 'https://github.com/org/repo/issues/3', labels: [], createdAt: '2026-01-01T00:00:00Z', closedAt: new Date(now - 8 * hour).toISOString() },
+      ]);
+
+      const cache = new OverviewCache();
+      const data = await cache.getOverview(tmpDir);
+
+      expect(data.recentlyClosed.map(i => i.id)).toEqual(['2', '3', '1']);
+    });
+
     it('enriches recently closed items with spec/plan/review paths (Bugfix #465)', async () => {
       createSpecFile(tmpDir, 42, 'my-feature');
       createPlanFile(tmpDir, 42, 'my-feature');

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -977,7 +977,7 @@ export class OverviewCache {
       });
 
       // Forge search APIs return relevance ("best match") order, not closure
-      // order, so sort most-recently-closed first here — one fix for every
+      // order, so sort most-recently-closed first here: one fix for every
       // forge, since `closedAt` is present on every item (issue #1191). Parse to
       // epoch millis rather than compare strings: provider scripts aren't
       // guaranteed to emit a normalized ISO form, matching the 24h-window filter.

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -975,6 +975,15 @@ export class OverviewCache {
         if (reviewFile) item.reviewPath = `codev/reviews/${reviewFile}`;
         return item;
       });
+
+      // Forge search APIs return relevance ("best match") order, not closure
+      // order, so sort most-recently-closed first here — one fix for every
+      // forge, since `closedAt` is present on every item (issue #1191). Parse to
+      // epoch millis rather than compare strings: provider scripts aren't
+      // guaranteed to emit a normalized ISO form, matching the 24h-window filter.
+      recentlyClosed.sort(
+        (a, b) => new Date(b.closedAt).getTime() - new Date(a.closedAt).getTime(),
+      );
     }
 
     // `architects` defaults to `[]` here — the filesystem/git-derived overview


### PR DESCRIPTION
# PIR Review: Sort Recently Closed by closedAt descending

Fixes #1191

## Summary

The Codev sidebar's **Recently Closed** section listed items in the forge search API's
relevance ("best match") order, so an item closed this morning could render below one closed
the previous day. This PR sorts the assembled `recentlyClosed` list by `closedAt` descending
in the shared overview-assembly layer (`overview.ts`), fixing ordering for every forge at
once since `closedAt` is present on every item.

## Files Changed

- `packages/codev/src/agent-farm/servers/overview.ts` (+9 / -0) — sort `recentlyClosed` by `closedAt` descending after assembly
- `packages/codev/src/agent-farm/__tests__/overview.test.ts` (+17 / -0) — regression test asserting descending order from an out-of-order fixture

## Commits

- `da7a44f86` [PIR #1191] Sort Recently Closed by closedAt descending
- `b33ac8f4c` [PIR #1191] thread: implement phase

## Test Results

- `pnpm --filter @cluesmith/codev build`: ✓ pass
- `pnpm --filter @cluesmith/codev test`: ✓ pass (4851 passed, 48 pre-existing skips; 1 new test)
- Manual verification: reviewer approved at the `dev-approval` gate.

## Architecture Updates

No arch changes — this is a localized ordering fix at an existing assembly point. It does not
change module boundaries, the forge abstraction, or any invariant. The fact that ordering
belongs in the shared assembly layer (not per-forge scripts) is already implied by the
existing single-assembly design.

## Lessons Learned Updates

No lessons captured — the change was a mechanical, well-scoped fix. The one reusable insight
(sort shared, forge-normalized fields in the assembly layer rather than patching each
provider script) is a narrow recipe, not a cross-cutting rule worth a hot/cold entry.

## Things to Look At During PR Review

- The sort parses `closedAt` to epoch millis (`new Date(x.closedAt).getTime()`) rather than
  comparing ISO strings lexicographically. Deliberate: provider scripts
  (github/gitlab/gitea/linear) aren't guaranteed to emit a normalized `Z`-suffixed form, and
  this matches how the existing 24h-window filter (`github.ts:216`) interprets `closedAt`.
- No `NaN` guarding: every item reaching the sort has already passed
  `fetchRecentlyClosed`'s `i.closedAt && new Date(i.closedAt).getTime() >= cutoff` filter, so
  `closedAt` is always present and parseable here.

## How to Test Locally

- **View diff**: VSCode sidebar → right-click builder pir-1191 → **Review Diff**
- **Run dev**: VSCode sidebar → **Run Dev**, or `afx dev pir-1191`
- **What to verify**: open the Codev sidebar → **Recently Closed**; items appear
  most-recently-closed first (an item closed this morning sits above yesterday's). Compare
  against `gh issue list --state closed --search "closed:>$(date -u -v-1d +%Y-%m-%dT%H:%M:%SZ)"`.
