### PR TITLE
Fix #1431: map verify-approval gate to view-diff in phaseArtifactVerb

### DIFF
--- a/apps/streamdeck/src/__tests__/actions.test.ts
+++ b/apps/streamdeck/src/__tests__/actions.test.ts
@@ -667,6 +667,7 @@ describe('reviewMode (dial mode from the shared resolver)', () => {
     expect(reviewMode(b({ protocolPhase: 'review' }))).toBe('diff');
     expect(reviewMode(b({ blockedGate: 'dev-approval' }))).toBe('diff');
     expect(reviewMode(b({ blockedGate: 'pr' }))).toBe('diff');
+    expect(reviewMode(b({ blockedGate: 'verify-approval' }))).toBe('diff'); // #1431: dials navigate the diff while the human reviews finished work
   });
   it('an unknown phase, no live status, or no builder → none', () => {
     expect(reviewMode(b({}))).toBe('none');

--- a/apps/streamdeck/src/__tests__/actions.test.ts
+++ b/apps/streamdeck/src/__tests__/actions.test.ts
@@ -640,6 +640,7 @@ describe('phaseArtifactVerb (shared resolver — recognised verb or undefined)',
     expect(phaseArtifactVerb(b({ protocolPhase: 'verify' }))).toBe('view-diff');
     expect(phaseArtifactVerb(b({ blockedGate: 'dev-approval' }))).toBe('view-diff');
     expect(phaseArtifactVerb(b({ blockedGate: 'pr' }))).toBe('view-diff');
+    expect(phaseArtifactVerb(b({ blockedGate: 'verify-approval' }))).toBe('view-diff'); // #1431: human reviewing finished work
   });
   it('gate beats phase (the stronger signal)', () => {
     expect(phaseArtifactVerb(b({ blockedGate: 'plan-approval', protocolPhase: 'implement' }))).toBe('open-plan');

--- a/apps/streamdeck/src/actions.ts
+++ b/apps/streamdeck/src/actions.ts
@@ -328,7 +328,7 @@ export function phaseArtifactVerb(b: OverviewBuilder): string | undefined {
   const gate = b.blockedGate ?? '';
   if (gate === 'spec-approval') return 'open-spec';
   if (gate === 'plan-approval') return 'open-plan';
-  if (gate === 'dev-approval' || gate === 'pr') return 'view-diff';
+  if (gate === 'dev-approval' || gate === 'pr' || gate === 'verify-approval') return 'view-diff';
   const phase = b.protocolPhase ?? '';
   if (phase === 'specify') return 'open-spec';
   if (phase === 'plan') return 'open-plan';

--- a/apps/streamdeck/src/face.ts
+++ b/apps/streamdeck/src/face.ts
@@ -49,8 +49,7 @@ export type GlyphKey = 'bolt' | 'book' | 'checklist' | 'code' | 'pull-request' |
 /**
  * Gate id → glyph. The streamdeck twin of `gateIconFor` in `apps/vscode/src/views/builder-row.ts`
  * — keep in sync. A blocked builder whose gate isn't mapped falls back to `bell` (see
- * `faceForBuilder`), matching the sidebar. `verify-approval` renders here even though the press
- * resolver doesn't handle it yet (that gap is BUGFIX #1431).
+ * `faceForBuilder`), matching the sidebar.
  */
 const GATE_ICONS: Record<string, GlyphKey> = {
   'spec-approval': 'book',

--- a/codev/projects/bugfix-1431-stream-deck-phaseartifactverb-/status.yaml
+++ b/codev/projects/bugfix-1431-stream-deck-phaseartifactverb-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1431
 title: stream-deck-phaseartifactverb-
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-13T01:30:28.426Z'
-updated_at: '2026-08-13T01:31:21.684Z'
+updated_at: '2026-08-13T01:33:37.600Z'

--- a/codev/projects/bugfix-1431-stream-deck-phaseartifactverb-/status.yaml
+++ b/codev/projects/bugfix-1431-stream-deck-phaseartifactverb-/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-08-13T01:36:52.822Z'
+    approved_at: '2026-08-13T07:19:28.351Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-13T01:30:28.426Z'
-updated_at: '2026-08-13T01:36:52.823Z'
-pr_ready_for_human: true
+updated_at: '2026-08-13T07:19:28.352Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1431-stream-deck-phaseartifactverb-/status.yaml
+++ b/codev/projects/bugfix-1431-stream-deck-phaseartifactverb-/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-08-13T01:36:52.822Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-13T01:30:28.426Z'
-updated_at: '2026-08-13T01:33:37.600Z'
+updated_at: '2026-08-13T01:36:52.823Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1431-stream-deck-phaseartifactverb-/status.yaml
+++ b/codev/projects/bugfix-1431-stream-deck-phaseartifactverb-/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1431
+title: stream-deck-phaseartifactverb-
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-13T01:30:28.426Z'
+updated_at: '2026-08-13T01:30:28.427Z'

--- a/codev/projects/bugfix-1431-stream-deck-phaseartifactverb-/status.yaml
+++ b/codev/projects/bugfix-1431-stream-deck-phaseartifactverb-/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1431
 title: stream-deck-phaseartifactverb-
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-13T01:30:28.426Z'
-updated_at: '2026-08-13T01:30:28.427Z'
+updated_at: '2026-08-13T01:31:21.684Z'

--- a/codev/state/bugfix-1431_thread.md
+++ b/codev/state/bugfix-1431_thread.md
@@ -53,3 +53,13 @@ Running all three (gemini/codex/claude) in the background.
 
 Two independent APPROVEs, no requested changes. Notifying architect and firing the
 pr gate; codex reported honestly as unavailable rather than a fabricated verdict.
+
+## Architect review of PR #1442 (compensating for codex being down)
+
+Flagged a real gap: the fix has a second behavioural effect neither the issue nor
+my tests covered — `reviewMode()` derives from `phaseArtifactVerb` (`view-diff` →
+`diff`), so a verify-approval-blocked builder's review dials flip from `none`
+(dead) to `diff` (navigating the diff). Correct and desirable (symmetric with
+dev-approval/pr), but was untested + undocumented. Added a `reviewMode` assertion
+beside the dev-approval/pr cases and documented the dial-mode consequence in the PR
+body. 125/125 pass. Still exactly in scope. Holding at the pr gate.

--- a/codev/state/bugfix-1431_thread.md
+++ b/codev/state/bugfix-1431_thread.md
@@ -1,0 +1,30 @@
+# Builder thread — bugfix-1431
+
+## Issue #1431 — phaseArtifactVerb missing verify-approval gate mapping
+
+Stream Deck's `phaseArtifactVerb` (apps/streamdeck/src/actions.ts:327) maps the
+`spec-approval`, `plan-approval`, `dev-approval`, and `pr` gates but not
+`verify-approval`. A builder blocked at `verify-approval` therefore returns
+`undefined`, and the Builder Action Automatic press falls back to `open-terminal`
+instead of opening the review diff. Meanwhile the #1428 faces already render this
+gate (yellow + `verified` glyph + `Verify` label) — so the key looks gate-blocked
+but the press opens a terminal: a face/behaviour contradiction.
+
+## Root cause (investigate phase — no code)
+
+Single missing branch in the gate section of `phaseArtifactVerb`. The VS Code
+sidebar's `gateIconFor` (apps/vscode/src/views/builder-row.ts) already knows
+`verify-approval` → `verified`; the Stream Deck resolver never caught up.
+
+## Fix (architect-scoped: strictly one line + one test + one comment cleanup)
+
+1. actions.ts `phaseArtifactVerb` gate branch: add `verify-approval` returning
+   `'view-diff'` (same as dev-approval/pr — human reviewing finished work). The
+   Automatic press then resolves view-diff → open-diff-first via
+   BuilderAction.resolveVerb (#1414), which is correct and intended.
+2. actions.test.ts: assertion beside the existing dev-approval/pr gate cases.
+3. face.ts ~line 52: delete the doc-comment clause saying the resolver "doesn't
+   handle it yet (that gap is BUGFIX #1431)" — this lane closes that gap.
+
+Do NOT touch anything else in face.ts/actions.ts (#1410 just landed a large change;
+keep this diff trivially reviewable).

--- a/codev/state/bugfix-1431_thread.md
+++ b/codev/state/bugfix-1431_thread.md
@@ -28,3 +28,28 @@ sidebar's `gateIconFor` (apps/vscode/src/views/builder-row.ts) already knows
 
 Do NOT touch anything else in face.ts/actions.ts (#1410 just landed a large change;
 keep this diff trivially reviewable).
+
+## Fix phase — done
+
+Made the three scoped edits. Regression test confirmed to fail without the fix
+(returns `undefined`) and pass with it (`view-diff`). Full suite 125/125,
+check-types clean, esbuild build clean (after building the `@cluesmith/codev-sdk`
+workspace dep first — the type/build errors before that were the unbuilt dep, not
+my change). Committed as `Fix #1431: ...`.
+
+## PR phase
+
+PR #1442 opened (Fixes #1431). CMAP consult needs `--project-id bugfix-1431` —
+auto-detect fails because the worktree's `codev/projects/` holds every project.
+Running all three (gemini/codex/claude) in the background.
+
+## CMAP verdicts
+
+- gemini = APPROVE (HIGH) — "clean, minimal fix … with unit test coverage."
+- claude = APPROVE (HIGH) — "correct one-line gate mapping … backed by a genuine
+  regression test; scope and hygiene are clean."
+- codex  = UNAVAILABLE — the codex lane errored on OpenAI billing ("no credits
+  remaining"), not a review verdict. Environment issue, unrelated to this change.
+
+Two independent APPROVEs, no requested changes. Notifying architect and firing the
+pr gate; codex reported honestly as unavailable rather than a fabricated verdict.


### PR DESCRIPTION
## Summary

Stream Deck's `phaseArtifactVerb` did not map the `verify-approval` gate, so a builder blocked there returned `undefined` and the Builder Action Automatic press fell back to opening a terminal instead of the review diff. The #1428 faces already render this gate (yellow + `verified` glyph + `Verify` label), so today the key looks gate-blocked but the press opens a terminal — a face/behaviour contradiction, the same class codex caught during #1428.

Fixes #1431

## Root Cause

`phaseArtifactVerb` (`apps/streamdeck/src/actions.ts`) mapped the `spec-approval`, `plan-approval`, `dev-approval`, and `pr` gates but not `verify-approval` — which the VS Code sidebar's gate vocabulary already knows (`gateIconFor` maps it to the `verified` codicon). The Stream Deck resolver never caught up, so the gate returned `undefined` and both callers that key off it (the Builder Action Automatic press and the phase-aware dial mode) took the fallback path.

## Fix

- Add `verify-approval` to the gate branch, returning `view-diff` (same as `dev-approval`/`pr` — the human is reviewing finished work). The Automatic press then resolves `view-diff` → `open-diff-first` via `BuilderAction.resolveVerb` (#1414), which is correct and intended.
- Add regression assertions beside the existing `dev-approval`/`pr` gate cases in `actions.test.ts`.
- Delete the now-stale `face.ts` doc-comment clause that noted the resolver did not handle this gate yet (BUGFIX #1431) — this change closes that gap.

## Second behavioural effect: review dials

`reviewMode()` derives from the same resolver (`verb === 'view-diff'` → `'diff'`), so this change also flips a `verify-approval`-blocked builder's review dials from `'none'` (dead) to `'diff'` (navigating the diff). This is **correct and desirable** — symmetric with `dev-approval`/`pr`; the dials should work while a human reviews finished work. Pinned with an added `reviewMode` assertion.

## Test Plan

- [x] Regression tests added — `phaseArtifactVerb(verify-approval)` → `view-diff` and `reviewMode(verify-approval)` → `diff` (both fail without the fix: `phaseArtifactVerb` returns `undefined`, `reviewMode` returns `none`)
- [x] Build passes
- [x] check-types clean
- [x] All tests pass (125/125)