### PR TITLE
[Bugfix #1437] Stream Deck: silence success checkmark + Run Dev key polish

### DIFF
--- a/apps/streamdeck/com.cluesmith.codev.sdPlugin/manifest.json
+++ b/apps/streamdeck/com.cluesmith.codev.sdPlugin/manifest.json
@@ -5,7 +5,7 @@
   "Author": "Cluesmith",
   "Category": "Codev",
   "CategoryIcon": "icons/category",
-  "Description": "Drive Codev's AI agent workflows from your Stream Deck. Approve gates, watch your builder fleet, step through diff reviews with dials, spawn builders from the backlog, and control your dev server, all without leaving your editor. Companion plugin for Codev (https://codevos.ai/): requires Codev and its Tower server running locally.",
+  "Description": "Drive Codev's AI agent workflows from your Stream Deck. Approve gates, watch your builder fleet, step through diff reviews with dials, spawn builders from the backlog, and run dev for your worktrees, all without leaving your editor. Companion plugin for Codev (https://codevos.ai/): requires Codev and its Tower server running locally.",
   "Icon": "icons/plugin",
   "URL": "https://github.com/cluesmith/codev",
   "SDKVersion": 3,
@@ -65,9 +65,9 @@
       ]
     },
     {
-      "Name": "Dev Server",
+      "Name": "Run Dev",
       "UUID": "com.cluesmith.codev.dev-server",
-      "Tooltip": "Start / stop the workspace dev server.",
+      "Tooltip": "Start / stop dev for the selected builder's worktree.",
       "Icon": "icons/list/dev-server",
       "Controllers": [
         "Keypad"

--- a/apps/streamdeck/src/__tests__/actions.test.ts
+++ b/apps/streamdeck/src/__tests__/actions.test.ts
@@ -75,7 +75,9 @@ describe('verb keypads', () => {
     const ev = keyEvent();
     await new CodevAction(ctx.store).onKeyDown(ev as never);
     expect(ctx.sent).toEqual([{ verb: 'refresh-overview', args: [], ws: '/work/alpha' }]);
-    expect(ev.action.showOk).toHaveBeenCalled();
+    // Success is silent now (no green checkmark); only failures alert.
+    expect(ev.action.showOk).not.toHaveBeenCalled();
+    expect(ev.action.showAlert).not.toHaveBeenCalled();
   });
 
   it('CodevAction honors a settings verb override', async () => {

--- a/apps/streamdeck/src/__tests__/actions.test.ts
+++ b/apps/streamdeck/src/__tests__/actions.test.ts
@@ -3,6 +3,7 @@ import { CodevStore } from '../store.js';
 import type { ControllerClient, TowerWorkspace } from '@cluesmith/codev-sdk/controller';
 import {
   CodevAction,
+  DevServerAction,
   BuilderAction,
   ApproveGate,
   PrNav,
@@ -78,6 +79,16 @@ describe('verb keypads', () => {
     // Success is silent now (no green checkmark); only failures alert.
     expect(ev.action.showOk).not.toHaveBeenCalled();
     expect(ev.action.showAlert).not.toHaveBeenCalled();
+  });
+
+  it('DevServerAction renders a composite face (play icon + "Dev" label), not a bare icon', () => {
+    const key = { isKey: () => true, setImage: vi.fn(), setTitle: vi.fn() };
+    new DevServerAction(ctx.store).onWillAppear({ action: key, payload: { settings: {} } } as never);
+    const arg = String(key.setImage.mock.calls.at(-1)?.[0] ?? '');
+    expect(arg.startsWith('data:image/svg+xml;base64,')).toBe(true);
+    const face = Buffer.from(arg.slice('data:image/svg+xml;base64,'.length), 'base64').toString('utf8');
+    expect(face).toContain('Dev');
+    expect(face).toContain('M8 5v14l11-7z'); // play glyph
   });
 
   it('CodevAction honors a settings verb override', async () => {

--- a/apps/streamdeck/src/__tests__/face.test.ts
+++ b/apps/streamdeck/src/__tests__/face.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { OverviewBuilder } from '@cluesmith/codev-sdk/controller';
-import { builderState, stateLabel, faceForBuilder, builderFaceSvg, gatesFaceSvg, svgToDataUri } from '../face.js';
+import { builderState, stateLabel, faceForBuilder, builderFaceSvg, gatesFaceSvg, labelFaceSvg, svgToDataUri } from '../face.js';
 
 /** Minimal builder fixture — only the fields the face reads matter; the rest are filler. */
 function builder(over: Partial<OverviewBuilder>): OverviewBuilder {
@@ -121,6 +121,17 @@ describe('gatesFaceSvg', () => {
     const svg = gatesFaceSvg(0);
     expect(svg).toContain('Gates');
     expect(svg).not.toContain('#cca700');
+  });
+});
+
+describe('labelFaceSvg', () => {
+  it('renders an icon over a single centered label (the Run Dev pattern)', () => {
+    const svg = labelFaceSvg('play', 'Dev', '#73c991');
+    expect(svg.startsWith('<svg')).toBe(true);
+    expect(svg).toContain('Dev');
+    expect(svg).toContain('#73c991');
+    expect(svg).toContain('M8 5v14l11-7z'); // the play glyph
+    expect(svg).toContain('width="72"');
   });
 });
 

--- a/apps/streamdeck/src/actions.ts
+++ b/apps/streamdeck/src/actions.ts
@@ -15,7 +15,7 @@ import type {
   CanvasCommandClientErrorCode,
 } from '@cluesmith/codev-sdk/controller';
 import type { CodevStore } from './store.js';
-import { builderFaceSvg, faceForBuilder, gatesFaceSvg, svgToDataUri } from './face.js';
+import { builderFaceSvg, faceForBuilder, gatesFaceSvg, labelFaceSvg, svgToDataUri } from './face.js';
 
 /**
  * The Stream Deck actions — thin adapters over CodevStore. Each maps a physical
@@ -65,13 +65,20 @@ export class CodevAction extends VerbKey {
   protected readonly defaultVerb = 'refresh-overview';
 }
 
-/** Run the dev server for the cursor-selected builder's worktree (no PI). */
+/** Run dev for the cursor-selected builder's worktree (no PI). */
 export class DevServerAction extends VerbKey {
   override readonly manifestId = 'com.cluesmith.codev.dev-server';
   protected readonly defaultVerb = 'run-dev';
   protected override args(): unknown[] {
     const b = this.store.selectedBuilder();
     return b ? [b.id] : [];
+  }
+  // Render the composite face (play icon + "Dev" label) so this key matches the other keys instead
+  // of showing a bare icon. Static — the label doesn't track running state.
+  override onWillAppear(ev: WillAppearEvent<VerbSettings>): void {
+    if (!ev.action.isKey()) return;
+    void ev.action.setImage(svgToDataUri(labelFaceSvg('play', 'Dev', '#73c991')));
+    void ev.action.setTitle('');
   }
 }
 

--- a/apps/streamdeck/src/actions.ts
+++ b/apps/streamdeck/src/actions.ts
@@ -35,7 +35,9 @@ function settingsVerb(ev: KeyDownEvent): string | undefined {
 }
 
 async function ack(action: KeyAction, ok: boolean): Promise<void> {
-  await (ok ? action.showOk() : action.showAlert());
+  // Success is silent — the green "OK" checkmark was redundant press feedback. Failures still
+  // surface a red alert so a rejected command is never silent.
+  if (!ok) await action.showAlert();
 }
 
 // ── Verb keypads ──────────────────────────────────────────────────────────

--- a/apps/streamdeck/src/face.ts
+++ b/apps/streamdeck/src/face.ts
@@ -44,7 +44,7 @@ const STATE_COLOR: Record<BuilderState, string> = {
 };
 
 /** The glyphs the face can draw: a gate shape when blocked, the bolt otherwise. */
-export type GlyphKey = 'bolt' | 'book' | 'checklist' | 'code' | 'pull-request' | 'verified' | 'bell';
+export type GlyphKey = 'bolt' | 'book' | 'checklist' | 'code' | 'pull-request' | 'verified' | 'bell' | 'play';
 
 /**
  * Gate id → glyph. The streamdeck twin of `gateIconFor` in `apps/vscode/src/views/builder-row.ts`
@@ -76,6 +76,7 @@ const GLYPHS: Record<GlyphKey, (color: string) => string> = {
     stroked(c, '<circle cx="7" cy="6" r="2.3"/><circle cx="7" cy="18" r="2.3"/><circle cx="17" cy="18" r="2.3"/><path d="M7 8.3v7.4"/><path d="M17 15.7V12a3 3 0 0 0-3-3h-3.5"/>'),
   verified: (c) => stroked(c, '<path d="M12 3l7 3v5c0 4.5-3 7.6-7 9.2C8 18.6 5 15.5 5 11V6z"/><path d="M8.6 12l2.3 2.3 4.6-4.6"/>'),
   bell: (c) => stroked(c, '<path d="M6 9a6 6 0 0 1 12 0c0 5 2 6 2 6H4s2-1 2-6z"/><path d="M10.5 20a1.6 1.6 0 0 0 3 0"/>'),
+  play: (c) => `<path d="M8 5v14l11-7z" fill="${c}"/>`, // VS Code's Run/Start-Dev affordance
 };
 
 /** Wrap line-glyph paths in a shared stroke group (round caps/joins, like the codicons). */
@@ -190,6 +191,15 @@ export function gatesFaceSvg(pendingCount: number): string {
     `${BG}${iconZone('bell', STATE_COLOR.blocked)}${DIVIDER}` +
       `${primaryLine(String(pendingCount))}${secondaryLine('Gates')}`,
   );
+}
+
+/**
+ * A simple action-key face: an icon over a single centered label, no primary datum. For keys that
+ * aren't builder-state-coded (e.g. the Run Dev key) but should still match the composite pattern
+ * — icon in the zone, text in the band, never stacked.
+ */
+export function labelFaceSvg(icon: GlyphKey, label: string, color: string): string {
+  return svg(`${BG}${iconZone(icon, color)}${DIVIDER}${centeredLine(label)}`);
 }
 
 /** Shared face frame: the rounded key ground and the hairline that splits icon zone from text band. */

--- a/codev/projects/bugfix-1437-stream-deck-silence-the-green-/status.yaml
+++ b/codev/projects/bugfix-1437-stream-deck-silence-the-green-/status.yaml
@@ -11,4 +11,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-13T00:08:55.521Z'
-updated_at: '2026-08-13T00:12:59.290Z'
+updated_at: '2026-08-13T00:13:45.643Z'
+pr_history:
+  - phase: pr
+    pr_number: 1438
+    branch: builder/bugfix-1437
+    created_at: '2026-08-13T00:13:45.642Z'

--- a/codev/projects/bugfix-1437-stream-deck-silence-the-green-/status.yaml
+++ b/codev/projects/bugfix-1437-stream-deck-silence-the-green-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1437
 title: stream-deck-silence-the-green-
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-13T00:08:55.521Z'
-updated_at: '2026-08-13T00:09:39.070Z'
+updated_at: '2026-08-13T00:12:59.290Z'

--- a/codev/projects/bugfix-1437-stream-deck-silence-the-green-/status.yaml
+++ b/codev/projects/bugfix-1437-stream-deck-silence-the-green-/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1437
+title: stream-deck-silence-the-green-
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-13T00:08:55.521Z'
+updated_at: '2026-08-13T00:08:55.521Z'

--- a/codev/projects/bugfix-1437-stream-deck-silence-the-green-/status.yaml
+++ b/codev/projects/bugfix-1437-stream-deck-silence-the-green-/status.yaml
@@ -6,16 +6,17 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-08-13T00:13:53.858Z'
+    approved_at: '2026-08-13T00:35:24.659Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-13T00:08:55.521Z'
-updated_at: '2026-08-13T00:13:53.859Z'
+updated_at: '2026-08-13T00:35:24.659Z'
 pr_history:
   - phase: pr
     pr_number: 1438
     branch: builder/bugfix-1437
     created_at: '2026-08-13T00:13:45.642Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1437-stream-deck-silence-the-green-/status.yaml
+++ b/codev/projects/bugfix-1437-stream-deck-silence-the-green-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1437
 title: stream-deck-silence-the-green-
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-13T00:08:55.521Z'
-updated_at: '2026-08-13T00:08:55.521Z'
+updated_at: '2026-08-13T00:09:39.070Z'

--- a/codev/projects/bugfix-1437-stream-deck-silence-the-green-/status.yaml
+++ b/codev/projects/bugfix-1437-stream-deck-silence-the-green-/status.yaml
@@ -7,13 +7,15 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-08-13T00:13:53.858Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-13T00:08:55.521Z'
-updated_at: '2026-08-13T00:13:45.643Z'
+updated_at: '2026-08-13T00:13:53.859Z'
 pr_history:
   - phase: pr
     pr_number: 1438
     branch: builder/bugfix-1437
     created_at: '2026-08-13T00:13:45.642Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1437-stream-deck-silence-the-green-/status.yaml
+++ b/codev/projects/bugfix-1437-stream-deck-silence-the-green-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1437
 title: stream-deck-silence-the-green-
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,7 +13,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-13T00:08:55.521Z'
-updated_at: '2026-08-13T00:35:24.659Z'
+updated_at: '2026-08-13T00:35:56.854Z'
 pr_history:
   - phase: pr
     pr_number: 1438

--- a/codev/state/bugfix-1437_thread.md
+++ b/codev/state/bugfix-1437_thread.md
@@ -50,3 +50,28 @@ imports — a pre-existing environment step, not part of the fix.
 Results in this worktree: check-types clean, build clean, tests 108/108.
 `porch check` green (build + tests).
 
+## Scope update — Run Dev key polish (2026-08-13)
+
+Architect folded in a second owner-directed, live-validated change (main's fold
+ruling, issue #1437 comment 5274289164). Superseding patch carries BOTH changes as
+one batch; PR #1438 stays the single PR. Applied the additional pieces verbatim:
+
+- `apps/streamdeck/src/face.ts` — new `play` glyph (`M8 5v14l11-7z`) and a
+  `labelFaceSvg(icon, label, color)` helper: icon zone + centered label, the
+  composite frame for keys that aren't builder-state-coded.
+- `apps/streamdeck/src/actions.ts` — `DevServerAction.onWillAppear` now renders the
+  composite face (green play glyph + "Dev" label) via `labelFaceSvg`, so the Run
+  Dev key matches the others instead of showing a bare icon. Static label (doesn't
+  track running state). Doc comment reworded "dev server" → "dev".
+- `apps/streamdeck/com.cluesmith.codev.sdPlugin/manifest.json` — action Name
+  "Dev Server" → "Run Dev"; Tooltip and plugin Description drop "dev server"
+  vocabulary. UUID (`com.cluesmith.codev.dev-server`) and icon filenames unchanged.
+  "Tower server" wording left intact (a different thing).
+- Tests: `actions.test.ts` gains a DevServerAction composite-face assertion;
+  `face.test.ts` gains a `labelFaceSvg` block.
+
+Both changes were validated live on the held worktree (110/110 + build + validate).
+Reproduced here: check-types clean, build clean, `streamdeck validate` successful,
+tests 110/110.
+
+

--- a/codev/state/bugfix-1437_thread.md
+++ b/codev/state/bugfix-1437_thread.md
@@ -1,0 +1,52 @@
+# bugfix-1437 — Stream Deck: silence green success checkmark
+
+## Investigate (2026-08-13)
+
+**Bug**: Stream Deck key presses flash a green success checkmark (`showOk`) on
+success. Owner directive (validated on live hardware): success should be silent;
+the red failure alert (`showAlert`) stays.
+
+**Root cause**: `apps/streamdeck/src/actions.ts:37-39`, the shared `ack(action, ok)`
+helper:
+```ts
+async function ack(action: KeyAction, ok: boolean): Promise<void> {
+  await (ok ? action.showOk() : action.showAlert());
+}
+```
+`ack` is the single acknowledgement path for all three verb keypads
+(`VerbKey.onKeyDown` at :56, and the two overrides at :134 and :211). So the
+green checkmark is shared across every key, and silencing it here silences it for
+all — exactly what the issue asks.
+
+**Fix** (architect-supplied, hardware-validated patch — apply verbatim): guard the
+success branch so success is silent, failure still alerts.
+
+**Test**: `apps/streamdeck/src/__tests__/actions.test.ts` currently asserts
+`showOk` was called on success; flip to assert `showOk` NOT called and `showAlert`
+NOT called on success.
+
+**Scope**: ~5 LOC of production change + test edit. Comfortably BUGFIX. Selection-
+border idea from the issue is explicitly out of scope (architect confirmed).
+
+Validation history (per issue #1437): the change was already run on the live deck
+in the held `.builders/pir-1428` worktree — check-types clean, 108/108 tests. This
+lane exists to land it on a real branch before the main-checkout re-link sweeps
+that worktree.
+
+## Fix (2026-08-13)
+
+Applied the architect's hardware-validated patch verbatim:
+- `apps/streamdeck/src/actions.ts` — `ack()` now guards with `if (!ok) await
+  action.showAlert()`; success path is silent.
+- `apps/streamdeck/src/__tests__/actions.test.ts` — the CodevAction success test
+  now asserts neither `showOk` nor `showAlert` was called. This is the regression:
+  it fails against the old `ok ? showOk() : showAlert()` (showOk would fire) and
+  passes with the guard. Failure-alert coverage (lines 130, 210) is untouched.
+
+Fresh worktree needed `@cluesmith/codev-types` + `@cluesmith/codev-sdk` built
+(no `dist/`) before streamdeck check-types/build could resolve the SDK subpath
+imports — a pre-existing environment step, not part of the fix.
+
+Results in this worktree: check-types clean, build clean, tests 108/108.
+`porch check` green (build + tests).
+


### PR DESCRIPTION
Two owner-directed, live-validated Stream Deck changes, folded into one batch per main's fold ruling (issue #1437, comment 5274289164).

## 1 — Silence the green success checkmark

`apps/streamdeck/src/actions.ts` — the shared `ack(action, ok)` helper (the acknowledgement path for all three verb keypads) did `ok ? action.showOk() : action.showAlert()`, so every successful key press flashed the green checkmark. Now guarded so success is silent; the red failure alert stays, shared across all keys:

```ts
async function ack(action: KeyAction, ok: boolean): Promise<void> {
  if (!ok) await action.showAlert();
}
```

Regression (`actions.test.ts`): the CodevAction success test asserts neither `showOk` nor `showAlert` fires — fails against the old code, passes with the guard. Failure-alert coverage untouched.

## 2 — Run Dev key polish

- `face.ts` — new `play` glyph and a `labelFaceSvg(icon, label, color)` helper (icon zone + centered label) for keys that aren't builder-state-coded.
- `actions.ts` — `DevServerAction.onWillAppear` renders the composite face (green play glyph + "Dev" label) so the key matches the others instead of showing a bare icon. Static label; doesn't track running state.
- `manifest.json` — action Name "Dev Server" → "Run Dev"; Tooltip and plugin Description drop "dev server" vocabulary. UUID (`com.cluesmith.codev.dev-server`) and icon filenames unchanged; "Tower server" wording left intact (a different thing).
- Tests +2: DevServerAction composite-face assertion (`actions.test.ts`) and a `labelFaceSvg` block (`face.test.ts`).

## Validation history

Both changes were validated live on the held `.builders/pir-1428` worktree — the current Elgato symlink target — where they ran on the physical deck with 110/110 tests + build + `streamdeck validate` passing. They were deliberately left uncommitted there to avoid orphaning them on the merged #1428 branch. This BUGFIX lands them on a proper branch off main so they survive the permanent main-checkout re-link.

Reproduced in this worktree: check-types clean, build clean, `streamdeck validate` successful, tests 110/110.

The cursor-selection-border idea noted in the issue remains explicitly out of scope.

Fixes #1437