### PR TITLE
Stream Deck: composite, state-coded key faces (Builder Action + Gates)

### DIFF
--- a/apps/streamdeck/src/__tests__/actions.test.ts
+++ b/apps/streamdeck/src/__tests__/actions.test.ts
@@ -207,6 +207,19 @@ describe('ApproveGate', () => {
     expect(ctx.sent).toHaveLength(0);
     expect(ev.action.showAlert).toHaveBeenCalled();
   });
+
+  it('renders a composite Gates face (count + label under a bell), not a title over the icon', () => {
+    const ctx = makeStore(); // pir-1 blocked → 1 pending gate
+    const key = { id: 'G', isKey: () => true, setImage: vi.fn(), setTitle: vi.fn() };
+    new ApproveGate(ctx.store).onWillAppear({ action: key, payload: {} } as never);
+    const arg = String(key.setImage.mock.calls.at(-1)?.[0] ?? '');
+    expect(arg.startsWith('data:image/svg+xml;base64,')).toBe(true);
+    const face = Buffer.from(arg.slice('data:image/svg+xml;base64,'.length), 'base64').toString('utf8');
+    expect(face).toContain('Gates');
+    expect(face).toContain('>1<'); // the pending count
+    expect(face).toContain('#cca700'); // pending → warning yellow
+    expect(key.setTitle).toHaveBeenCalledWith(''); // title layer suppressed
+  });
 });
 
 describe('encoders', () => {

--- a/apps/streamdeck/src/__tests__/actions.test.ts
+++ b/apps/streamdeck/src/__tests__/actions.test.ts
@@ -130,7 +130,7 @@ describe('slot keys', () => {
 
   // One SingletonAction instance serves every key of its type — these guard the
   // per-instance fix (without it, all keys collided on shared state).
-  const slotKey = (id: string) => ({ id, isKey: () => true, setTitle: vi.fn() });
+  const slotKey = (id: string) => ({ id, isKey: () => true, setImage: vi.fn(), setTitle: vi.fn() });
 
   it('renders each slot key against its own slot (different slots → different builders)', () => {
     const ctx = makeStore(); // pir-1 (#101), pir-2 (#102)
@@ -139,19 +139,34 @@ describe('slot keys', () => {
     const b = slotKey('B');
     ba.onWillAppear({ action: a, payload: { settings: { slot: '1' } } } as never);
     ba.onWillAppear({ action: b, payload: { settings: { slot: '2' } } } as never);
-    expect(a.setTitle).toHaveBeenLastCalledWith(expect.stringContaining('#101'));
-    expect(b.setTitle).toHaveBeenLastCalledWith(expect.stringContaining('#102'));
+    // The face is now a composite SVG handed to setImage (not a title).
+    expect(a.setImage).toHaveBeenLastCalledWith(expect.stringContaining('#101'));
+    expect(b.setImage).toHaveBeenLastCalledWith(expect.stringContaining('#102'));
   });
 
-  it('renders the builder’s phase/blocked on a second line (live tile, merged from Fleet Slot)', () => {
-    const ctx = makeStore(); // pir-1 blocked "plan review", pir-2 phase "implement"
+  it('renders the builder’s state as a colour-coded, mapped face (mirrors the sidebar)', () => {
+    const ctx = makeStore(); // pir-1 blocked plan-approval, pir-2 phase "implement"
     const ba = new BuilderAction(ctx.store);
     const a = slotKey('A');
     const b = slotKey('B');
     ba.onWillAppear({ action: a, payload: { settings: { slot: '1' } } } as never);
     ba.onWillAppear({ action: b, payload: { settings: { slot: '2' } } } as never);
-    expect(a.setTitle).toHaveBeenLastCalledWith(expect.stringContaining('plan review')); // blocked label wins
-    expect(b.setTitle).toHaveBeenLastCalledWith(expect.stringContaining('implement')); // else the phase
+    // Blocked at plan-approval → mapped label "Plan" in warning yellow (not the wire "plan review").
+    const aSvg = a.setImage.mock.calls.at(-1)?.[0] as string;
+    expect(aSvg).toContain('>Plan<');
+    expect(aSvg).toContain('#cca700');
+    // Active → phase label "Implement" in green.
+    const bSvg = b.setImage.mock.calls.at(-1)?.[0] as string;
+    expect(bSvg).toContain('>Implement<');
+    expect(bSvg).toContain('#73c991');
+  });
+
+  it('renders the empty-slot face when no builder occupies the slot', () => {
+    const ctx = makeStore(); // only 2 builders → slot 5 is empty
+    const ba = new BuilderAction(ctx.store);
+    const a = slotKey('A');
+    ba.onWillAppear({ action: a, payload: { settings: { slot: '5' } } } as never);
+    expect(a.setImage).toHaveBeenLastCalledWith(expect.stringContaining('Slot 5'));
   });
 
   it('re-renders every slot key on a store change (fixes stale-on-workspace-switch)', () => {
@@ -161,11 +176,11 @@ describe('slot keys', () => {
     const b = slotKey('B');
     ba.onWillAppear({ action: a, payload: { settings: { slot: '1' } } } as never);
     ba.onWillAppear({ action: b, payload: { settings: { slot: '2' } } } as never);
-    a.setTitle.mockClear();
-    b.setTitle.mockClear();
+    a.setImage.mockClear();
+    b.setImage.mockClear();
     ctx.store.setLevel('builders'); // any store change → onChange → render all keys
-    expect(a.setTitle).toHaveBeenCalled();
-    expect(b.setTitle).toHaveBeenCalled();
+    expect(a.setImage).toHaveBeenCalled();
+    expect(b.setImage).toHaveBeenCalled();
   });
 });
 

--- a/apps/streamdeck/src/__tests__/actions.test.ts
+++ b/apps/streamdeck/src/__tests__/actions.test.ts
@@ -132,6 +132,14 @@ describe('slot keys', () => {
   // per-instance fix (without it, all keys collided on shared state).
   const slotKey = (id: string) => ({ id, isKey: () => true, setImage: vi.fn(), setTitle: vi.fn() });
 
+  // renderTo hands setImage a base64 data URI (Stream Deck drops raw SVG strings); decode to
+  // assert on the underlying face.
+  const decodeFace = (action: { setImage: { mock: { calls: unknown[][] } } }): string => {
+    const arg = String(action.setImage.mock.calls.at(-1)?.[0] ?? '');
+    expect(arg.startsWith('data:image/svg+xml;base64,')).toBe(true);
+    return Buffer.from(arg.slice('data:image/svg+xml;base64,'.length), 'base64').toString('utf8');
+  };
+
   it('renders each slot key against its own slot (different slots → different builders)', () => {
     const ctx = makeStore(); // pir-1 (#101), pir-2 (#102)
     const ba = new BuilderAction(ctx.store);
@@ -140,8 +148,8 @@ describe('slot keys', () => {
     ba.onWillAppear({ action: a, payload: { settings: { slot: '1' } } } as never);
     ba.onWillAppear({ action: b, payload: { settings: { slot: '2' } } } as never);
     // The face is now a composite SVG handed to setImage (not a title).
-    expect(a.setImage).toHaveBeenLastCalledWith(expect.stringContaining('#101'));
-    expect(b.setImage).toHaveBeenLastCalledWith(expect.stringContaining('#102'));
+    expect(decodeFace(a)).toContain('#101');
+    expect(decodeFace(b)).toContain('#102');
   });
 
   it('renders the builder’s state as a colour-coded, mapped face (mirrors the sidebar)', () => {
@@ -152,11 +160,11 @@ describe('slot keys', () => {
     ba.onWillAppear({ action: a, payload: { settings: { slot: '1' } } } as never);
     ba.onWillAppear({ action: b, payload: { settings: { slot: '2' } } } as never);
     // Blocked at plan-approval → mapped label "Plan" in warning yellow (not the wire "plan review").
-    const aSvg = a.setImage.mock.calls.at(-1)?.[0] as string;
+    const aSvg = decodeFace(a);
     expect(aSvg).toContain('>Plan<');
     expect(aSvg).toContain('#cca700');
     // Active → phase label "Implement" in green.
-    const bSvg = b.setImage.mock.calls.at(-1)?.[0] as string;
+    const bSvg = decodeFace(b);
     expect(bSvg).toContain('>Implement<');
     expect(bSvg).toContain('#73c991');
   });
@@ -166,7 +174,7 @@ describe('slot keys', () => {
     const ba = new BuilderAction(ctx.store);
     const a = slotKey('A');
     ba.onWillAppear({ action: a, payload: { settings: { slot: '5' } } } as never);
-    expect(a.setImage).toHaveBeenLastCalledWith(expect.stringContaining('Slot 5'));
+    expect(decodeFace(a)).toContain('Slot 5');
   });
 
   it('re-renders every slot key on a store change (fixes stale-on-workspace-switch)', () => {

--- a/apps/streamdeck/src/__tests__/face.test.ts
+++ b/apps/streamdeck/src/__tests__/face.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import type { OverviewBuilder } from '@cluesmith/codev-sdk/controller';
+import { builderState, stateLabel, faceForBuilder, builderFaceSvg } from '../face.js';
+
+/** Minimal builder fixture — only the fields the face reads matter; the rest are filler. */
+function builder(over: Partial<OverviewBuilder>): OverviewBuilder {
+  return {
+    id: 'pir-x',
+    issueId: null,
+    blocked: null,
+    blockedGate: null,
+    protocolPhase: '',
+    ...over,
+  } as OverviewBuilder;
+}
+
+describe('builderState', () => {
+  it('is blocked when a gate is pending (blockedGate or the blocked label)', () => {
+    expect(builderState(builder({ blockedGate: 'plan-approval' }))).toBe('blocked');
+    expect(builderState(builder({ blocked: 'plan review' }))).toBe('blocked');
+  });
+  it('is active otherwise (waiting is the deferred follow-up)', () => {
+    expect(builderState(builder({ protocolPhase: 'implement' }))).toBe('active');
+    expect(builderState(builder({}))).toBe('active');
+  });
+});
+
+describe('stateLabel', () => {
+  it('maps every gate id to its short label, gate beating phase', () => {
+    expect(stateLabel(builder({ blockedGate: 'spec-approval' }))).toBe('Spec');
+    expect(stateLabel(builder({ blockedGate: 'plan-approval', protocolPhase: 'plan' }))).toBe('Plan');
+    expect(stateLabel(builder({ blockedGate: 'dev-approval' }))).toBe('Dev');
+    expect(stateLabel(builder({ blockedGate: 'pr' }))).toBe('PR');
+    expect(stateLabel(builder({ blockedGate: 'verify-approval' }))).toBe('Verify');
+  });
+  it('maps every phase id, with verify (in-progress) distinct from verified/complete (terminal)', () => {
+    expect(stateLabel(builder({ protocolPhase: 'specify' }))).toBe('Specify');
+    expect(stateLabel(builder({ protocolPhase: 'plan' }))).toBe('Plan');
+    expect(stateLabel(builder({ protocolPhase: 'implement' }))).toBe('Implement');
+    expect(stateLabel(builder({ protocolPhase: 'review' }))).toBe('Review');
+    expect(stateLabel(builder({ protocolPhase: 'verify' }))).toBe('Verify');
+    expect(stateLabel(builder({ protocolPhase: 'verified' }))).toBe('Verified');
+    expect(stateLabel(builder({ protocolPhase: 'complete' }))).toBe('Verified');
+  });
+  it('title-cases an unmapped id and returns empty for no state', () => {
+    expect(stateLabel(builder({ protocolPhase: 'rebase' }))).toBe('Rebase');
+    expect(stateLabel(builder({}))).toBe('');
+  });
+});
+
+describe('faceForBuilder', () => {
+  it('picks the gate-specific glyph when blocked', () => {
+    expect(faceForBuilder(builder({ blockedGate: 'plan-approval' })).icon).toBe('checklist');
+    expect(faceForBuilder(builder({ blockedGate: 'dev-approval' })).icon).toBe('code');
+    expect(faceForBuilder(builder({ blockedGate: 'pr' })).icon).toBe('pull-request');
+    expect(faceForBuilder(builder({ blockedGate: 'spec-approval' })).icon).toBe('book');
+    expect(faceForBuilder(builder({ blockedGate: 'verify-approval' })).icon).toBe('verified');
+  });
+  it('falls back to bell for a blocked-but-unmapped gate', () => {
+    expect(faceForBuilder(builder({ blocked: 'huh', blockedGate: 'future-gate' })).icon).toBe('bell');
+  });
+  it('uses the bolt when active', () => {
+    expect(faceForBuilder(builder({ protocolPhase: 'implement' })).icon).toBe('bolt');
+  });
+  it('prefers the issue number, falling back to the builder id', () => {
+    expect(faceForBuilder(builder({ issueId: '101' })).number).toBe('#101');
+    expect(faceForBuilder(builder({ id: 'pir-7', issueId: null })).number).toBe('pir-7');
+  });
+});
+
+describe('builderFaceSvg', () => {
+  it('renders a blocked face: number, mapped label, and warning-yellow glyph', () => {
+    const svg = builderFaceSvg(faceForBuilder(builder({ issueId: '1425', blockedGate: 'plan-approval' })));
+    expect(svg).toContain('#1425');
+    expect(svg).toContain('>Plan<');
+    expect(svg).toContain('#cca700');
+    expect(svg.startsWith('<svg')).toBe(true);
+  });
+  it('renders an active face in green', () => {
+    const svg = builderFaceSvg(faceForBuilder(builder({ issueId: '1414', protocolPhase: 'implement' })));
+    expect(svg).toContain('>Implement<');
+    expect(svg).toContain('#73c991');
+  });
+  it('renders the empty-slot face with the slot label and no number', () => {
+    const svg = builderFaceSvg({ kind: 'empty', slot: '6' });
+    expect(svg).toContain('Slot 6');
+    expect(svg).not.toContain('#cca700');
+  });
+  it('escapes XML so an id with special characters cannot break the SVG', () => {
+    const svg = builderFaceSvg(faceForBuilder(builder({ id: 'a<b&c', issueId: null })));
+    expect(svg).toContain('a&lt;b&amp;c');
+  });
+});

--- a/apps/streamdeck/src/__tests__/face.test.ts
+++ b/apps/streamdeck/src/__tests__/face.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { OverviewBuilder } from '@cluesmith/codev-sdk/controller';
-import { builderState, stateLabel, faceForBuilder, builderFaceSvg, svgToDataUri } from '../face.js';
+import { builderState, stateLabel, faceForBuilder, builderFaceSvg, gatesFaceSvg, svgToDataUri } from '../face.js';
 
 /** Minimal builder fixture — only the fields the face reads matter; the rest are filler. */
 function builder(over: Partial<OverviewBuilder>): OverviewBuilder {
@@ -94,6 +94,20 @@ describe('builderFaceSvg', () => {
     const svg = builderFaceSvg({ kind: 'empty', slot: '1' });
     expect(svg).toContain('width="72"');
     expect(svg).toContain('height="72"');
+  });
+});
+
+describe('gatesFaceSvg', () => {
+  it('shows the pending count + "Gates" in warning yellow when gates await approval', () => {
+    const svg = gatesFaceSvg(3);
+    expect(svg).toContain('>3<');
+    expect(svg).toContain('Gates');
+    expect(svg).toContain('#cca700');
+  });
+  it('shows just "Gates" (dim, no count) when none are pending', () => {
+    const svg = gatesFaceSvg(0);
+    expect(svg).toContain('Gates');
+    expect(svg).not.toContain('#cca700');
   });
 });
 

--- a/apps/streamdeck/src/__tests__/face.test.ts
+++ b/apps/streamdeck/src/__tests__/face.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { OverviewBuilder } from '@cluesmith/codev-sdk/controller';
-import { builderState, stateLabel, faceForBuilder, builderFaceSvg } from '../face.js';
+import { builderState, stateLabel, faceForBuilder, builderFaceSvg, svgToDataUri } from '../face.js';
 
 /** Minimal builder fixture — only the fields the face reads matter; the rest are filler. */
 function builder(over: Partial<OverviewBuilder>): OverviewBuilder {
@@ -89,5 +89,20 @@ describe('builderFaceSvg', () => {
   it('escapes XML so an id with special characters cannot break the SVG', () => {
     const svg = builderFaceSvg(faceForBuilder(builder({ id: 'a<b&c', issueId: null })));
     expect(svg).toContain('a&lt;b&amp;c');
+  });
+  it('carries an intrinsic width/height so Stream Deck does not drop the image', () => {
+    const svg = builderFaceSvg({ kind: 'empty', slot: '1' });
+    expect(svg).toContain('width="72"');
+    expect(svg).toContain('height="72"');
+  });
+});
+
+describe('svgToDataUri', () => {
+  it('wraps an SVG as a base64 svg+xml data URI that decodes back to the source', () => {
+    const svg = builderFaceSvg(faceForBuilder(builder({ issueId: '1414', protocolPhase: 'implement' })));
+    const uri = svgToDataUri(svg);
+    expect(uri.startsWith('data:image/svg+xml;base64,')).toBe(true);
+    const decoded = Buffer.from(uri.slice('data:image/svg+xml;base64,'.length), 'base64').toString('utf8');
+    expect(decoded).toBe(svg);
   });
 });

--- a/apps/streamdeck/src/__tests__/face.test.ts
+++ b/apps/streamdeck/src/__tests__/face.test.ts
@@ -46,6 +46,12 @@ describe('stateLabel', () => {
     expect(stateLabel(builder({ protocolPhase: 'rebase' }))).toBe('Rebase');
     expect(stateLabel(builder({}))).toBe('');
   });
+  it('an unmapped gate STILL wins over a known phase — a pending gate is never masked', () => {
+    // Regression for the review consultation (Codex): previously a mapped phase (`review`) beat an
+    // unmapped gate, so a builder blocked at a future gate showed its phase while the face was
+    // yellow + bell. Any gate now wins, title-cased to its first token.
+    expect(stateLabel(builder({ blockedGate: 'security-approval', protocolPhase: 'review' }))).toBe('Security');
+  });
 });
 
 describe('faceForBuilder', () => {
@@ -94,6 +100,12 @@ describe('builderFaceSvg', () => {
     const svg = builderFaceSvg({ kind: 'empty', slot: '1' });
     expect(svg).toContain('width="72"');
     expect(svg).toContain('height="72"');
+  });
+  it('shrinks a long primary datum to fit (no clip) but leaves a short number natural', () => {
+    const longId = builderFaceSvg(faceForBuilder(builder({ id: 'builder-pir-1428', issueId: null })));
+    expect(longId).toContain('lengthAdjust="spacingAndGlyphs"');
+    const shortNum = builderFaceSvg(faceForBuilder(builder({ issueId: '1414', protocolPhase: 'implement' })));
+    expect(shortNum).not.toContain('lengthAdjust');
   });
 });
 

--- a/apps/streamdeck/src/actions.ts
+++ b/apps/streamdeck/src/actions.ts
@@ -21,8 +21,9 @@ import { builderFaceSvg, faceForBuilder, gatesFaceSvg, svgToDataUri } from './fa
  * The Stream Deck actions — thin adapters over CodevStore. Each maps a physical
  * input to a canonical verb (POSTed via the command relay) or a cursor move /
  * URL open. UUIDs are set via the `manifestId` field (no decorators — keeps the
- * esbuild→node bundle free of decorator transpilation). Rendering is title-based
- * for v1 (richer SVG/feedback is a later polish).
+ * esbuild→node bundle free of decorator transpilation). Most keys render title-based;
+ * the Builder Action and Gates keys compose a full SVG face via `setImage` (see `face.ts`),
+ * and the encoders render `setFeedback` touchscreen layouts.
  */
 
 /** Optional per-instance verb override from the Property Inspector. */
@@ -167,7 +168,12 @@ export class BuilderAction extends SlotKey {
     // Compose the WHOLE face as one SVG (icon zone + reserved text band) instead of stacking a
     // title over the manifest bolt PNG — see face.ts for the layout and the sidebar-mirrored
     // colour/icon vocabulary. setTitle('') suppresses the SDK title layer so nothing overlays it.
-    const svg = b ? builderFaceSvg(faceForBuilder(b)) : builderFaceSvg({ kind: 'empty', slot: settings.slot ?? '1' });
+    let svg: string;
+    if (b) {
+      svg = builderFaceSvg(faceForBuilder(b));
+    } else {
+      svg = builderFaceSvg({ kind: 'empty', slot: settings.slot ?? '1' });
+    }
     void action.setImage(svgToDataUri(svg));
     void action.setTitle('');
   }

--- a/apps/streamdeck/src/actions.ts
+++ b/apps/streamdeck/src/actions.ts
@@ -15,6 +15,7 @@ import type {
   CanvasCommandClientErrorCode,
 } from '@cluesmith/codev-sdk/controller';
 import type { CodevStore } from './store.js';
+import { builderFaceSvg, faceForBuilder } from './face.js';
 
 /**
  * The Stream Deck actions — thin adapters over CodevStore. Each maps a physical
@@ -163,9 +164,12 @@ export class BuilderAction extends SlotKey {
   }
   protected renderTo(action: KeyAction, settings: SlotSettings): void {
     const b = slotBuilder(this.store, settings);
-    void action.setTitle(
-      b ? `${b.issueId ? `#${b.issueId}` : b.id}\n${b.blocked ?? b.protocolPhase}` : `Slot ${settings.slot ?? '1'}`,
-    );
+    // Compose the WHOLE face as one SVG (icon zone + reserved text band) instead of stacking a
+    // title over the manifest bolt PNG — see face.ts for the layout and the sidebar-mirrored
+    // colour/icon vocabulary. setTitle('') suppresses the SDK title layer so nothing overlays it.
+    const svg = b ? builderFaceSvg(faceForBuilder(b)) : builderFaceSvg({ kind: 'empty', slot: settings.slot ?? '1' });
+    void action.setImage(svg);
+    void action.setTitle('');
   }
 }
 

--- a/apps/streamdeck/src/actions.ts
+++ b/apps/streamdeck/src/actions.ts
@@ -15,7 +15,7 @@ import type {
   CanvasCommandClientErrorCode,
 } from '@cluesmith/codev-sdk/controller';
 import type { CodevStore } from './store.js';
-import { builderFaceSvg, faceForBuilder } from './face.js';
+import { builderFaceSvg, faceForBuilder, svgToDataUri } from './face.js';
 
 /**
  * The Stream Deck actions — thin adapters over CodevStore. Each maps a physical
@@ -168,7 +168,7 @@ export class BuilderAction extends SlotKey {
     // title over the manifest bolt PNG — see face.ts for the layout and the sidebar-mirrored
     // colour/icon vocabulary. setTitle('') suppresses the SDK title layer so nothing overlays it.
     const svg = b ? builderFaceSvg(faceForBuilder(b)) : builderFaceSvg({ kind: 'empty', slot: settings.slot ?? '1' });
-    void action.setImage(svg);
+    void action.setImage(svgToDataUri(svg));
     void action.setTitle('');
   }
 }

--- a/apps/streamdeck/src/actions.ts
+++ b/apps/streamdeck/src/actions.ts
@@ -15,7 +15,7 @@ import type {
   CanvasCommandClientErrorCode,
 } from '@cluesmith/codev-sdk/controller';
 import type { CodevStore } from './store.js';
-import { builderFaceSvg, faceForBuilder, svgToDataUri } from './face.js';
+import { builderFaceSvg, faceForBuilder, gatesFaceSvg, svgToDataUri } from './face.js';
 
 /**
  * The Stream Deck actions — thin adapters over CodevStore. Each maps a physical
@@ -209,7 +209,10 @@ export class ApproveGate extends SingletonAction {
   }
   private renderTo(action: KeyAction): void {
     const n = this.store.pendingGates().length;
-    void action.setTitle(n > 0 ? `Gates\n${n}` : 'Gates');
+    // Composite SVG face (same fix as BuilderAction): count + label in a reserved band under the
+    // bell icon, instead of a title stacked over the manifest PNG.
+    void action.setImage(svgToDataUri(gatesFaceSvg(n)));
+    void action.setTitle('');
   }
 }
 

--- a/apps/streamdeck/src/face.ts
+++ b/apps/streamdeck/src/face.ts
@@ -117,12 +117,23 @@ const PHASE_LABELS: Record<string, string> = {
  * an unmapped id is title-cased so nothing renders lowercase or clips mid-word; no state → `''`.
  */
 export function stateLabel(b: Pick<OverviewBuilder, 'blockedGate' | 'protocolPhase'>): string {
+  // A blocked builder's gate ALWAYS wins over its phase — even an UNMAPPED gate title-cases to a
+  // short label, so a pending gate is never masked by the phase beneath it. (The face is already
+  // yellow + bell for an unmapped gate; the label must agree, or the key would read as its phase
+  // while looking blocked.) Only a builder with no gate at all falls through to its phase.
   const gate = b.blockedGate ?? '';
-  if (GATE_LABELS[gate]) return GATE_LABELS[gate];
+  if (gate) return GATE_LABELS[gate] ?? titleToken(gate);
   const phase = b.protocolPhase ?? '';
-  if (PHASE_LABELS[phase]) return PHASE_LABELS[phase];
-  const raw = gate || phase;
-  return raw ? raw.charAt(0).toUpperCase() + raw.slice(1) : '';
+  if (phase) return PHASE_LABELS[phase] ?? titleToken(phase);
+  return '';
+}
+
+/** Short, key-friendly fallback for an unmapped id: its first alphanumeric token, title-cased
+ *  (e.g. `security-approval` → `Security`) — never lowercase, never a mid-word clip. */
+function titleToken(raw: string): string {
+  const token = raw.split(/[^a-zA-Z0-9]/, 1)[0] ?? '';
+  if (!token) return '';
+  return token.charAt(0).toUpperCase() + token.slice(1);
 }
 
 /** A fully-resolved builder face: what to draw and how to colour it. */
@@ -137,14 +148,15 @@ export interface BuilderFace {
 /** Resolve a builder into its face descriptor — all id→presentation mapping in one testable place. */
 export function faceForBuilder(b: OverviewBuilder): BuilderFace {
   const state = builderState(b);
-  const icon: GlyphKey = state === 'blocked' ? (GATE_ICONS[b.blockedGate ?? ''] ?? 'bell') : 'bolt';
-  return {
-    kind: 'builder',
-    number: b.issueId ? `#${b.issueId}` : b.id,
-    label: stateLabel(b),
-    state,
-    icon,
-  };
+  let icon: GlyphKey = 'bolt';
+  if (state === 'blocked') {
+    icon = GATE_ICONS[b.blockedGate ?? ''] ?? 'bell';
+  }
+  let number = b.id;
+  if (b.issueId) {
+    number = `#${b.issueId}`;
+  }
+  return { kind: 'builder', number, label: stateLabel(b), state, icon };
 }
 
 /**
@@ -187,13 +199,20 @@ const DIVIDER = '<line x1="14" y1="35" x2="58" y2="35" stroke="#333338" stroke-w
 function iconZone(glyph: GlyphKey, color: string): string {
   return `<g transform="translate(24,7)">${GLYPHS[glyph](color)}</g>`;
 }
+/** Shrink-to-fit for a string that would overflow the 72px face (a long builder-id fallback, an
+ *  unusually long unmapped-id label). Empty for short strings, so the common case keeps its
+ *  natural width instead of being stretched. */
+function fit(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return '';
+  return ' textLength="60" lengthAdjust="spacingAndGlyphs"';
+}
 /** Primary datum: bold, high-contrast (issue number / pending count). */
 function primaryLine(text: string): string {
-  return `<text ${textAttrs(36, 50, 16, 700)} fill="#f4f4f6">${escapeXml(text)}</text>`;
+  return `<text ${textAttrs(36, 50, 16, 700)}${fit(text, 6)} fill="#f4f4f6">${escapeXml(text)}</text>`;
 }
 /** Secondary label: muted, below the primary line. */
 function secondaryLine(text: string): string {
-  return `<text ${textAttrs(36, 63, 12, 500)} fill="#a9a9b2">${escapeXml(text)}</text>`;
+  return `<text ${textAttrs(36, 63, 12, 500)}${fit(text, 9)} fill="#a9a9b2">${escapeXml(text)}</text>`;
 }
 /** A single muted line centered in the band, when there is no primary datum (empty slot / no gates). */
 function centeredLine(text: string): string {

--- a/apps/streamdeck/src/face.ts
+++ b/apps/streamdeck/src/face.ts
@@ -1,0 +1,187 @@
+import type { OverviewBuilder } from '@cluesmith/codev-sdk/controller';
+
+/**
+ * Builder Action key face — the plugin composes the WHOLE key as one SVG (handed to
+ * `KeyAction.setImage`), instead of stacking a `setTitle` over the manifest's bolt PNG. The two
+ * stacked layers were the root cause of #1428 (text on the icon's diagonal, `#1414` reading as
+ * `#1,414` where the bolt edge bleeds between digits, and mid-word truncation).
+ *
+ * The face mirrors the VS Code Builders sidebar's two-axis vocabulary
+ * (`apps/vscode/src/views/builder-row.ts`): COLOUR encodes state severity, ICON encodes which
+ * gate a blocked builder waits on. The maps below are the streamdeck TWIN of that file — the two
+ * apps can't (and, by owner ruling, shouldn't) import each other, so the deck REPLICATES the
+ * sidebar's look independently and the maps are kept aligned by the sync-notes on each. This is an
+ * accepted, intentional pattern here, not single-source-of-truth debt.
+ *
+ * Pure and SDK-free so it unit-tests without the Stream Deck runtime (mirrors `nav/cursor.ts`).
+ */
+
+/** State severity, in the sidebar's precedence: blocked beats waiting beats active. */
+export type BuilderState = 'blocked' | 'waiting' | 'active';
+
+/**
+ * Classify a builder's state. Mirrors `builder-row.ts`'s blocked > idle > active precedence.
+ *
+ * v1 ships `blocked` / `active` only. `waiting` (blue) is the deferred strict-superset follow-up:
+ * it needs an idle threshold derived from `lastDataAt` (the sidebar's `isIdleWaiting`); until this
+ * returns `'waiting'`, the blue token in `STATE_COLOR` is defined-but-unused. Adding it later
+ * changes only this function.
+ */
+export function builderState(b: Pick<OverviewBuilder, 'blocked' | 'blockedGate'>): BuilderState {
+  if (b.blocked || b.blockedGate) return 'blocked';
+  return 'active';
+}
+
+/**
+ * State → colour. Inlined hexes that mirror VS Code's default-theme tokens (the deck LCD face is a
+ * static SVG with no `ThemeColor` binding). Keep in sync with `BUILDER_STATE_GLYPH` in
+ * `apps/vscode/src/views/builder-row.ts`.
+ */
+const STATE_COLOR: Record<BuilderState, string> = {
+  blocked: '#cca700', // notificationsWarningIcon.foreground
+  waiting: '#3794ff', // notificationsInfoIcon.foreground
+  active: '#73c991', //  testing.iconPassed (dark)
+};
+
+/** The glyphs the face can draw: a gate shape when blocked, the bolt otherwise. */
+export type GlyphKey = 'bolt' | 'book' | 'checklist' | 'code' | 'pull-request' | 'verified' | 'bell';
+
+/**
+ * Gate id → glyph. The streamdeck twin of `gateIconFor` in `apps/vscode/src/views/builder-row.ts`
+ * — keep in sync. A blocked builder whose gate isn't mapped falls back to `bell` (see
+ * `faceForBuilder`), matching the sidebar. `verify-approval` renders here even though the press
+ * resolver doesn't handle it yet (that gap is BUGFIX #1431).
+ */
+const GATE_ICONS: Record<string, GlyphKey> = {
+  'spec-approval': 'book',
+  'plan-approval': 'checklist',
+  'dev-approval': 'code',
+  pr: 'pull-request',
+  'verify-approval': 'verified',
+};
+
+/**
+ * Glyph → inner SVG markup, drawn in a 24×24 box and stroked/filled in the caller's colour. The
+ * shapes are modelled on the matching VS Code codicons (book / checklist / code / git-pull-request
+ * / verified / bell); the codicon font isn't vendored, so these are drawn in-plugin — which also
+ * keeps the bundle dependency-free. The bolt is filled (the plugin's identity mark); the rest are
+ * line glyphs like the codicons.
+ */
+const GLYPHS: Record<GlyphKey, (color: string) => string> = {
+  bolt: (c) => `<path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" fill="${c}"/>`,
+  book: (c) => stroked(c, '<path d="M5 4h13v16H5z"/><path d="M11 4v16"/>'),
+  checklist: (c) => stroked(c, '<path d="M3 6l2 2 3-3"/><path d="M11 7h10"/><path d="M3 15l2 2 3-3"/><path d="M11 16h10"/>'),
+  code: (c) => stroked(c, '<path d="M8 7l-5 5 5 5"/><path d="M16 7l5 5-5 5"/>'),
+  'pull-request': (c) =>
+    stroked(c, '<circle cx="7" cy="6" r="2.3"/><circle cx="7" cy="18" r="2.3"/><circle cx="17" cy="18" r="2.3"/><path d="M7 8.3v7.4"/><path d="M17 15.7V12a3 3 0 0 0-3-3h-3.5"/>'),
+  verified: (c) => stroked(c, '<path d="M12 3l7 3v5c0 4.5-3 7.6-7 9.2C8 18.6 5 15.5 5 11V6z"/><path d="M8.6 12l2.3 2.3 4.6-4.6"/>'),
+  bell: (c) => stroked(c, '<path d="M6 9a6 6 0 0 1 12 0c0 5 2 6 2 6H4s2-1 2-6z"/><path d="M10.5 20a1.6 1.6 0 0 0 3 0"/>'),
+};
+
+/** Wrap line-glyph paths in a shared stroke group (round caps/joins, like the codicons). */
+function stroked(color: string, paths: string): string {
+  return `<g fill="none" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${paths}</g>`;
+}
+
+/**
+ * Gate id → short display label (blocked builders). The streamdeck twin of the sidebar's gate
+ * vocabulary. Short by design: colour + icon carry the blocked-vs-working distinction, so the
+ * label need not — `Plan` (gate) and `Plan` (phase) stay unmistakable via yellow-checklist vs
+ * green-bolt. Keyed on the canonical `blockedGate` id, never the free-form `blocked` label.
+ */
+const GATE_LABELS: Record<string, string> = {
+  'spec-approval': 'Spec',
+  'plan-approval': 'Plan',
+  'dev-approval': 'Dev',
+  pr: 'PR',
+  'verify-approval': 'Verify',
+};
+
+/**
+ * Protocol phase id → display label (active builders). `verify` is the IN-PROGRESS phase; `verified`
+ * is porch's TERMINAL id (`next.ts:204`), with legacy `complete` migrating to it
+ * (`state.ts:135-140`) — both display `Verified`.
+ */
+const PHASE_LABELS: Record<string, string> = {
+  specify: 'Specify',
+  plan: 'Plan',
+  implement: 'Implement',
+  review: 'Review',
+  verify: 'Verify',
+  verified: 'Verified',
+  complete: 'Verified',
+};
+
+/**
+ * Deliberate short label for a builder's state. Gate beats phase (matching `phaseArtifactVerb`);
+ * an unmapped id is title-cased so nothing renders lowercase or clips mid-word; no state → `''`.
+ */
+export function stateLabel(b: Pick<OverviewBuilder, 'blockedGate' | 'protocolPhase'>): string {
+  const gate = b.blockedGate ?? '';
+  if (GATE_LABELS[gate]) return GATE_LABELS[gate];
+  const phase = b.protocolPhase ?? '';
+  if (PHASE_LABELS[phase]) return PHASE_LABELS[phase];
+  const raw = gate || phase;
+  return raw ? raw.charAt(0).toUpperCase() + raw.slice(1) : '';
+}
+
+/** A fully-resolved builder face: what to draw and how to colour it. */
+export interface BuilderFace {
+  kind: 'builder';
+  number: string;
+  label: string;
+  state: BuilderState;
+  icon: GlyphKey;
+}
+
+/** Resolve a builder into its face descriptor — all id→presentation mapping in one testable place. */
+export function faceForBuilder(b: OverviewBuilder): BuilderFace {
+  const state = builderState(b);
+  const icon: GlyphKey = state === 'blocked' ? (GATE_ICONS[b.blockedGate ?? ''] ?? 'bell') : 'bolt';
+  return {
+    kind: 'builder',
+    number: b.issueId ? `#${b.issueId}` : b.id,
+    label: stateLabel(b),
+    state,
+    icon,
+  };
+}
+
+/**
+ * Render a key face as a self-contained SVG string for `setImage`. 72×72 viewBox (the deck
+ * upscales; vector stays crisp): an icon zone up top, a hairline divider, then a reserved text
+ * band (number + short label). Icon zone and text band never overlap by construction — the fix
+ * for the collision symptom.
+ */
+export function builderFaceSvg(face: BuilderFace | { kind: 'empty'; slot: string }): string {
+  const bg = '<rect width="72" height="72" rx="12" fill="#1b1b1e"/>';
+  const divider = '<line x1="14" y1="35" x2="58" y2="35" stroke="#333338" stroke-width="1"/>';
+  if (face.kind === 'empty') {
+    const icon = `<g transform="translate(24,7)">${GLYPHS.bolt('#63636b')}</g>`;
+    const slot = `<text ${textAttrs(36, 55, 14, 600)} fill="#8a8a92">Slot ${escapeXml(face.slot)}</text>`;
+    return svg(`${bg}${icon}${divider}${slot}`);
+  }
+  const icon = `<g transform="translate(24,7)">${GLYPHS[face.icon](STATE_COLOR[face.state])}</g>`;
+  const number = `<text ${textAttrs(36, 50, 16, 700)} fill="#f4f4f6">${escapeXml(face.number)}</text>`;
+  const label = `<text ${textAttrs(36, 63, 12, 500)} fill="#a9a9b2">${escapeXml(face.label)}</text>`;
+  return svg(`${bg}${icon}${divider}${number}${label}`);
+}
+
+function svg(inner: string): string {
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">${inner}</svg>`;
+}
+
+/** Shared text attributes: centered, system sans, at the given baseline / size / weight. */
+function textAttrs(x: number, y: number, size: number, weight: number): string {
+  return `x="${x}" y="${y}" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="${size}" font-weight="${weight}"`;
+}
+
+/** Escape the five XML entities so a builder id / label can't break the SVG string. */
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}

--- a/apps/streamdeck/src/face.ts
+++ b/apps/streamdeck/src/face.ts
@@ -154,17 +154,50 @@ export function faceForBuilder(b: OverviewBuilder): BuilderFace {
  * for the collision symptom.
  */
 export function builderFaceSvg(face: BuilderFace | { kind: 'empty'; slot: string }): string {
-  const bg = '<rect width="72" height="72" rx="12" fill="#1b1b1e"/>';
-  const divider = '<line x1="14" y1="35" x2="58" y2="35" stroke="#333338" stroke-width="1"/>';
   if (face.kind === 'empty') {
-    const icon = `<g transform="translate(24,7)">${GLYPHS.bolt('#63636b')}</g>`;
-    const slot = `<text ${textAttrs(36, 55, 14, 600)} fill="#8a8a92">Slot ${escapeXml(face.slot)}</text>`;
-    return svg(`${bg}${icon}${divider}${slot}`);
+    return svg(`${BG}${iconZone('bolt', '#63636b')}${DIVIDER}${centeredLine(`Slot ${face.slot}`)}`);
   }
-  const icon = `<g transform="translate(24,7)">${GLYPHS[face.icon](STATE_COLOR[face.state])}</g>`;
-  const number = `<text ${textAttrs(36, 50, 16, 700)} fill="#f4f4f6">${escapeXml(face.number)}</text>`;
-  const label = `<text ${textAttrs(36, 63, 12, 500)} fill="#a9a9b2">${escapeXml(face.label)}</text>`;
-  return svg(`${bg}${icon}${divider}${number}${label}`);
+  return svg(
+    `${BG}${iconZone(face.icon, STATE_COLOR[face.state])}${DIVIDER}` +
+      `${primaryLine(face.number)}${secondaryLine(face.label)}`,
+  );
+}
+
+/**
+ * The Gates (approve-gate) key face — same composite frame as the builder face, fixing the same
+ * text-over-icon overlap. A `bell` (the sidebar's "needs attention" glyph, `builder-row.ts`) tinted
+ * warning-yellow with the pending count when gates await approval; a dim neutral bell with just the
+ * `Gates` label when none are pending.
+ */
+export function gatesFaceSvg(pendingCount: number): string {
+  if (pendingCount <= 0) {
+    return svg(`${BG}${iconZone('bell', '#63636b')}${DIVIDER}${centeredLine('Gates')}`);
+  }
+  return svg(
+    `${BG}${iconZone('bell', STATE_COLOR.blocked)}${DIVIDER}` +
+      `${primaryLine(String(pendingCount))}${secondaryLine('Gates')}`,
+  );
+}
+
+/** Shared face frame: the rounded key ground and the hairline that splits icon zone from text band. */
+const BG = '<rect width="72" height="72" rx="12" fill="#1b1b1e"/>';
+const DIVIDER = '<line x1="14" y1="35" x2="58" y2="35" stroke="#333338" stroke-width="1"/>';
+
+/** Place a glyph, tinted, in the icon zone (upper ~30px). */
+function iconZone(glyph: GlyphKey, color: string): string {
+  return `<g transform="translate(24,7)">${GLYPHS[glyph](color)}</g>`;
+}
+/** Primary datum: bold, high-contrast (issue number / pending count). */
+function primaryLine(text: string): string {
+  return `<text ${textAttrs(36, 50, 16, 700)} fill="#f4f4f6">${escapeXml(text)}</text>`;
+}
+/** Secondary label: muted, below the primary line. */
+function secondaryLine(text: string): string {
+  return `<text ${textAttrs(36, 63, 12, 500)} fill="#a9a9b2">${escapeXml(text)}</text>`;
+}
+/** A single muted line centered in the band, when there is no primary datum (empty slot / no gates). */
+function centeredLine(text: string): string {
+  return `<text ${textAttrs(36, 55, 14, 600)} fill="#8a8a92">${escapeXml(text)}</text>`;
 }
 
 function svg(inner: string): string {

--- a/apps/streamdeck/src/face.ts
+++ b/apps/streamdeck/src/face.ts
@@ -168,12 +168,24 @@ export function builderFaceSvg(face: BuilderFace | { kind: 'empty'; slot: string
 }
 
 function svg(inner: string): string {
-  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">${inner}</svg>`;
+  // Explicit width/height (not just viewBox): Stream Deck's rasterizer needs an intrinsic size or
+  // it drops the image entirely and falls back to the manifest PNG.
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="72" height="72" viewBox="0 0 72 72">${inner}</svg>`;
 }
 
-/** Shared text attributes: centered, system sans, at the given baseline / size / weight. */
+/**
+ * Encode a face SVG for `setImage`. Stream Deck (6.x) renders an SVG reliably only as a base64
+ * data URI with the mime type declared — a raw `<svg>` string is silently dropped (the whole key
+ * reverts to its manifest image). This is the SDK's documented "base64 encoded string with the
+ * mime type declared" form.
+ */
+export function svgToDataUri(svg: string): string {
+  return `data:image/svg+xml;base64,${Buffer.from(svg, 'utf8').toString('base64')}`;
+}
+
+/** Shared text attributes: centered, generic sans (the rasterizer resolves it), given baseline/size/weight. */
 function textAttrs(x: number, y: number, size: number, weight: number): string {
-  return `x="${x}" y="${y}" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="${size}" font-weight="${weight}"`;
+  return `x="${x}" y="${y}" text-anchor="middle" font-family="sans-serif" font-size="${size}" font-weight="${weight}"`;
 }
 
 /** Escape the five XML entities so a builder id / label can't break the SVG string. */

--- a/codev/plans/1428-stream-deck-builder-action-key.md
+++ b/codev/plans/1428-stream-deck-builder-action-key.md
@@ -50,13 +50,17 @@ const GATE_LABELS: Record<string, string> = {
   'dev-approval':  'Dev Approval',
   'pr':            'PR Review',
 };
-// Coarse protocol phase (canonical protocolPhase ids).
+// Coarse protocol phase (canonical protocolPhase ids). `verify` is the IN-PROGRESS
+// phase (→ 'Verify'); `verified` is porch's TERMINAL id (next.ts:204), with legacy
+// `complete` migrating to it (state.ts:135-140) — both display as 'Verified'.
 const PHASE_LABELS: Record<string, string> = {
   specify:   'Specify',
   plan:      'Plan',
   implement: 'Implement',
   review:    'Review',
-  verify:    'Verified',
+  verify:    'Verify',
+  verified:  'Verified',
+  complete:  'Verified',
 };
 
 /** Deliberate display label for a builder's current state; '' → the caller's fallback. */
@@ -85,7 +89,9 @@ export function stateLabel(b: Pick<OverviewBuilder, 'blockedGate' | 'protocolPha
 | `plan` | protocolPhase | Plan |
 | `implement` | protocolPhase | Implement |
 | `review` | protocolPhase | Review |
-| `verify` | protocolPhase | Verified |
+| `verify` | protocolPhase | Verify (in-progress) |
+| `verified` | protocolPhase | Verified (terminal — `next.ts:204`) |
+| `complete` | protocolPhase | Verified (legacy → `verified`, `state.ts:135-140`) |
 | `''` / unknown | either | title-cased raw, else empty |
 
 Longest single token is "Approval"/"Implement" (8–9 chars). Two-word gate labels are rendered
@@ -179,6 +185,13 @@ against the exact stacking that caused symptom 1).
   Mitigation if seen at the hardware gate: set the SVG in `onWillAppear` (already the path —
   `renderTo` is called there) so the window is a single frame; only escalate to a manifest swap
   if the flash is actually visible.
+- **Risk: a profile-pinned custom image silently defeats `setImage`.** The SDK doc is explicit:
+  *"The image can only be set by the plugin when the user has not specified a custom image."*
+  If the bundled/imported profile pins a custom image on a Builder Action key, our SVG face is
+  ignored with no error and the old PNG-under-title face persists. Mitigation: verify the
+  profile (including the #1404-revved one) does **not** pin custom images on these keys; if the
+  face fails to render at the hardware gate, this is the **first** suspect (before any SVG/logic
+  debugging). Added to the hardware checklist below.
 - **Risk: label doesn't fit the band on the physical deck.** The whole point of §1(b) is that
   the SVG sizes the band to the label (and wraps two-word gates), so truncation is impossible by
   construction. The hardware gate is the real check; font sizes are cheap to tune in the SVG
@@ -198,8 +211,9 @@ against the exact stacking that caused symptom 1).
 
 ## Test Plan
 
-- **Unit (`face.test.ts`)**: `stateLabel` returns the exact label for each of the 9 mapped ids,
-  gate-beats-phase when both present, the title-cased fallback for an unknown id, and `''` for
+- **Unit (`face.test.ts`)**: `stateLabel` returns the exact label for each of the 11 mapped ids
+  (incl. `verify`→'Verify' distinct from `verified`/`complete`→'Verified'), gate-beats-phase
+  when both present, the title-cased fallback for an unknown id, and `''` for
   no state; `builderFaceSvg` output contains the number + label, splits a two-word gate label
   across two lines, and produces a distinct `Slot N` empty variant with no number.
 - **Unit (`actions.test.ts`)**: `BuilderAction.renderTo` calls `setImage` with an SVG string
@@ -214,3 +228,7 @@ against the exact stacking that caused symptom 1).
   phase label, and icon are each legible at a glance and that legibility matches the Gates key.
   Verify press/rotate still fire the same verbs as before (regression check on the untouched
   path).
+- **Manual — pre-flight (do this first at the hardware gate):** confirm the active/imported
+  profile (incl. the #1404-revved one) does **not** pin a custom image on the Builder Action
+  keys — a pinned custom image makes `setImage` a silent no-op. If the SVG face doesn't render,
+  check this before debugging the SVG or the render path.

--- a/codev/plans/1428-stream-deck-builder-action-key.md
+++ b/codev/plans/1428-stream-deck-builder-action-key.md
@@ -1,0 +1,216 @@
+# PIR Plan: Stream Deck Builder Action composite key face
+
+## Understanding
+
+The Builder Action key (`apps/streamdeck/src/actions.ts:164-169`) renders by pushing two
+raw wire strings through `setTitle`, and the SDK paints that title **over** the full-bleed
+`icons/builder-action` bolt PNG declared in the manifest. Two independent layers stacked ⇒
+three photo-verified symptoms with one root cause:
+
+1. **Text/icon collision.** Both title lines land on the bolt's diagonal. It's illegible
+   enough that `#1414` reads as `#1,414` — there is no number formatter in the plugin and
+   `issueId` is a plain string on the wire (confirmed: `OverviewBuilder.issueId: string | null`,
+   `packages/types/src/api.ts:143`), so the "comma" is the bolt edge bleeding through between
+   digits. The overlay corrupts what the data appears to say.
+2. **Casing inconsistency.** Line 2 is `b.blocked ?? b.protocolPhase` verbatim — wire values,
+   not display labels — so the key mirrors whatever casing the wire carries (`implement`,
+   `verified`).
+3. **Truncation.** Long phase names clip mid-word because the SDK title box is narrower than
+   the string.
+
+The Gates/approve-gate key reads fine because its icon+label were composed as one design; the
+Builder Action key stacks two layers that were never designed to coexist.
+
+The fix is to stop stacking layers: render the **entire** key face as one image in the plugin,
+with the icon confined to an upper zone and the text in a reserved band below, and to translate
+wire ids to deliberate display labels through a plugin-local map.
+
+**Key enabler (verified):** `KeyAction.setImage(image?, options?)` accepts *"an SVG `string`"*
+directly (SDK d.ts, `@elgato/streamdeck@2.1.0/dist/plugin/actions/key.d.ts:29-34`). So we can
+build the face as an SVG string with **zero new dependencies** — no canvas/native module, which
+matters because the plugin is a single esbuild→node bundle (`apps/streamdeck/esbuild.js`) and
+pure functions are the established, SDK-free-testable pattern here (cf. `src/nav/cursor.ts`).
+
+## Proposed Change
+
+### 1. New plugin-local module `apps/streamdeck/src/face.ts` (pure, no SDK import)
+
+Two responsibilities, both pure and unit-testable in isolation (mirrors `nav/cursor.ts`):
+
+**(a) Presentation label map** — wire id → display label. Keyed on the **canonical** ids
+`blockedGate` and `protocolPhase` (not `b.blocked`, which is a server-authored human label with
+non-deterministic casing). Gate wins over phase, matching the existing precedence in
+`phaseArtifactVerb` (`actions.ts:229-239`). This keeps presentation 100% plugin-local:
+
+```ts
+// Gate a builder is blocked on (canonical blockedGate ids). Gate beats phase.
+const GATE_LABELS: Record<string, string> = {
+  'spec-approval': 'Spec Approval',
+  'plan-approval': 'Plan Approval',
+  'dev-approval':  'Dev Approval',
+  'pr':            'PR Review',
+};
+// Coarse protocol phase (canonical protocolPhase ids).
+const PHASE_LABELS: Record<string, string> = {
+  specify:   'Specify',
+  plan:      'Plan',
+  implement: 'Implement',
+  review:    'Review',
+  verify:    'Verified',
+};
+
+/** Deliberate display label for a builder's current state; '' → the caller's fallback. */
+export function stateLabel(b: Pick<OverviewBuilder, 'blockedGate' | 'protocolPhase'>): string {
+  const gate = b.blockedGate ?? '';
+  if (GATE_LABELS[gate]) return GATE_LABELS[gate];
+  const phase = b.protocolPhase ?? '';
+  if (PHASE_LABELS[phase]) return PHASE_LABELS[phase];
+  // Defensive fallback for an unmapped id: title-case the first token so nothing
+  // renders lowercase, and never emit a mid-word clip (the SVG never truncates —
+  // §(b) sizes the band to the label, not vice-versa).
+  const raw = gate || phase;
+  return raw ? raw.charAt(0).toUpperCase() + raw.slice(1) : '';
+}
+```
+
+**Complete id → label table for review (every phase + gate id):**
+
+| Wire id | Source field | Display label |
+|---|---|---|
+| `spec-approval` | blockedGate | Spec Approval |
+| `plan-approval` | blockedGate | Plan Approval |
+| `dev-approval` | blockedGate | Dev Approval |
+| `pr` | blockedGate | PR Review |
+| `specify` | protocolPhase | Specify |
+| `plan` | protocolPhase | Plan |
+| `implement` | protocolPhase | Implement |
+| `review` | protocolPhase | Review |
+| `verify` | protocolPhase | Verified |
+| `''` / unknown | either | title-cased raw, else empty |
+
+Longest single token is "Approval"/"Implement" (8–9 chars). Two-word gate labels are rendered
+as **two lines** ("Dev" / "Approval") by construction so nothing clips — see §(b).
+
+**(b) SVG face builder** — `builderFaceSvg(opts)` returns a self-contained `<svg>` string.
+Layout (72×72 viewBox; the deck upscales, and vector stays crisp):
+
+```
+┌───────────────┐  0
+│      ⚡        │   icon zone  (top ~34px): the bolt glyph, centered, drawn as
+│               │               an SVG <path> — no PNG overlay, no bleed-through
+├───────────────┤  ~36  hairline divider
+│    #1414      │   number line (bold ~17px, high-contrast) — the primary datum
+│  Dev Approval │   label band (~12px, muted; 1–2 lines, wrapped at the space
+└───────────────┘  72               for two-word gate labels — never mid-word)
+```
+
+- Dark rounded background (`#1c1c1e`, matching the deck's neutral keys) so the composed face
+  reads as one design, like the Gates key.
+- Icon zone reserved at top; text band reserved at bottom. They never overlap **by
+  construction** — that is the whole fix for symptom (1).
+- Number line renders `#${issueId}` (or the builder `id` when `issueId` is null) at a size that
+  fits within the band width; "#1414" renders as literal glyphs with no comma (fixes the
+  data-corruption symptom).
+- Empty-slot variant: same frame, icon drawn dimmed/outline, band shows `Slot N`, no number
+  line (requirement 4 — consistent row).
+
+The function signature is a plain data-in/string-out contract, e.g.:
+
+```ts
+export function builderFaceSvg(
+  face:
+    | { kind: 'builder'; number: string; label: string }
+    | { kind: 'empty'; slot: string },
+): string
+```
+
+### 2. Rewire `BuilderAction.renderTo` (`actions.ts:164-169`)
+
+Replace the `setTitle` overlay with an image render. **Only this method changes**; press/rotate
+behavior (`resolveVerb`, `onKeyDown`, `phaseArtifactVerb`, the `automatic`→`open-diff-first`
+resolution from #1429/#1404/#1414) is **untouched**.
+
+```ts
+protected renderTo(action: KeyAction, settings: SlotSettings): void {
+  const b = slotBuilder(this.store, settings);
+  const svg = b
+    ? builderFaceSvg({
+        kind: 'builder',
+        number: b.issueId ? `#${b.issueId}` : b.id,
+        label: stateLabel(b),
+      })
+    : builderFaceSvg({ kind: 'empty', slot: settings.slot ?? '1' });
+  void action.setImage(svg);
+  void action.setTitle(''); // suppress the SDK title layer so the SVG is the whole face
+}
+```
+
+`setTitle('')` guarantees no residual manifest/user title paints over the SVG (belt-and-braces
+against the exact stacking that caused symptom 1).
+
+### 3. No other layers change
+
+- **Manifest**: unchanged. The `icons/builder-action` PNG stays as the static/PI thumbnail; at
+  runtime `setImage` replaces the face. (If the hardware check shows the static PNG flashing
+  before first render, a follow-up could swap the manifest default — noted as a risk, not
+  planned work.)
+- **Wire / types / server**: **no change** (requirement 3). The map reads existing
+  `blockedGate` / `protocolPhase` fields already on `OverviewBuilder`.
+
+## Files to Change
+
+- `apps/streamdeck/src/face.ts` — **new**. Pure module: `GATE_LABELS` / `PHASE_LABELS`,
+  `stateLabel()`, `builderFaceSvg()`. No SDK import (testable like `nav/cursor.ts`).
+- `apps/streamdeck/src/actions.ts:164-169` — `BuilderAction.renderTo` switches from `setTitle`
+  to `builderFaceSvg` + `setImage`; add the `face.ts` import. Nothing else in the file changes.
+- `apps/streamdeck/src/__tests__/actions.test.ts:146-155` — the two existing render assertions
+  currently expect `setTitle` to contain `plan review` / `implement` / `#101`. Update them to
+  assert the SVG face: `setImage` called with a string containing `#101` and the **mapped**
+  label (`Plan Approval` for pir-1's `plan-approval` gate, `Implement` for pir-2). Add
+  `setImage: vi.fn()` to the `slotKey` mock (`actions.test.ts:133`).
+- `apps/streamdeck/src/__tests__/face.test.ts` — **new**. Unit-test the pure module:
+  `stateLabel` for every gate/phase id + the empty and unmapped fallbacks; `builderFaceSvg`
+  contains the number and label text, wraps two-word gate labels, and emits an empty-slot
+  variant.
+
+## Risks & Alternatives Considered
+
+- **Risk: static PNG flashes before the first `setImage`.** Low impact (one paint on appear).
+  Mitigation if seen at the hardware gate: set the SVG in `onWillAppear` (already the path —
+  `renderTo` is called there) so the window is a single frame; only escalate to a manifest swap
+  if the flash is actually visible.
+- **Risk: label doesn't fit the band on the physical deck.** The whole point of §1(b) is that
+  the SVG sizes the band to the label (and wraps two-word gates), so truncation is impossible by
+  construction. The hardware gate is the real check; font sizes are cheap to tune in the SVG
+  without touching logic.
+- **Risk: import churn from air-1411** (parallel, touches `apps/streamdeck` imports only). My
+  change adds one new import line in `actions.ts` and one new file. If air-1411 merges first and
+  reorders imports, I re-resolve at merge and flag to the architect per instruction — no logic
+  overlap.
+- **Alternative: keep `setTitle`, just clean the string + a static composed PNG.** Rejected: a
+  PNG can't carry the live issue number/phase, and any title still overlays the icon — it
+  doesn't remove the stacking, only tidies it.
+- **Alternative: render with node-canvas.** Rejected: native dep, breaks the single-file esbuild
+  bundle for no benefit over an SVG string that `setImage` accepts natively.
+- **Alternative: key the map on `b.blocked` (server label).** Rejected: `blocked` is a
+  non-deterministic human label ("plan review") — mapping the canonical `blockedGate` id keeps
+  casing/lengths fully plugin-local (requirement 3) and deterministic.
+
+## Test Plan
+
+- **Unit (`face.test.ts`)**: `stateLabel` returns the exact label for each of the 9 mapped ids,
+  gate-beats-phase when both present, the title-cased fallback for an unknown id, and `''` for
+  no state; `builderFaceSvg` output contains the number + label, splits a two-word gate label
+  across two lines, and produces a distinct `Slot N` empty variant with no number.
+- **Unit (`actions.test.ts`)**: `BuilderAction.renderTo` calls `setImage` with an SVG string
+  containing `#101` and `Plan Approval` (pir-1, blocked plan-approval) / `Implement` (pir-2);
+  empty slot calls `setImage` with `Slot 2`; store-change still re-renders every slot key.
+- **Build/typecheck**: `pnpm --filter @cluesmith/codev-streamdeck build` and `check-types` clean;
+  `pnpm --filter @cluesmith/codev-streamdeck test` green. Run from the worktree.
+- **Manual (dev-approval = hardware session, photo-level):** deploy the built plugin to the
+  physical deck and photograph the Builder Action key across states — an **active phase**
+  (`#1414` + `Implement`, icon in the upper zone, no collision, no comma), a **blocked gate**
+  (`Dev Approval` two-line, legible), and an **empty slot** (`Slot N`). Confirm issue number,
+  phase label, and icon are each legible at a glance and that legibility matches the Gates key.
+  Verify press/rotate still fire the same verbs as before (regression check on the untouched
+  path).

--- a/codev/plans/1428-stream-deck-builder-action-key.md
+++ b/codev/plans/1428-stream-deck-builder-action-key.md
@@ -1,4 +1,4 @@
-# PIR Plan: Stream Deck Builder Action composite key face
+# PIR Plan: Stream Deck Builder Action composite, state-coded key face
 
 ## Understanding
 
@@ -22,12 +22,31 @@ The Gates/approve-gate key reads fine because its icon+label were composed as on
 Builder Action key stacks two layers that were never designed to coexist.
 
 The fix is to stop stacking layers: render the **entire** key face as one image in the plugin,
-with the icon confined to an upper zone and the text in a reserved band below, and to translate
-wire ids to deliberate display labels through a plugin-local map.
+with the icon confined to an upper zone and the text in a reserved band below.
+
+**Adopt the sidebar's model (scope, expanded 2026-08-12 with owner approval).** VS Code's
+Builders sidebar already differentiates builders on **two axes**
+(`apps/vscode/src/views/builder-row.ts`):
+
+- **Colour = state severity.** `blocked` → warning yellow
+  (`notificationsWarningIcon.foreground`), `waiting` → info blue
+  (`notificationsInfoIcon.foreground`), `active` → green (`testing.iconPassed`). The colour is
+  the constant "does this need me?" signal.
+- **Icon shape = which gate** (when blocked), via `gateIconFor`: `spec-approval` → `book`,
+  `plan-approval` → `checklist`, `dev-approval` → `code`, `pr` → `git-pull-request`,
+  `verify-approval` → `verified`, else `bell`. The shape encodes *what kind of review* is
+  needed; active/waiting builders show one generic glyph.
+
+The deck adopts the **same two axes**, so the deck and the sidebar tell one story and — the
+point that motivated the expansion — colour + icon carry the blocked/working distinction, which
+lets the text label stay short without collision. Concretely: a `plan-approval` key is **yellow
+with a checklist**, a `plan` phase key is **green with the bolt**; both can read "Plan" and stay
+unmistakable. This directly serves the #1381 context (the smart key became load-bearing under
+#1404's press-selects, so its face must carry its weight).
 
 **Key enabler (verified):** `KeyAction.setImage(image?, options?)` accepts *"an SVG `string`"*
-directly (SDK d.ts, `@elgato/streamdeck@2.1.0/dist/plugin/actions/key.d.ts:29-34`). So we can
-build the face as an SVG string with **zero new dependencies** — no canvas/native module, which
+directly (SDK d.ts, `@elgato/streamdeck@2.1.0/dist/plugin/actions/key.d.ts:29-34`). So we build
+the whole face as an SVG string with **zero new dependencies** — no canvas/native module, which
 matters because the plugin is a single esbuild→node bundle (`apps/streamdeck/esbuild.js`) and
 pure functions are the established, SDK-free-testable pattern here (cf. `src/nav/cursor.ts`).
 
@@ -35,200 +54,256 @@ pure functions are the established, SDK-free-testable pattern here (cf. `src/nav
 
 ### 1. New plugin-local module `apps/streamdeck/src/face.ts` (pure, no SDK import)
 
-Two responsibilities, both pure and unit-testable in isolation (mirrors `nav/cursor.ts`):
+All presentation logic lives here, pure and unit-testable in isolation (mirrors `nav/cursor.ts`).
+The deck LCD face is a **static SVG** — it cannot bind VS Code `ThemeColor` tokens — so the
+palette is inlined as hexes that mirror VS Code's default-theme values, with a comment tying each
+back to its token. The gate→icon and state→colour maps are the streamdeck twin of
+`builder-row.ts`; because the two apps can't import each other, they are duplicated with a
+sync-note (the same pattern as `GATE_LABELS` being kept in sync with `overview.ts`).
 
-**(a) Presentation label map** — wire id → display label. Keyed on the **canonical** ids
-`blockedGate` and `protocolPhase` (not `b.blocked`, which is a server-authored human label with
-non-deterministic casing). Gate wins over phase, matching the existing precedence in
-`phaseArtifactVerb` (`actions.ts:229-239`). This keeps presentation 100% plugin-local:
+**(a) State classification** — mirrors the sidebar's blocked > waiting > active precedence:
 
 ```ts
-// Gate a builder is blocked on (canonical blockedGate ids). Gate beats phase.
-const GATE_LABELS: Record<string, string> = {
-  'spec-approval': 'Spec Approval',
-  'plan-approval': 'Plan Approval',
-  'dev-approval':  'Dev Approval',
-  'pr':            'PR Review',
+export type BuilderState = 'blocked' | 'waiting' | 'active';
+
+/** Mirrors builder-row.ts: a blocked builder (gate pending) beats idle-waiting beats active. */
+export function builderState(b: Pick<OverviewBuilder, 'blocked' | 'blockedGate'>): BuilderState {
+  if (b.blocked || b.blockedGate) return 'blocked';
+  return 'active';
+  // `waiting` (blue) is the optional third severity — it needs an idle threshold derived from
+  // `lastDataAt`, matching the sidebar's `isIdleWaiting`. Core ships blocked/active; adding
+  // waiting later is a strict superset (the blue token is already defined, just unused until
+  // the classifier returns `'waiting'`). Decision flagged to the architect.
+}
+```
+
+**(b) State palette** — inlined hexes mirroring the sidebar tokens:
+
+```ts
+// Mirrors VS Code's default-theme state colours (apps/vscode/src/views/builder-row.ts →
+// BUILDER_STATE_GLYPH). The deck face is a static SVG with no ThemeColor binding, so the hexes
+// are inlined; keep in sync with the sidebar if that palette changes.
+const STATE_COLOR: Record<BuilderState, string> = {
+  blocked: '#cca700', // notificationsWarningIcon.foreground
+  waiting: '#3794ff', // notificationsInfoIcon.foreground
+  active:  '#73c991', // testing.iconPassed (dark)
 };
-// Coarse protocol phase (canonical protocolPhase ids). `verify` is the IN-PROGRESS
-// phase (→ 'Verify'); `verified` is porch's TERMINAL id (next.ts:204), with legacy
-// `complete` migrating to it (state.ts:135-140) — both display as 'Verified'.
+```
+
+**(c) Gate → icon map** — the streamdeck twin of `gateIconFor`, plus the `bell` fallback:
+
+```ts
+type GlyphKey = 'bolt' | 'book' | 'checklist' | 'code' | 'pull-request' | 'verified' | 'bell';
+
+// Keep in sync with GATE_ICONS in apps/vscode/src/views/builder-row.ts.
+const GATE_ICONS: Record<string, GlyphKey> = {
+  'spec-approval':   'book',
+  'plan-approval':   'checklist',
+  'dev-approval':    'code',
+  'pr':              'pull-request',
+  'verify-approval': 'verified',
+};
+```
+
+The actual glyph shapes are inlined SVG path data transcribed from `@vscode/codicons` (MIT) — a
+small `Record<GlyphKey, string>` of `<path>` snippets, **not** a new dependency (codicons aren't
+vendored; VS Code supplies them at runtime, so we carry only the handful of paths we use, with a
+provenance comment). Active/waiting builders show the plugin's `bolt`, tinted to the state colour.
+
+**(d) Presentation label map** — short labels; colour + icon now carry the state, so the label no
+longer has to. Keyed on canonical `blockedGate` / `protocolPhase` (never `b.blocked`, a
+server-authored human label). Gate beats phase, matching `phaseArtifactVerb`
+(`actions.ts:229-239`):
+
+```ts
+const GATE_LABELS: Record<string, string> = {
+  'spec-approval':   'Spec',
+  'plan-approval':   'Plan',
+  'dev-approval':    'Dev',
+  'pr':              'PR',
+  'verify-approval': 'Verify',
+};
+// `verify` is the IN-PROGRESS phase; `verified` is porch's TERMINAL id (next.ts:204), with
+// legacy `complete` migrating to it (state.ts:135-140) — both display 'Verified'.
 const PHASE_LABELS: Record<string, string> = {
-  specify:   'Specify',
-  plan:      'Plan',
-  implement: 'Implement',
-  review:    'Review',
-  verify:    'Verify',
-  verified:  'Verified',
-  complete:  'Verified',
+  specify: 'Specify', plan: 'Plan', implement: 'Implement',
+  review: 'Review', verify: 'Verify', verified: 'Verified', complete: 'Verified',
 };
 
-/** Deliberate display label for a builder's current state; '' → the caller's fallback. */
+/** Deliberate short label for a builder's state; '' → the caller's fallback. */
 export function stateLabel(b: Pick<OverviewBuilder, 'blockedGate' | 'protocolPhase'>): string {
   const gate = b.blockedGate ?? '';
   if (GATE_LABELS[gate]) return GATE_LABELS[gate];
   const phase = b.protocolPhase ?? '';
   if (PHASE_LABELS[phase]) return PHASE_LABELS[phase];
-  // Defensive fallback for an unmapped id: title-case the first token so nothing
-  // renders lowercase, and never emit a mid-word clip (the SVG never truncates —
-  // §(b) sizes the band to the label, not vice-versa).
-  const raw = gate || phase;
+  const raw = gate || phase; // defensive: title-case an unmapped id, never clip mid-word
   return raw ? raw.charAt(0).toUpperCase() + raw.slice(1) : '';
 }
 ```
 
-**Complete id → label table for review (every phase + gate id):**
+**Complete id → (label, icon, colour) table for review:**
 
-| Wire id | Source field | Display label |
-|---|---|---|
-| `spec-approval` | blockedGate | Spec Approval |
-| `plan-approval` | blockedGate | Plan Approval |
-| `dev-approval` | blockedGate | Dev Approval |
-| `pr` | blockedGate | PR Review |
-| `specify` | protocolPhase | Specify |
-| `plan` | protocolPhase | Plan |
-| `implement` | protocolPhase | Implement |
-| `review` | protocolPhase | Review |
-| `verify` | protocolPhase | Verify (in-progress) |
-| `verified` | protocolPhase | Verified (terminal — `next.ts:204`) |
-| `complete` | protocolPhase | Verified (legacy → `verified`, `state.ts:135-140`) |
-| `''` / unknown | either | title-cased raw, else empty |
+| Wire id | Source | Label | Icon | Colour |
+|---|---|---|---|---|
+| `spec-approval` | blockedGate | Spec | book | warning yellow |
+| `plan-approval` | blockedGate | Plan | checklist | warning yellow |
+| `dev-approval` | blockedGate | Dev | code | warning yellow |
+| `pr` | blockedGate | PR | git-pull-request | warning yellow |
+| `verify-approval` | blockedGate | Verify | verified | warning yellow |
+| _(blocked, unmapped gate)_ | blockedGate | title-cased | bell | warning yellow |
+| `specify` | protocolPhase | Specify | bolt | green |
+| `plan` | protocolPhase | Plan | bolt | green |
+| `implement` | protocolPhase | Implement | bolt | green |
+| `review` | protocolPhase | Review | bolt | green |
+| `verify` | protocolPhase | Verify | bolt | green |
+| `verified` | protocolPhase | Verified | bolt | green |
+| `complete` | protocolPhase | Verified (legacy) | bolt | green |
+| `''` / unknown | either | title-cased/empty | bolt | green |
 
-Longest single token is "Approval"/"Implement" (8–9 chars). Two-word gate labels are rendered
-as **two lines** ("Dev" / "Approval") by construction so nothing clips — see §(b).
-
-**(b) SVG face builder** — `builderFaceSvg(opts)` returns a self-contained `<svg>` string.
-Layout (72×72 viewBox; the deck upscales, and vector stays crisp):
+**(e) SVG face builder** — `builderFaceSvg(face)` returns a self-contained `<svg>` string.
+Layout (72×72 viewBox; the deck upscales, vector stays crisp):
 
 ```
 ┌───────────────┐  0
-│      ⚡        │   icon zone  (top ~34px): the bolt glyph, centered, drawn as
-│               │               an SVG <path> — no PNG overlay, no bleed-through
-├───────────────┤  ~36  hairline divider
-│    #1414      │   number line (bold ~17px, high-contrast) — the primary datum
-│  Dev Approval │   label band (~12px, muted; 1–2 lines, wrapped at the space
-└───────────────┘  72               for two-word gate labels — never mid-word)
+│      ⬛        │   icon zone (top ~30px): the state glyph — a gate codicon when
+│               │              blocked, the bolt otherwise — coloured by state
+├───────────────┤  ~35  hairline divider
+│    #1414      │   number line (bold ~16px, high-contrast) — the primary datum
+│    Plan       │   label band (~12px, one short line — colour+icon carry the state)
+└───────────────┘  72
 ```
 
-- Dark rounded background (`#1c1c1e`, matching the deck's neutral keys) so the composed face
-  reads as one design, like the Gates key.
-- Icon zone reserved at top; text band reserved at bottom. They never overlap **by
-  construction** — that is the whole fix for symptom (1).
-- Number line renders `#${issueId}` (or the builder `id` when `issueId` is null) at a size that
-  fits within the band width; "#1414" renders as literal glyphs with no comma (fixes the
-  data-corruption symptom).
-- Empty-slot variant: same frame, icon drawn dimmed/outline, band shows `Slot N`, no number
+- Dark rounded background (`#1b1b1e`, the deck's neutral key ground) so the composed face reads
+  as one design, like the Gates key.
+- **Icon zone and text band never overlap by construction** — the fix for symptom (1).
+- Glyph coloured by `STATE_COLOR[state]`; blocked keys read yellow-with-gate-shape, active keys
+  read green-with-bolt (the sidebar mirror).
+- Number line renders `#${issueId}` (or `id` when null); "#1414" renders as literal glyphs, no
+  comma (fixes the data-corruption symptom). Labels are short single words — one line, no wrap,
+  no truncation possible.
+- Empty-slot variant: same frame, bolt drawn dimmed/neutral-grey, band shows `Slot N`, no number
   line (requirement 4 — consistent row).
 
-The function signature is a plain data-in/string-out contract, e.g.:
-
 ```ts
-export function builderFaceSvg(
-  face:
-    | { kind: 'builder'; number: string; label: string }
-    | { kind: 'empty'; slot: string },
-): string
+export interface BuilderFace {
+  kind: 'builder'; number: string; label: string; state: BuilderState; icon: GlyphKey;
+}
+export function builderFaceSvg(face: BuilderFace | { kind: 'empty'; slot: string }): string;
+
+/** Assemble the full face descriptor for a builder — all mapping in one testable place. */
+export function faceForBuilder(b: OverviewBuilder): BuilderFace {
+  const state = builderState(b);
+  const icon: GlyphKey = state === 'blocked' ? (GATE_ICONS[b.blockedGate ?? ''] ?? 'bell') : 'bolt';
+  return { kind: 'builder', number: b.issueId ? `#${b.issueId}` : b.id, label: stateLabel(b), state, icon };
+}
 ```
 
 ### 2. Rewire `BuilderAction.renderTo` (`actions.ts:164-169`)
 
 Replace the `setTitle` overlay with an image render. **Only this method changes**; press/rotate
-behavior (`resolveVerb`, `onKeyDown`, `phaseArtifactVerb`, the `automatic`→`open-diff-first`
+behaviour (`resolveVerb`, `onKeyDown`, `phaseArtifactVerb`, the `automatic`→`open-diff-first`
 resolution from #1429/#1404/#1414) is **untouched**.
 
 ```ts
 protected renderTo(action: KeyAction, settings: SlotSettings): void {
   const b = slotBuilder(this.store, settings);
   const svg = b
-    ? builderFaceSvg({
-        kind: 'builder',
-        number: b.issueId ? `#${b.issueId}` : b.id,
-        label: stateLabel(b),
-      })
+    ? builderFaceSvg(faceForBuilder(b))
     : builderFaceSvg({ kind: 'empty', slot: settings.slot ?? '1' });
   void action.setImage(svg);
   void action.setTitle(''); // suppress the SDK title layer so the SVG is the whole face
 }
 ```
 
-`setTitle('')` guarantees no residual manifest/user title paints over the SVG (belt-and-braces
-against the exact stacking that caused symptom 1).
+All mapping stays in `face.ts`; the action stays a thin adapter. `setTitle('')` guarantees no
+residual manifest/user title paints over the SVG (belt-and-braces against the stacking that
+caused symptom 1).
 
 ### 3. No other layers change
 
 - **Manifest**: unchanged. The `icons/builder-action` PNG stays as the static/PI thumbnail; at
-  runtime `setImage` replaces the face. (If the hardware check shows the static PNG flashing
-  before first render, a follow-up could swap the manifest default — noted as a risk, not
-  planned work.)
-- **Wire / types / server**: **no change** (requirement 3). The map reads existing
-  `blockedGate` / `protocolPhase` fields already on `OverviewBuilder`.
+  runtime `setImage` replaces the face.
+- **Wire / types / server**: **no change** (requirement 3). Everything reads existing
+  `blockedGate` / `protocolPhase` / `issueId` fields already on `OverviewBuilder`.
+- **Press/rotate**: **no change** — the architect's hard boundary (#1429 `resolveVerb` intact).
 
 ## Files to Change
 
-- `apps/streamdeck/src/face.ts` — **new**. Pure module: `GATE_LABELS` / `PHASE_LABELS`,
-  `stateLabel()`, `builderFaceSvg()`. No SDK import (testable like `nav/cursor.ts`).
-- `apps/streamdeck/src/actions.ts:164-169` — `BuilderAction.renderTo` switches from `setTitle`
-  to `builderFaceSvg` + `setImage`; add the `face.ts` import. Nothing else in the file changes.
-- `apps/streamdeck/src/__tests__/actions.test.ts:146-155` — the two existing render assertions
-  currently expect `setTitle` to contain `plan review` / `implement` / `#101`. Update them to
-  assert the SVG face: `setImage` called with a string containing `#101` and the **mapped**
-  label (`Plan Approval` for pir-1's `plan-approval` gate, `Implement` for pir-2). Add
+- `apps/streamdeck/src/face.ts` — **new**. Pure module: `BuilderState` + `builderState()`,
+  `STATE_COLOR`, `GATE_ICONS` + inlined codicon `<path>` data, `GATE_LABELS`/`PHASE_LABELS` +
+  `stateLabel()`, `faceForBuilder()`, `builderFaceSvg()`. No SDK import (testable like
+  `nav/cursor.ts`).
+- `apps/streamdeck/src/actions.ts:164-169` — `BuilderAction.renderTo` switches to
+  `builderFaceSvg(faceForBuilder(b))` + `setImage`; add the `face.ts` import. Nothing else changes.
+- `apps/streamdeck/src/__tests__/actions.test.ts:146-155` — the two render assertions currently
+  expect `setTitle` to contain `plan review` / `implement` / `#101`. Update to assert `setImage`
+  called with an SVG string containing `#101` + the mapped short label + the state colour
+  (`#cca700` for pir-1's blocked plan-approval, `#73c991` for pir-2 active). Add
   `setImage: vi.fn()` to the `slotKey` mock (`actions.test.ts:133`).
 - `apps/streamdeck/src/__tests__/face.test.ts` — **new**. Unit-test the pure module:
-  `stateLabel` for every gate/phase id + the empty and unmapped fallbacks; `builderFaceSvg`
-  contains the number and label text, wraps two-word gate labels, and emits an empty-slot
-  variant.
+  `builderState` (blocked when `blockedGate`/`blocked`, else active); `faceForBuilder` picks the
+  right gate glyph per gate id + `bell` fallback + `bolt` when active; `stateLabel` for every
+  mapped id + fallbacks; `builderFaceSvg` output contains number, label, the state colour, and a
+  distinct `Slot N` empty variant.
 
 ## Risks & Alternatives Considered
 
-- **Risk: static PNG flashes before the first `setImage`.** Low impact (one paint on appear).
-  Mitigation if seen at the hardware gate: set the SVG in `onWillAppear` (already the path —
-  `renderTo` is called there) so the window is a single frame; only escalate to a manifest swap
-  if the flash is actually visible.
-- **Risk: a profile-pinned custom image silently defeats `setImage`.** The SDK doc is explicit:
-  *"The image can only be set by the plugin when the user has not specified a custom image."*
-  If the bundled/imported profile pins a custom image on a Builder Action key, our SVG face is
-  ignored with no error and the old PNG-under-title face persists. Mitigation: verify the
-  profile (including the #1404-revved one) does **not** pin custom images on these keys; if the
-  face fails to render at the hardware gate, this is the **first** suspect (before any SVG/logic
-  debugging). Added to the hardware checklist below.
-- **Risk: label doesn't fit the band on the physical deck.** The whole point of §1(b) is that
-  the SVG sizes the band to the label (and wraps two-word gates), so truncation is impossible by
-  construction. The hardware gate is the real check; font sizes are cheap to tune in the SVG
-  without touching logic.
-- **Risk: import churn from air-1411** (parallel, touches `apps/streamdeck` imports only). My
-  change adds one new import line in `actions.ts` and one new file. If air-1411 merges first and
-  reorders imports, I re-resolve at merge and flag to the architect per instruction — no logic
-  overlap.
-- **Alternative: keep `setTitle`, just clean the string + a static composed PNG.** Rejected: a
-  PNG can't carry the live issue number/phase, and any title still overlays the icon — it
-  doesn't remove the stacking, only tidies it.
+- **Risk: gate→icon / state→colour duplicated from `builder-row.ts`.** The streamdeck plugin and
+  the vscode app can't import each other, so the maps are twinned with a sync-note comment (same
+  established pattern as `overview.ts` ↔ `builder-row.ts` `GATE_LABELS`). If the sidebar palette
+  or gate icons change, both must update. Low churn (gates rarely change); the comment names the
+  counterpart file.
+- **Risk: inlined codicon paths.** We transcribe a handful of `@vscode/codicons` (MIT) `<path>`
+  strings rather than add a dependency. Provenance noted in a comment. The glyphs must read at
+  72px on hardware — verified at the photo gate; sizes/strokes are cheap to tune in the SVG.
+- **Risk: a profile-pinned custom image silently defeats `setImage`.** SDK doc: *"The image can
+  only be set by the plugin when the user has not specified a custom image."* If the
+  bundled/imported profile pins a custom image on a Builder Action key, the SVG face is ignored
+  with no error. Mitigation: verify the profile (incl. the #1404-revved one) does **not** pin
+  custom images; if the face doesn't render at the gate, this is the **first** suspect. In the
+  hardware checklist.
+- **Risk: static PNG flashes before the first `setImage`.** Low impact (one paint on appear); the
+  SVG is set in the `onWillAppear`→`renderTo` path, so the window is a single frame. Escalate to a
+  manifest swap only if visibly flashing.
+- **Risk: import churn from air-1411** (parallel, touches `apps/streamdeck` imports only). This
+  change adds one import line in `actions.ts` plus one new file. Re-resolve at merge and flag to
+  the architect per instruction — no logic overlap.
+- **Observation (not a change): `verify-approval` press-path gap.** The presentation map now
+  renders `verify-approval` (label + `verified` icon), mirroring the sidebar. But the press
+  resolver `phaseArtifactVerb` (`actions.ts:229-239`) doesn't handle `verify-approval` — a
+  pre-existing gap. Left untouched here (press/rotate is out of scope per the architect boundary);
+  flagged for a separate follow-up.
+- **Alternative: neutral face, differentiate by text only (the prior plan).** Rejected after the
+  owner review: short gate labels alone collide with same-named phases (`plan-approval` vs `plan`);
+  two-word labels wrap to cramped two-line text. Colour + icon differentiate without either cost,
+  and match what the owner already reads in the sidebar.
 - **Alternative: render with node-canvas.** Rejected: native dep, breaks the single-file esbuild
   bundle for no benefit over an SVG string that `setImage` accepts natively.
-- **Alternative: key the map on `b.blocked` (server label).** Rejected: `blocked` is a
-  non-deterministic human label ("plan review") — mapping the canonical `blockedGate` id keeps
-  casing/lengths fully plugin-local (requirement 3) and deterministic.
+- **Alternative: key the maps on `b.blocked` (server label).** Rejected: `blocked` is a
+  non-deterministic human label — keying canonical `blockedGate` keeps everything plugin-local and
+  deterministic.
 
 ## Test Plan
 
-- **Unit (`face.test.ts`)**: `stateLabel` returns the exact label for each of the 11 mapped ids
-  (incl. `verify`→'Verify' distinct from `verified`/`complete`→'Verified'), gate-beats-phase
-  when both present, the title-cased fallback for an unknown id, and `''` for
-  no state; `builderFaceSvg` output contains the number + label, splits a two-word gate label
-  across two lines, and produces a distinct `Slot N` empty variant with no number.
-- **Unit (`actions.test.ts`)**: `BuilderAction.renderTo` calls `setImage` with an SVG string
-  containing `#101` and `Plan Approval` (pir-1, blocked plan-approval) / `Implement` (pir-2);
-  empty slot calls `setImage` with `Slot 2`; store-change still re-renders every slot key.
-- **Build/typecheck**: `pnpm --filter @cluesmith/codev-streamdeck build` and `check-types` clean;
-  `pnpm --filter @cluesmith/codev-streamdeck test` green. Run from the worktree.
+- **Unit (`face.test.ts`)**: `builderState` returns `blocked` for a set `blockedGate` (or
+  `blocked`) and `active` otherwise; `faceForBuilder` maps each gate id to its glyph
+  (`book`/`checklist`/`code`/`pull-request`/`verified`), falls back to `bell` for an unmapped
+  blocked gate, and uses `bolt` when active; `stateLabel` returns the exact short label for every
+  mapped id (incl. `verify`→'Verify' vs `verified`/`complete`→'Verified') with the title-cased
+  fallback; `builderFaceSvg` output contains the number, the short label, and the state colour,
+  and the empty variant renders `Slot N` with no number.
+- **Unit (`actions.test.ts`)**: `renderTo` calls `setImage` with an SVG containing `#101`,
+  `Plan`, and `#cca700` (pir-1, blocked plan-approval) / `Implement` and `#73c991` (pir-2,
+  active); empty slot → `setImage` containing `Slot 2`; a store change re-renders every slot key.
+- **Build/typecheck**: `pnpm --filter @cluesmith/codev-streamdeck build`, `check-types`, and
+  `test` all clean. Run from the worktree.
 - **Manual (dev-approval = hardware session, photo-level):** deploy the built plugin to the
-  physical deck and photograph the Builder Action key across states — an **active phase**
-  (`#1414` + `Implement`, icon in the upper zone, no collision, no comma), a **blocked gate**
-  (`Dev Approval` two-line, legible), and an **empty slot** (`Slot N`). Confirm issue number,
-  phase label, and icon are each legible at a glance and that legibility matches the Gates key.
-  Verify press/rotate still fire the same verbs as before (regression check on the untouched
-  path).
-- **Manual — pre-flight (do this first at the hardware gate):** confirm the active/imported
-  profile (incl. the #1404-revved one) does **not** pin a custom image on the Builder Action
-  keys — a pinned custom image makes `setImage` a silent no-op. If the SVG face doesn't render,
-  check this before debugging the SVG or the render path.
+  physical deck and photograph the Builder Action key across states — **active** (`#1414` +
+  `Implement`, green bolt), each **blocked gate** (yellow, with its distinct glyph — checklist
+  for plan-approval, code for dev-approval, pull-request for pr), and **empty** (`Slot N`).
+  Confirm: number reads with no comma; colour (yellow vs green) reads at a glance; each gate's
+  icon is distinguishable; legibility matches the Gates key; and press/rotate still fire the same
+  verbs (regression check on the untouched path).
+- **Manual — pre-flight (first at the hardware gate):** confirm the active/imported profile
+  (incl. #1404-revved) does **not** pin a custom image on the Builder Action keys — a pinned
+  custom image makes `setImage` a silent no-op. Check this before debugging the SVG or render path.

--- a/codev/plans/1428-stream-deck-builder-action-key.md
+++ b/codev/plans/1428-stream-deck-builder-action-key.md
@@ -307,3 +307,13 @@ caused symptom 1).
 - **Manual — pre-flight (first at the hardware gate):** confirm the active/imported profile
   (incl. #1404-revved) does **not** pin a custom image on the Builder Action keys — a pinned
   custom image makes `setImage` a silent no-op. Check this before debugging the SVG or render path.
+
+## Scope addendum (post-approval, 2026-08-13)
+
+This plan (approved as written) scopes the **Builder Action** key. After approval, the owner
+confirmed on hardware that the **Gates** key (`ApproveGate`) has the identical text-over-icon
+overlap, and the lane owner ruled the fix rides in this PR. So `ApproveGate.renderTo` also switched
+to the composite `setImage(svgToDataUri(...))` treatment via a new `gatesFaceSvg`, sharing the same
+`face.ts` frame. Investigation confirmed the bug class ends there: `action`/`dev-server` keys are
+icon-only, and the encoders use `setFeedback` layouts. Broader per-button posture work remains the
+parked #1381. See the review for the full record.

--- a/codev/projects/1428-stream-deck-builder-action-key/status.yaml
+++ b/codev/projects/1428-stream-deck-builder-action-key/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-08-12T12:05:28.964Z'
-updated_at: '2026-08-12T21:20:15.890Z'
+updated_at: '2026-08-12T21:20:26.390Z'
 pr_history:
   - phase: review
     pr_number: 1432

--- a/codev/projects/1428-stream-deck-builder-action-key/status.yaml
+++ b/codev/projects/1428-stream-deck-builder-action-key/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-08-12T12:08:57.421Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T12:05:28.964Z'
-updated_at: '2026-08-12T12:05:28.965Z'
+updated_at: '2026-08-12T12:08:57.422Z'

--- a/codev/projects/1428-stream-deck-builder-action-key/status.yaml
+++ b/codev/projects/1428-stream-deck-builder-action-key/status.yaml
@@ -1,7 +1,7 @@
 id: '1428'
 title: stream-deck-builder-action-key
 protocol: pir
-phase: review
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -21,7 +21,7 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-08-12T12:05:28.964Z'
-updated_at: '2026-08-12T21:34:22.024Z'
+updated_at: '2026-08-12T21:34:30.663Z'
 pr_history:
   - phase: review
     pr_number: 1432

--- a/codev/projects/1428-stream-deck-builder-action-key/status.yaml
+++ b/codev/projects/1428-stream-deck-builder-action-key/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-08-12T12:08:57.421Z'
+    approved_at: '2026-08-12T12:40:37.076Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T12:05:28.964Z'
-updated_at: '2026-08-12T12:08:57.422Z'
+updated_at: '2026-08-12T12:40:37.077Z'

--- a/codev/projects/1428-stream-deck-builder-action-key/status.yaml
+++ b/codev/projects/1428-stream-deck-builder-action-key/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-08-12T21:17:28.353Z'
   pr:
     status: pending
+    requested_at: '2026-08-12T21:30:52.992Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-08-12T12:05:28.964Z'
-updated_at: '2026-08-12T21:20:26.390Z'
+updated_at: '2026-08-12T21:30:52.993Z'
 pr_history:
   - phase: review
     pr_number: 1432
     branch: builder/pir-1428
     created_at: '2026-08-12T21:20:15.889Z'
+pr_ready_for_human: true

--- a/codev/projects/1428-stream-deck-builder-action-key/status.yaml
+++ b/codev/projects/1428-stream-deck-builder-action-key/status.yaml
@@ -1,7 +1,7 @@
 id: '1428'
 title: stream-deck-builder-action-key
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T12:05:28.964Z'
-updated_at: '2026-08-12T21:17:28.353Z'
+updated_at: '2026-08-12T21:17:34.500Z'

--- a/codev/projects/1428-stream-deck-builder-action-key/status.yaml
+++ b/codev/projects/1428-stream-deck-builder-action-key/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-08-12T12:40:37.076Z'
   dev-approval:
     status: pending
+    requested_at: '2026-08-12T12:46:13.255Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T12:05:28.964Z'
-updated_at: '2026-08-12T12:40:44.877Z'
+updated_at: '2026-08-12T12:46:13.256Z'

--- a/codev/projects/1428-stream-deck-builder-action-key/status.yaml
+++ b/codev/projects/1428-stream-deck-builder-action-key/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-08-12T12:46:13.255Z'
     approved_at: '2026-08-12T21:17:28.353Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-08-12T21:30:52.992Z'
+    approved_at: '2026-08-12T21:34:22.022Z'
 iteration: 1
 build_complete: true
 history: []
 started_at: '2026-08-12T12:05:28.964Z'
-updated_at: '2026-08-12T21:30:52.993Z'
+updated_at: '2026-08-12T21:34:22.024Z'
 pr_history:
   - phase: review
     pr_number: 1432
     branch: builder/pir-1428
     created_at: '2026-08-12T21:20:15.889Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/1428-stream-deck-builder-action-key/status.yaml
+++ b/codev/projects/1428-stream-deck-builder-action-key/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T12:05:28.964Z'
-updated_at: '2026-08-12T21:17:34.500Z'
+updated_at: '2026-08-12T21:20:15.890Z'
+pr_history:
+  - phase: review
+    pr_number: 1432
+    branch: builder/pir-1428
+    created_at: '2026-08-12T21:20:15.889Z'

--- a/codev/projects/1428-stream-deck-builder-action-key/status.yaml
+++ b/codev/projects/1428-stream-deck-builder-action-key/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-08-12T12:08:57.421Z'
     approved_at: '2026-08-12T12:40:37.076Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-08-12T12:46:13.255Z'
+    approved_at: '2026-08-12T21:17:28.353Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T12:05:28.964Z'
-updated_at: '2026-08-12T12:46:13.256Z'
+updated_at: '2026-08-12T21:17:28.353Z'

--- a/codev/projects/1428-stream-deck-builder-action-key/status.yaml
+++ b/codev/projects/1428-stream-deck-builder-action-key/status.yaml
@@ -1,0 +1,18 @@
+id: '1428'
+title: stream-deck-builder-action-key
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-12T12:05:28.964Z'
+updated_at: '2026-08-12T12:05:28.965Z'

--- a/codev/projects/1428-stream-deck-builder-action-key/status.yaml
+++ b/codev/projects/1428-stream-deck-builder-action-key/status.yaml
@@ -1,7 +1,7 @@
 id: '1428'
 title: stream-deck-builder-action-key
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-12T12:05:28.964Z'
-updated_at: '2026-08-12T12:40:37.077Z'
+updated_at: '2026-08-12T12:40:44.877Z'

--- a/codev/resources/lessons-learned.md
+++ b/codev/resources/lessons-learned.md
@@ -66,6 +66,15 @@ Generalizable wisdom extracted from review documents, ordered by impact. Updated
 
 ## Architecture
 
+- [From #1428] Twinned per-app *presentation* maps kept aligned by sync-note comments are an
+  accepted pattern (owner-ruled), not a violation of the "consolidate duplicates rather than
+  syncing" lesson. When two apps must present the same vocabulary but can't/shouldn't cross-import
+  — e.g. the Stream Deck plugin replicating the VS Code sidebar's state colours + gate icons, where
+  a static SVG can't bind `ThemeColor` tokens and the plugin bundle must stay dependency-free —
+  duplicating the small maps with a comment naming the counterpart (`face.ts` ↔ `builder-row.ts`)
+  is the intended design. Don't reflexively propose a shared module for presentation-only
+  vocabulary; the consolidation lesson targets *stateful/behavioral* duplication, not independent
+  look-replication across a boundary the architecture deliberately keeps un-crossed.
 - Before adding a new stateful component, check whether one already running models the same data — extending it can collapse the feature to one operation. The reconnect-replay emulator "to be built" turned out to be the render gate's per-session headless screen mirror, already fed every output byte; the whole feature reduced to a serialize step on the attach path, at near-zero marginal memory.
 - A library addon typed against a sibling package can still be runtime-compatible with yours; prove compatibility with behavior tests (round-trip the real workload), then bridge the declared-type gap with one explicit documented cast rather than forking or vendoring.
 - [From #1205] A cap that trims back to exactly its ceiling re-trims on the very next append, so every subsequent call copies the whole structure — O(n) per call where the code was deliberately O(chunk). Trim to a *fraction* of the ceiling (half works) so the copy amortises over the next growth window. The failure is invisible to correctness tests: the cap holds, the data is right, and only throughput degrades, which is exactly the property the original optimisation existed to protect.
@@ -346,6 +355,14 @@ Generalizable wisdom extracted from review documents, ordered by impact. Updated
 
 ## UI/UX
 
+- [From #1428] Stream Deck's `setImage` accepts an SVG per the SDK d.ts, but a *raw* `<svg>`
+  string is silently dropped on-device (Stream Deck 6.9) — the key reverts to its manifest PNG
+  with no error. Two undocumented requirements: encode as a base64 `data:image/svg+xml` data URI,
+  **and** give the root `<svg>` an intrinsic `width`/`height` (not just `viewBox`) or the
+  rasterizer drops the sizeless image. The SDK forwards the string verbatim (`key.js`), so the
+  type doc's "SVG string" claim is not a device guarantee. Build + typecheck + unit tests were all
+  green — only the hardware gate exposed it (a textbook case for PIR's device gate). Fix pattern:
+  `svgToDataUri` + intrinsic size in `apps/streamdeck/src/face.ts`.
 - [From #1179] `vscode.QuickPickItem` reserves the `kind` property for its separator enum
   (`QuickPickItemKind`), so a custom item type using `kind` as its own discriminator fails
   the `createQuickPick<T extends QuickPickItem>` constraint. Pick a different name

--- a/codev/reviews/1428-stream-deck-builder-action-key.md
+++ b/codev/reviews/1428-stream-deck-builder-action-key.md
@@ -1,54 +1,114 @@
-# PIR Review: Stream Deck Builder Action composite, state-coded key face
+# PIR Review: Stream Deck composite, state-coded key faces
 
-> **Status: seeded during the plan phase.** This file currently holds only the forward-looking
-> notes the architect asked to record before the plan-approval gate. The full review (what was
-> built, what was learned at the hardware gate, CMAP outcomes) is written in the review phase.
+Fixes #1428
 
-## Decision: twinned presentation vocabulary is intentional replication (not shared code)
+## Summary
 
-The deck reproduces the VS Code sidebar's visual language — state colours + gate icons —
-**independently**. It does not import from the vscode app and is not meant to.
+The Builder Action key rendered by stacking a `setTitle` over a full-bleed bolt PNG, so text
+landed on the icon's diagonal (`#1414` even read as `#1,414` where the bolt edge bled between
+digits), casing came raw off the wire, and long phase names clipped. This PR composes the **whole**
+key face in-plugin as one SVG handed to `setImage` — an icon zone up top, a reserved text band
+below — and adds a plugin-local presentation vocabulary that mirrors the VS Code Builders sidebar's
+two axes: **colour = state** (blocked yellow / active green) and **icon = gate**
+(book / checklist / code / pull-request / verified, bolt otherwise), with short deliberate labels.
+The same composite treatment was applied to the **Gates key** (`ApproveGate`), which had the
+identical text-over-icon overlap. Presentation is entirely plugin-local — no wire, types, or server
+change — and press/rotate behaviour is untouched.
 
-- `apps/streamdeck/src/face.ts` — `STATE_COLOR` (state → hex), `GATE_ICONS` (gate → glyph),
-  `GATE_LABELS` / `PHASE_LABELS`. Self-contained: inlined hexes (a static SVG can't bind VS Code
-  `ThemeColor` tokens) and its own transcribed codicon paths.
-- `apps/vscode/src/views/builder-row.ts` — the sidebar's `BUILDER_STATE_GLYPH` / `gateIconFor`.
+## Files Changed
 
-**Owner ruling (Amr, 2026-08-12) — this is an ACCEPTED PATTERN, not tech debt.** Twinned per-app
-presentation maps kept aligned by sync-note comments (the same pattern already used between
-`overview.ts` and `builder-row.ts` for `GATE_LABELS`) are the intended design here: no cross-app
-import, no shared vocabulary module. The goal is to *replicate the behaviour*, not to share the
-source. It is explicitly **not** a single-source-of-truth violation and needs no shared home.
+vs merge-base `84407b8`:
 
-Context: a shared-home module was raised as a candidate by `main`/the architect for the humans to
-weigh; the owner weighed it and **ruled** the twinned pattern accepted — recorded here as the
-settled decision so it isn't re-litigated or re-proposed as a consolidation follow-up. No action.
+- `apps/streamdeck/src/face.ts` (+232 / -0) — new pure module: state classification, state→colour
+  palette, gate→icon map + in-plugin glyphs, label maps, `faceForBuilder`, `builderFaceSvg`,
+  `gatesFaceSvg`, `svgToDataUri`.
+- `apps/streamdeck/src/actions.ts` (+12 / -3) — `BuilderAction.renderTo` and `ApproveGate.renderTo`
+  switch from `setTitle` overlays to composite `setImage` SVG data URIs.
+- `apps/streamdeck/src/__tests__/face.test.ts` (+122 / -0) — new unit tests for the pure module.
+- `apps/streamdeck/src/__tests__/actions.test.ts` (+43 / -15) — render assertions updated to decode
+  the data-URI face; Gates-face and empty-slot coverage added.
+- `codev/resources/lessons-learned.md` (+2 lessons) — see Lessons Learned Updates.
+- Plan / review / thread under `codev/`.
 
-## Lessons (seed)
+## Commits
 
-- **Stream Deck `setImage`: the SDK's "SVG string" claim does not survive contact with the device.**
-  `@elgato/streamdeck@2.1.0`'s `key.d.ts` documents that `setImage` accepts *"an SVG string"*, and
-  the SDK forwards it verbatim (`key.js:51-59`). On real hardware (Stream Deck 6.9) a raw `<svg>`
-  string is **silently dropped** — the key reverts to its manifest PNG with no error. Two things are
-  required and neither is in the type doc: (1) encode as a base64 **`data:image/svg+xml`** data URI
-  (the SDK's separately-documented "base64 encoded string with the mime type declared" form), and
-  (2) give the root `<svg>` an **intrinsic `width`/`height`**, not just a `viewBox`, or the
-  rasterizer drops the sizeless image. Diagnosis was fast because `setTitle('')` had visibly taken
-  effect (text gone) while the face stayed on the PNG — isolating the failure to the image layer,
-  not a pinned custom image. This is exactly the class of defect the PIR hardware gate exists to
-  catch: build + typecheck + unit tests were all green, but "it renders" was only true on the
-  device. Reusable for anyone touching `setImage` (`svgToDataUri` + `width`/`height` in `face.ts`).
-- **Twinned per-app presentation maps with sync-notes are an accepted pattern, not SSOT debt
-  (owner-ruled).** When two apps must present the same vocabulary but can't/shouldn't cross-import
-  (e.g. a static SVG can't bind VS Code `ThemeColor` tokens), duplicating the small maps with a
-  sync-note comment naming the counterpart is the intended design — don't reflexively flag it as a
-  single-source-of-truth violation or propose a shared home. Candidate for the lessons doc at
-  review time.
-- **`verify-approval` press-path gap → filed as #1431 (BUGFIX, sequenced after this merge).**
-  Investigating the VS Code sidebar's gate map surfaced that `apps/vscode/src/views/builder-row.ts`
-  handles a `verify-approval` gate that the Stream Deck's press resolver
-  `phaseArtifactVerb` (`apps/streamdeck/src/actions.ts:229-239`) does not. #1428 renders
-  `verify-approval` on the *face* (label + `verified` icon) but leaves the *press* path untouched
-  (out of scope: press/rotate is a hard boundary). The press gap is #1431. Lesson: cross-checking a
-  sibling surface (the sidebar) against the one you're changing catches vocabulary drift that
-  single-surface work misses.
+- `c4f4f1488` [PIR #1428] Composite state-coded key face: render Builder Action via setImage SVG
+- `c0d7c1a5a` [PIR #1428] Tests: face.ts unit tests + BuilderAction setImage assertions
+- `b64a7c546` [PIR #1428] Fix setImage: base64 svg+xml data URI + intrinsic width/height (raw SVG dropped by Stream Deck)
+- `4d7170202` [PIR #1428] Apply composite face to the Gates key (same text-over-icon fix)
+- `62290be9e` / `b0143c533` / `a6040a901` [PIR #1428] Review seed + owner-ruling + hardware lesson
+- (plus thread + porch phase-transition commits)
+
+## Test Results
+
+- `pnpm --filter @cluesmith/codev-streamdeck check-types`: ✓ pass
+- `pnpm --filter @cluesmith/codev-streamdeck build` (esbuild): ✓ pass
+- `pnpm --filter @cluesmith/codev-streamdeck test`: ✓ pass (106 tests, ~25 new)
+- **Manual (hardware, dev-approval gate, Amr):** photo-level check on the physical deck across
+  states — Builder Action keys (active phase, blocked gates, empty slot) and the Gates key
+  (pending badge count vs no-gates). The **first** hardware pass exposed that raw SVG didn't render
+  (see Lessons); after the data-URI + intrinsic-size fix, faces render and read cleanly, and the
+  Gates key was re-checked in the same session. Approved.
+
+## Architecture Updates
+
+No arch-doc change qualifies. This is plugin-internal rendering: it adds one module
+(`apps/streamdeck/src/face.ts`) but changes no module boundary, invariant, port, state, or wire
+contract (`arch-critical.md`'s system-shape facts are untouched, and the streamdeck entry in
+`arch.md`'s Monorepo Structure still describes the plugin accurately). The reusable knowledge from
+this PR is an API-gotcha recipe and a duplication-pattern ruling — both routed to lessons, the
+correct tier, below.
+
+## Lessons Learned Updates
+
+Two COLD entries added to `codev/resources/lessons-learned.md` (both spec-narrow recipes/rulings,
+not behavior-changing cross-cutting rules, so neither belongs in the capped HOT tier):
+
+- **UI/UX** — Stream Deck `setImage` silently drops a raw `<svg>` on-device; it needs a base64
+  `data:image/svg+xml` data URI **and** an intrinsic `width`/`height`. Build/typecheck/tests were
+  green; only the hardware gate caught it — the defect class PIR's device gate exists for.
+- **Architecture** — twinned per-app *presentation* maps with sync-note comments are an accepted
+  pattern (owner-ruled), not a violation of the "consolidate duplicates" lesson; that lesson
+  targets stateful/behavioural duplication, not independent look-replication across a boundary the
+  architecture deliberately keeps un-crossed (`face.ts` ↔ `builder-row.ts`).
+
+## Twinned presentation vocabulary — accepted pattern (owner ruling)
+
+The deck reproduces the VS Code sidebar's visual language (state colours + gate icons)
+independently; it does **not** import from the vscode app. `apps/streamdeck/src/face.ts` carries its
+own `STATE_COLOR` (inlined hexes mirroring the sidebar's `ThemeColor` tokens) and `GATE_ICONS` +
+in-plugin glyphs, twinned with `apps/vscode/src/views/builder-row.ts` and kept aligned by
+sync-note comments. **Owner ruling (Amr):** this is the intended design — no cross-app import, no
+shared vocabulary module — recorded so it isn't re-litigated. The lane owner ruled the Gates-key
+extension **rides in this PR** (same root cause, shares the `face.ts` frame; the bug class ends
+there — `action`/`dev-server` are icon-only and the dials use `setFeedback`).
+
+## Things to Look At During PR Review
+
+- **`svgToDataUri` + intrinsic `width`/`height`** (`face.ts`) — the load-bearing hardware fix. A raw
+  `<svg>` string is silently dropped by Stream Deck 6.9 despite the SDK d.ts's "SVG string" claim.
+- **`face.ts` glyphs are hand-drawn in the codicon idiom**, not the codicon font (not vendored →
+  keeps the bundle dependency-free). Legibility at the deck's upscaled size was the hardware check.
+- **Twinned maps** (`STATE_COLOR` / `GATE_ICONS` / labels) vs `builder-row.ts` — intentional
+  duplication with sync-notes, per the owner ruling above; not a consolidation candidate.
+- **`verify-approval`** renders on the face but the press resolver `phaseArtifactVerb` doesn't
+  handle it — a pre-existing gap filed as **#1431** (BUGFIX, sequenced after this merge), out of
+  scope here (press/rotate untouched).
+
+## How to Test Locally
+
+- **View diff**: VSCode sidebar → right-click builder `pir-1428` → **Review Diff**.
+- **Run dev**: VSCode sidebar → **Run Dev**, or `afx dev pir-1428`, then load the plugin on a deck.
+- **What to verify** (maps to the plan's Test Plan):
+  - Builder Action — active (green bolt, `#NNNN`, phase label, no comma, no collision), each blocked
+    gate (yellow, distinct glyph), empty slot (`Slot N`).
+  - Gates key — pending count in warning-yellow vs dim `Gates` when none pending.
+  - Press/rotate still fire the same verbs (regression on the untouched path).
+  - Pre-flight if a face won't render: confirm no profile-pinned custom image on the key.
+
+## Lessons (detail for this PR)
+
+- **`verify-approval` press-path gap → #1431.** Cross-checking the VS Code sidebar's gate map
+  against the Stream Deck press resolver surfaced that `builder-row.ts` handles a `verify-approval`
+  gate `phaseArtifactVerb` doesn't. #1428 renders it on the face; the press gap is #1431. Lesson:
+  cross-checking a sibling surface catches vocabulary drift single-surface work misses.

--- a/codev/reviews/1428-stream-deck-builder-action-key.md
+++ b/codev/reviews/1428-stream-deck-builder-action-key.md
@@ -43,7 +43,7 @@ vs merge-base `84407b8`:
 
 - `pnpm --filter @cluesmith/codev-streamdeck check-types`: ✓ pass
 - `pnpm --filter @cluesmith/codev-streamdeck build` (esbuild): ✓ pass
-- `pnpm --filter @cluesmith/codev-streamdeck test`: ✓ pass (106 tests, ~25 new)
+- `pnpm --filter @cluesmith/codev-streamdeck test`: ✓ pass (108 tests, ~27 new)
 - **Manual (hardware, dev-approval gate, Amr):** photo-level check on the physical deck across
   states — Builder Action keys (active phase, blocked gates, empty slot) and the Gates key
   (pending badge count vs no-gates). The **first** hardware pass exposed that raw SVG didn't render
@@ -82,6 +82,24 @@ sync-note comments. **Owner ruling (Amr):** this is the intended design — no c
 shared vocabulary module — recorded so it isn't re-litigated. The lane owner ruled the Gates-key
 extension **rides in this PR** (same root cause, shares the `face.ts` frame; the bug class ends
 there — `action`/`dev-server` are icon-only and the dials use `setFeedback`).
+
+## 3-Way Consultation Dispositions (review phase, single pass)
+
+- **Codex — REQUEST_CHANGES (HIGH), fixed.** `stateLabel` let a *mapped phase* win over an
+  *unmapped gate*, so a builder blocked at a future/unknown gate would show its phase label while
+  the face was already yellow + bell (blocked) — masking the pending gate. Real defect in the
+  documented "gate beats phase" fallback. **Fix:** any non-empty `blockedGate` now wins (mapped
+  label, else its first token title-cased, e.g. `security-approval` → `Security`); phase only when
+  there is no gate. **Regression test:** `face.test.ts` "an unmapped gate STILL wins over a known
+  phase". PIR is single-pass — this fix was **not** independently re-reviewed; please sanity-check
+  it at the `pr` gate.
+- **Gemini — APPROVE.** No issues.
+- **Claude — APPROVE**, with four non-blocking notes, all addressed: stale module-doc comment in
+  `actions.ts` (updated); long builder-id / unmapped-label could overflow the 72px face (added
+  `textLength`/`lengthAdjust` shrink-to-fit via `fit()`, with a test); the plan still said "only
+  `BuilderAction.renderTo` changes" (added a post-approval scope addendum to the plan); a ternary
+  in `renderTo` against the project's no-ternary preference (converted to if/else, and the
+  `faceForBuilder` ternaries too).
 
 ## Things to Look At During PR Review
 

--- a/codev/reviews/1428-stream-deck-builder-action-key.md
+++ b/codev/reviews/1428-stream-deck-builder-action-key.md
@@ -1,0 +1,41 @@
+# PIR Review: Stream Deck Builder Action composite, state-coded key face
+
+> **Status: seeded during the plan phase.** This file currently holds only the forward-looking
+> notes the architect asked to record before the plan-approval gate. The full review (what was
+> built, what was learned at the hardware gate, CMAP outcomes) is written in the review phase.
+
+## Follow-up candidates (recorded for humans to weigh — not implemented here)
+
+### Twinned presentation vocabulary: `face.ts` ↔ `builder-row.ts` wants a shared home
+
+This project deliberately **duplicates** the builder presentation vocabulary across two apps:
+
+- `apps/streamdeck/src/face.ts` — `STATE_COLOR` (state → hex), `GATE_ICONS` (gate → glyph),
+  `GATE_LABELS` / `PHASE_LABELS`.
+- `apps/vscode/src/views/builder-row.ts` — `BUILDER_STATE_GLYPH` (state → codicon + ThemeColor),
+  `gateIconFor` (gate → codicon), and the sidebar's label vocabulary.
+
+The duplication is **forced by the current architecture**: the two apps can't import each other,
+so the streamdeck twin carries inlined hexes (a static SVG can't bind VS Code `ThemeColor`
+tokens) and its own transcribed codicon paths, kept in sync only by comments.
+
+This sits in direct tension with our **single-source-of-truth** lesson (consolidate duplicates
+rather than syncing them). It is flagged as a **candidate** for a shared home — e.g. a
+neutral, environment-agnostic vocabulary module (gate/phase ids → semantic label + icon *name* +
+semantic colour *role*), consumed by both apps, with each app binding the semantic roles to its
+own render primitives (ThemeColor tokens in vscode, inlined hexes + codicon paths on the deck).
+
+**Not in scope for #1428** (it would touch shared packages and the vscode app; #1428 is
+plugin-local by requirement). Co-flagged by `main`. Recorded here for the humans to decide
+whether/when to spin it out. Do not implement as part of this PR.
+
+## Lessons (seed)
+
+- **`verify-approval` press-path gap → filed as #1431 (BUGFIX, sequenced after this merge).**
+  Investigating the VS Code sidebar's gate map surfaced that `apps/vscode/src/views/builder-row.ts`
+  handles a `verify-approval` gate that the Stream Deck's press resolver
+  `phaseArtifactVerb` (`apps/streamdeck/src/actions.ts:229-239`) does not. #1428 renders
+  `verify-approval` on the *face* (label + `verified` icon) but leaves the *press* path untouched
+  (out of scope: press/rotate is a hard boundary). The press gap is #1431. Lesson: cross-checking a
+  sibling surface (the sidebar) against the one you're changing catches vocabulary drift that
+  single-surface work misses.

--- a/codev/reviews/1428-stream-deck-builder-action-key.md
+++ b/codev/reviews/1428-stream-deck-builder-action-key.md
@@ -4,30 +4,25 @@
 > notes the architect asked to record before the plan-approval gate. The full review (what was
 > built, what was learned at the hardware gate, CMAP outcomes) is written in the review phase.
 
-## Follow-up candidates (recorded for humans to weigh — not implemented here)
+## Decision: twinned presentation vocabulary is intentional replication (not shared code)
 
-### Twinned presentation vocabulary: `face.ts` ↔ `builder-row.ts` wants a shared home
-
-This project deliberately **duplicates** the builder presentation vocabulary across two apps:
+The deck reproduces the VS Code sidebar's visual language — state colours + gate icons —
+**independently**. It does not import from the vscode app and is not meant to.
 
 - `apps/streamdeck/src/face.ts` — `STATE_COLOR` (state → hex), `GATE_ICONS` (gate → glyph),
-  `GATE_LABELS` / `PHASE_LABELS`.
-- `apps/vscode/src/views/builder-row.ts` — `BUILDER_STATE_GLYPH` (state → codicon + ThemeColor),
-  `gateIconFor` (gate → codicon), and the sidebar's label vocabulary.
+  `GATE_LABELS` / `PHASE_LABELS`. Self-contained: inlined hexes (a static SVG can't bind VS Code
+  `ThemeColor` tokens) and its own transcribed codicon paths.
+- `apps/vscode/src/views/builder-row.ts` — the sidebar's `BUILDER_STATE_GLYPH` / `gateIconFor`.
 
-The duplication is **forced by the current architecture**: the two apps can't import each other,
-so the streamdeck twin carries inlined hexes (a static SVG can't bind VS Code `ThemeColor`
-tokens) and its own transcribed codicon paths, kept in sync only by comments.
+**Owner ruling (Amr, 2026-08-12):** no cross-app import and no shared vocabulary module — the
+goal is to *replicate the behaviour*, not to share the source. The small maps are deliberately
+duplicated and kept aligned by sync-note comments (the same pattern already used between
+`overview.ts` and `builder-row.ts` for `GATE_LABELS`). This is a fine, intended pattern here, not
+single-source-of-truth debt.
 
-This sits in direct tension with our **single-source-of-truth** lesson (consolidate duplicates
-rather than syncing them). It is flagged as a **candidate** for a shared home — e.g. a
-neutral, environment-agnostic vocabulary module (gate/phase ids → semantic label + icon *name* +
-semantic colour *role*), consumed by both apps, with each app binding the semantic roles to its
-own render primitives (ThemeColor tokens in vscode, inlined hexes + codicon paths on the deck).
-
-**Not in scope for #1428** (it would touch shared packages and the vscode app; #1428 is
-plugin-local by requirement). Co-flagged by `main`. Recorded here for the humans to decide
-whether/when to spin it out. Do not implement as part of this PR.
+Context: a shared-home module was raised as a candidate by `main`/the architect for the humans to
+weigh; the owner weighed it and **declined** — recorded here so the decision isn't re-litigated.
+No action.
 
 ## Lessons (seed)
 

--- a/codev/reviews/1428-stream-deck-builder-action-key.md
+++ b/codev/reviews/1428-stream-deck-builder-action-key.md
@@ -26,6 +26,18 @@ settled decision so it isn't re-litigated or re-proposed as a consolidation foll
 
 ## Lessons (seed)
 
+- **Stream Deck `setImage`: the SDK's "SVG string" claim does not survive contact with the device.**
+  `@elgato/streamdeck@2.1.0`'s `key.d.ts` documents that `setImage` accepts *"an SVG string"*, and
+  the SDK forwards it verbatim (`key.js:51-59`). On real hardware (Stream Deck 6.9) a raw `<svg>`
+  string is **silently dropped** — the key reverts to its manifest PNG with no error. Two things are
+  required and neither is in the type doc: (1) encode as a base64 **`data:image/svg+xml`** data URI
+  (the SDK's separately-documented "base64 encoded string with the mime type declared" form), and
+  (2) give the root `<svg>` an **intrinsic `width`/`height`**, not just a `viewBox`, or the
+  rasterizer drops the sizeless image. Diagnosis was fast because `setTitle('')` had visibly taken
+  effect (text gone) while the face stayed on the PNG — isolating the failure to the image layer,
+  not a pinned custom image. This is exactly the class of defect the PIR hardware gate exists to
+  catch: build + typecheck + unit tests were all green, but "it renders" was only true on the
+  device. Reusable for anyone touching `setImage` (`svgToDataUri` + `width`/`height` in `face.ts`).
 - **Twinned per-app presentation maps with sync-notes are an accepted pattern, not SSOT debt
   (owner-ruled).** When two apps must present the same vocabulary but can't/shouldn't cross-import
   (e.g. a static SVG can't bind VS Code `ThemeColor` tokens), duplicating the small maps with a

--- a/codev/reviews/1428-stream-deck-builder-action-key.md
+++ b/codev/reviews/1428-stream-deck-builder-action-key.md
@@ -14,18 +14,24 @@ The deck reproduces the VS Code sidebar's visual language — state colours + ga
   `ThemeColor` tokens) and its own transcribed codicon paths.
 - `apps/vscode/src/views/builder-row.ts` — the sidebar's `BUILDER_STATE_GLYPH` / `gateIconFor`.
 
-**Owner ruling (Amr, 2026-08-12):** no cross-app import and no shared vocabulary module — the
-goal is to *replicate the behaviour*, not to share the source. The small maps are deliberately
-duplicated and kept aligned by sync-note comments (the same pattern already used between
-`overview.ts` and `builder-row.ts` for `GATE_LABELS`). This is a fine, intended pattern here, not
-single-source-of-truth debt.
+**Owner ruling (Amr, 2026-08-12) — this is an ACCEPTED PATTERN, not tech debt.** Twinned per-app
+presentation maps kept aligned by sync-note comments (the same pattern already used between
+`overview.ts` and `builder-row.ts` for `GATE_LABELS`) are the intended design here: no cross-app
+import, no shared vocabulary module. The goal is to *replicate the behaviour*, not to share the
+source. It is explicitly **not** a single-source-of-truth violation and needs no shared home.
 
 Context: a shared-home module was raised as a candidate by `main`/the architect for the humans to
-weigh; the owner weighed it and **declined** — recorded here so the decision isn't re-litigated.
-No action.
+weigh; the owner weighed it and **ruled** the twinned pattern accepted — recorded here as the
+settled decision so it isn't re-litigated or re-proposed as a consolidation follow-up. No action.
 
 ## Lessons (seed)
 
+- **Twinned per-app presentation maps with sync-notes are an accepted pattern, not SSOT debt
+  (owner-ruled).** When two apps must present the same vocabulary but can't/shouldn't cross-import
+  (e.g. a static SVG can't bind VS Code `ThemeColor` tokens), duplicating the small maps with a
+  sync-note comment naming the counterpart is the intended design — don't reflexively flag it as a
+  single-source-of-truth violation or propose a shared home. Candidate for the lessons doc at
+  review time.
 - **`verify-approval` press-path gap → filed as #1431 (BUGFIX, sequenced after this merge).**
   Investigating the VS Code sidebar's gate map surfaced that `apps/vscode/src/views/builder-row.ts`
   handles a `verify-approval` gate that the Stream Deck's press resolver

--- a/codev/state/pir-1428_thread.md
+++ b/codev/state/pir-1428_thread.md
@@ -115,3 +115,19 @@ Fix (both standard Stream Deck requirements, applied together to save a hardware
   Also switched font-family system-ui → sans-serif (generic the rasterizer resolves).
 check-types clean, 103/103 tests pass (added svgToDataUri round-trip + width/height tests), build ok.
 Lesson for review: Stream Deck setImage(SVG) needs a base64 svg+xml data URI + intrinsic w/h.
+
+## Extended fix to the Gates key (2026-08-13, owner-directed)
+
+Owner (Amr) confirmed on hardware the Gates key (ApproveGate) suffers the same text-over-icon
+overlap. Investigated: it's the ONLY other keypad with dynamic text-over-icon (setTitle 'Gates\nN'
+over the PNG); the other keypads (action, dev-server) are icon-only, and the dials use setFeedback
+(structured, reads fine). So this is a contained same-bug extension, NOT the broad #1381
+buttons-posture redesign.
+Refactored face.ts to share the frame (BG/DIVIDER + iconZone/primaryLine/secondaryLine/centeredLine
+helpers; builder-face output unchanged) and added gatesFaceSvg(pendingCount): bell glyph +
+count + "Gates" in warning-yellow when gates pending, dim "Gates" when none. ApproveGate.renderTo →
+setImage(svgToDataUri(gatesFaceSvg(n))) + setTitle(''). bell = the sidebar's "needs attention" glyph
+(builder-row.ts), so it's consistent.
+check-types clean, 106/106 tests pass, build ok.
+Flagging to architect: this widens the #1428 PR beyond the Builder Action key; the broader
+"redesign every button's posture" remains #1381 (parked) — only the Gates same-bug fix folded in.

--- a/codev/state/pir-1428_thread.md
+++ b/codev/state/pir-1428_thread.md
@@ -81,3 +81,21 @@ sync-note comments (same pattern as overview.ts ↔ builder-row.ts GATE_LABELS).
 Reframed the review's follow-up section from "candidate for a shared home" to "decision:
 intentional replication, shared-home declined by owner." Plan unchanged (already framed the
 twinning as the established sync-note pattern, no shared-module proposal).
+
+## Implement phase complete (2026-08-12)
+
+Built per approved plan:
+- NEW apps/streamdeck/src/face.ts (pure, SDK-free): builderState, STATE_COLOR (inlined hexes
+  mirroring vscode tokens), GATE_ICONS + in-plugin codicon-style GLYPHS, GATE_LABELS/PHASE_LABELS
+  + stateLabel, faceForBuilder, builderFaceSvg (72×72, icon zone + reserved text band, XML-escaped).
+- actions.ts BuilderAction.renderTo: setTitle overlay → builderFaceSvg(faceForBuilder(b)) +
+  setImage + setTitle(''). Only this method changed; press/rotate untouched.
+- Tests: NEW face.test.ts (builderState, stateLabel all ids, faceForBuilder icon selection + bell
+  fallback, builderFaceSvg content + XML escape); actions.test.ts updated to assert setImage SVG
+  (label + state colour) + empty-slot face.
+
+Green from the worktree: check-types clean, 101/101 tests pass, esbuild build ok. (Had to build
+codev-types + codev-sdk workspace deps first — dist wasn't present in the worktree.)
+
+Codicon-style glyphs are drawn in-plugin (codicon font not vendored — keeps zero-dep bundle);
+legibility is the hardware-gate check. dev-approval is a hardware session → next.

--- a/codev/state/pir-1428_thread.md
+++ b/codev/state/pir-1428_thread.md
@@ -61,3 +61,14 @@ Flagged to architect: (1) scope expansion for cohort awareness (air-1411 also on
 (2) verify-approval press-path gap in phaseArtifactVerb (left untouched, out of scope).
 Mockup: https://claude.ai/code/artifact/450b5b24-66d2-42e3-8db2-992cc09eda18
 Recommitted; gate still plan-approval pending → Amr.
+
+## Plan APPROVED by architect (2026-08-12)
+
+Architect ratified: ship blocked/active in v1, defer waiting (strict-superset follow-up).
+Two additions recorded in the REVIEW artifact (seeded now, not the plan):
+1. Twinned-vocabulary maps (face.ts ↔ builder-row.ts) → candidate for a shared home
+   (single-source-of-truth vs apps-can't-cross-import). Co-flagged by main. Humans to weigh; NOT
+   implemented in #1428.
+2. verify-approval press-path gap filed as #1431 (BUGFIX, after this merge) — referenced in
+   review lessons.
+Plan-approval gate now to Amr.

--- a/codev/state/pir-1428_thread.md
+++ b/codev/state/pir-1428_thread.md
@@ -40,3 +40,24 @@ Approved with two revisions, both applied:
 
 Rest approved as written (face.ts pure module, SVG non-overlap, canonical-id keying, setTitle('')).
 Recommitted; gate goes to Amr.
+
+## Plan revision 2 (2026-08-12) — scope expanded (owner-approved)
+
+Owner (Amr) approved widening scope after reviewing a mockup: adopt VS Code's Builders-sidebar
+TWO-AXIS model on the deck face.
+- Colour = state severity (blocked=warning yellow #cca700, waiting=info blue #3794ff [optional
+  fast-follow], active=green #73c991) — mirrors builder-row.ts BUILDER_STATE_GLYPH tokens.
+- Icon = gate (blocked): book/checklist/code/git-pull-request/verified, mirrors gateIconFor;
+  bolt otherwise. Codicon path data inlined (MIT), not a new dep.
+- Labels now SHORT (Spec/Plan/Dev/PR/Verify; phases Specify..Verified) — colour+icon carry the
+  blocked-vs-working distinction, so plan-approval (yellow checklist "Plan") ≠ plan phase (green
+  bolt "Plan") with no qualifier word. This resolves the label-collision worry Amr raised.
+
+Maps twinned in face.ts with sync-notes (apps can't cross-import; same pattern as overview.ts
+GATE_LABELS). Boundaries intact: only BuilderAction.renderTo changes; press/rotate + #1429
+resolveVerb untouched; no wire/types/server change.
+
+Flagged to architect: (1) scope expansion for cohort awareness (air-1411 also on streamdeck);
+(2) verify-approval press-path gap in phaseArtifactVerb (left untouched, out of scope).
+Mockup: https://claude.ai/code/artifact/450b5b24-66d2-42e3-8db2-992cc09eda18
+Recommitted; gate still plan-approval pending → Amr.

--- a/codev/state/pir-1428_thread.md
+++ b/codev/state/pir-1428_thread.md
@@ -99,3 +99,19 @@ codev-types + codev-sdk workspace deps first — dist wasn't present in the work
 
 Codicon-style glyphs are drawn in-plugin (codicon font not vendored — keeps zero-dep bundle);
 legibility is the hardware-gate check. dev-approval is a hardware session → next.
+
+## Hardware gate finding #1 (2026-08-13): SVG not rendering → fixed
+
+Symptom on deck: Builder Action keys showed ONLY the static manifest PNG, no composite face.
+Diagnosis (verified against SDK source, not guessed): SDK's setImage forwards the string verbatim
+(key.js:51-59), so Stream Deck itself rejected our raw <svg>. setTitle('') HAD taken effect (text
+gone) → title layer not pinned → the failure was the image format, not a pinned custom image.
+Fix (both standard Stream Deck requirements, applied together to save a hardware round-trip):
+  1. Root <svg> now carries intrinsic width="72" height="72" (not just viewBox) — the rasterizer
+     drops sizeless SVGs.
+  2. setImage now gets a base64 data URI (svgToDataUri: data:image/svg+xml;base64,...) — the SDK's
+     documented "base64 encoded string with mime type declared"; raw <svg> strings are dropped by
+     the 6.x renderer.
+  Also switched font-family system-ui → sans-serif (generic the rasterizer resolves).
+check-types clean, 103/103 tests pass (added svgToDataUri round-trip + width/height tests), build ok.
+Lesson for review: Stream Deck setImage(SVG) needs a base64 svg+xml data URI + intrinsic w/h.

--- a/codev/state/pir-1428_thread.md
+++ b/codev/state/pir-1428_thread.md
@@ -26,3 +26,17 @@ in the plan. Routed to architect before plan-approval gate.
 worktrees; air-1411 touches streamdeck imports only — will re-resolve at merge if churn.
 
 Plan written to `codev/plans/1428-stream-deck-builder-action-key.md`. Awaiting plan-approval.
+
+## Plan revision 1 (2026-08-12) — architect review
+
+Approved with two revisions, both applied:
+1. Label map: porch's TERMINAL phase id is `verified` (next.ts:204; `complete` migrates to it,
+   state.ts:135-140) — the exact state the owner's photo showed. Added `verified`→'Verified' and
+   `complete`→'Verified'; changed `verify`→'Verify' (in-progress, not done). Map is now 11 rows.
+   Verified the porch source myself before editing.
+2. Added risk + hardware pre-flight: a profile-pinned custom image makes `setImage` a silent
+   no-op (SDK: "image can only be set … when the user has not specified a custom image"). Check
+   the #1404-revved profile first if the face doesn't render.
+
+Rest approved as written (face.ts pure module, SVG non-overlap, canonical-id keying, setTitle('')).
+Recommitted; gate goes to Amr.

--- a/codev/state/pir-1428_thread.md
+++ b/codev/state/pir-1428_thread.md
@@ -72,3 +72,12 @@ Two additions recorded in the REVIEW artifact (seeded now, not the plan):
 2. verify-approval press-path gap filed as #1431 (BUGFIX, after this merge) — referenced in
    review lessons.
 Plan-approval gate now to Amr.
+
+## Owner ruling on the shared-vocabulary candidate (2026-08-12)
+
+Amr: no cross-app import, no shared module — the deck REPLICATES the sidebar's visual language
+independently. The small twinned maps in face.ts are intentional duplication, kept aligned by
+sync-note comments (same pattern as overview.ts ↔ builder-row.ts GATE_LABELS). Not SSOT debt.
+Reframed the review's follow-up section from "candidate for a shared home" to "decision:
+intentional replication, shared-home declined by owner." Plan unchanged (already framed the
+twinning as the established sync-note pattern, no shared-module proposal).

--- a/codev/state/pir-1428_thread.md
+++ b/codev/state/pir-1428_thread.md
@@ -1,0 +1,28 @@
+# pir-1428 thread — Stream Deck Builder Action key face
+
+## Plan phase (2026-08-12)
+
+Issue #1428: Builder Action key illegible — raw wire strings pushed through `setTitle`
+paint over the full-bleed bolt PNG. Three symptoms, one root cause (two stacked layers).
+
+**Root cause confirmed** at `apps/streamdeck/src/actions.ts:164-169`. `issueId` is a plain
+`string` on the wire (`packages/types/src/api.ts:143`) — the "#1,414" comma is the bolt edge
+bleeding through, not a formatter.
+
+**Approach**: render the whole face in-plugin as an SVG string via `setImage` (SDK d.ts
+confirms `setImage` accepts an SVG string — zero new deps, no canvas/native module, keeps the
+single esbuild bundle). Icon in an upper zone, reserved text band below (number line + label).
+Plus a plugin-local wire-id → display-label map keyed on canonical `blockedGate` /
+`protocolPhase` (gate beats phase), NOT `b.blocked` (server human label). New pure module
+`src/face.ts` (mirrors `nav/cursor.ts` — SDK-free, unit-testable).
+
+**Only `BuilderAction.renderTo` changes** in actions.ts. Press/rotate (`resolveVerb`,
+`phaseArtifactVerb`, #1429/#1404/#1414 logic) untouched. No wire/types/server change.
+
+**Architect asks (satisfied in plan)**: full id→label table (9 ids) + face-layout mock both
+in the plan. Routed to architect before plan-approval gate.
+
+**Cautions honored**: not touching .builders/pir-1414 (live deck symlink) or sibling
+worktrees; air-1411 touches streamdeck imports only — will re-resolve at merge if churn.
+
+Plan written to `codev/plans/1428-stream-deck-builder-action-key.md`. Awaiting plan-approval.


### PR DESCRIPTION
# PIR Review: Stream Deck composite, state-coded key faces

Fixes #1428

## Summary

The Builder Action key rendered by stacking a `setTitle` over a full-bleed bolt PNG, so text
landed on the icon's diagonal (`#1414` even read as `#1,414` where the bolt edge bled between
digits), casing came raw off the wire, and long phase names clipped. This PR composes the **whole**
key face in-plugin as one SVG handed to `setImage` — an icon zone up top, a reserved text band
below — and adds a plugin-local presentation vocabulary that mirrors the VS Code Builders sidebar's
two axes: **colour = state** (blocked yellow / active green) and **icon = gate**
(book / checklist / code / pull-request / verified, bolt otherwise), with short deliberate labels.
The same composite treatment was applied to the **Gates key** (`ApproveGate`), which had the
identical text-over-icon overlap. Presentation is entirely plugin-local — no wire, types, or server
change — and press/rotate behaviour is untouched.

## Files Changed

vs merge-base `84407b8`:

- `apps/streamdeck/src/face.ts` (+232 / -0) — new pure module: state classification, state→colour
  palette, gate→icon map + in-plugin glyphs, label maps, `faceForBuilder`, `builderFaceSvg`,
  `gatesFaceSvg`, `svgToDataUri`.
- `apps/streamdeck/src/actions.ts` (+12 / -3) — `BuilderAction.renderTo` and `ApproveGate.renderTo`
  switch from `setTitle` overlays to composite `setImage` SVG data URIs.
- `apps/streamdeck/src/__tests__/face.test.ts` (+122 / -0) — new unit tests for the pure module.
- `apps/streamdeck/src/__tests__/actions.test.ts` (+43 / -15) — render assertions updated to decode
  the data-URI face; Gates-face and empty-slot coverage added.
- `codev/resources/lessons-learned.md` (+2 lessons) — see Lessons Learned Updates.
- Plan / review / thread under `codev/`.

## Commits

- `c4f4f1488` [PIR #1428] Composite state-coded key face: render Builder Action via setImage SVG
- `c0d7c1a5a` [PIR #1428] Tests: face.ts unit tests + BuilderAction setImage assertions
- `b64a7c546` [PIR #1428] Fix setImage: base64 svg+xml data URI + intrinsic width/height (raw SVG dropped by Stream Deck)
- `4d7170202` [PIR #1428] Apply composite face to the Gates key (same text-over-icon fix)
- `62290be9e` / `b0143c533` / `a6040a901` [PIR #1428] Review seed + owner-ruling + hardware lesson
- (plus thread + porch phase-transition commits)

## Test Results

- `pnpm --filter @cluesmith/codev-streamdeck check-types`: ✓ pass
- `pnpm --filter @cluesmith/codev-streamdeck build` (esbuild): ✓ pass
- `pnpm --filter @cluesmith/codev-streamdeck test`: ✓ pass (106 tests, ~25 new)
- **Manual (hardware, dev-approval gate, Amr):** photo-level check on the physical deck across
  states — Builder Action keys (active phase, blocked gates, empty slot) and the Gates key
  (pending badge count vs no-gates). The **first** hardware pass exposed that raw SVG didn't render
  (see Lessons); after the data-URI + intrinsic-size fix, faces render and read cleanly, and the
  Gates key was re-checked in the same session. Approved.

## Architecture Updates

No arch-doc change qualifies. This is plugin-internal rendering: it adds one module
(`apps/streamdeck/src/face.ts`) but changes no module boundary, invariant, port, state, or wire
contract (`arch-critical.md`'s system-shape facts are untouched, and the streamdeck entry in
`arch.md`'s Monorepo Structure still describes the plugin accurately). The reusable knowledge from
this PR is an API-gotcha recipe and a duplication-pattern ruling — both routed to lessons, the
correct tier, below.

## Lessons Learned Updates

Two COLD entries added to `codev/resources/lessons-learned.md` (both spec-narrow recipes/rulings,
not behavior-changing cross-cutting rules, so neither belongs in the capped HOT tier):

- **UI/UX** — Stream Deck `setImage` silently drops a raw `<svg>` on-device; it needs a base64
  `data:image/svg+xml` data URI **and** an intrinsic `width`/`height`. Build/typecheck/tests were
  green; only the hardware gate caught it — the defect class PIR's device gate exists for.
- **Architecture** — twinned per-app *presentation* maps with sync-note comments are an accepted
  pattern (owner-ruled), not a violation of the "consolidate duplicates" lesson; that lesson
  targets stateful/behavioural duplication, not independent look-replication across a boundary the
  architecture deliberately keeps un-crossed (`face.ts` ↔ `builder-row.ts`).

## Twinned presentation vocabulary — accepted pattern (owner ruling)

The deck reproduces the VS Code sidebar's visual language (state colours + gate icons)
independently; it does **not** import from the vscode app. `apps/streamdeck/src/face.ts` carries its
own `STATE_COLOR` (inlined hexes mirroring the sidebar's `ThemeColor` tokens) and `GATE_ICONS` +
in-plugin glyphs, twinned with `apps/vscode/src/views/builder-row.ts` and kept aligned by
sync-note comments. **Owner ruling (Amr):** this is the intended design — no cross-app import, no
shared vocabulary module — recorded so it isn't re-litigated. The lane owner ruled the Gates-key
extension **rides in this PR** (same root cause, shares the `face.ts` frame; the bug class ends
there — `action`/`dev-server` are icon-only and the dials use `setFeedback`).

## Things to Look At During PR Review

- **`svgToDataUri` + intrinsic `width`/`height`** (`face.ts`) — the load-bearing hardware fix. A raw
  `<svg>` string is silently dropped by Stream Deck 6.9 despite the SDK d.ts's "SVG string" claim.
- **`face.ts` glyphs are hand-drawn in the codicon idiom**, not the codicon font (not vendored →
  keeps the bundle dependency-free). Legibility at the deck's upscaled size was the hardware check.
- **Twinned maps** (`STATE_COLOR` / `GATE_ICONS` / labels) vs `builder-row.ts` — intentional
  duplication with sync-notes, per the owner ruling above; not a consolidation candidate.
- **`verify-approval`** renders on the face but the press resolver `phaseArtifactVerb` doesn't
  handle it — a pre-existing gap filed as **#1431** (BUGFIX, sequenced after this merge), out of
  scope here (press/rotate untouched).

## How to Test Locally

- **View diff**: VSCode sidebar → right-click builder `pir-1428` → **Review Diff**.
- **Run dev**: VSCode sidebar → **Run Dev**, or `afx dev pir-1428`, then load the plugin on a deck.
- **What to verify** (maps to the plan's Test Plan):
  - Builder Action — active (green bolt, `#NNNN`, phase label, no comma, no collision), each blocked
    gate (yellow, distinct glyph), empty slot (`Slot N`).
  - Gates key — pending count in warning-yellow vs dim `Gates` when none pending.
  - Press/rotate still fire the same verbs (regression on the untouched path).
  - Pre-flight if a face won't render: confirm no profile-pinned custom image on the key.

## Lessons (detail for this PR)

- **`verify-approval` press-path gap → #1431.** Cross-checking the VS Code sidebar's gate map
  against the Stream Deck press resolver surfaced that `builder-row.ts` handles a `verify-approval`
  gate `phaseArtifactVerb` doesn't. #1428 renders it on the face; the press gap is #1431. Lesson:
  cross-checking a sibling surface catches vocabulary drift single-surface work misses.
