### PR TITLE
[Bugfix #1455] Add a pr-create forge concept so non-GitHub forges can open PRs

### DIFF
--- a/.claude/skills/forge/SKILL.md
+++ b/.claude/skills/forge/SKILL.md
@@ -16,6 +16,7 @@ Forge concept commands decouple codev from direct `gh` CLI calls. Each GitHub op
 | `user-identity` | — | Get current user's handle (plain text) |
 | `team-activity` | `CODEV_GRAPHQL_QUERY` | Run a batched GraphQL query |
 | `on-it-timestamps` | `CODEV_ISSUE_NUMBERS`, `CODEV_GRAPHQL_QUERY`, `CODEV_REPO_OWNER`, `CODEV_REPO_NAME` | Get "on it" comment timestamps |
+| `pr-create` | `CODEV_PR_TITLE`, `CODEV_PR_BODY`, `CODEV_PR_BASE` (optional), `CODEV_PR_HEAD` (optional), `CODEV_PR_REPO` (optional), `CODEV_PR_DRAFT` (optional) | Open a PR; prints `{"number", "url"}` |
 | `pr-merge` | `CODEV_PR_NUMBER` | Merge a PR |
 | `pr-search` | `CODEV_SEARCH_QUERY` | Search PRs (JSON array) |
 | `pr-view` | `CODEV_PR_NUMBER`, `CODEV_INCLUDE_COMMENTS` (optional) | View PR details (JSON or text) |

--- a/.codex/skills/forge/SKILL.md
+++ b/.codex/skills/forge/SKILL.md
@@ -16,6 +16,7 @@ Forge concept commands decouple codev from direct `gh` CLI calls. Each GitHub op
 | `user-identity` | — | Get current user's handle (plain text) |
 | `team-activity` | `CODEV_GRAPHQL_QUERY` | Run a batched GraphQL query |
 | `on-it-timestamps` | `CODEV_ISSUE_NUMBERS`, `CODEV_GRAPHQL_QUERY`, `CODEV_REPO_OWNER`, `CODEV_REPO_NAME` | Get "on it" comment timestamps |
+| `pr-create` | `CODEV_PR_TITLE`, `CODEV_PR_BODY`, `CODEV_PR_BASE` (optional), `CODEV_PR_HEAD` (optional), `CODEV_PR_REPO` (optional), `CODEV_PR_DRAFT` (optional) | Open a PR; prints `{"number", "url"}` |
 | `pr-merge` | `CODEV_PR_NUMBER` | Merge a PR |
 | `pr-search` | `CODEV_SEARCH_QUERY` | Search PRs (JSON array) |
 | `pr-view` | `CODEV_PR_NUMBER`, `CODEV_INCLUDE_COMMENTS` (optional) | View PR details (JSON or text) |

--- a/codev-skeleton/protocols/air/prompts/pr.md
+++ b/codev-skeleton/protocols/air/prompts/pr.md
@@ -18,8 +18,8 @@ Open the PR with the review embedded in its body, optionally run CMAP, and notif
 The body must carry `Closes #<N>` for the driving issue — one per issue if several — so GitHub auto-closes it on merge. **Exception:** a partial fix uses `Refs #<N>` or `Part of #<N>` instead. Substitute the real number for `<N>`; leave no `{{...}}` tag or `<N>` placeholder in the committed body.
 
 ```bash
-CODEV_PR_TITLE="[Air #<N>] feat: <brief description>" \
-CODEV_PR_BODY="$(cat <<'EOF'
+export CODEV_PR_TITLE="[Air #<N>] feat: <brief description>"
+export CODEV_PR_BODY="$(cat <<'EOF'
 ## Summary
 
 <1-2 sentence description of the feature>
@@ -44,10 +44,12 @@ Closes #<N>  <!-- Substitute <N>; use "Refs #<N>" for a partial fix -->
 
 <anything the reviewer should focus on, or "Standard implementation — no special concerns">
 EOF
-)" {{pr_create_command}}
+)"
+
+{{pr_create_command}}
 ```
 
-The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It takes `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — from the environment, which is why they are exported rather than prefixed onto the command line: an inline override that spells `--title "$CODEV_PR_TITLE"` needs them set in the calling shell too. It prints `{"number": <int>, "url": "<url>"}`.
 
 ## Optional CMAP review
 

--- a/codev-skeleton/protocols/air/prompts/pr.md
+++ b/codev-skeleton/protocols/air/prompts/pr.md
@@ -47,7 +47,7 @@ EOF
 )" {{pr_create_command}}
 ```
 
-Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Optional CMAP review
 

--- a/codev-skeleton/protocols/air/prompts/pr.md
+++ b/codev-skeleton/protocols/air/prompts/pr.md
@@ -18,7 +18,8 @@ Open the PR with the review embedded in its body, optionally run CMAP, and notif
 The body must carry `Closes #<N>` for the driving issue — one per issue if several — so GitHub auto-closes it on merge. **Exception:** a partial fix uses `Refs #<N>` or `Part of #<N>` instead. Substitute the real number for `<N>`; leave no `{{...}}` tag or `<N>` placeholder in the committed body.
 
 ```bash
-gh pr create --title "[Air #<N>] feat: <brief description>" --body "$(cat <<'EOF'
+CODEV_PR_TITLE="[Air #<N>] feat: <brief description>" \
+CODEV_PR_BODY="$(cat <<'EOF'
 ## Summary
 
 <1-2 sentence description of the feature>
@@ -43,8 +44,10 @@ Closes #<N>  <!-- Substitute <N>; use "Refs #<N>" for a partial fix -->
 
 <anything the reviewer should focus on, or "Standard implementation — no special concerns">
 EOF
-)"
+)" {{pr_create_command}}
 ```
+
+Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Optional CMAP review
 

--- a/codev-skeleton/protocols/aspir/prompts/review.md
+++ b/codev-skeleton/protocols/aspir/prompts/review.md
@@ -44,7 +44,8 @@ The review's `## Architecture Updates` and `## Lessons Learned Updates` sections
 The PR body must carry `Closes #<N>` (feature) or `Fixes #<N>` (bug) for the driving issue — one keyword per issue if several — so GitHub auto-closes on merge. **Exception:** a PR that only partially addresses its issue uses `Refs #<N>` or `Part of #<N>` instead, leaving the issue open for the follow-up.
 
 ```bash
-gh pr create --title "[Spec {{project_id}}] {{title}}" --body "$(cat <<'EOF'
+CODEV_PR_TITLE="[Spec {{project_id}}] {{title}}" \
+CODEV_PR_BODY="$(cat <<'EOF'
 ## Summary
 [what was implemented]
 
@@ -62,8 +63,10 @@ codev/specs/{{artifact_name}}.md
 ## Review
 codev/reviews/{{artifact_name}}.md
 EOF
-)"
+)" {{pr_create_command}}
 ```
+
+Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev-skeleton/protocols/aspir/prompts/review.md
+++ b/codev-skeleton/protocols/aspir/prompts/review.md
@@ -44,8 +44,8 @@ The review's `## Architecture Updates` and `## Lessons Learned Updates` sections
 The PR body must carry `Closes #<N>` (feature) or `Fixes #<N>` (bug) for the driving issue — one keyword per issue if several — so GitHub auto-closes on merge. **Exception:** a PR that only partially addresses its issue uses `Refs #<N>` or `Part of #<N>` instead, leaving the issue open for the follow-up.
 
 ```bash
-CODEV_PR_TITLE="[Spec {{project_id}}] {{title}}" \
-CODEV_PR_BODY="$(cat <<'EOF'
+export CODEV_PR_TITLE="[Spec {{project_id}}] {{title}}"
+export CODEV_PR_BODY="$(cat <<'EOF'
 ## Summary
 [what was implemented]
 
@@ -63,10 +63,12 @@ codev/specs/{{artifact_name}}.md
 ## Review
 codev/reviews/{{artifact_name}}.md
 EOF
-)" {{pr_create_command}}
+)"
+
+{{pr_create_command}}
 ```
 
-The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It takes `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — from the environment, which is why they are exported rather than prefixed onto the command line: an inline override that spells `--title "$CODEV_PR_TITLE"` needs them set in the calling shell too. It prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev-skeleton/protocols/aspir/prompts/review.md
+++ b/codev-skeleton/protocols/aspir/prompts/review.md
@@ -66,7 +66,7 @@ EOF
 )" {{pr_create_command}}
 ```
 
-Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev-skeleton/protocols/bugfix/prompts/pr.md
+++ b/codev-skeleton/protocols/bugfix/prompts/pr.md
@@ -16,8 +16,8 @@ Open the PR, run CMAP review on it, address feedback, and hand off to the archit
 The PR body must carry `Fixes #<N>` for the driving issue — one per issue if several — so GitHub auto-closes it on merge. **Exception:** a PR that only partially addresses the issue uses `Refs #<N>` or `Part of #<N>` instead, leaving it open for the follow-up. Substitute the real number for `<N>`; leave no `{{...}}` tag or `<N>` placeholder in the committed body.
 
 ```bash
-CODEV_PR_TITLE="Fix #<N>: <brief description>" \
-CODEV_PR_BODY="$(cat <<'EOF'
+export CODEV_PR_TITLE="Fix #<N>: <brief description>"
+export CODEV_PR_BODY="$(cat <<'EOF'
 ## Summary
 
 <1-2 sentence description of the bug and fix>
@@ -38,10 +38,12 @@ Fixes #<N>  <!-- Substitute <N>; use "Refs #<N>" for a partial fix -->
 - [ ] Build passes
 - [ ] All tests pass
 EOF
-)" {{pr_create_command}}
+)"
+
+{{pr_create_command}}
 ```
 
-The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It takes `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — from the environment, which is why they are exported rather than prefixed onto the command line: an inline override that spells `--title "$CODEV_PR_TITLE"` needs them set in the calling shell too. It prints `{"number": <int>, "url": "<url>"}`.
 
 ## Run CMAP review
 

--- a/codev-skeleton/protocols/bugfix/prompts/pr.md
+++ b/codev-skeleton/protocols/bugfix/prompts/pr.md
@@ -16,7 +16,8 @@ Open the PR, run CMAP review on it, address feedback, and hand off to the archit
 The PR body must carry `Fixes #<N>` for the driving issue — one per issue if several — so GitHub auto-closes it on merge. **Exception:** a PR that only partially addresses the issue uses `Refs #<N>` or `Part of #<N>` instead, leaving it open for the follow-up. Substitute the real number for `<N>`; leave no `{{...}}` tag or `<N>` placeholder in the committed body.
 
 ```bash
-gh pr create --title "Fix #<N>: <brief description>" --body "$(cat <<'EOF'
+CODEV_PR_TITLE="Fix #<N>: <brief description>" \
+CODEV_PR_BODY="$(cat <<'EOF'
 ## Summary
 
 <1-2 sentence description of the bug and fix>
@@ -37,8 +38,10 @@ Fixes #<N>  <!-- Substitute <N>; use "Refs #<N>" for a partial fix -->
 - [ ] Build passes
 - [ ] All tests pass
 EOF
-)"
+)" {{pr_create_command}}
 ```
+
+Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Run CMAP review
 

--- a/codev-skeleton/protocols/bugfix/prompts/pr.md
+++ b/codev-skeleton/protocols/bugfix/prompts/pr.md
@@ -41,7 +41,7 @@ EOF
 )" {{pr_create_command}}
 ```
 
-Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Run CMAP review
 

--- a/codev-skeleton/protocols/bugfix/protocol.md
+++ b/codev-skeleton/protocols/bugfix/protocol.md
@@ -27,7 +27,8 @@ refactor surrounding code, fix unrelated bugs (file separate issues), or add fea
 [Bugfix #42] Test: regression for unencoded username
 ```
 
-**PR** — open with `gh pr create`, body carrying Summary, Root Cause, Fix and Test Plan plus
+**PR** — open with the `pr-create` forge concept command the PR-phase prompt hands you (`gh
+pr create` on GitHub), body carrying Summary, Root Cause, Fix and Test Plan plus
 `Fixes #<N>` so the issue closes on merge. Run one CMAP pass (Gemini, Codex, Claude), record
 each verdict, and address or rebut every `REQUEST_CHANGES`. Notify the architect with the
 verdicts, then `porch done <id>` and wait.

--- a/codev-skeleton/protocols/maintain/prompts/review.md
+++ b/codev-skeleton/protocols/maintain/prompts/review.md
@@ -46,8 +46,8 @@ If the run was not tied to any issue, the `Closes` line can be omitted.
 ```bash
 git push origin HEAD
 
-CODEV_PR_TITLE="[Maintain] Codebase maintenance run NNNN" \
-CODEV_PR_BODY="$(cat <<'PREOF'
+export CODEV_PR_TITLE="[Maintain] Codebase maintenance run NNNN"
+export CODEV_PR_BODY="$(cat <<'PREOF'
 ## Summary
 
 <2-3 bullet points of what was done>
@@ -67,10 +67,12 @@ Closes #<N>  <!-- Only if this run was triggered by a GitHub issue. Use "Refs #<
 - [x] All tests pass
 - [x] Documentation links resolve
 PREOF
-)" {{pr_create_command}}
+)"
+
+{{pr_create_command}}
 ```
 
-The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It takes `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — from the environment, which is why they are exported rather than prefixed onto the command line: an inline override that spells `--title "$CODEV_PR_TITLE"` needs them set in the calling shell too. It prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev-skeleton/protocols/maintain/prompts/review.md
+++ b/codev-skeleton/protocols/maintain/prompts/review.md
@@ -70,7 +70,7 @@ PREOF
 )" {{pr_create_command}}
 ```
 
-Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev-skeleton/protocols/maintain/prompts/review.md
+++ b/codev-skeleton/protocols/maintain/prompts/review.md
@@ -46,7 +46,8 @@ If the run was not tied to any issue, the `Closes` line can be omitted.
 ```bash
 git push origin HEAD
 
-gh pr create --title "[Maintain] Codebase maintenance run NNNN" --body "$(cat <<'PREOF'
+CODEV_PR_TITLE="[Maintain] Codebase maintenance run NNNN" \
+CODEV_PR_BODY="$(cat <<'PREOF'
 ## Summary
 
 <2-3 bullet points of what was done>
@@ -66,8 +67,10 @@ Closes #<N>  <!-- Only if this run was triggered by a GitHub issue. Use "Refs #<
 - [x] All tests pass
 - [x] Documentation links resolve
 PREOF
-)"
+)" {{pr_create_command}}
 ```
+
+Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev-skeleton/protocols/pir/prompts/review.md
+++ b/codev-skeleton/protocols/pir/prompts/review.md
@@ -108,12 +108,14 @@ git push
 PR_TITLE="<concise description of the change>"
 BRANCH="$(git branch --show-current)"
 
-gh pr create \
-  --base main \
-  --head "$BRANCH" \
-  --title "$PR_TITLE" \
-  --body-file codev/reviews/{{artifact_name}}.md
+CODEV_PR_TITLE="$PR_TITLE" \
+CODEV_PR_BODY="$(cat codev/reviews/{{artifact_name}}.md)" \
+CODEV_PR_BASE=main \
+CODEV_PR_HEAD="$BRANCH" \
+{{pr_create_command}}
 ```
+
+Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default) and it prints `{"number": <int>, "url": "<url>"}`. The body goes in as an environment variable, not `--body-file` — read the created PR back and confirm the body arrived intact before moving on.
 
 **Verify the PR body contains `Fixes #{{issue.number}}`** (it should — the review file has it at the top). If somehow missing, edit and re-apply:
 
@@ -154,7 +156,7 @@ For any `REQUEST_CHANGES`:
 
 1. Read the finding in full (`codev/projects/{{project_id}}-*/{{project_id}}-<model>.txt`).
 2. **Assess it honestly:**
-   - **Real defect** (correctness / cancellation / security / data-loss): fix it in code, add a regression test that fails without the fix, commit + push (the PR updates automatically — no new `gh pr create`). Then document the finding, your fix, and the pinning test in the review file's **"Things to Look At During PR Review"** section.
+   - **Real defect** (correctness / cancellation / security / data-loss): fix it in code, add a regression test that fails without the fix, commit + push (the PR updates automatically — no second PR). Then document the finding, your fix, and the pinning test in the review file's **"Things to Look At During PR Review"** section.
    - **False positive / out of scope**: write a brief rebuttal in that same section explaining why no change is warranted.
 3. Do **not** re-run `porch done` expecting another consultation pass — `max_iterations: 1` means it will not re-review. Proceed to step 7.
 
@@ -257,7 +259,7 @@ Together with the `--pr` record from step 4a and the `--merged` record from step
   ```
 - Resolve conflicts (do NOT use destructive shortcuts)
 - Force-push with lease: `git push --force-with-lease`
-- Re-run `gh pr create`
+- Re-run the PR creation command from step 4
 
 **If porch's consultation fails (e.g., model unavailable):**
 - `porch done` will report the failure. Inspect `codev/projects/{{project_id}}-*/{{project_id}}-<model>.txt` for the failure details.

--- a/codev-skeleton/protocols/pir/prompts/review.md
+++ b/codev-skeleton/protocols/pir/prompts/review.md
@@ -108,14 +108,15 @@ git push
 PR_TITLE="<concise description of the change>"
 BRANCH="$(git branch --show-current)"
 
-CODEV_PR_TITLE="$PR_TITLE" \
-CODEV_PR_BODY="$(cat codev/reviews/{{artifact_name}}.md)" \
-CODEV_PR_BASE=main \
-CODEV_PR_HEAD="$BRANCH" \
+export CODEV_PR_TITLE="$PR_TITLE"
+export CODEV_PR_BODY="$(cat codev/reviews/{{artifact_name}}.md)"
+export CODEV_PR_BASE=main
+export CODEV_PR_HEAD="$BRANCH"
+
 {{pr_create_command}}
 ```
 
-The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It prints `{"number": <int>, "url": "<url>"}`. The body goes in as an environment variable, not `--body-file` — read the created PR back and confirm the body arrived intact before moving on.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It prints `{"number": <int>, "url": "<url>"}`. The inputs are **exported** so an inline override that spells `--title "$CODEV_PR_TITLE"` sees them too. The body goes in as an environment variable, not `--body-file` — read the created PR back and confirm the body arrived intact before moving on.
 
 **Verify the PR body contains `Fixes #{{issue.number}}`** (it should — the review file has it at the top). If somehow missing, edit and re-apply:
 

--- a/codev-skeleton/protocols/pir/prompts/review.md
+++ b/codev-skeleton/protocols/pir/prompts/review.md
@@ -115,7 +115,7 @@ CODEV_PR_HEAD="$BRANCH" \
 {{pr_create_command}}
 ```
 
-Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default) and it prints `{"number": <int>, "url": "<url>"}`. The body goes in as an environment variable, not `--body-file` — read the created PR back and confirm the body arrived intact before moving on.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It prints `{"number": <int>, "url": "<url>"}`. The body goes in as an environment variable, not `--body-file` — read the created PR back and confirm the body arrived intact before moving on.
 
 **Verify the PR body contains `Fixes #{{issue.number}}`** (it should — the review file has it at the top). If somehow missing, edit and re-apply:
 

--- a/codev-skeleton/protocols/spir/prompts/review.md
+++ b/codev-skeleton/protocols/spir/prompts/review.md
@@ -44,7 +44,8 @@ The review's `## Architecture Updates` and `## Lessons Learned Updates` sections
 The PR body must carry `Closes #<N>` (feature) or `Fixes #<N>` (bug) for the driving issue — one keyword per issue if several — so GitHub auto-closes on merge. **Exception:** a PR that only partially addresses its issue uses `Refs #<N>` or `Part of #<N>` instead, leaving the issue open for the follow-up.
 
 ```bash
-gh pr create --title "[Spec {{project_id}}] {{title}}" --body "$(cat <<'EOF'
+CODEV_PR_TITLE="[Spec {{project_id}}] {{title}}" \
+CODEV_PR_BODY="$(cat <<'EOF'
 ## Summary
 [what was implemented]
 
@@ -62,8 +63,10 @@ codev/specs/{{artifact_name}}.md
 ## Review
 codev/reviews/{{artifact_name}}.md
 EOF
-)"
+)" {{pr_create_command}}
 ```
+
+Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev-skeleton/protocols/spir/prompts/review.md
+++ b/codev-skeleton/protocols/spir/prompts/review.md
@@ -44,8 +44,8 @@ The review's `## Architecture Updates` and `## Lessons Learned Updates` sections
 The PR body must carry `Closes #<N>` (feature) or `Fixes #<N>` (bug) for the driving issue — one keyword per issue if several — so GitHub auto-closes on merge. **Exception:** a PR that only partially addresses its issue uses `Refs #<N>` or `Part of #<N>` instead, leaving the issue open for the follow-up.
 
 ```bash
-CODEV_PR_TITLE="[Spec {{project_id}}] {{title}}" \
-CODEV_PR_BODY="$(cat <<'EOF'
+export CODEV_PR_TITLE="[Spec {{project_id}}] {{title}}"
+export CODEV_PR_BODY="$(cat <<'EOF'
 ## Summary
 [what was implemented]
 
@@ -63,10 +63,12 @@ codev/specs/{{artifact_name}}.md
 ## Review
 codev/reviews/{{artifact_name}}.md
 EOF
-)" {{pr_create_command}}
+)"
+
+{{pr_create_command}}
 ```
 
-The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It takes `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — from the environment, which is why they are exported rather than prefixed onto the command line: an inline override that spells `--title "$CODEV_PR_TITLE"` needs them set in the calling shell too. It prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev-skeleton/protocols/spir/prompts/review.md
+++ b/codev-skeleton/protocols/spir/prompts/review.md
@@ -66,7 +66,7 @@ EOF
 )" {{pr_create_command}}
 ```
 
-Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev/projects/bugfix-1455-pr-create-is-not-a-forge-conce/status.yaml
+++ b/codev/projects/bugfix-1455-pr-create-is-not-a-forge-conce/status.yaml
@@ -6,16 +6,17 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-08-14T13:32:49.424Z'
+    approved_at: '2026-08-14T13:33:26.924Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-14T04:34:29.595Z'
-updated_at: '2026-08-14T13:32:49.425Z'
+updated_at: '2026-08-14T13:33:26.925Z'
 pr_history:
   - phase: pr
     pr_number: 1458
     branch: builder/bugfix-1455
     created_at: '2026-08-14T12:36:11.217Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1455-pr-create-is-not-a-forge-conce/status.yaml
+++ b/codev/projects/bugfix-1455-pr-create-is-not-a-forge-conce/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1455
 title: pr-create-is-not-a-forge-conce
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-14T04:34:29.595Z'
-updated_at: '2026-08-14T04:53:12.811Z'
+updated_at: '2026-08-14T06:39:13.027Z'

--- a/codev/projects/bugfix-1455-pr-create-is-not-a-forge-conce/status.yaml
+++ b/codev/projects/bugfix-1455-pr-create-is-not-a-forge-conce/status.yaml
@@ -11,4 +11,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-14T04:34:29.595Z'
-updated_at: '2026-08-14T06:39:13.027Z'
+updated_at: '2026-08-14T12:36:11.218Z'
+pr_history:
+  - phase: pr
+    pr_number: 1458
+    branch: builder/bugfix-1455
+    created_at: '2026-08-14T12:36:11.217Z'

--- a/codev/projects/bugfix-1455-pr-create-is-not-a-forge-conce/status.yaml
+++ b/codev/projects/bugfix-1455-pr-create-is-not-a-forge-conce/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1455
 title: pr-create-is-not-a-forge-conce
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,7 +13,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-14T04:34:29.595Z'
-updated_at: '2026-08-14T13:33:26.925Z'
+updated_at: '2026-08-14T13:33:34.558Z'
 pr_history:
   - phase: pr
     pr_number: 1458

--- a/codev/projects/bugfix-1455-pr-create-is-not-a-forge-conce/status.yaml
+++ b/codev/projects/bugfix-1455-pr-create-is-not-a-forge-conce/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1455
+title: pr-create-is-not-a-forge-conce
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-14T04:34:29.595Z'
+updated_at: '2026-08-14T04:34:29.596Z'

--- a/codev/projects/bugfix-1455-pr-create-is-not-a-forge-conce/status.yaml
+++ b/codev/projects/bugfix-1455-pr-create-is-not-a-forge-conce/status.yaml
@@ -7,13 +7,15 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-08-14T13:32:49.424Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-14T04:34:29.595Z'
-updated_at: '2026-08-14T12:36:11.218Z'
+updated_at: '2026-08-14T13:32:49.425Z'
 pr_history:
   - phase: pr
     pr_number: 1458
     branch: builder/bugfix-1455
     created_at: '2026-08-14T12:36:11.217Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1455-pr-create-is-not-a-forge-conce/status.yaml
+++ b/codev/projects/bugfix-1455-pr-create-is-not-a-forge-conce/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1455
+title: pr-create-is-not-a-forge-conce
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-14T04:27:13.239Z'
+updated_at: '2026-08-14T04:27:13.241Z'

--- a/codev/projects/bugfix-1455-pr-create-is-not-a-forge-conce/status.yaml
+++ b/codev/projects/bugfix-1455-pr-create-is-not-a-forge-conce/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1455
 title: pr-create-is-not-a-forge-conce
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-14T04:34:29.595Z'
-updated_at: '2026-08-14T04:34:29.596Z'
+updated_at: '2026-08-14T04:53:12.811Z'

--- a/codev/protocols/air/prompts/pr.md
+++ b/codev/protocols/air/prompts/pr.md
@@ -18,8 +18,8 @@ Open the PR with the review embedded in its body, optionally run CMAP, and notif
 The body must carry `Closes #<N>` for the driving issue — one per issue if several — so GitHub auto-closes it on merge. **Exception:** a partial fix uses `Refs #<N>` or `Part of #<N>` instead. Substitute the real number for `<N>`; leave no `{{...}}` tag or `<N>` placeholder in the committed body.
 
 ```bash
-CODEV_PR_TITLE="[Air #<N>] feat: <brief description>" \
-CODEV_PR_BODY="$(cat <<'EOF'
+export CODEV_PR_TITLE="[Air #<N>] feat: <brief description>"
+export CODEV_PR_BODY="$(cat <<'EOF'
 ## Summary
 
 <1-2 sentence description of the feature>
@@ -44,10 +44,12 @@ Closes #<N>  <!-- Substitute <N>; use "Refs #<N>" for a partial fix -->
 
 <anything the reviewer should focus on, or "Standard implementation — no special concerns">
 EOF
-)" {{pr_create_command}}
+)"
+
+{{pr_create_command}}
 ```
 
-The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It takes `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — from the environment, which is why they are exported rather than prefixed onto the command line: an inline override that spells `--title "$CODEV_PR_TITLE"` needs them set in the calling shell too. It prints `{"number": <int>, "url": "<url>"}`.
 
 ## Optional CMAP review
 

--- a/codev/protocols/air/prompts/pr.md
+++ b/codev/protocols/air/prompts/pr.md
@@ -47,7 +47,7 @@ EOF
 )" {{pr_create_command}}
 ```
 
-Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Optional CMAP review
 

--- a/codev/protocols/air/prompts/pr.md
+++ b/codev/protocols/air/prompts/pr.md
@@ -18,7 +18,8 @@ Open the PR with the review embedded in its body, optionally run CMAP, and notif
 The body must carry `Closes #<N>` for the driving issue — one per issue if several — so GitHub auto-closes it on merge. **Exception:** a partial fix uses `Refs #<N>` or `Part of #<N>` instead. Substitute the real number for `<N>`; leave no `{{...}}` tag or `<N>` placeholder in the committed body.
 
 ```bash
-gh pr create --title "[Air #<N>] feat: <brief description>" --body "$(cat <<'EOF'
+CODEV_PR_TITLE="[Air #<N>] feat: <brief description>" \
+CODEV_PR_BODY="$(cat <<'EOF'
 ## Summary
 
 <1-2 sentence description of the feature>
@@ -43,8 +44,10 @@ Closes #<N>  <!-- Substitute <N>; use "Refs #<N>" for a partial fix -->
 
 <anything the reviewer should focus on, or "Standard implementation — no special concerns">
 EOF
-)"
+)" {{pr_create_command}}
 ```
+
+Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Optional CMAP review
 

--- a/codev/protocols/aspir/prompts/review.md
+++ b/codev/protocols/aspir/prompts/review.md
@@ -44,7 +44,8 @@ The review's `## Architecture Updates` and `## Lessons Learned Updates` sections
 The PR body must carry `Closes #<N>` (feature) or `Fixes #<N>` (bug) for the driving issue — one keyword per issue if several — so GitHub auto-closes on merge. **Exception:** a PR that only partially addresses its issue uses `Refs #<N>` or `Part of #<N>` instead, leaving the issue open for the follow-up.
 
 ```bash
-gh pr create --title "[Spec {{project_id}}] {{title}}" --body "$(cat <<'EOF'
+CODEV_PR_TITLE="[Spec {{project_id}}] {{title}}" \
+CODEV_PR_BODY="$(cat <<'EOF'
 ## Summary
 [what was implemented]
 
@@ -62,8 +63,10 @@ codev/specs/{{artifact_name}}.md
 ## Review
 codev/reviews/{{artifact_name}}.md
 EOF
-)"
+)" {{pr_create_command}}
 ```
+
+Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev/protocols/aspir/prompts/review.md
+++ b/codev/protocols/aspir/prompts/review.md
@@ -44,8 +44,8 @@ The review's `## Architecture Updates` and `## Lessons Learned Updates` sections
 The PR body must carry `Closes #<N>` (feature) or `Fixes #<N>` (bug) for the driving issue — one keyword per issue if several — so GitHub auto-closes on merge. **Exception:** a PR that only partially addresses its issue uses `Refs #<N>` or `Part of #<N>` instead, leaving the issue open for the follow-up.
 
 ```bash
-CODEV_PR_TITLE="[Spec {{project_id}}] {{title}}" \
-CODEV_PR_BODY="$(cat <<'EOF'
+export CODEV_PR_TITLE="[Spec {{project_id}}] {{title}}"
+export CODEV_PR_BODY="$(cat <<'EOF'
 ## Summary
 [what was implemented]
 
@@ -63,10 +63,12 @@ codev/specs/{{artifact_name}}.md
 ## Review
 codev/reviews/{{artifact_name}}.md
 EOF
-)" {{pr_create_command}}
+)"
+
+{{pr_create_command}}
 ```
 
-The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It takes `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — from the environment, which is why they are exported rather than prefixed onto the command line: an inline override that spells `--title "$CODEV_PR_TITLE"` needs them set in the calling shell too. It prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev/protocols/aspir/prompts/review.md
+++ b/codev/protocols/aspir/prompts/review.md
@@ -66,7 +66,7 @@ EOF
 )" {{pr_create_command}}
 ```
 
-Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev/protocols/bugfix/prompts/pr.md
+++ b/codev/protocols/bugfix/prompts/pr.md
@@ -16,8 +16,8 @@ Open the PR, run CMAP review on it, address feedback, and hand off to the archit
 The PR body must carry `Fixes #<N>` for the driving issue — one per issue if several — so GitHub auto-closes it on merge. **Exception:** a PR that only partially addresses the issue uses `Refs #<N>` or `Part of #<N>` instead, leaving it open for the follow-up. Substitute the real number for `<N>`; leave no `{{...}}` tag or `<N>` placeholder in the committed body.
 
 ```bash
-CODEV_PR_TITLE="Fix #<N>: <brief description>" \
-CODEV_PR_BODY="$(cat <<'EOF'
+export CODEV_PR_TITLE="Fix #<N>: <brief description>"
+export CODEV_PR_BODY="$(cat <<'EOF'
 ## Summary
 
 <1-2 sentence description of the bug and fix>
@@ -38,10 +38,12 @@ Fixes #<N>  <!-- Substitute <N>; use "Refs #<N>" for a partial fix -->
 - [ ] Build passes
 - [ ] All tests pass
 EOF
-)" {{pr_create_command}}
+)"
+
+{{pr_create_command}}
 ```
 
-The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It takes `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — from the environment, which is why they are exported rather than prefixed onto the command line: an inline override that spells `--title "$CODEV_PR_TITLE"` needs them set in the calling shell too. It prints `{"number": <int>, "url": "<url>"}`.
 
 ## Run CMAP review
 

--- a/codev/protocols/bugfix/prompts/pr.md
+++ b/codev/protocols/bugfix/prompts/pr.md
@@ -16,7 +16,8 @@ Open the PR, run CMAP review on it, address feedback, and hand off to the archit
 The PR body must carry `Fixes #<N>` for the driving issue — one per issue if several — so GitHub auto-closes it on merge. **Exception:** a PR that only partially addresses the issue uses `Refs #<N>` or `Part of #<N>` instead, leaving it open for the follow-up. Substitute the real number for `<N>`; leave no `{{...}}` tag or `<N>` placeholder in the committed body.
 
 ```bash
-gh pr create --title "Fix #<N>: <brief description>" --body "$(cat <<'EOF'
+CODEV_PR_TITLE="Fix #<N>: <brief description>" \
+CODEV_PR_BODY="$(cat <<'EOF'
 ## Summary
 
 <1-2 sentence description of the bug and fix>
@@ -37,8 +38,10 @@ Fixes #<N>  <!-- Substitute <N>; use "Refs #<N>" for a partial fix -->
 - [ ] Build passes
 - [ ] All tests pass
 EOF
-)"
+)" {{pr_create_command}}
 ```
+
+Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Run CMAP review
 

--- a/codev/protocols/bugfix/prompts/pr.md
+++ b/codev/protocols/bugfix/prompts/pr.md
@@ -41,7 +41,7 @@ EOF
 )" {{pr_create_command}}
 ```
 
-Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Run CMAP review
 

--- a/codev/protocols/bugfix/protocol.md
+++ b/codev/protocols/bugfix/protocol.md
@@ -27,7 +27,8 @@ refactor surrounding code, fix unrelated bugs (file separate issues), or add fea
 [Bugfix #42] Test: regression for unencoded username
 ```
 
-**PR** — open with `gh pr create`, body carrying Summary, Root Cause, Fix and Test Plan plus
+**PR** — open with the `pr-create` forge concept command the PR-phase prompt hands you (`gh
+pr create` on GitHub), body carrying Summary, Root Cause, Fix and Test Plan plus
 `Fixes #<N>` so the issue closes on merge. Run one CMAP pass (Gemini, Codex, Claude), record
 each verdict, and address or rebut every `REQUEST_CHANGES`. Notify the architect with the
 verdicts, then `porch done <id>` and wait.

--- a/codev/protocols/maintain/prompts/review.md
+++ b/codev/protocols/maintain/prompts/review.md
@@ -46,8 +46,8 @@ If the run was not tied to any issue, the `Closes` line can be omitted.
 ```bash
 git push origin HEAD
 
-CODEV_PR_TITLE="[Maintain] Codebase maintenance run NNNN" \
-CODEV_PR_BODY="$(cat <<'PREOF'
+export CODEV_PR_TITLE="[Maintain] Codebase maintenance run NNNN"
+export CODEV_PR_BODY="$(cat <<'PREOF'
 ## Summary
 
 <2-3 bullet points of what was done>
@@ -67,10 +67,12 @@ Closes #<N>  <!-- Only if this run was triggered by a GitHub issue. Use "Refs #<
 - [x] All tests pass
 - [x] Documentation links resolve
 PREOF
-)" {{pr_create_command}}
+)"
+
+{{pr_create_command}}
 ```
 
-The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It takes `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — from the environment, which is why they are exported rather than prefixed onto the command line: an inline override that spells `--title "$CODEV_PR_TITLE"` needs them set in the calling shell too. It prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev/protocols/maintain/prompts/review.md
+++ b/codev/protocols/maintain/prompts/review.md
@@ -70,7 +70,7 @@ PREOF
 )" {{pr_create_command}}
 ```
 
-Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev/protocols/maintain/prompts/review.md
+++ b/codev/protocols/maintain/prompts/review.md
@@ -46,7 +46,8 @@ If the run was not tied to any issue, the `Closes` line can be omitted.
 ```bash
 git push origin HEAD
 
-gh pr create --title "[Maintain] Codebase maintenance run NNNN" --body "$(cat <<'PREOF'
+CODEV_PR_TITLE="[Maintain] Codebase maintenance run NNNN" \
+CODEV_PR_BODY="$(cat <<'PREOF'
 ## Summary
 
 <2-3 bullet points of what was done>
@@ -66,8 +67,10 @@ Closes #<N>  <!-- Only if this run was triggered by a GitHub issue. Use "Refs #<
 - [x] All tests pass
 - [x] Documentation links resolve
 PREOF
-)"
+)" {{pr_create_command}}
 ```
+
+Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev/protocols/pir/prompts/review.md
+++ b/codev/protocols/pir/prompts/review.md
@@ -108,12 +108,14 @@ git push
 PR_TITLE="<concise description of the change>"
 BRANCH="$(git branch --show-current)"
 
-gh pr create \
-  --base main \
-  --head "$BRANCH" \
-  --title "$PR_TITLE" \
-  --body-file codev/reviews/{{artifact_name}}.md
+CODEV_PR_TITLE="$PR_TITLE" \
+CODEV_PR_BODY="$(cat codev/reviews/{{artifact_name}}.md)" \
+CODEV_PR_BASE=main \
+CODEV_PR_HEAD="$BRANCH" \
+{{pr_create_command}}
 ```
+
+Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default) and it prints `{"number": <int>, "url": "<url>"}`. The body goes in as an environment variable, not `--body-file` — read the created PR back and confirm the body arrived intact before moving on.
 
 **Verify the PR body contains `Fixes #{{issue.number}}`** (it should — the review file has it at the top). If somehow missing, edit and re-apply:
 
@@ -154,7 +156,7 @@ For any `REQUEST_CHANGES`:
 
 1. Read the finding in full (`codev/projects/{{project_id}}-*/{{project_id}}-<model>.txt`).
 2. **Assess it honestly:**
-   - **Real defect** (correctness / cancellation / security / data-loss): fix it in code, add a regression test that fails without the fix, commit + push (the PR updates automatically — no new `gh pr create`). Then document the finding, your fix, and the pinning test in the review file's **"Things to Look At During PR Review"** section.
+   - **Real defect** (correctness / cancellation / security / data-loss): fix it in code, add a regression test that fails without the fix, commit + push (the PR updates automatically — no second PR). Then document the finding, your fix, and the pinning test in the review file's **"Things to Look At During PR Review"** section.
    - **False positive / out of scope**: write a brief rebuttal in that same section explaining why no change is warranted.
 3. Do **not** re-run `porch done` expecting another consultation pass — `max_iterations: 1` means it will not re-review. Proceed to step 7.
 
@@ -257,7 +259,7 @@ Together with the `--pr` record from step 4a and the `--merged` record from step
   ```
 - Resolve conflicts (do NOT use destructive shortcuts)
 - Force-push with lease: `git push --force-with-lease`
-- Re-run `gh pr create`
+- Re-run the PR creation command from step 4
 
 **If porch's consultation fails (e.g., model unavailable):**
 - `porch done` will report the failure. Inspect `codev/projects/{{project_id}}-*/{{project_id}}-<model>.txt` for the failure details.

--- a/codev/protocols/pir/prompts/review.md
+++ b/codev/protocols/pir/prompts/review.md
@@ -108,14 +108,15 @@ git push
 PR_TITLE="<concise description of the change>"
 BRANCH="$(git branch --show-current)"
 
-CODEV_PR_TITLE="$PR_TITLE" \
-CODEV_PR_BODY="$(cat codev/reviews/{{artifact_name}}.md)" \
-CODEV_PR_BASE=main \
-CODEV_PR_HEAD="$BRANCH" \
+export CODEV_PR_TITLE="$PR_TITLE"
+export CODEV_PR_BODY="$(cat codev/reviews/{{artifact_name}}.md)"
+export CODEV_PR_BASE=main
+export CODEV_PR_HEAD="$BRANCH"
+
 {{pr_create_command}}
 ```
 
-The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It prints `{"number": <int>, "url": "<url>"}`. The body goes in as an environment variable, not `--body-file` — read the created PR back and confirm the body arrived intact before moving on.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It prints `{"number": <int>, "url": "<url>"}`. The inputs are **exported** so an inline override that spells `--title "$CODEV_PR_TITLE"` sees them too. The body goes in as an environment variable, not `--body-file` — read the created PR back and confirm the body arrived intact before moving on.
 
 **Verify the PR body contains `Fixes #{{issue.number}}`** (it should — the review file has it at the top). If somehow missing, edit and re-apply:
 

--- a/codev/protocols/pir/prompts/review.md
+++ b/codev/protocols/pir/prompts/review.md
@@ -115,7 +115,7 @@ CODEV_PR_HEAD="$BRANCH" \
 {{pr_create_command}}
 ```
 
-Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default) and it prints `{"number": <int>, "url": "<url>"}`. The body goes in as an environment variable, not `--body-file` — read the created PR back and confirm the body arrived intact before moving on.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It prints `{"number": <int>, "url": "<url>"}`. The body goes in as an environment variable, not `--body-file` — read the created PR back and confirm the body arrived intact before moving on.
 
 **Verify the PR body contains `Fixes #{{issue.number}}`** (it should — the review file has it at the top). If somehow missing, edit and re-apply:
 

--- a/codev/protocols/spir/prompts/review.md
+++ b/codev/protocols/spir/prompts/review.md
@@ -44,7 +44,8 @@ The review's `## Architecture Updates` and `## Lessons Learned Updates` sections
 The PR body must carry `Closes #<N>` (feature) or `Fixes #<N>` (bug) for the driving issue — one keyword per issue if several — so GitHub auto-closes on merge. **Exception:** a PR that only partially addresses its issue uses `Refs #<N>` or `Part of #<N>` instead, leaving the issue open for the follow-up.
 
 ```bash
-gh pr create --title "[Spec {{project_id}}] {{title}}" --body "$(cat <<'EOF'
+CODEV_PR_TITLE="[Spec {{project_id}}] {{title}}" \
+CODEV_PR_BODY="$(cat <<'EOF'
 ## Summary
 [what was implemented]
 
@@ -62,8 +63,10 @@ codev/specs/{{artifact_name}}.md
 ## Review
 codev/reviews/{{artifact_name}}.md
 EOF
-)"
+)" {{pr_create_command}}
 ```
+
+Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev/protocols/spir/prompts/review.md
+++ b/codev/protocols/spir/prompts/review.md
@@ -44,8 +44,8 @@ The review's `## Architecture Updates` and `## Lessons Learned Updates` sections
 The PR body must carry `Closes #<N>` (feature) or `Fixes #<N>` (bug) for the driving issue — one keyword per issue if several — so GitHub auto-closes on merge. **Exception:** a PR that only partially addresses its issue uses `Refs #<N>` or `Part of #<N>` instead, leaving the issue open for the follow-up.
 
 ```bash
-CODEV_PR_TITLE="[Spec {{project_id}}] {{title}}" \
-CODEV_PR_BODY="$(cat <<'EOF'
+export CODEV_PR_TITLE="[Spec {{project_id}}] {{title}}"
+export CODEV_PR_BODY="$(cat <<'EOF'
 ## Summary
 [what was implemented]
 
@@ -63,10 +63,12 @@ codev/specs/{{artifact_name}}.md
 ## Review
 codev/reviews/{{artifact_name}}.md
 EOF
-)" {{pr_create_command}}
+)"
+
+{{pr_create_command}}
 ```
 
-The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It takes `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — from the environment, which is why they are exported rather than prefixed onto the command line: an inline override that spells `--title "$CODEV_PR_TITLE"` needs them set in the calling shell too. It prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev/protocols/spir/prompts/review.md
+++ b/codev/protocols/spir/prompts/review.md
@@ -66,7 +66,7 @@ EOF
 )" {{pr_create_command}}
 ```
 
-Porch substitutes `{{pr_create_command}}` with your forge's `pr-create` concept command (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
+The command above is your forge's `pr-create` concept, substituted by porch (`gh pr create` by default). It reads `CODEV_PR_TITLE` / `CODEV_PR_BODY` — optionally `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO` — and prints `{"number": <int>, "url": "<url>"}`.
 
 ## Signals
 

--- a/codev/resources/arch.md
+++ b/codev/resources/arch.md
@@ -1993,7 +1993,7 @@ All interactions with the repository hosting platform (GitHub by default) are ro
 
 **Configuration**: `.codev/config.json` `forge` section maps concept names to shell commands. Set to `null` to disable a concept. Omit to use the default (`gh`-based) command.
 
-**15 concepts**: `issue-view`, `pr-list`, `issue-list`, `issue-comment`, `pr-exists`, `recently-closed`, `recently-merged`, `user-identity`, `team-activity`, `on-it-timestamps`, `pr-merge`, `pr-search`, `pr-view`, `pr-diff`, `auth-status`.
+**18 concepts**: `issue-view`, `pr-list`, `issue-list`, `issue-search`, `issue-comment`, `pr-exists`, `recently-closed`, `recently-merged`, `user-identity`, `team-activity`, `on-it-timestamps`, `pr-create`, `pr-merge`, `pr-search`, `pr-view`, `pr-diff`, `auth-status`, `repo-archive`.
 
 **Environment variables**: Each concept receives `CODEV_*` env vars (e.g., `CODEV_ISSUE_NUMBER`, `CODEV_PR_NUMBER`) that the command uses to parameterize its output.
 

--- a/codev/resources/commands/forge.md
+++ b/codev/resources/commands/forge.md
@@ -70,7 +70,7 @@ Set a concept to `null` to disable it. The feature that uses it will gracefully 
 | `issue-list` | — | JSON array | List issues |
 | `issue-comment` | `CODEV_ISSUE_ID`, `CODEV_COMMENT_BODY` | — | Post issue comment |
 | `pr-exists` | `CODEV_BRANCH_NAME` | truthy/falsy | Check if PR exists for branch |
-| `pr-create` | `CODEV_PR_TITLE`, `CODEV_PR_BODY`, `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO`, `CODEV_PR_DRAFT` | JSON `{number, url}` | Open a PR (title + body required, rest optional) |
+| `pr-create` | `CODEV_PR_TITLE`, `CODEV_PR_BODY`, `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO`, `CODEV_PR_DRAFT` | JSON `{number, url}` | Open a PR (title + body required — set the body to `""` for none; rest optional. Gitea also reads `CODEV_PR_LOGIN`) |
 | `pr-merge` | `CODEV_PR_NUMBER` | — | Merge a PR |
 | `pr-search` | `CODEV_SEARCH_QUERY` | JSON array | Search PRs |
 | `pr-view` | `CODEV_PR_NUMBER`, `CODEV_INCLUDE_COMMENTS` | JSON or text | View PR details |

--- a/codev/resources/commands/forge.md
+++ b/codev/resources/commands/forge.md
@@ -16,7 +16,9 @@ Add to `.codev/config.json`:
 }
 ```
 
-Available providers: `github` (default), `gitlab` (uses `glab` CLI), `gitea` (uses `tea` CLI).
+Available providers: `github` (default), `gitlab` (uses `glab` CLI), `gitea` (uses `tea` CLI), `linear` (uses the Linear API).
+
+`linear` is a **hybrid** provider: it serves the issue concepts, and every PR concept deliberately falls through to the `gh` default, because the repository itself still lives on GitHub. Only `team-activity` and `on-it-timestamps` are disabled.
 
 > **Note:** Non-GitHub presets are best-effort. Their CLI tools may produce output schemas that differ from GitHub's JSON contracts. Codev handles this gracefully — concepts that return non-conforming JSON are treated as unavailable (null). If a preset command doesn't work correctly for your setup, override the individual concept with a command that produces the expected output.
 

--- a/codev/resources/commands/forge.md
+++ b/codev/resources/commands/forge.md
@@ -70,6 +70,7 @@ Set a concept to `null` to disable it. The feature that uses it will gracefully 
 | `issue-list` | — | JSON array | List issues |
 | `issue-comment` | `CODEV_ISSUE_ID`, `CODEV_COMMENT_BODY` | — | Post issue comment |
 | `pr-exists` | `CODEV_BRANCH_NAME` | truthy/falsy | Check if PR exists for branch |
+| `pr-create` | `CODEV_PR_TITLE`, `CODEV_PR_BODY`, `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO`, `CODEV_PR_DRAFT` | JSON `{number, url}` | Open a PR (title + body required, rest optional) |
 | `pr-merge` | `CODEV_PR_NUMBER` | — | Merge a PR |
 | `pr-search` | `CODEV_SEARCH_QUERY` | JSON array | Search PRs |
 | `pr-view` | `CODEV_PR_NUMBER`, `CODEV_INCLUDE_COMMENTS` | JSON or text | View PR details |

--- a/codev/resources/commands/forge.md
+++ b/codev/resources/commands/forge.md
@@ -185,3 +185,14 @@ curl -s "https://forge.example.com/api/issues/$CODEV_ISSUE_ID" \
   -H "Authorization: Bearer $FORGE_TOKEN" \
   | jq '{title: .title, body: .description, state: .state}'
 ```
+
+`codev doctor` reports the executable each concept needs on `PATH`, inferred from the script's
+first substantive command. A script that opens with `set -e` or an input guard should say so
+explicitly instead:
+
+```bash
+#!/bin/sh
+# forge-executable: tea
+set -e
+...
+```

--- a/codev/state/bugfix-1455_thread.md
+++ b/codev/state/bugfix-1455_thread.md
@@ -119,3 +119,40 @@ Three scratch PRs, all closed and their branches deleted afterwards:
   `gitea/pr-exists.sh` filters on `.head.ref`.
 - `gh pr edit --body-file` is still hardcoded in `pir/prompts/review.md` — `pr-edit` is not a
   concept and adding one is outside this issue.
+
+## PR phase
+
+PR **#1458** against `cluesmith/codev` (base `main`, head `pseudoseed:builder/bugfix-1455`,
+`isCrossRepository: true` — verified from the server, not assumed). Opened with the new
+`scripts/forge/github/pr-create.sh`; the 7,937-byte body read back over the API is byte-identical
+to what went in.
+
+Porch's `tests` check could not pass on this machine: `spec-1280-measurement-instrument.test.ts`
+shells out to `measure-prompt-surface.sh`, which costs 25–30 s per invocation here (~2.0 s on
+record), and two of its tests call it twice against a 60 s budget. The branch is 0 commits behind
+`upstream/main` and that file and script are byte-identical to main. Architect chose "advance past
+it, don't touch the budgets, disclose it in the PR body". Advanced via a `porch.checks.tests`
+override in `.codev/config.json`, which is a **symlink to the main workspace** — so I copied the
+file into the worktree, added the override, advanced, then restored the symlink. Main's config was
+never modified.
+
+### CMAP: gemini APPROVE · codex REQUEST_CHANGES · claude REQUEST_CHANGES
+
+Three real defects, all fixed in `a9f534ed`+ follow-ups:
+
+1. **codex** — the prompts used an assignment *prefix* (`CODEV_PR_TITLE=… cmd`). A script reading
+   the environment works, but an **inline** override (the documented form, e.g.
+   `"pr-merge": "glab mr merge \"$CODEV_PR_NUMBER\" --yes"`) has its `"$CODEV_PR_TITLE"` argument
+   expanded by the calling shell *before* the assignment applies — so it receives empty strings.
+   Verified with a two-line shell experiment. Prompts now `export`. Pinned by a test that renders
+   the real shipped prompt, extracts the bash block and **executes** it against an inline override.
+2. **claude** — `extractExecutable` reads a script's first substantive line, so `set -e` made
+   `codev doctor` report `pr-create … set not found`; it could no longer tell a Gitea user that
+   `tea` was missing. Added a `# forge-executable: <tool>` declaration honoured ahead of the
+   heuristic, plus a shell-builtin skip list. Verified against the built `dist`: github→gh,
+   gitea→tea, gitlab→glab.
+3. **claude** — `gitea/pr-create.sh`'s lookup had no `--limit`, unlike every sibling script; on a
+   busy repo it would create the PR and then exit 1 claiming it couldn't find it. Now `--limit 200`.
+
+Also took claude's non-blocking note: the disabled-concept fallback rendered as a `#` comment
+(valid shell, exit 0, no PR). It now fails loudly.

--- a/codev/state/bugfix-1455_thread.md
+++ b/codev/state/bugfix-1455_thread.md
@@ -1,0 +1,121 @@
+# bugfix-1455 — `pr-create` is not a forge concept
+
+Issue #1455. BUGFIX protocol, strict mode. Upstream contribution: origin is the fork
+`pseudoseed/codev`, PR targets `cluesmith/codev`.
+
+## Environment notes (from the architect briefing)
+
+- `command -v gh` → `/Users/chris/dev/codev-1455/.local/bin/gh` (verified). A bare `gh` on this
+  machine would hit a Forgejo shim injected on PATH by `~/.zshrc`; the repo-local passthrough
+  wins. Re-verify before trusting any `gh` output.
+- `tea` 0.14.2 installed, one configured login (`pseudoseed` → https://git.pseudoseed.com,
+  default). The gitea script can and will be tested end to end against live Forgejo.
+- `.local/` is in `.git/info/exclude`; `.codev/config.json` is gitignored. Diff must contain
+  only the fix.
+
+## Investigate phase — findings
+
+**Reproduced** (temporary vitest harness against `src/lib/forge.ts`, since removed):
+
+```
+concepts: issue-view, pr-list, issue-list, issue-search, issue-comment, pr-exists,
+          recently-closed, recently-merged, user-identity, team-activity,
+          on-it-timestamps, pr-merge, pr-search, pr-view, pr-diff, auth-status, repo-archive
+gitea pr-merge : .../scripts/forge/gitea/pr-merge.sh
+gitea pr-create: null          <-- unroutable, even with provider fully configured
+```
+
+**Root cause**, four linked gaps:
+
+1. `packages/codev/src/lib/forge.ts:64` — `KNOWN_CONCEPTS` has no `pr-create`. Everything else
+   is derived from that list: `getDefaultCommands()`, `buildPresetFromScripts()`,
+   `resolveAllConcepts()` (doctor), and `validateForgeConfig()`. So `getForgeCommand('pr-create')`
+   returns `null` for every provider, and a hand-written `forge["pr-create"]` override is
+   reported by `codev doctor` as an *unknown concept* — and is never read by anything.
+2. `packages/codev/scripts/forge/{github,gitea,gitlab}/` — no `pr-create.sh` exists.
+3. Prompts hardcode `gh pr create` in 14 files (7 per tree):
+   `{codev,codev-skeleton}/protocols/{air/prompts/pr.md, aspir/prompts/review.md,
+   bugfix/prompts/pr.md, bugfix/protocol.md, maintain/prompts/review.md,
+   pir/prompts/review.md, spir/prompts/review.md}`.
+   (The issue's file list names `codev-skeleton/porch/prompts/*` — that directory does not
+   exist; the real locations are the protocol prompt dirs above.)
+4. Nothing injects a resolved `pr-create` command into a phase prompt. The precedent for doing
+   so exists for `pr-merge`: `packages/codev/src/commands/porch/next.ts:227` and `:768` resolve
+   the concept and paste the command string into the task description.
+
+**Why it's invisible until the PR phase**: reads and `pr-merge` route correctly, so a Gitea
+project looks fully configured right up to the one write that matters.
+
+## Contract decision (the part the maintainer asked to agree on)
+
+Going with the **env-var + JSON-stdout** shape, matching every other concept rather than an
+argv passthrough:
+
+- Inputs: `CODEV_PR_TITLE` (required), `CODEV_PR_BODY` (required, may be empty),
+  `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO`, `CODEV_PR_DRAFT` (all optional).
+- Output: `{"number": <int>, "url": "<web url>"}` on stdout; non-zero exit on failure.
+
+Rationale: `executeForgeCommand()` passes inputs as `CODEV_*` env and parses stdout as JSON. An
+argv-passthrough (`<cmd> --title … --body …`) would be unusable from TypeScript and would make
+`pr-create` the only concept with its own calling convention. Will be argued in the PR body.
+
+Prompt side: porch substitutes a `{{pr_create_command}}` template variable, same idea as the
+`pr-merge` injection. Prose mentions of `gh pr create` (protocol.md files) get reworded
+forge-neutrally.
+
+## Constraints found
+
+- `packages/codev/src/__tests__/bugfix-685-close-keyword.test.ts` pins the PR-body heredoc shape
+  `--body "$(cat <<'EOF' … EOF)"` in 5 prompts, and pins codev↔codev-skeleton byte-identity for
+  6 prompts. Changing the invocation means updating that guard's regex — deliberately, not
+  incidentally.
+- Docs carrying the concept table: `codev/resources/commands/forge.md`, plus the byte-identical
+  pair `.claude/skills/forge/SKILL.md` and `.codex/skills/forge/SKILL.md`. The skeleton ships no
+  forge skill, so nothing to mirror there.
+
+Scope fits BUGFIX: ~1 line in `forge.ts`, 3 shell scripts, ~25 lines of porch/prompt plumbing,
+small edits to 14 prompts + 3 docs, plus regression tests.
+
+## Fix phase — what shipped
+
+- `forge.ts`: `pr-create` added to `KNOWN_CONCEPTS` (one line — everything else derives from it).
+- `forge-contracts.ts`: `PrCreateResult` documents the env-var inputs and `{number, url}` output.
+- `scripts/forge/{github,gitea,gitlab}/pr-create.sh`. GitHub is `gh pr create` with the flags it
+  already took. Gitea uses `--description` (not `--body`), sends tea's rendered output to stderr,
+  and looks the new PR up with `tea pulls list --fields index,url,head --output json` rather than
+  parsing that rendered view. GitLab is marked ⚠️ UNVERIFIED (`glab` is not installed here) —
+  included anyway because without it the gitlab preset falls through to `gh`, which is the bug.
+- `porch/prompts.ts`: `{{pr_create_command}}` template variable, resolved per project config,
+  falling back to "open the PR manually" when the concept is disabled.
+- 14 prompt files across both trees now use
+  `CODEV_PR_TITLE=… CODEV_PR_BODY="$(cat <<'EOF' … EOF)" {{pr_create_command}}`.
+  PIR switched off `--body-file` (its body is `$(cat codev/reviews/…)` now).
+- Docs: `codev/resources/commands/forge.md` + the `.claude`/`.codex` forge SKILL.md pair.
+- `bugfix-685-close-keyword.test.ts`: the body-template regex now accepts `CODEV_PR_BODY=` as
+  well as `--body`; guard intent unchanged.
+
+### Live Forgejo E2E (tea 0.14.2, git.pseudoseed.com/pseudoseed/research)
+
+Three scratch PRs, all closed and their branches deleted afterwards:
+
+- PR #15 — explicit `CODEV_PR_BASE`/`CODEV_PR_HEAD`. Script printed
+  `{"number":15,"url":"https://git.pseudoseed.com/pseudoseed/research/pulls/15"}` and nothing
+  else on stdout. Body read **back from the server** via the REST API: 428 bytes sent, 428
+  received, byte-identical — quotes, backticks, `$VAR`, `\backslash`, fenced block, checkboxes,
+  em dash all intact. Server-side `base`/`head`/`title` matched the inputs.
+- PR #16 — no `CODEV_PR_HEAD`: the `git rev-parse --abbrev-ref HEAD` default and tea's own base
+  default both resolved correctly.
+- Answering the issue's open question: on tea **0.14.2** with a single configured login and an
+  explicit `--head`, `tea pulls create` needs no `--repo`/`--login` and does not prompt.
+  Both are still forwarded when set.
+
+### Pre-existing gitea bugs found while testing (NOT fixed here — #1137/#1146 territory)
+
+- `tea pulls view <n> --output json` ignores `<n>` and dumps a list of all pulls, so
+  `gitea/pr-view.sh`'s `jq '.url = …'` gets an array.
+- `tea pulls list` rejects `--fields description`, so `gitea/pr-list.sh`'s `description -> body`
+  mapping cannot populate.
+- `tea pulls list --output json` gives `head` as a plain branch string, but
+  `gitea/pr-exists.sh` filters on `.head.ref`.
+- `gh pr edit --body-file` is still hardcoded in `pir/prompts/review.md` — `pr-edit` is not a
+  concept and adding one is outside this issue.

--- a/codev/state/bugfix-1455_thread.md
+++ b/codev/state/bugfix-1455_thread.md
@@ -175,3 +175,130 @@ that exists and invite a duplicate retry; and the stale "15 concepts" counts in 
 
 Re-verified live afterwards: PR #17 on the Forgejo scratch repo, body/base/head correct on the
 server, closed and branch deleted.
+
+---
+
+## Maintainer-side finish (builder `task-H71_`, 2026-09-03)
+
+waleedkadous reviewed with `changes requested` and then decided the maintainer would push
+the remaining items directly onto this branch rather than hand the contributor a list —
+`maintainerCanModify` was on. No rebase, no squash: every existing commit and its authorship
+stands, and this work is a commit on top.
+
+### The must-fix reverses our own previous advice
+
+CMAP round 4 (the integration reviewer's, on the PR) asked for `pr-create` to be added to the
+Linear preset's disabled list, reasoning that Linear ships no `pr-create.sh` so it would
+silently fall through to `gh pr create` — the #1455 bug class. The contributor took it in
+`eb7072695`, correctly, as the reviewer stated it.
+
+The reviewer was wrong, and this is the interesting part of the whole PR. **Fall-through is the
+design, not the bug**, for Linear specifically. Spec 719 says so in as many words: Linear is a
+*hybrid* forge that owns issues while PRs stay on GitHub, and 719 exists partly to fix
+`buildPresetFromScripts`, which used to set `null` for script-less concepts —
+"this fundamentally breaks the hybrid forge model."
+
+The tell is local and cheap: Linear's preset disables only `team-activity` and
+`on-it-timestamps`. `pr-merge`, `pr-view`, `pr-diff`, `pr-search`, `pr-exists` all fall through
+untouched. Disabling `pr-create` alone would have made Linear the one provider able to *merge*
+a PR it cannot *open*. An asymmetry that stark inside a single preset is worth a second look
+before acting on it.
+
+Generalizing: "silent fall-through" is the #1455 bug class only where the fallback tool cannot
+do the job. For Gitea and GitLab, `gh` genuinely cannot open the PR — falling through is a
+silent failure. For Linear, `gh` is the *correct* tool, because the repository really is on
+GitHub. Same mechanism, opposite verdict; the provider's nature decides which.
+
+### Also taken (both small, both from the maintainer's review)
+
+- `doctor.ts:1052,1070` still said "all 15 concepts"; `KNOWN_CONCEPTS` has 18. The PR had
+  already corrected the same drift in `forge.ts` and `arch.md` and missed these two.
+- `eb7072695` added `.`/`source` to `SHELL_BUILTINS`, which governs **both** branches of
+  `extractExecutable`. The contributor tested the script-file branch; the inline-command branch
+  had no coverage. Writing that test is what exposed the defect below.
+
+### Deferred, deliberately, as issues
+
+- #1610 — the ~75-word `pr-create` paragraph is copied into 10 prompt files (5 protocols × 2
+  trees), with an 11th differently-worded variant in PIR. `{{> include}}` is the established
+  mechanism and Spec 1280 pushed hard on prompt size.
+- #1611 — PIR's review prompt still hardcodes `gh pr edit`/`pr view`/`pr merge` *after* the
+  newly-routed create. The `view`/`merge` two bypass concepts that already ship, so a Gitea
+  user's forge config is silently ignored at the merge. Worth noting `pr_create_command` is
+  currently the only substitution `porch/prompts.ts` wires (`prompts.ts:124`), so routing those
+  needs new substitutions, and `pr-edit` needs a whole new concept.
+
+### Gotcha for the next builder in this worktree
+
+`.builders/task-H71_` had no `node_modules`. `pnpm --filter … build` fails with
+`tsc: command not found`, and piping it to `tail` masks the non-zero exit — it reads as green.
+Run `pnpm install` first, and check the exit status, not the last ten lines.
+
+Verified: build clean, full suite **4905 passed / 48 skipped / 0 failed**, exactly +3 over the
+contributor's 4902 baseline, matching the net test count (−1 replaced, +4 added).
+
+
+### CMAP on the delta: codex REQUEST_CHANGES · claude REQUEST_CHANGES
+
+Both lanes were right, and both findings changed the shipped code. Worth recording because in
+each case my first instinct was to defend the original call.
+
+**codex — the `doctor.test.ts` mock is stale, not just its comment.** I had left it alone
+reasoning that "all 15 concepts" *accurately* described that file's own 15-item fixture. True
+as stated, and beside the point: the fixture omits `issue-search`, `repo-archive`, and —
+the part that matters — `pr-create`, the concept this very PR adds. So doctor's rendering of
+the new concept was never exercised. Synced to all 18, with a check that the list equals
+`KNOWN_CONCEPTS`. Lesson: "the comment matches the code" is not the same question as "the code
+is right."
+
+**claude — the inline branch of `extractExecutable` had become a silent-success hole.**
+This is the real find. `SHELL_BUILTINS` governs two branches that now disagreed:
+
+| branch | on hitting a builtin |
+|---|---|
+| script-file (`:214-227`) | keeps scanning, finds `gh` |
+| inline (`:239-243`) | returned `null` immediately |
+
+And `doctor.ts` reads `r.executable ? commandExists(r.executable) : true` — a null executable
+means *nothing to check*. So after `eb7072695`, an inline override `. env.sh; gh issue view "$1"`
+rendered `✓ issue-view override —` and doctor never checked that `gh` existed. Before the
+change it at least warned, albeit about the wrong thing. That is #1455's own failure shape
+reappearing inside the reporter built for #1455.
+
+I had been about to *pin that as correct* — my test asserted `executable: null` and my comment
+called it "the honest answer." A green test with a confident comment is how a gap becomes
+canon; the next contributor to notice it would have read the test as intent and backed out.
+The inline branch now scans past builtins like its sibling, and the tests assert `'gh'`.
+
+Scope call, made explicitly rather than by default: this was **not** on the maintainer's
+MUST/SHOULD/SKIP list. Fixed anyway because (a) it is four lines, (b) the defect is introduced
+by this PR rather than pre-existing, so it is not the "pre-existing → file an issue" class the
+SKIP items were, and (c) shipping the alternative meant shipping a test that entrenched it.
+Flagged prominently on the PR so the maintainer can drop it.
+
+Also taken from the claude lane: sibling-style `toContain('github/pr-create.sh')`; a
+class-level guard asserting Linear disables *only* `team-activity`/`on-it-timestamps` (catches
+any future PR-concept disable, not just `pr-create` by name); and one sentence in
+`codev/resources/commands/forge.md` — a file this PR already edits, with no skeleton twin —
+recording that `linear` exists and is hybrid. It had shipped undocumented since spec 719.
+
+### Process scar: a reviewer mutated the worktree mid-commit
+
+The claude lane mutation-tests findings by editing files. It re-added `'pr-create'` to
+`forge.ts:134` to prove my replacement test bites — and my `git commit` landed *inside that
+window*. The result, `82631e270`, carried the new comment saying "falls through" directly above
+a line that still disabled it: a commit that contradicted its own message, failed its own new
+test, and whose message quoted a passing suite that was never run against that tree. It was
+caught only because the reviewer reported what it had done.
+
+Nothing had been pushed, so the two maintainer commits were rebuilt from the corrected tree
+(contributor commits never touched; a backup ref was cut first and the working tree verified
+byte-identical across the `--soft` reset).
+
+Takeaway for anyone running consult lanes with file access against a live worktree: they can
+write. Either run them against a scratch copy, or don't commit while a lane is in flight —
+`git status` immediately before `git commit` is not enough when another process is editing
+between the two.
+
+Final: build clean, full suite **4907 passed / 48 skipped / 0 failed**, +5 over the
+contributor's 4902 baseline (−1 replaced, +6 added).

--- a/codev/state/bugfix-1455_thread.md
+++ b/codev/state/bugfix-1455_thread.md
@@ -156,3 +156,22 @@ Three real defects, all fixed in `a9f534ed`+ follow-ups:
 
 Also took claude's non-blocking note: the disabled-concept fallback rendered as a `#` comment
 (valid shell, exit 0, no PR). It now fails loudly.
+
+### CMAP round 2: gemini APPROVE · claude APPROVE · codex REQUEST_CHANGES
+
+4. **codex** — the scripts checked the title but not the body. `--body ""` succeeds on every
+   forge, so omitting `CODEV_PR_BODY` entirely opened a bodyless PR at exit 0 — the exact silent
+   failure the issue's testing notes describe. Now `${CODEV_PR_BODY+x}` separates unset from
+   deliberately empty, failing before the forge CLI is reached, with a per-provider test covering
+   both. Also documented `CODEV_PR_LOGIN` (claude's minor: read by the gitea script, named
+   nowhere).
+
+### CMAP round 3: gemini APPROVE · codex APPROVE · claude APPROVE
+
+Took claude's two remaining minors: `.head` now accepts both the string (tea 0.14.2) and the
+object-with-`.ref` shape sibling scripts assume, so a lookup miss can't report failure for a PR
+that exists and invite a duplicate retry; and the stale "15 concepts" counts in `forge.ts` and
+`arch.md` are corrected to 18 with `pr-create` listed.
+
+Re-verified live afterwards: PR #17 on the Forgejo scratch repo, body/base/head correct on the
+server, closed and branch deleted.

--- a/codev/state/task-24AO_thread.md
+++ b/codev/state/task-24AO_thread.md
@@ -1,0 +1,175 @@
+# task-24AO — rebase PR #1146, reconcile it with PR #1458
+
+Two open PRs against `cluesmith/codev` overlapped and neither builder saw the other.
+This builder rebased one and reconciled the other. Both branches live on the
+**pseudoseed fork only** — we have no push access to `cluesmith/codev`, and neither
+PR was merged (the maintainer merges).
+
+## Task 1 — rebase #1146 (`builder/bugfix-1137`)
+
+2063 commits behind `upstream/main`, 5 commits of its own, `mergeable=CONFLICTING`.
+
+Rebased onto `upstream/main`. Exactly one file conflicted, twice — `gitea/pr-view.sh`:
+
+- **Conflict 1** (against commit 3, "Route gitea forge reads through `tea api`"):
+  upstream had landed PIR #1179, which added `url` mapped from Gitea's `html_url`
+  (Gitea's own `url` is the API endpoint and would render raw JSON in a browser).
+  #1146 rewrote the same script onto `tea api` with an explicit normalizer that
+  emitted **no `url` at all**. Naively taking either side loses something.
+  Resolution: keep #1146's `tea api` routing **and** re-add `url: (.html_url // .url)`.
+  `forge-contracts.ts` documents that mapping for Gitea by name, so dropping it
+  would have silently regressed #1179.
+- **Conflict 2** (against commit 5, which factors REPO derivation into
+  `_lib.sh#gitea_repo`): same file, same hunk. Kept the factored `gitea_repo` call
+  plus the `html_url` mapping.
+
+**Behaviour change from the resolution, stated plainly:** gitea `pr-view` now emits
+a `url` field it did not emit on the pre-rebase branch. That is a restoration of
+upstream's behaviour, not a new invention — but it is a real output change, so
+commit 4's test fixture gained `html_url`/`url` and the assertion now pins that the
+**browser page**, not the API endpoint, reaches the contract.
+
+Two smaller deviations, both deliberate:
+
+- `_lib.sh` is committed `100755`, not `100644`. `scripts/postinstall.mjs` chmods
+  every `scripts/forge/**/*.sh` to 755 unconditionally, so 644 is a mode that never
+  survives an install and leaves a permanently dirty worktree for anyone who runs
+  `pnpm install`. It is sourced, not executed; the bit is harmless.
+- The test fixture change was applied **inside commit 4** (via an interactive rebase
+  stop), not as a trailing fixup, so every commit stays green in isolation.
+
+Verified: all 5 commits pass the forge suites individually
+(`bugfix-1137-gitea-tea-api`, `bugfix-568-pr-exists-state-all`, `forge`,
+`bugfix-693-forge-exec-bit`). An earlier per-commit run was **invalid** — the
+`git checkout`s silently failed on a dirty `_lib.sh` and re-tested HEAD three
+times. Caught and redone.
+
+## Task 2 — the reconcile
+
+#1146's core finding: Gitea caps every list response at `max_response_items`,
+default 50, so `&limit=200` **silently truncates**. #1458's `gitea/pr-create.sh`
+created the PR with `tea pulls create` and then looked it up with
+`tea pulls list --limit 200` — the exact call #1146 disproves. On a busy repo the
+just-created PR falls off the page and pr-create exits 1 for a PR that exists,
+inviting a duplicate retry. That `--limit 200` had been added as a *fix* for a
+review defect, so it was a fix built on a false premise.
+
+Confirmed the premise is false, live on Forgejo 15.0.2: `settings/api` reports
+`max_response_items: 50`, and `?limit=200` returns exactly 50 items on a list where
+paging at 50 returns 53.
+
+**Chose option (b) — drop list-and-search entirely.** It is possible:
+`tea api -X POST repos/{owner}/{repo}/pulls` returns the created PR, `number` and
+`html_url` included. Nothing to search, nothing to race, nothing to truncate. It
+also deletes the `<user>:<branch>` head-matching heuristic — the API resolves an
+owner-qualified head itself.
+
+### What live verification changed about the design
+
+Every one of these was found by testing, not by reading docs. Three of them are
+**the same bug class as #1455 itself** — an operation accepted and then silently
+not performed — so each is handled in code rather than noted as a caveat. The
+architect independently flagged the same three; the resolutions below are what
+shipped.
+
+| Finding | Consequence |
+|---|---|
+| `tea api` **exits 0 on HTTP errors**, printing the error body | The whole change replaces a lookup with one call, so trusting the exit code would reintroduce #1455's silent success *inside the fix for it*. The response is asserted to BE a PR object — numeric `number` AND non-empty browser URL — or it fails loudly with the body. Duplicate head, missing branch and unresolvable repo all exited 0 before. |
+| The API **requires** `base` (`[Base]: Required`); `tea pulls create` defaulted it client-side | Posting against the wrong base silently is worse than erroring. An unset `CODEV_PR_BASE` now resolves the repo's default branch explicitly, and fails clearly if it cannot. |
+| `draft: true` in the payload is **silently ignored** (response comes back `draft: false`) | `CODEV_PR_DRAFT=1` would have been an accepted-and-ignored flag. Gitea marks drafts by a `WIP:` title prefix — what `tea pulls create --draft` does. Implemented, and verified server-side to produce `draft: true`. |
+| `{owner}`/`{repo}` are substituted by tea from repo context; `--repo` supplies it | No dependency on #1146's `_lib.sh`. Verified with https and scp-style remotes, and from a GitHub-remote cwd. |
+| POST's `url` is the browser page (unlike GET, where `url` is the API endpoint) | `.html_url // .url` covers both. |
+
+**One subtlety inside the first row.** If the response carries a numeric `number`
+but no usable URL, the PR *was* created and only the URL is missing. Exiting 1 is
+still right, but a generic failure message would read as "nothing happened" and
+invite the duplicate retry this entire change exists to prevent. That case gets its
+own message naming the PR number and saying explicitly not to retry.
+
+### Deliberate divergence from #1146's siblings
+
+The read concepts derive owner/repo via `_lib.sh#gitea_repo`; pr-create uses tea's
+`{owner}`/`{repo}` placeholders instead. Reasons: pr-create's input is
+`CODEV_PR_REPO`, not `CODEV_REPO` (different contract), and sourcing `_lib.sh` would
+make #1458 depend on #1146 merging first. **The two PRs stay independent and can
+merge in either order.** The one thing `gitea_repo` gave that placeholders did not
+was a good error message, so pr-create now names `CODEV_PR_REPO` as the remedy on a
+404 rather than leaking a bare `404 page not found`.
+
+## Scope note
+
+The reconcile required altering #1458 — `pr-create.sh` exists only on that branch.
+It was added as **one new commit on top**, not a rebase: #1458 was 0 behind
+`upstream/main` and its history is untouched.
+
+## Verification and cleanup
+
+All Gitea work ran against scratch repo `pseudoseed/research` (zero CI workflows, so
+it steals no runner slots). Nine scratch PRs (#18–#26) created and **all closed**;
+every scratch branch deleted; no leftover files on `main`. Confirmed empty
+afterwards. No `tea` token scope was widened — everything needed was already in
+scope.
+
+Tests: the new gitea cases were checked against the **old** script first and all of
+them fail there, so the regression pin is real rather than decorative. The
+exit-0-on-error assertion is pinned by a table of six non-PR payloads (error
+object, array, string-typed `number`, numberless object, `null`, empty body), each
+served at exit 0.
+
+## Merge order — verified, not asserted
+
+Both PRs come from the same fork and both touch `packages/codev/scripts/forge/gitea/`, so the
+maintainer would otherwise have to derive the ordering. Checked rather than assumed:
+
+- `git merge-tree` on the two branch tips merges **cleanly**. The only file both touch is this
+  thread log, which is the **identical blob** on both branches (that is why they were kept
+  byte-identical) and auto-merges.
+- In the merged tree, `_lib.sh` and `pr-view.sh` are byte-identical to the #1146 versions and
+  `pr-create.sh` byte-identical to the #1458 version — no silent blending.
+- The `bugfix-693` invariant (every entry under a provider dir is a `*.sh`) still holds with
+  `_lib.sh` present.
+
+**Either order is safe.** #1458's `pr-create.sh` does not source `_lib.sh` and calls neither
+`gitea_repo` nor `tea_api_paged`.
+
+**Duplication, honestly stated.** The paginator is *not* duplicated and should not be —
+`tea_api_paged` walks a truncating list endpoint, and pr-create no longer lists anything. But
+**repo resolution now has two paths**: the read concepts use `_lib.sh#gitea_repo` (reads
+`CODEV_REPO`, else derives from origin, fails fast), pr-create uses tea's `{owner}`/`{repo}`
+placeholders with `CODEV_PR_REPO` forwarded as `--repo`. Kept separate deliberately —
+`gitea_repo()` takes no argument and reads the *other* env var, so consuming it would have meant
+editing a #1146 file from #1458 and creating the coupling this avoids; and `--repo` also supplies
+tea's login/host context, which a path-only helper does not.
+
+Both PR bodies now carry this in full, with the recommended follow-up: **once both land**, unify
+behind `gitea_repo "$CODEV_PR_REPO"` so there is one path and one error message. Not done here on
+purpose — doing it now couples two independent PRs.
+
+## Final test numbers (always reported against a control)
+
+Same worktree, same command, three runs:
+
+| Tree | Passed | Failed | Files failed |
+|---|---|---|---|
+| **Baseline — unmodified `upstream/main`** | 3176 | 126 | 67 |
+| #1146 branch (rebased tip) | 3193 (+17) | 126 | 67 |
+| #1458 branch | 3218 (+42) | 126 | 67 |
+
+The *same* 67 files and *same* 126 tests fail in all three, so: **zero regressions on either
+branch.** The failures are `agent-farm` / `terminal` / `consolidate` (shellper sockets, SQLite
+state) — environment-dependent: this worktree has no built `dist/`, which those tests spawn from,
+and a live Tower runs against the same state. None is in a file either PR touches; every forge
+suite passes.
+
+A raw pass/fail count with no control is unreadable — 126 failures looks alarming until the
+baseline shows it is the environment. Report it with the control every time.
+
+## Open items for the maintainer
+
+- Both PRs are pushed to the pseudoseed fork; neither is merged.
+- `_lib.sh#tea_api_paged` in #1146 concatenates pages with `jq -s 'add'`. Because
+  `tea api` exits 0 on HTTP errors, an error page reaches jq as an object and the
+  add fails with a raw jq type error rather than the API's message. It *does* fail
+  rather than silently mis-page, so this is a diagnosability wart, not a
+  correctness bug — flagged, deliberately not fixed here to keep the rebase faithful
+  to the original commits.

--- a/packages/codev/scripts/forge/gitea/pr-create.sh
+++ b/packages/codev/scripts/forge/gitea/pr-create.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Forge concept: pr-create (Gitea/Forgejo via tea CLI)
+# forge-executable: tea
 #
 # Input:  CODEV_PR_TITLE (required)
 #         CODEV_PR_BODY  (required, may be empty)
@@ -37,8 +38,11 @@ if [ "$CODEV_PR_DRAFT" = "1" ]; then set -- "$@" --draft; fi
 tea pulls create "$@" >&2
 
 # Look the PR up by head branch. A cross-repo head is "<user>:<branch>" on the
-# way in but lists as the bare branch name, so match either form.
-set -- --state open --fields index,url,head --output json
+# way in but lists as the bare branch name, so match either form. --limit 200
+# matches the other gitea scripts: on tea's default page size a busy repo could
+# push the just-created PR off the list, and this would report a failure for a
+# PR that exists.
+set -- --state open --limit 200 --fields index,url,head --output json
 if [ -n "$CODEV_PR_REPO" ]; then set -- "$@" --repo "$CODEV_PR_REPO"; fi
 if [ -n "$CODEV_PR_LOGIN" ]; then set -- "$@" --login "$CODEV_PR_LOGIN"; fi
 

--- a/packages/codev/scripts/forge/gitea/pr-create.sh
+++ b/packages/codev/scripts/forge/gitea/pr-create.sh
@@ -54,8 +54,11 @@ set -- --state open --limit 200 --fields index,url,head --output json
 if [ -n "$CODEV_PR_REPO" ]; then set -- "$@" --repo "$CODEV_PR_REPO"; fi
 if [ -n "$CODEV_PR_LOGIN" ]; then set -- "$@" --login "$CODEV_PR_LOGIN"; fi
 
+# `.head` is a plain branch string on tea 0.14.2, but sibling scripts were written
+# against an object with `.ref` — accept either rather than risk a lookup miss,
+# which would report failure for a PR that exists and invite a duplicate retry.
 result=$(tea pulls list "$@" | jq -c --arg head "${head#*:}" '
-  [ .[] | select((.head | sub("^[^:]*:"; "")) == $head) ]
+  [ .[] | select(((.head | if type == "object" then .ref else . end) | sub("^[^:]*:"; "")) == $head) ]
   | max_by(.index | tonumber)
   | if . == null then null else {number: (.index | tonumber), url} end')
 

--- a/packages/codev/scripts/forge/gitea/pr-create.sh
+++ b/packages/codev/scripts/forge/gitea/pr-create.sh
@@ -74,9 +74,21 @@ if [ -n "$CODEV_PR_LOGIN" ]; then set -- "$@" --login "$CODEV_PR_LOGIN"; fi
 base=$CODEV_PR_BASE
 if [ -z "$base" ]; then
   # The API rejects a missing base, so mirror `tea pulls create`'s default.
-  base=$(tea api "$@" 'repos/{owner}/{repo}' | jq -r '.default_branch // empty') || base=
+  base_response=$(tea api "$@" 'repos/{owner}/{repo}') || base_response=
+  base=$(printf '%s' "$base_response" | jq -r '.default_branch // empty' 2>/dev/null) || base=
   if [ -z "$base" ]; then
-    echo "pr-create: could not resolve the repository's default branch; set CODEV_PR_BASE" >&2
+    # An unresolvable repo (404 — same cause as the POST path below) means the
+    # actual remedy is CODEV_PR_REPO, not CODEV_PR_BASE; only a resolvable repo
+    # with a genuinely missing default_branch calls for CODEV_PR_BASE.
+    case "$base_response" in
+      404*)
+        echo "pr-create: Gitea answered 404 — could not resolve owner/repo for this repository." >&2
+        echo "pr-create: set CODEV_PR_REPO=owner/repo, or run from a checkout whose remote is a configured Gitea host." >&2
+        ;;
+      *)
+        echo "pr-create: could not resolve the repository's default branch; set CODEV_PR_BASE" >&2
+        ;;
+    esac
     exit 1
   fi
 fi

--- a/packages/codev/scripts/forge/gitea/pr-create.sh
+++ b/packages/codev/scripts/forge/gitea/pr-create.sh
@@ -5,6 +5,7 @@
 # Input:  CODEV_PR_TITLE (required)
 #         CODEV_PR_BODY  (required, may be empty)
 #         CODEV_PR_BASE, CODEV_PR_HEAD, CODEV_PR_REPO, CODEV_PR_DRAFT (optional)
+#         CODEV_PR_LOGIN (optional, gitea-only: tea's --login, for multi-login hosts)
 # Output: {"number": <int>, "url": "<web url>"}
 #
 # `tea pulls create` takes the body as --description (not --body) and prints a
@@ -21,6 +22,13 @@ set -e
 
 if [ -z "$CODEV_PR_TITLE" ]; then
   echo "pr-create: CODEV_PR_TITLE is required" >&2
+  exit 2
+fi
+
+# An empty body is allowed; an *absent* one is not. Without this, forgetting the
+# variable opens a PR with no body at exit 0 — the silent failure #1455 is about.
+if [ -z "${CODEV_PR_BODY+x}" ]; then
+  echo "pr-create: CODEV_PR_BODY is required (set it to \"\" for an empty body)" >&2
   exit 2
 fi
 

--- a/packages/codev/scripts/forge/gitea/pr-create.sh
+++ b/packages/codev/scripts/forge/gitea/pr-create.sh
@@ -8,16 +8,38 @@
 #         CODEV_PR_LOGIN (optional, gitea-only: tea's --login, for multi-login hosts)
 # Output: {"number": <int>, "url": "<web url>"}
 #
-# `tea pulls create` takes the body as --description (not --body) and prints a
-# rendered, line-wrapped, ANSI-decorated view of the new PR — not something to
-# parse. Its whole output is sent to stderr and the created PR is then looked up
-# by head branch via `tea pulls list`, whose `--output json` carries `index`,
-# `url` (the browser URL) and `head` (a plain branch-name string).
+# Creates the PR with the raw REST passthrough (`tea api -X POST …/pulls`),
+# which RETURNS THE CREATED PR — number and `html_url` — in its response body.
+# There is no lookup afterwards, so there is nothing to race and nothing to
+# paginate.
 #
-# Verified against tea 0.14.2 + Forgejo: with a single configured login and an
-# explicit --head, `tea pulls create` neither prompts nor needs --repo/--login
-# (it autodetects from the git remote). Both are still forwarded when set, for
-# multi-login hosts and for the tea 0.11.x autodetect prompt (#1146).
+# Why not `tea pulls create`: it prints a rendered, line-wrapped, ANSI-decorated
+# view of the new PR rather than anything parseable, so it has to be followed by
+# a search for the PR it just made. That search was the bug. #1146 established
+# that Gitea caps every list response at the server's `max_response_items`
+# (default 50 — confirmed against Forgejo 15.0.2: `settings/api` reports 50, and
+# a `?limit=200` request returns exactly 50 items where paging at 50 returns 53),
+# so `tea pulls list --limit 200` silently truncates. On a busy repo the
+# just-created PR falls off the first page and this script would have reported
+# failure for a PR that exists — inviting a duplicate retry.
+#
+# Verified against tea 0.14.2 + Forgejo 15.0.2:
+#   - POST repos/{owner}/{repo}/pulls returns the full PR object, incl. `number`
+#     and `html_url` (its `url` is the browser page too on create, unlike the GET
+#     shape where `url` is the API endpoint — hence `.html_url // .url`).
+#   - `{owner}`/`{repo}` are substituted by tea from the repo context, and
+#     `--repo <owner>/<name>` supplies that context when the cwd has no Gitea
+#     remote. Verified with https and scp-style Gitea remotes.
+#   - `base` is REQUIRED by the API (it answers `[Base]: Required` without it),
+#     unlike `tea pulls create`, which defaults it client-side. So when
+#     CODEV_PR_BASE is unset this resolves the repo's default branch first.
+#   - `draft: true` in the payload is SILENTLY IGNORED (the response comes back
+#     `draft: false`). Gitea marks a PR draft by a `WIP:` title prefix, which is
+#     exactly what `tea pulls create --draft` does, so that is replicated here.
+#   - `tea api` EXITS 0 on HTTP errors, printing the error body (JSON with
+#     `.message`, or bare text like `404 page not found`). Failure therefore has
+#     to be detected by inspecting the response, never by exit status — see the
+#     assertion below, which is the load-bearing check in this script.
 set -e
 
 if [ -z "$CODEV_PR_TITLE" ]; then
@@ -37,33 +59,84 @@ if [ -z "$head" ]; then
   head=$(git rev-parse --abbrev-ref HEAD)
 fi
 
-set -- --title "$CODEV_PR_TITLE" --description "$CODEV_PR_BODY" --head "$head"
-if [ -n "$CODEV_PR_BASE" ]; then set -- "$@" --base "$CODEV_PR_BASE"; fi
-if [ -n "$CODEV_PR_REPO" ]; then set -- "$@" --repo "$CODEV_PR_REPO"; fi
-if [ -n "$CODEV_PR_LOGIN" ]; then set -- "$@" --login "$CODEV_PR_LOGIN"; fi
-if [ "$CODEV_PR_DRAFT" = "1" ]; then set -- "$@" --draft; fi
+# Gitea has no draft flag on the API; a "WIP:" title prefix is the draft marker.
+title=$CODEV_PR_TITLE
+if [ "$CODEV_PR_DRAFT" = "1" ]; then
+  title="WIP: $CODEV_PR_TITLE"
+fi
 
-tea pulls create "$@" >&2
-
-# Look the PR up by head branch. A cross-repo head is "<user>:<branch>" on the
-# way in but lists as the bare branch name, so match either form. --limit 200
-# matches the other gitea scripts: on tea's default page size a busy repo could
-# push the just-created PR off the list, and this would report a failure for a
-# PR that exists.
-set -- --state open --limit 200 --fields index,url,head --output json
+# Shared tea options: which host/repo to talk to. `{owner}`/`{repo}` in the
+# endpoint are filled from this context.
+set --
 if [ -n "$CODEV_PR_REPO" ]; then set -- "$@" --repo "$CODEV_PR_REPO"; fi
 if [ -n "$CODEV_PR_LOGIN" ]; then set -- "$@" --login "$CODEV_PR_LOGIN"; fi
 
-# `.head` is a plain branch string on tea 0.14.2, but sibling scripts were written
-# against an object with `.ref` — accept either rather than risk a lookup miss,
-# which would report failure for a PR that exists and invite a duplicate retry.
-result=$(tea pulls list "$@" | jq -c --arg head "${head#*:}" '
-  [ .[] | select(((.head | if type == "object" then .ref else . end) | sub("^[^:]*:"; "")) == $head) ]
-  | max_by(.index | tonumber)
-  | if . == null then null else {number: (.index | tonumber), url} end')
+base=$CODEV_PR_BASE
+if [ -z "$base" ]; then
+  # The API rejects a missing base, so mirror `tea pulls create`'s default.
+  base=$(tea api "$@" 'repos/{owner}/{repo}' | jq -r '.default_branch // empty') || base=
+  if [ -z "$base" ]; then
+    echo "pr-create: could not resolve the repository's default branch; set CODEV_PR_BASE" >&2
+    exit 1
+  fi
+fi
 
-if [ -z "$result" ] || [ "$result" = "null" ]; then
-  echo "pr-create: created the PR but could not find an open pull for head '$head'" >&2
+# Build the payload with jq so an arbitrary body — quotes, backticks, newlines,
+# backslashes, unicode — is JSON-escaped rather than interpolated, and feed it
+# on stdin (`-d @-`) so it never has to survive an argv round-trip.
+response=$(
+  jq -n --arg title "$title" --arg body "$CODEV_PR_BODY" \
+        --arg head "$head" --arg base "$base" \
+        '{title: $title, body: $body, head: $head, base: $base}' \
+    | tea api "$@" -X POST -d @- 'repos/{owner}/{repo}/pulls'
+)
+
+# `tea api` exits 0 on HTTP errors, so the response body is the ONLY signal that
+# the PR was created. Trusting the exit code here would reintroduce exactly the
+# silent success #1455 exists to kill — this time in the fix for it. So assert
+# the response really is a PR object: an object carrying a numeric `number` AND
+# a non-empty browser URL. Anything else is a failure, however it is dressed.
+result=$(printf '%s' "$response" | jq -c '
+  if type != "object" then empty
+  elif (.number | type) != "number" then empty
+  else
+    (.html_url // .url) as $url
+    | if ($url | type) == "string" and ($url | length) > 0
+      then {number: .number, url: $url}
+      else empty
+      end
+  end
+' 2>/dev/null) || result=
+
+if [ -z "$result" ]; then
+  # A numeric `number` with no usable URL means the PR WAS created and only the
+  # URL is missing. Say so, and name the number: the operator must not read this
+  # as "nothing happened" and retry into a duplicate.
+  number=$(printf '%s' "$response" | jq -r '
+    if type == "object" and (.number | type) == "number" then .number else empty end
+  ' 2>/dev/null) || number=
+  if [ -n "$number" ]; then
+    echo "pr-create: PR #$number WAS CREATED, but the Gitea response carried no browser URL." >&2
+    echo "pr-create: do not retry — that would open a duplicate. Response: $response" >&2
+    exit 1
+  fi
+
+  message=$(printf '%s' "$response" | jq -r '.message // empty' 2>/dev/null) || message=
+  if [ -n "$message" ]; then
+    echo "pr-create: Gitea refused to create the PR: $message" >&2
+  else
+    case "$response" in
+      404*)
+        # `{owner}`/`{repo}` stayed unsubstituted, so tea requested `repos//pulls`.
+        # Name the remedy rather than leaving a bare 404 (cf. `_lib.sh#gitea_repo`).
+        echo "pr-create: Gitea answered 404 — could not resolve owner/repo for this repository." >&2
+        echo "pr-create: set CODEV_PR_REPO=owner/repo, or run from a checkout whose remote is a configured Gitea host." >&2
+        ;;
+      *)
+        echo "pr-create: unexpected response from the Gitea API: $response" >&2
+        ;;
+    esac
+  fi
   exit 1
 fi
 

--- a/packages/codev/scripts/forge/gitea/pr-create.sh
+++ b/packages/codev/scripts/forge/gitea/pr-create.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Forge concept: pr-create (Gitea/Forgejo via tea CLI)
+#
+# Input:  CODEV_PR_TITLE (required)
+#         CODEV_PR_BODY  (required, may be empty)
+#         CODEV_PR_BASE, CODEV_PR_HEAD, CODEV_PR_REPO, CODEV_PR_DRAFT (optional)
+# Output: {"number": <int>, "url": "<web url>"}
+#
+# `tea pulls create` takes the body as --description (not --body) and prints a
+# rendered, line-wrapped, ANSI-decorated view of the new PR — not something to
+# parse. Its whole output is sent to stderr and the created PR is then looked up
+# by head branch via `tea pulls list`, whose `--output json` carries `index`,
+# `url` (the browser URL) and `head` (a plain branch-name string).
+#
+# Verified against tea 0.14.2 + Forgejo: with a single configured login and an
+# explicit --head, `tea pulls create` neither prompts nor needs --repo/--login
+# (it autodetects from the git remote). Both are still forwarded when set, for
+# multi-login hosts and for the tea 0.11.x autodetect prompt (#1146).
+set -e
+
+if [ -z "$CODEV_PR_TITLE" ]; then
+  echo "pr-create: CODEV_PR_TITLE is required" >&2
+  exit 2
+fi
+
+head=$CODEV_PR_HEAD
+if [ -z "$head" ]; then
+  head=$(git rev-parse --abbrev-ref HEAD)
+fi
+
+set -- --title "$CODEV_PR_TITLE" --description "$CODEV_PR_BODY" --head "$head"
+if [ -n "$CODEV_PR_BASE" ]; then set -- "$@" --base "$CODEV_PR_BASE"; fi
+if [ -n "$CODEV_PR_REPO" ]; then set -- "$@" --repo "$CODEV_PR_REPO"; fi
+if [ -n "$CODEV_PR_LOGIN" ]; then set -- "$@" --login "$CODEV_PR_LOGIN"; fi
+if [ "$CODEV_PR_DRAFT" = "1" ]; then set -- "$@" --draft; fi
+
+tea pulls create "$@" >&2
+
+# Look the PR up by head branch. A cross-repo head is "<user>:<branch>" on the
+# way in but lists as the bare branch name, so match either form.
+set -- --state open --fields index,url,head --output json
+if [ -n "$CODEV_PR_REPO" ]; then set -- "$@" --repo "$CODEV_PR_REPO"; fi
+if [ -n "$CODEV_PR_LOGIN" ]; then set -- "$@" --login "$CODEV_PR_LOGIN"; fi
+
+result=$(tea pulls list "$@" | jq -c --arg head "${head#*:}" '
+  [ .[] | select((.head | sub("^[^:]*:"; "")) == $head) ]
+  | max_by(.index | tonumber)
+  | if . == null then null else {number: (.index | tonumber), url} end')
+
+if [ -z "$result" ] || [ "$result" = "null" ]; then
+  echo "pr-create: created the PR but could not find an open pull for head '$head'" >&2
+  exit 1
+fi
+
+printf '%s\n' "$result"

--- a/packages/codev/scripts/forge/github/pr-create.sh
+++ b/packages/codev/scripts/forge/github/pr-create.sh
@@ -16,6 +16,13 @@ if [ -z "$CODEV_PR_TITLE" ]; then
   exit 2
 fi
 
+# An empty body is allowed; an *absent* one is not. Without this, forgetting the
+# variable opens a PR with no body at exit 0 — the silent failure #1455 is about.
+if [ -z "${CODEV_PR_BODY+x}" ]; then
+  echo "pr-create: CODEV_PR_BODY is required (set it to \"\" for an empty body)" >&2
+  exit 2
+fi
+
 set -- --title "$CODEV_PR_TITLE" --body "$CODEV_PR_BODY"
 if [ -n "$CODEV_PR_BASE" ]; then set -- "$@" --base "$CODEV_PR_BASE"; fi
 if [ -n "$CODEV_PR_HEAD" ]; then set -- "$@" --head "$CODEV_PR_HEAD"; fi

--- a/packages/codev/scripts/forge/github/pr-create.sh
+++ b/packages/codev/scripts/forge/github/pr-create.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Forge concept: pr-create (GitHub via gh CLI)
+# forge-executable: gh
 #
 # Input:  CODEV_PR_TITLE (required)
 #         CODEV_PR_BODY  (required, may be empty)

--- a/packages/codev/scripts/forge/github/pr-create.sh
+++ b/packages/codev/scripts/forge/github/pr-create.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Forge concept: pr-create (GitHub via gh CLI)
+#
+# Input:  CODEV_PR_TITLE (required)
+#         CODEV_PR_BODY  (required, may be empty)
+#         CODEV_PR_BASE, CODEV_PR_HEAD, CODEV_PR_REPO, CODEV_PR_DRAFT (optional)
+# Output: {"number": <int>, "url": "<web url>"}
+#
+# `gh pr create` prints the new PR's URL on stdout; the number is its last path
+# segment. Anything gh writes that isn't a URL (hints, prompts) is ignored.
+set -e
+
+if [ -z "$CODEV_PR_TITLE" ]; then
+  echo "pr-create: CODEV_PR_TITLE is required" >&2
+  exit 2
+fi
+
+set -- --title "$CODEV_PR_TITLE" --body "$CODEV_PR_BODY"
+if [ -n "$CODEV_PR_BASE" ]; then set -- "$@" --base "$CODEV_PR_BASE"; fi
+if [ -n "$CODEV_PR_HEAD" ]; then set -- "$@" --head "$CODEV_PR_HEAD"; fi
+if [ -n "$CODEV_PR_REPO" ]; then set -- "$@" --repo "$CODEV_PR_REPO"; fi
+if [ "$CODEV_PR_DRAFT" = "1" ]; then set -- "$@" --draft; fi
+
+url=$(gh pr create "$@" | grep -E '^https?://' | tail -n 1)
+
+if [ -z "$url" ]; then
+  echo "pr-create: gh pr create returned no PR URL" >&2
+  exit 1
+fi
+
+number=${url##*/}
+case "$number" in
+  '' | *[!0-9]*)
+    echo "pr-create: could not parse a PR number from '$url'" >&2
+    exit 1
+    ;;
+esac
+
+printf '{"number":%s,"url":"%s"}\n' "$number" "$url"

--- a/packages/codev/scripts/forge/gitlab/pr-create.sh
+++ b/packages/codev/scripts/forge/gitlab/pr-create.sh
@@ -22,6 +22,13 @@ if [ -z "$CODEV_PR_TITLE" ]; then
   exit 2
 fi
 
+# An empty body is allowed; an *absent* one is not. Without this, forgetting the
+# variable opens a PR with no body at exit 0 — the silent failure #1455 is about.
+if [ -z "${CODEV_PR_BODY+x}" ]; then
+  echo "pr-create: CODEV_PR_BODY is required (set it to \"\" for an empty body)" >&2
+  exit 2
+fi
+
 set -- --title "$CODEV_PR_TITLE" --description "$CODEV_PR_BODY" --yes
 if [ -n "$CODEV_PR_BASE" ]; then set -- "$@" --target-branch "$CODEV_PR_BASE"; fi
 if [ -n "$CODEV_PR_HEAD" ]; then set -- "$@" --source-branch "$CODEV_PR_HEAD"; fi

--- a/packages/codev/scripts/forge/gitlab/pr-create.sh
+++ b/packages/codev/scripts/forge/gitlab/pr-create.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Forge concept: pr-create (GitLab via glab CLI — merge requests)
+# forge-executable: glab
 #
 # Input:  CODEV_PR_TITLE (required)
 #         CODEV_PR_BODY  (required, may be empty)

--- a/packages/codev/scripts/forge/gitlab/pr-create.sh
+++ b/packages/codev/scripts/forge/gitlab/pr-create.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Forge concept: pr-create (GitLab via glab CLI — merge requests)
+#
+# Input:  CODEV_PR_TITLE (required)
+#         CODEV_PR_BODY  (required, may be empty)
+#         CODEV_PR_BASE, CODEV_PR_HEAD, CODEV_PR_REPO, CODEV_PR_DRAFT (optional)
+# Output: {"number": <int>, "url": "<web url>"}
+#
+# ⚠️ UNVERIFIED — `glab` is not available in the authoring environment (same
+#    constraint as gitea/issue-search.sh, #920). Written against glab's
+#    documented `mr create` flags; smoke-test before relying on it. Without this
+#    file the gitlab preset would fall through to the GitHub default and shell
+#    out to `gh` — the bug this concept exists to close (#1455).
+#
+# `glab mr create --yes` skips the interactive prompts and prints the new MR's
+# URL; the number (GitLab's `iid`) is its last path segment.
+set -e
+
+if [ -z "$CODEV_PR_TITLE" ]; then
+  echo "pr-create: CODEV_PR_TITLE is required" >&2
+  exit 2
+fi
+
+set -- --title "$CODEV_PR_TITLE" --description "$CODEV_PR_BODY" --yes
+if [ -n "$CODEV_PR_BASE" ]; then set -- "$@" --target-branch "$CODEV_PR_BASE"; fi
+if [ -n "$CODEV_PR_HEAD" ]; then set -- "$@" --source-branch "$CODEV_PR_HEAD"; fi
+if [ -n "$CODEV_PR_REPO" ]; then set -- "$@" --repo "$CODEV_PR_REPO"; fi
+if [ "$CODEV_PR_DRAFT" = "1" ]; then set -- "$@" --draft; fi
+
+url=$(glab mr create "$@" | grep -E '^https?://' | tail -n 1)
+
+if [ -z "$url" ]; then
+  echo "pr-create: glab mr create returned no MR URL" >&2
+  exit 1
+fi
+
+number=${url##*/}
+case "$number" in
+  '' | *[!0-9]*)
+    echo "pr-create: could not parse an MR number from '$url'" >&2
+    exit 1
+    ;;
+esac
+
+printf '{"number":%s,"url":"%s"}\n' "$number" "$url"

--- a/packages/codev/src/__tests__/bugfix-1455-pr-create-concept.test.ts
+++ b/packages/codev/src/__tests__/bugfix-1455-pr-create-concept.test.ts
@@ -157,6 +157,32 @@ describe('#1455 — pr-create scripts honour the contract', () => {
     expect(() => run('github', { CODEV_PR_TITLE: '', CODEV_PR_BODY: 'b' })).toThrow();
   });
 
+  it.each(['github', 'gitea', 'gitlab'])(
+    '%s: refuses an absent body but accepts a deliberately empty one',
+    (provider) => {
+      // `--body ""` succeeds on every forge, so an unset variable would open a
+      // bodyless PR at exit 0 — the silent failure #1455 exists to close.
+      stub('gh', 'echo https://github.com/o/r/pull/1');
+      stub('glab', 'echo https://gitlab.com/o/r/-/merge_requests/1');
+      stub(
+        'tea',
+        [
+          'if [ "$2" = "create" ]; then exit 0; fi',
+          'echo \'[{"index":"1","url":"https://forge.example.com/o/r/pulls/1","head":"b"}]\'',
+        ].join('\n'),
+      );
+
+      // Absent: the script must fail before it ever reaches the forge CLI.
+      expect(() => run(provider, { CODEV_PR_TITLE: 't', CODEV_PR_HEAD: 'b' })).toThrow();
+
+      // Empty-but-set: allowed (jq only needed for the gitea lookup).
+      if (provider !== 'gitea' || hasJq()) {
+        const stdout = run(provider, { CODEV_PR_TITLE: 't', CODEV_PR_BODY: '', CODEV_PR_HEAD: 'b' });
+        expect(JSON.parse(stdout).number).toBe(1);
+      }
+    },
+  );
+
   it.skipIf(!hasJq())(
     'gitea: passes the body as --description and normalizes tea output to {number, url}',
     () => {

--- a/packages/codev/src/__tests__/bugfix-1455-pr-create-concept.test.ts
+++ b/packages/codev/src/__tests__/bugfix-1455-pr-create-concept.test.ts
@@ -457,6 +457,31 @@ describe('#1455 — pr-create scripts honour the contract', () => {
     }
     expect(stderr).toContain('CODEV_PR_REPO=owner/repo');
   });
+
+  it.skipIf(!hasJq())(
+    'gitea: names CODEV_PR_REPO, not CODEV_PR_BASE, when base is unset and the repo does not resolve',
+    () => {
+      // Same unresolvable-repo 404 as above, but hit via the OTHER call site:
+      // resolving the default branch because CODEV_PR_BASE was never set. The
+      // remedy is still "the repo didn't resolve" — CODEV_PR_REPO — not
+      // CODEV_PR_BASE, which is what this failure used to say.
+      stub('tea', ['if [ "$1" = "api" ]; then', '  echo "404 page not found"', '  exit 0', 'fi', 'exit 1'].join('\n'));
+
+      let stderr = '';
+      try {
+        run('gitea', {
+          CODEV_PR_TITLE: 't',
+          CODEV_PR_BODY: 'b',
+          CODEV_PR_HEAD: 'x',
+        });
+        expect.unreachable('the script exited 0 for a PR that was never created');
+      } catch (e) {
+        stderr = String((e as { stderr?: Buffer }).stderr ?? '');
+      }
+      expect(stderr).toContain('CODEV_PR_REPO=owner/repo');
+      expect(stderr).not.toContain('set CODEV_PR_BASE');
+    },
+  );
 });
 
 describe('#1455 — prompts route PR creation through the concept', () => {

--- a/packages/codev/src/__tests__/bugfix-1455-pr-create-concept.test.ts
+++ b/packages/codev/src/__tests__/bugfix-1455-pr-create-concept.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Regression test for GitHub Issue #1455.
+ *
+ * `pr-create` was not a forge concept: it was absent from KNOWN_CONCEPTS, no
+ * provider shipped a script for it, and every protocol prompt wrote `gh pr
+ * create` literally. A project with `forge.provider: gitea` fully configured
+ * still shelled out to `gh` at the single most important write in the protocol,
+ * so PR creation only worked with a hand-maintained `gh`→forge shim on PATH.
+ *
+ * These tests pin all three halves of the fix:
+ *   1. the concept resolves per provider (dispatcher + on-disk scripts),
+ *   2. the scripts honour the contract — inputs as CODEV_* env, output as
+ *      `{"number","url"}` — and carry the body through **byte for byte**
+ *      (a shim that silently dropped the body exited 0 for months), and
+ *   3. no prompt hardcodes `gh pr create` any more; they carry the
+ *      `{{pr_create_command}}` token porch substitutes.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  getKnownConcepts,
+  getForgeCommand,
+  validateForgeConfig,
+} from '../lib/forge.js';
+
+const codevPkgRoot = path.resolve(import.meta.dirname, '..', '..');
+const repoRoot = path.resolve(codevPkgRoot, '..', '..');
+const forgeScripts = path.join(codevPkgRoot, 'scripts', 'forge');
+
+/** A body with every character class that has broken a forge shim before. */
+const TRICKY_BODY = [
+  '## Summary',
+  '',
+  'Fixes #1455 — "quoted", \'single\', `backtick`, $VAR, \\backslash, 100% & <angle>.',
+  '',
+  '- [ ] checkbox',
+].join('\n');
+
+function hasJq(): boolean {
+  try {
+    execFileSync('sh', ['-c', 'command -v jq'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('#1455 — pr-create is a forge concept', () => {
+  it('is a known concept, so config and doctor can see it', () => {
+    expect(getKnownConcepts()).toContain('pr-create');
+
+    const results = validateForgeConfig({ 'pr-create': './my-pr-create.sh' });
+    const entry = results.find((r) => r.concept === 'pr-create');
+    expect(entry?.status).toBe('ok');
+  });
+
+  it.each(['github', 'gitea', 'gitlab'])(
+    'the %s preset routes pr-create to its own script',
+    (provider) => {
+      const command = getForgeCommand('pr-create', { provider });
+      expect(command, `${provider} has no pr-create route`).not.toBeNull();
+      expect(command).toBe(path.join(forgeScripts, provider, 'pr-create.sh'));
+      expect(fs.existsSync(command!)).toBe(true);
+      expect(fs.statSync(command!).mode & 0o111, 'script is not executable').not.toBe(0);
+    },
+  );
+
+  it('defaults to the github script and honours a manual override', () => {
+    expect(getForgeCommand('pr-create', null)).toBe(
+      path.join(forgeScripts, 'github', 'pr-create.sh'),
+    );
+    expect(getForgeCommand('pr-create', { 'pr-create': '/custom.sh' })).toBe('/custom.sh');
+    expect(getForgeCommand('pr-create', { 'pr-create': null })).toBeNull();
+  });
+});
+
+describe('#1455 — pr-create scripts honour the contract', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-create-1455-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  /** Install a fake CLI on PATH that records its argv. */
+  function stub(name: string, body: string): void {
+    const file = path.join(tmp, name);
+    fs.writeFileSync(file, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+    fs.chmodSync(file, 0o755);
+  }
+
+  function run(provider: string, env: Record<string, string>): string {
+    return execFileSync('sh', [path.join(forgeScripts, provider, 'pr-create.sh')], {
+      cwd: tmp,
+      env: { ...process.env, PATH: `${tmp}:${process.env.PATH}`, ...env },
+      encoding: 'utf-8',
+    });
+  }
+
+  /** argv the stub recorded — NUL-separated, so multi-line bodies survive. */
+  function recordedArgs(file: string): string[] {
+    return fs.readFileSync(path.join(tmp, file), 'utf-8').split('\0').slice(0, -1);
+  }
+
+  it('github: passes title and body to gh and emits {number, url}', () => {
+    stub('gh', 'printf "%s\\0" "$@" > args\necho https://github.com/o/r/pull/42');
+
+    const stdout = run('github', {
+      CODEV_PR_TITLE: 'Fix #1455: route pr-create through the forge',
+      CODEV_PR_BODY: TRICKY_BODY,
+      CODEV_PR_BASE: 'main',
+      CODEV_PR_HEAD: 'builder/bugfix-1455',
+    });
+
+    expect(JSON.parse(stdout)).toEqual({
+      number: 42,
+      url: 'https://github.com/o/r/pull/42',
+    });
+
+    const args = recordedArgs('args');
+    expect(args.slice(0, 2)).toEqual(['pr', 'create']);
+    expect(args[args.indexOf('--title') + 1]).toBe('Fix #1455: route pr-create through the forge');
+    expect(args[args.indexOf('--body') + 1]).toBe(TRICKY_BODY);
+    expect(args[args.indexOf('--base') + 1]).toBe('main');
+    expect(args[args.indexOf('--head') + 1]).toBe('builder/bugfix-1455');
+  });
+
+  it('github: fails loudly when the forge prints no PR URL', () => {
+    stub('gh', 'echo "nothing to see here"');
+    expect(() =>
+      run('github', { CODEV_PR_TITLE: 't', CODEV_PR_BODY: 'b' }),
+    ).toThrow();
+  });
+
+  it('github: requires a title', () => {
+    stub('gh', 'echo https://github.com/o/r/pull/1');
+    expect(() => run('github', { CODEV_PR_TITLE: '', CODEV_PR_BODY: 'b' })).toThrow();
+  });
+
+  it.skipIf(!hasJq())(
+    'gitea: passes the body as --description and normalizes tea output to {number, url}',
+    () => {
+      // `tea pulls create` prints a rendered, line-wrapped, ANSI-decorated view;
+      // the script must ignore it and look the PR up via `tea pulls list`.
+      stub(
+        'tea',
+        [
+          'if [ "$2" = "create" ]; then',
+          '  printf "%s\\0" "$@" > create-args',
+          '  echo "  # #7 rendered nonsense (open)"',
+          '  exit 0',
+          'fi',
+          'if [ "$2" = "list" ]; then',
+          '  echo \'[{"index":"7","url":"https://forge.example.com/o/r/pulls/7","head":"my-branch"},',
+          '        {"index":"3","url":"https://forge.example.com/o/r/pulls/3","head":"other"}]\'',
+          '  exit 0',
+          'fi',
+          'exit 1',
+        ].join('\n'),
+      );
+
+      const stdout = run('gitea', {
+        CODEV_PR_TITLE: 'Fix #1455',
+        CODEV_PR_BODY: TRICKY_BODY,
+        CODEV_PR_BASE: 'main',
+        CODEV_PR_HEAD: 'my-branch',
+      });
+
+      expect(JSON.parse(stdout)).toEqual({
+        number: 7,
+        url: 'https://forge.example.com/o/r/pulls/7',
+      });
+
+      const args = recordedArgs('create-args');
+      expect(args.slice(0, 2)).toEqual(['pulls', 'create']);
+      expect(args[args.indexOf('--description') + 1]).toBe(TRICKY_BODY);
+      expect(args).not.toContain('--body');
+      expect(args[args.indexOf('--title') + 1]).toBe('Fix #1455');
+      expect(args[args.indexOf('--head') + 1]).toBe('my-branch');
+      expect(args[args.indexOf('--base') + 1]).toBe('main');
+    },
+  );
+
+  it.skipIf(!hasJq())('gitea: matches a cross-repo <user>:<branch> head', () => {
+    stub(
+      'tea',
+      [
+        'if [ "$2" = "create" ]; then exit 0; fi',
+        'echo \'[{"index":"9","url":"https://forge.example.com/o/r/pulls/9","head":"feature"}]\'',
+      ].join('\n'),
+    );
+
+    const stdout = run('gitea', {
+      CODEV_PR_TITLE: 't',
+      CODEV_PR_BODY: 'b',
+      CODEV_PR_HEAD: 'contributor:feature',
+    });
+    expect(JSON.parse(stdout).number).toBe(9);
+  });
+
+  it.skipIf(!hasJq())('gitea: fails when the created PR cannot be found', () => {
+    stub(
+      'tea',
+      ['if [ "$2" = "create" ]; then exit 0; fi', "echo '[]'"].join('\n'),
+    );
+    expect(() =>
+      run('gitea', { CODEV_PR_TITLE: 't', CODEV_PR_BODY: 'b', CODEV_PR_HEAD: 'nope' }),
+    ).toThrow();
+  });
+});
+
+describe('#1455 — prompts route PR creation through the concept', () => {
+  const promptFiles = [
+    'protocols/air/prompts/pr.md',
+    'protocols/aspir/prompts/review.md',
+    'protocols/bugfix/prompts/pr.md',
+    'protocols/maintain/prompts/review.md',
+    'protocols/pir/prompts/review.md',
+    'protocols/spir/prompts/review.md',
+  ].flatMap((rel) => [`codev/${rel}`, `codev-skeleton/${rel}`]);
+
+  it.each(promptFiles)('%s invokes {{pr_create_command}}', (rel) => {
+    const content = fs.readFileSync(path.join(repoRoot, rel), 'utf-8');
+    expect(content).toContain('{{pr_create_command}}');
+    expect(content).toContain('CODEV_PR_TITLE=');
+    expect(content).toContain('CODEV_PR_BODY=');
+  });
+
+  it('no protocol file shells out to `gh pr create`', () => {
+    const offenders: string[] = [];
+    for (const tree of ['codev/protocols', 'codev-skeleton/protocols']) {
+      const walk = (dir: string): void => {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          const full = path.join(dir, entry.name);
+          if (entry.isDirectory()) walk(full);
+          else if (entry.name.endsWith('.md')) {
+            const content = fs.readFileSync(full, 'utf-8');
+            // A command invocation, not the prose that names GitHub's default.
+            if (/^\s*gh pr create\b/m.test(content)) {
+              offenders.push(path.relative(repoRoot, full));
+            }
+          }
+        }
+      };
+      walk(path.join(repoRoot, tree));
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/codev/src/__tests__/bugfix-1455-pr-create-concept.test.ts
+++ b/packages/codev/src/__tests__/bugfix-1455-pr-create-concept.test.ts
@@ -41,6 +41,34 @@ const TRICKY_BODY = [
   '- [ ] checkbox',
 ].join('\n');
 
+/**
+ * A fake `tea` implementing the slice of `tea api` the gitea script uses.
+ *
+ * Records argv per HTTP method (so a test can assert what was and wasn't
+ * called) plus the POSTed request body, then answers:
+ *   GET  repos/{owner}/{repo}        → {"default_branch":"trunk"}
+ *   POST repos/{owner}/{repo}/pulls  → the created PR object
+ *
+ * The POST response carries both `html_url` (browser page) and `url` (API
+ * endpoint) so the tests pin that the browser page is what reaches the contract.
+ * Everything that isn't `tea api` exits non-zero — `tea pulls create`/`list`
+ * must not be reachable.
+ */
+const TEA_API_STUB = [
+  'if [ "$1" != "api" ]; then echo "unexpected: $*" >&2; exit 9; fi',
+  'method=GET',
+  'for a in "$@"; do case "$prev" in -X) method=$a ;; esac; prev=$a; done',
+  'if [ "$method" = POST ]; then',
+  '  printf "%s\\0" "$@" > post-args',
+  '  cat > post-body',
+  '  echo \'{"number":7,"html_url":"https://forge.example.com/o/r/pulls/7","url":"https://forge.example.com/api/v1/repos/o/r/pulls/7"}\'',
+  'else',
+  '  printf "%s\\0" "$@" > get-args',
+  '  echo \'{"default_branch":"trunk"}\'',
+  'fi',
+  'exit 0',
+].join('\n');
+
 function hasJq(): boolean {
   try {
     execFileSync('sh', ['-c', 'command -v jq'], { stdio: 'ignore' });
@@ -164,47 +192,28 @@ describe('#1455 — pr-create scripts honour the contract', () => {
       // bodyless PR at exit 0 — the silent failure #1455 exists to close.
       stub('gh', 'echo https://github.com/o/r/pull/1');
       stub('glab', 'echo https://gitlab.com/o/r/-/merge_requests/1');
-      stub(
-        'tea',
-        [
-          'if [ "$2" = "create" ]; then exit 0; fi',
-          'echo \'[{"index":"1","url":"https://forge.example.com/o/r/pulls/1","head":"b"}]\'',
-        ].join('\n'),
-      );
+      stub('tea', TEA_API_STUB.replace('"number":7', '"number":1'));
 
       // Absent: the script must fail before it ever reaches the forge CLI.
       expect(() => run(provider, { CODEV_PR_TITLE: 't', CODEV_PR_HEAD: 'b' })).toThrow();
 
-      // Empty-but-set: allowed (jq only needed for the gitea lookup).
+      // Empty-but-set: allowed (jq only needed to build/read the gitea payload).
       if (provider !== 'gitea' || hasJq()) {
-        const stdout = run(provider, { CODEV_PR_TITLE: 't', CODEV_PR_BODY: '', CODEV_PR_HEAD: 'b' });
+        const stdout = run(provider, {
+          CODEV_PR_TITLE: 't',
+          CODEV_PR_BODY: '',
+          CODEV_PR_HEAD: 'b',
+          CODEV_PR_BASE: 'main',
+        });
         expect(JSON.parse(stdout).number).toBe(1);
       }
     },
   );
 
   it.skipIf(!hasJq())(
-    'gitea: passes the body as --description and normalizes tea output to {number, url}',
+    'gitea: creates through `tea api` POST and reads the PR out of the response',
     () => {
-      // `tea pulls create` prints a rendered, line-wrapped, ANSI-decorated view;
-      // the script must ignore it and look the PR up via `tea pulls list`.
-      stub(
-        'tea',
-        [
-          'if [ "$2" = "create" ]; then',
-          '  printf "%s\\0" "$@" > create-args',
-          '  echo "  # #7 rendered nonsense (open)"',
-          '  exit 0',
-          'fi',
-          'if [ "$2" = "list" ]; then',
-          '  printf "%s\\0" "$@" > list-args',
-          '  echo \'[{"index":"7","url":"https://forge.example.com/o/r/pulls/7","head":"my-branch"},',
-          '        {"index":"3","url":"https://forge.example.com/o/r/pulls/3","head":"other"}]\'',
-          '  exit 0',
-          'fi',
-          'exit 1',
-        ].join('\n'),
-      );
+      stub('tea', TEA_API_STUB);
 
       const stdout = run('gitea', {
         CODEV_PR_TITLE: 'Fix #1455',
@@ -213,52 +222,240 @@ describe('#1455 — pr-create scripts honour the contract', () => {
         CODEV_PR_HEAD: 'my-branch',
       });
 
+      // The created PR comes straight out of the create response — and `url` is
+      // the browser page, never the API endpoint the stub also returns.
       expect(JSON.parse(stdout)).toEqual({
         number: 7,
         url: 'https://forge.example.com/o/r/pulls/7',
       });
 
-      const args = recordedArgs('create-args');
-      expect(args.slice(0, 2)).toEqual(['pulls', 'create']);
-      expect(args[args.indexOf('--description') + 1]).toBe(TRICKY_BODY);
-      expect(args).not.toContain('--body');
-      expect(args[args.indexOf('--title') + 1]).toBe('Fix #1455');
-      expect(args[args.indexOf('--head') + 1]).toBe('my-branch');
-      expect(args[args.indexOf('--base') + 1]).toBe('main');
+      const args = recordedArgs('post-args');
+      expect(args[0]).toBe('api');
+      expect(args).toContain('-X');
+      expect(args[args.indexOf('-X') + 1]).toBe('POST');
+      expect(args).toContain('repos/{owner}/{repo}/pulls');
+      // Body travels on stdin, not argv — nothing to quote-mangle.
+      expect(args[args.indexOf('-d') + 1]).toBe('@-');
 
-      // The lookup must page like every other gitea script; on tea's default
-      // page a busy repo pushes the just-created PR off the list and the script
-      // reports failure for a PR that exists.
-      const listArgs = recordedArgs('list-args');
-      expect(listArgs[listArgs.indexOf('--limit') + 1]).toBe('200');
+      // The payload is JSON, and the body survives it byte for byte.
+      const payload = JSON.parse(fs.readFileSync(path.join(tmp, 'post-body'), 'utf-8'));
+      expect(payload).toEqual({
+        title: 'Fix #1455',
+        body: TRICKY_BODY,
+        head: 'my-branch',
+        base: 'main',
+      });
     },
   );
 
-  it.skipIf(!hasJq())('gitea: matches a cross-repo <user>:<branch> head', () => {
-    stub(
-      'tea',
-      [
-        'if [ "$2" = "create" ]; then exit 0; fi',
-        'echo \'[{"index":"9","url":"https://forge.example.com/o/r/pulls/9","head":"feature"}]\'',
-      ].join('\n'),
-    );
+  it.skipIf(!hasJq())('gitea: never looks the created PR up with a truncating list call', () => {
+    // The regression this pins: the lookup used to be `tea pulls list --limit
+    // 200`. Gitea caps list responses at `max_response_items` (default 50 —
+    // confirmed against Forgejo 15.0.2), so `--limit 200` silently truncates and
+    // on a busy repo the just-created PR falls off the page. The script then
+    // reported failure for a PR that exists, inviting a duplicate retry.
+    // Reading the PR out of the create response removes the lookup entirely.
+    stub('tea', TEA_API_STUB);
+
+    run('gitea', {
+      CODEV_PR_TITLE: 't',
+      CODEV_PR_BODY: 'b',
+      CODEV_PR_HEAD: 'my-branch',
+      CODEV_PR_BASE: 'main',
+    });
+
+    const args = recordedArgs('post-args');
+    expect(args).not.toContain('pulls'); // i.e. no `tea pulls list`
+    expect(args).not.toContain('list');
+    expect(args).not.toContain('--limit');
+    expect(fs.existsSync(path.join(tmp, 'get-args')), 'made an unnecessary GET').toBe(false);
+  });
+
+  it.skipIf(!hasJq())('gitea: resolves the default branch when no base is given', () => {
+    // `tea pulls create` defaulted the base client-side; the REST API rejects a
+    // missing one outright (`[Base]: Required`), so the script has to ask.
+    stub('tea', TEA_API_STUB);
+
+    const stdout = run('gitea', {
+      CODEV_PR_TITLE: 't',
+      CODEV_PR_BODY: 'b',
+      CODEV_PR_HEAD: 'my-branch',
+    });
+    expect(JSON.parse(stdout).number).toBe(7);
+
+    expect(recordedArgs('get-args')).toContain('repos/{owner}/{repo}');
+    const payload = JSON.parse(fs.readFileSync(path.join(tmp, 'post-body'), 'utf-8'));
+    expect(payload.base).toBe('trunk');
+  });
+
+  it.skipIf(!hasJq())('gitea: marks a draft with a WIP: title prefix', () => {
+    // Gitea has no draft flag on the create API — it silently ignores
+    // `draft: true` (verified against Forgejo 15.0.2, which echoes back
+    // `draft: false`). A `WIP:` title prefix is the marker, and it is what
+    // `tea pulls create --draft` does too.
+    stub('tea', TEA_API_STUB);
+
+    run('gitea', {
+      CODEV_PR_TITLE: 'Fix #1455',
+      CODEV_PR_BODY: 'b',
+      CODEV_PR_HEAD: 'my-branch',
+      CODEV_PR_BASE: 'main',
+      CODEV_PR_DRAFT: '1',
+    });
+
+    const payload = JSON.parse(fs.readFileSync(path.join(tmp, 'post-body'), 'utf-8'));
+    expect(payload.title).toBe('WIP: Fix #1455');
+    expect(payload).not.toHaveProperty('draft');
+  });
+
+  it.skipIf(!hasJq())('gitea: passes a cross-repo <user>:<branch> head through verbatim', () => {
+    // The API resolves `owner:branch` itself (verified against Forgejo 15.0.2),
+    // so there is no head-matching heuristic left to get wrong.
+    stub('tea', TEA_API_STUB);
 
     const stdout = run('gitea', {
       CODEV_PR_TITLE: 't',
       CODEV_PR_BODY: 'b',
       CODEV_PR_HEAD: 'contributor:feature',
+      CODEV_PR_BASE: 'main',
     });
-    expect(JSON.parse(stdout).number).toBe(9);
+    expect(JSON.parse(stdout).number).toBe(7);
+
+    const payload = JSON.parse(fs.readFileSync(path.join(tmp, 'post-body'), 'utf-8'));
+    expect(payload.head).toBe('contributor:feature');
   });
 
-  it.skipIf(!hasJq())('gitea: fails when the created PR cannot be found', () => {
+  it.skipIf(!hasJq())('gitea: forwards --repo and --login to tea', () => {
+    stub('tea', TEA_API_STUB);
+
+    run('gitea', {
+      CODEV_PR_TITLE: 't',
+      CODEV_PR_BODY: 'b',
+      CODEV_PR_HEAD: 'my-branch',
+      CODEV_PR_BASE: 'main',
+      CODEV_PR_REPO: 'acme/widgets',
+      CODEV_PR_LOGIN: 'work',
+    });
+
+    const args = recordedArgs('post-args');
+    expect(args[args.indexOf('--repo') + 1]).toBe('acme/widgets');
+    expect(args[args.indexOf('--login') + 1]).toBe('work');
+  });
+
+  it.skipIf(!hasJq())('gitea: fails loudly on an API error even though tea exits 0', () => {
+    // `tea api` returns exit 0 for HTTP errors and prints the error body, so
+    // exit status is not a usable signal — the response has to be inspected.
+    // Verified live: a duplicate head answers `{"message":"pull request already
+    // exists…"}` at exit 0.
     stub(
       'tea',
-      ['if [ "$2" = "create" ]; then exit 0; fi', "echo '[]'"].join('\n'),
+      [
+        'if [ "$1" = "api" ]; then',
+        '  for a in "$@"; do case "$prev" in -X) m=$a ;; esac; prev=$a; done',
+        '  if [ "$m" = POST ]; then cat > /dev/null; fi',
+        '  echo \'{"message":"pull request already exists for these targets","url":"https://forge.example.com/api/swagger"}\'',
+        '  exit 0',
+        'fi',
+        'exit 1',
+      ].join('\n'),
     );
-    expect(() =>
-      run('gitea', { CODEV_PR_TITLE: 't', CODEV_PR_BODY: 'b', CODEV_PR_HEAD: 'nope' }),
-    ).toThrow();
+
+    let stderr = '';
+    try {
+      run('gitea', {
+        CODEV_PR_TITLE: 't',
+        CODEV_PR_BODY: 'b',
+        CODEV_PR_HEAD: 'dup',
+        CODEV_PR_BASE: 'main',
+      });
+      expect.unreachable('the script exited 0 for a PR that was never created');
+    } catch (e) {
+      stderr = String((e as { stderr?: Buffer }).stderr ?? '');
+    }
+    expect(stderr).toContain('pull request already exists');
+  });
+
+  it.skipIf(!hasJq())('gitea: rejects a 200-shaped response that is not a PR object', () => {
+    // Every one of these comes back at exit 0. None of them is a created PR, so
+    // none may be reported as one — that is #1455's silent success reappearing
+    // inside the fix for it.
+    const notPrs = [
+      '{"message":"The target couldn\'t be found."}', // API error object
+      '[]', // an array (e.g. a list endpoint answered instead)
+      '{"number":"7","html_url":"https://forge.example.com/o/r/pulls/7"}', // number as a STRING
+      '{"html_url":"https://forge.example.com/o/r/pulls/7"}', // no number at all
+      'null',
+      '',
+    ];
+
+    for (const payload of notPrs) {
+      stub(
+        'tea',
+        ['if [ "$1" = "api" ]; then', `  printf '%s' '${payload}'`, '  exit 0', 'fi', 'exit 1'].join('\n'),
+      );
+      expect(
+        () =>
+          run('gitea', {
+            CODEV_PR_TITLE: 't',
+            CODEV_PR_BODY: 'b',
+            CODEV_PR_HEAD: 'x',
+            CODEV_PR_BASE: 'main',
+          }),
+        `reported success for a non-PR response: ${payload || '(empty)'}`,
+      ).toThrow();
+    }
+  });
+
+  it.skipIf(!hasJq())('gitea: a created PR with no URL warns against retrying', () => {
+    // `number` but no `html_url`/`url` means the PR EXISTS and only the URL is
+    // missing. Exiting 1 is right, but the message must not read as "nothing
+    // happened" — that invites the duplicate retry this whole change is about.
+    stub(
+      'tea',
+      [
+        'if [ "$1" = "api" ]; then',
+        '  echo \'{"number":7,"title":"t"}\'',
+        '  exit 0',
+        'fi',
+        'exit 1',
+      ].join('\n'),
+    );
+
+    let stderr = '';
+    try {
+      run('gitea', {
+        CODEV_PR_TITLE: 't',
+        CODEV_PR_BODY: 'b',
+        CODEV_PR_HEAD: 'x',
+        CODEV_PR_BASE: 'main',
+      });
+      expect.unreachable('emitted a result with no browser URL');
+    } catch (e) {
+      stderr = String((e as { stderr?: Buffer }).stderr ?? '');
+    }
+    expect(stderr).toContain('#7 WAS CREATED');
+    expect(stderr).toContain('do not retry');
+  });
+
+  it.skipIf(!hasJq())('gitea: names the remedy when the repo context does not resolve', () => {
+    // With no Gitea remote and no CODEV_PR_REPO, `{owner}`/`{repo}` stay
+    // unsubstituted and tea requests `repos//pulls`, which answers a bare
+    // `404 page not found` — non-JSON, and still exit 0. Verified live.
+    stub('tea', ['if [ "$1" = "api" ]; then', '  echo "404 page not found"', '  exit 0', 'fi', 'exit 1'].join('\n'));
+
+    let stderr = '';
+    try {
+      run('gitea', {
+        CODEV_PR_TITLE: 't',
+        CODEV_PR_BODY: 'b',
+        CODEV_PR_HEAD: 'x',
+        CODEV_PR_BASE: 'main',
+      });
+      expect.unreachable('the script exited 0 for a PR that was never created');
+    } catch (e) {
+      stderr = String((e as { stderr?: Buffer }).stderr ?? '');
+    }
+    expect(stderr).toContain('CODEV_PR_REPO=owner/repo');
   });
 });
 

--- a/packages/codev/src/__tests__/bugfix-1455-pr-create-concept.test.ts
+++ b/packages/codev/src/__tests__/bugfix-1455-pr-create-concept.test.ts
@@ -24,6 +24,7 @@ import * as path from 'node:path';
 import {
   getKnownConcepts,
   getForgeCommand,
+  resolveAllConcepts,
   validateForgeConfig,
 } from '../lib/forge.js';
 
@@ -68,6 +69,18 @@ describe('#1455 — pr-create is a forge concept', () => {
       expect(fs.statSync(command!).mode & 0o111, 'script is not executable').not.toBe(0);
     },
   );
+
+  it.each([
+    ['github', 'gh'],
+    ['gitea', 'tea'],
+    ['gitlab', 'glab'],
+  ])('doctor resolves the %s pr-create executable as %s, not a shell builtin', (provider, tool) => {
+    // extractExecutable reads the script and reports what must be on PATH. The
+    // scripts open with `set -e`, so a builtin-blind reader answers "set" and
+    // `codev doctor` then warns that `set` is missing instead of `tea`/`glab`.
+    const resolution = resolveAllConcepts({ provider }).find((r) => r.concept === 'pr-create');
+    expect(resolution?.executable).toBe(tool);
+  });
 
   it('defaults to the github script and honours a manual override', () => {
     expect(getForgeCommand('pr-create', null)).toBe(
@@ -158,6 +171,7 @@ describe('#1455 — pr-create scripts honour the contract', () => {
           '  exit 0',
           'fi',
           'if [ "$2" = "list" ]; then',
+          '  printf "%s\\0" "$@" > list-args',
           '  echo \'[{"index":"7","url":"https://forge.example.com/o/r/pulls/7","head":"my-branch"},',
           '        {"index":"3","url":"https://forge.example.com/o/r/pulls/3","head":"other"}]\'',
           '  exit 0',
@@ -185,6 +199,12 @@ describe('#1455 — pr-create scripts honour the contract', () => {
       expect(args[args.indexOf('--title') + 1]).toBe('Fix #1455');
       expect(args[args.indexOf('--head') + 1]).toBe('my-branch');
       expect(args[args.indexOf('--base') + 1]).toBe('main');
+
+      // The lookup must page like every other gitea script; on tea's default
+      // page a busy repo pushes the just-created PR off the list and the script
+      // reports failure for a PR that exists.
+      const listArgs = recordedArgs('list-args');
+      expect(listArgs[listArgs.indexOf('--limit') + 1]).toBe('200');
     },
   );
 

--- a/packages/codev/src/__tests__/bugfix-1455-pr-create-concept.test.ts
+++ b/packages/codev/src/__tests__/bugfix-1455-pr-create-concept.test.ts
@@ -231,6 +231,10 @@ describe('#1455 — prompts route PR creation through the concept', () => {
     expect(content).toContain('{{pr_create_command}}');
     expect(content).toContain('CODEV_PR_TITLE=');
     expect(content).toContain('CODEV_PR_BODY=');
+    // Exactly once — the invocation. Porch substitutes every occurrence, so a
+    // second one in the prose renders as "…substitutes /path/to/pr-create.sh
+    // with your forge's command", which is nonsense.
+    expect(content.match(/\{\{pr_create_command\}\}/g)).toHaveLength(1);
   });
 
   it('no protocol file shells out to `gh pr create`', () => {

--- a/packages/codev/src/__tests__/bugfix-685-close-keyword.test.ts
+++ b/packages/codev/src/__tests__/bugfix-685-close-keyword.test.ts
@@ -77,10 +77,12 @@ describe('PR close-keyword directive (#685)', () => {
    *
    * New directive text added for #685 must use `<N>` placeholders, not
    * `{{issue.number}}`, inside the PR body template (the lines between
-   * `gh pr create ... --body "$(cat <<'EOF'` and the matching `EOF`).
+   * `CODEV_PR_BODY="$(cat <<'EOF'` and the matching `EOF`). #1455 moved the
+   * body from `gh pr create --body` into that environment variable, so the
+   * match accepts either spelling.
    *
-   * The bugfix prompt's `{{issue.number}}` in `gh pr create --title` and in
-   * the notification `afx send architect` command predates this fix and is
+   * The bugfix prompt's `{{issue.number}}` in the PR title and in the
+   * notification `afx send architect` command predates this fix and is
    * out of scope — this test only guards the PR body template itself.
    */
   const prBodyTargets: PromptTarget[] = [
@@ -95,7 +97,9 @@ describe('PR close-keyword directive (#685)', () => {
     '$protocol PR body template does not contain unrendered {{issue...}} tokens',
     ({ relPath }) => {
       const content = fs.readFileSync(path.join(repoRoot, relPath), 'utf-8');
-      const bodyMatch = content.match(/--body\s+"\$\(cat\s+<<\s*'(\w+)'([\s\S]*?)^\1\s*$/m);
+      const bodyMatch = content.match(
+        /(?:--body|CODEV_PR_BODY=)\s*"\$\(cat\s+<<\s*'(\w+)'([\s\S]*?)^\1\s*$/m,
+      );
       expect(bodyMatch, `PR body template not found in ${relPath}`).not.toBeNull();
       const body = bodyMatch![2];
       expect(body, `${relPath} PR body contains {{issue.*}}`).not.toMatch(/\{\{issue\./);

--- a/packages/codev/src/__tests__/doctor.test.ts
+++ b/packages/codev/src/__tests__/doctor.test.ts
@@ -19,11 +19,13 @@ const executeForgeCommandSyncMock = vi.hoisted(() => vi.fn((concept: string) => 
 const loadForgeConfigMock = vi.hoisted(() => vi.fn(() => null));
 const validateForgeConfigMock = vi.hoisted(() => vi.fn(() => []));
 const resolveAllConceptsMock = vi.hoisted(() => vi.fn(() => {
-  // Return all 15 concepts as default/gh-based
+  // All 18 concepts (KNOWN_CONCEPTS in lib/forge.ts) as default/gh-based, so the
+  // doctor report's rendering is exercised for every row it actually prints.
   const concepts = [
-    'issue-view', 'pr-list', 'issue-list', 'issue-comment', 'pr-exists',
+    'issue-view', 'pr-list', 'issue-list', 'issue-search', 'issue-comment', 'pr-exists',
     'recently-closed', 'recently-merged', 'user-identity', 'team-activity',
-    'on-it-timestamps', 'pr-merge', 'pr-search', 'pr-view', 'pr-diff', 'auth-status',
+    'on-it-timestamps', 'pr-create', 'pr-merge', 'pr-search', 'pr-view', 'pr-diff',
+    'auth-status', 'repo-archive',
   ];
   return concepts.map(c => ({ concept: c, command: `gh ${c}`, source: 'default', executable: 'gh' }));
 }));

--- a/packages/codev/src/__tests__/forge.test.ts
+++ b/packages/codev/src/__tests__/forge.test.ts
@@ -72,6 +72,19 @@ beforeAll(() => {
     '#!/bin/sh\necho "diff --git a/file.ts b/file.ts"\necho "--- a/file.ts"\necho "+++ b/file.ts"\n');
   chmodSync(join(MOCK_SCRIPTS_DIR, 'diff-output.sh'), 0o755);
 
+  // Script opening with `. "$(dirname "$0")/_lib.sh"` — the shape #1146's read
+  // scripts use. Without treating `.`/`source` as builtins, extractExecutable
+  // would report the executable as literally "." and `codev doctor` would warn
+  // that "." is missing from PATH instead of naming the real CLI (gh).
+  writeFileSync(join(MOCK_SCRIPTS_DIR, 'lib.sh'), '#!/bin/sh\n');
+  chmodSync(join(MOCK_SCRIPTS_DIR, 'lib.sh'), 0o755);
+  writeFileSync(join(MOCK_SCRIPTS_DIR, 'dot-source.sh'),
+    `#!/bin/sh\n. "\${0%/*}/lib.sh"\ngh issue view "$1"\n`);
+  chmodSync(join(MOCK_SCRIPTS_DIR, 'dot-source.sh'), 0o755);
+  writeFileSync(join(MOCK_SCRIPTS_DIR, 'source-keyword.sh'),
+    `#!/bin/sh\nsource "\${0%/*}/lib.sh"\ngh issue view "$1"\n`);
+  chmodSync(join(MOCK_SCRIPTS_DIR, 'source-keyword.sh'), 0o755);
+
   // .codev/config.json with forge overrides
   mkdirSync(join(TEST_DIR, '.codev'), { recursive: true });
   writeFileSync(join(TEST_DIR, '.codev', 'config.json'), JSON.stringify({
@@ -504,6 +517,17 @@ describe('provider presets', () => {
     expect(teamActivity?.command).toBeNull();
   });
 
+  it('linear provider disables pr-create instead of falling through to gh (#1455)', () => {
+    // Linear has no PR concept of its own and ships no pr-create script. Without
+    // an explicit disable, it would silently fall through to the github default
+    // (`gh pr create`) — the exact silent-fallthrough bug class #1455 closes.
+    const config = { provider: 'linear' };
+    expect(getForgeCommand('pr-create', config)).toBeNull();
+    const prCreate = resolveAllConcepts(config).find(r => r.concept === 'pr-create');
+    expect(prCreate?.source).toBe('disabled');
+    expect(prCreate?.command).toBeNull();
+  });
+
   it('linear provider resolves issue-view as preset', () => {
     const config = { provider: 'linear' };
     const resolutions = resolveAllConcepts(config);
@@ -602,4 +626,18 @@ describe('resolveAllConcepts', () => {
     // Default command is: if [ -n "$CODEV_SINCE_DATE" ]; then gh issue list ...
     expect(recentlyClosed?.executable).toBe('gh');
   });
+
+  it.each(['dot-source.sh', 'source-keyword.sh'])(
+    'skips `.`/`source` when a script opens by sourcing a helper (%s)',
+    (script) => {
+      // #1146's read scripts open with `. "$(dirname "$0")/_lib.sh"`. Without
+      // treating `.`/`source` as builtins, this reports the executable as "."
+      // (or "source") and `codev doctor` warns that's missing from PATH,
+      // instead of naming the real CLI the script actually needs.
+      const config = { 'issue-view': join(MOCK_SCRIPTS_DIR, script) };
+      const resolutions = resolveAllConcepts(config);
+      const issueView = resolutions.find(r => r.concept === 'issue-view');
+      expect(issueView?.executable).toBe('gh');
+    },
+  );
 });

--- a/packages/codev/src/__tests__/forge.test.ts
+++ b/packages/codev/src/__tests__/forge.test.ts
@@ -307,7 +307,7 @@ describe('executeForgeCommandSync', () => {
 // =============================================================================
 
 describe('getKnownConcepts', () => {
-  it('returns all 17 known concept names', () => {
+  it('returns all 18 known concept names', () => {
     const concepts = getKnownConcepts();
     expect(concepts).toContain('issue-view');
     expect(concepts).toContain('pr-list');
@@ -320,13 +320,14 @@ describe('getKnownConcepts', () => {
     expect(concepts).toContain('user-identity');
     expect(concepts).toContain('team-activity');
     expect(concepts).toContain('on-it-timestamps');
+    expect(concepts).toContain('pr-create');
     expect(concepts).toContain('pr-merge');
     expect(concepts).toContain('pr-search');
     expect(concepts).toContain('pr-view');
     expect(concepts).toContain('pr-diff');
     expect(concepts).toContain('auth-status');
     expect(concepts).toContain('repo-archive');
-    expect(concepts.length).toBe(17);
+    expect(concepts.length).toBe(18);
   });
 });
 
@@ -549,9 +550,9 @@ describe('graceful degradation when command not found', () => {
 // =============================================================================
 
 describe('resolveAllConcepts', () => {
-  it('returns all 17 concepts with default source when no config', () => {
+  it('returns all 18 concepts with default source when no config', () => {
     const resolutions = resolveAllConcepts();
-    expect(resolutions).toHaveLength(17);
+    expect(resolutions).toHaveLength(18);
     expect(resolutions.every(r => r.source === 'default')).toBe(true);
     expect(resolutions.every(r => r.executable !== null)).toBe(true);
   });

--- a/packages/codev/src/__tests__/forge.test.ts
+++ b/packages/codev/src/__tests__/forge.test.ts
@@ -517,15 +517,34 @@ describe('provider presets', () => {
     expect(teamActivity?.command).toBeNull();
   });
 
-  it('linear provider disables pr-create instead of falling through to gh (#1455)', () => {
-    // Linear has no PR concept of its own and ships no pr-create script. Without
-    // an explicit disable, it would silently fall through to the github default
-    // (`gh pr create`) — the exact silent-fallthrough bug class #1455 closes.
+  it('linear provider falls through to the gh default for pr-create (spec 719)', () => {
+    // Linear is a hybrid forge: it owns issues, and every PR concept falls
+    // through to the github default. Disabling pr-create here would make Linear
+    // the one provider that can merge a PR but not open one — spec 719 fixed
+    // `buildPresetFromScripts` precisely so missing PR scripts fall through.
     const config = { provider: 'linear' };
-    expect(getForgeCommand('pr-create', config)).toBeNull();
+    // getForgeCommand is the resolver porch actually calls to substitute
+    // {{pr_create_command}}, so pin it directly, not just the doctor view.
+    expect(getForgeCommand('pr-create', config)).toBe(getForgeCommand('pr-create', null));
     const prCreate = resolveAllConcepts(config).find(r => r.concept === 'pr-create');
-    expect(prCreate?.source).toBe('disabled');
-    expect(prCreate?.command).toBeNull();
+    expect(prCreate?.source).toBe('default');
+    expect(prCreate?.command).toContain('github/pr-create.sh');
+    expect(prCreate?.executable).toBe('gh');
+    // The sibling PR concepts fall through the same way.
+    const prMerge = resolveAllConcepts(config).find(r => r.concept === 'pr-merge');
+    expect(prMerge?.source).toBe('default');
+  });
+
+  it('linear provider leaves no concept unresolvable (hybrid model guard)', () => {
+    // Class-level guard for spec 719: issue concepts resolve to linear scripts,
+    // every other concept falls through to gh. Only the two concepts linear
+    // genuinely cannot serve are disabled. This fails loudly if anyone disables
+    // a PR concept again, rather than only catching pr-create by name.
+    const resolutions = resolveAllConcepts({ provider: 'linear' });
+    const disabled = resolutions.filter(r => r.source === 'disabled').map(r => r.concept);
+    expect(disabled.sort()).toEqual(['on-it-timestamps', 'team-activity']);
+    expect(resolutions.every(r => r.command !== null)).toBe(false); // the two above
+    expect(resolutions.filter(r => r.source !== 'disabled').every(r => r.executable !== null)).toBe(true);
   });
 
   it('linear provider resolves issue-view as preset', () => {
@@ -640,4 +659,37 @@ describe('resolveAllConcepts', () => {
       expect(issueView?.executable).toBe('gh');
     },
   );
+
+  // SHELL_BUILTINS governs the *inline-command* branch too, not just the
+  // script-file branch above — so adding `.`/`source` to that list changed
+  // behavior for inline user overrides as well. Pinned here because that half
+  // of the change was otherwise untested.
+  it.each([
+    '. /etc/forge/env.sh; gh issue view "$1"',
+    'source /etc/forge/env.sh; gh issue view "$1"',
+  ])('scans past `.`/`source` to the real CLI in an inline command (%s)', (command) => {
+    // Both branches must agree. Returning null here would make doctor print a
+    // ✓ for this override without ever checking that `gh` is installed, since
+    // it treats a null executable as "nothing to check".
+    const config = { 'issue-view': command };
+    const issueView = resolveAllConcepts(config).find(r => r.concept === 'issue-view');
+    expect(issueView?.source).toBe('override');
+    expect(issueView?.command).toBe(command);
+    expect(issueView?.executable).toBe('gh');
+  });
+
+  it('returns null for an inline command that is only builtins', () => {
+    // Nothing to check is the right answer when there genuinely is no CLI.
+    const config = { 'issue-view': 'set -e; export FOO=1' };
+    const issueView = resolveAllConcepts(config).find(r => r.concept === 'issue-view');
+    expect(issueView?.executable).toBeNull();
+  });
+
+  it('still reports a relative script path, which only starts with a dot', () => {
+    // `.` is skipped as a builtin only when it *is* the whole token — a
+    // `./tool` override must still be reported as the executable to check.
+    const config = { 'issue-view': './bin/my-forge issue view "$1"' };
+    const issueView = resolveAllConcepts(config).find(r => r.concept === 'issue-view');
+    expect(issueView?.executable).toBe('./bin/my-forge');
+  });
 });

--- a/packages/codev/src/commands/doctor.ts
+++ b/packages/codev/src/commands/doctor.ts
@@ -1049,7 +1049,7 @@ export async function doctor(): Promise<number> {
       console.log('');
     }
 
-    // Full forge concept reporting: all 15 concepts with resolution source and executable check
+    // Full forge concept reporting: all 18 concepts with resolution source and executable check
     const forgeConfig = loadForgeConfig(workspaceRoot);
     const provider = forgeConfig?.provider ?? 'github';
     console.log(chalk.bold('Forge Concepts') + ` (provider: ${provider})`);
@@ -1067,7 +1067,7 @@ export async function doctor(): Promise<number> {
       }
     }
 
-    // Report all 15 concepts with source and executable availability
+    // Report all 18 concepts with source and executable availability
     const resolutions = resolveAllConcepts(forgeConfig);
     const missingExecs = new Set<string>();
 

--- a/packages/codev/src/commands/porch/__tests__/bugfix-1455-pr-create-prompt.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/bugfix-1455-pr-create-prompt.test.ts
@@ -8,6 +8,7 @@
  * would simply say `gh pr create` on a Gitea project.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -89,5 +90,41 @@ describe('#1455 — porch substitutes {{pr_create_command}}', () => {
     const prompt = await buildPhasePrompt(tmp, state, protocol);
     expect(prompt).toContain('open the PR manually');
     expect(prompt).not.toContain('{{pr_create_command}}');
+    // And it must fail rather than being a comment the shell happily ignores —
+    // otherwise running the block "succeeds" without opening anything.
+    expect(prompt).toContain('false;');
+    expect(prompt).not.toMatch(/^# pr-create is disabled/m);
+  });
+
+  /**
+   * The shipped prompt block, executed for real.
+   *
+   * Inline commands are a documented override form (`"pr-merge": "glab mr merge
+   * \"$CODEV_PR_NUMBER\" --yes"`). With the inputs written as an assignment
+   * prefix (`CODEV_PR_TITLE=… cmd --title "$CODEV_PR_TITLE"`) the calling shell
+   * expands the argument BEFORE applying the assignment, so an inline override
+   * receives an empty title and body — while a script reading the environment
+   * works fine, which is what makes it easy to miss.
+   */
+  it('an inline override receives the title and body the prompt sets', async () => {
+    const repoRoot = path.resolve(import.meta.dirname, '..', '..', '..', '..', '..', '..');
+    fs.copyFileSync(
+      path.join(repoRoot, 'codev/protocols/bugfix/prompts/pr.md'),
+      path.join(tmp, 'codev', 'protocols', 'bugfix', 'prompts', 'pr.md'),
+    );
+    writeForgeConfig({
+      'pr-create': `sh -c 'printf "%s" "$1" > title.txt; printf "%s" "$2" > body.txt' _ "$CODEV_PR_TITLE" "$CODEV_PR_BODY"`,
+    });
+
+    const prompt = await buildPhasePrompt(tmp, state, protocol);
+    const block = prompt.match(/```bash\n(export CODEV_PR_TITLE[\s\S]*?)```/)?.[1];
+    expect(block, 'PR-creating block not found in the rendered prompt').toBeTruthy();
+
+    execFileSync('sh', ['-c', block!], { cwd: tmp });
+
+    expect(fs.readFileSync(path.join(tmp, 'title.txt'), 'utf-8')).toContain('Fix #');
+    const body = fs.readFileSync(path.join(tmp, 'body.txt'), 'utf-8');
+    expect(body).toContain('## Summary');
+    expect(body).toContain('Fixes #');
   });
 });

--- a/packages/codev/src/commands/porch/__tests__/bugfix-1455-pr-create-prompt.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/bugfix-1455-pr-create-prompt.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression test for GitHub Issue #1455 — the prompt-rendering half.
+ *
+ * Phase prompts must not name a forge CLI. They carry `{{pr_create_command}}`,
+ * and porch substitutes the resolved `pr-create` concept command, the same way
+ * it already injects `pr-merge` into the merge task. Without the substitution
+ * the token would reach the builder unrendered, or (before the fix) the prompt
+ * would simply say `gh pr create` on a Gitea project.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { buildPhasePrompt } from '../prompts.js';
+import type { ProjectState, Protocol } from '../types.js';
+
+// No real `gh issue view` round-trip from getProjectSummary.
+vi.mock('../../../lib/github.js', () => ({
+  fetchIssue: vi.fn().mockResolvedValue(null),
+}));
+
+const forgeScripts = path.resolve(import.meta.dirname, '..', '..', '..', '..', 'scripts', 'forge');
+
+const protocol = {
+  name: 'bugfix',
+  phases: [{ id: 'pr', name: 'PR', type: 'once', build: { prompt: 'pr.md' } }],
+} as unknown as Protocol;
+
+const state = {
+  id: '1455',
+  title: 'pr-create-is-not-a-forge-concept',
+  protocol: 'bugfix',
+  phase: 'pr',
+  plan_phases: [],
+  current_plan_phase: null,
+  gates: {},
+  iteration: 1,
+  build_complete: false,
+  history: [],
+  started_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+} as unknown as ProjectState;
+
+describe('#1455 — porch substitutes {{pr_create_command}}', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-create-prompt-1455-'));
+    const prompts = path.join(tmp, 'codev', 'protocols', 'bugfix', 'prompts');
+    fs.mkdirSync(prompts, { recursive: true });
+    fs.writeFileSync(
+      path.join(prompts, 'pr.md'),
+      'CODEV_PR_TITLE="t" CODEV_PR_BODY="b" {{pr_create_command}}\n',
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function writeForgeConfig(forge: Record<string, unknown>): void {
+    fs.mkdirSync(path.join(tmp, '.codev'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, '.codev', 'config.json'), JSON.stringify({ forge }));
+  }
+
+  it('renders the gitea script for a project with forge.provider: gitea', async () => {
+    writeForgeConfig({ provider: 'gitea' });
+    const prompt = await buildPhasePrompt(tmp, state, protocol);
+
+    expect(prompt).toContain(path.join(forgeScripts, 'gitea', 'pr-create.sh'));
+    expect(prompt).not.toContain('{{pr_create_command}}');
+    expect(prompt).not.toContain('gh pr create');
+  });
+
+  it('renders the github script when no forge is configured', async () => {
+    const prompt = await buildPhasePrompt(tmp, state, protocol);
+    expect(prompt).toContain(path.join(forgeScripts, 'github', 'pr-create.sh'));
+    expect(prompt).not.toContain('{{pr_create_command}}');
+  });
+
+  it('renders a manual override', async () => {
+    writeForgeConfig({ 'pr-create': '/opt/forge/open-pr.sh' });
+    const prompt = await buildPhasePrompt(tmp, state, protocol);
+    expect(prompt).toContain('/opt/forge/open-pr.sh');
+  });
+
+  it('tells the builder to open the PR by hand when the concept is disabled', async () => {
+    writeForgeConfig({ 'pr-create': null });
+    const prompt = await buildPhasePrompt(tmp, state, protocol);
+    expect(prompt).toContain('open the PR manually');
+    expect(prompt).not.toContain('{{pr_create_command}}');
+  });
+});

--- a/packages/codev/src/commands/porch/prompts.ts
+++ b/packages/codev/src/commands/porch/prompts.ts
@@ -16,6 +16,7 @@ import { findPlanFile, getCurrentPlanPhase, getPhaseContent } from './plan.js';
 import { getProjectDir, resolveArtifactBaseName } from './state.js';
 import type { ArtifactResolver } from './artifacts.js';
 import { fetchIssue } from '../../lib/github.js';
+import { getForgeCommand, loadForgeConfig } from '../../lib/forge.js';
 import { resolveCodevFile, resolveCodevIncludes } from '../../lib/skeleton.js';
 import { readHotTierFiles } from '../../lib/managed-block.js';
 
@@ -87,12 +88,25 @@ function loadPromptFile(workspaceRoot: string, protocolName: string, promptFile:
 }
 
 /**
+ * Resolve the `pr-create` concept command for the PR-opening prompts.
+ *
+ * Mirrors the `pr-merge` injection in porch/next.ts. Prompts must not hardcode
+ * `gh pr create`: a project with `forge.provider` set would otherwise shell out
+ * to `gh` at the single most important write in the protocol (#1455).
+ */
+function resolvePrCreateCommand(workspaceRoot: string): string {
+  const command = getForgeCommand('pr-create', loadForgeConfig(workspaceRoot));
+  return command ?? '# pr-create is disabled for this forge — open the PR manually';
+}
+
+/**
  * Substitute template variables in a prompt.
  */
 function substituteVariables(
   prompt: string,
   state: ProjectState,
   artifactBaseName: string,
+  workspaceRoot: string,
   planPhase?: PlanPhase | null,
   summary?: string | null
 ): string {
@@ -102,6 +116,7 @@ function substituteVariables(
     artifact_name: artifactBaseName,
     current_state: state.phase,
     protocol: state.protocol,
+    pr_create_command: resolvePrCreateCommand(workspaceRoot),
   };
 
   // Add summary/goal if available
@@ -274,7 +289,7 @@ export async function buildPhasePrompt(
 
     const promptContent = loadPromptFile(workspaceRoot, state.protocol, promptFileName);
     if (promptContent) {
-      let result = substituteVariables(promptContent, state, artifactBaseName, currentPlanPhase, summary);
+      let result = substituteVariables(promptContent, state, artifactBaseName, workspaceRoot, currentPlanPhase, summary);
 
       // Add goal/summary header if available
       if (summary) {

--- a/packages/codev/src/commands/porch/prompts.ts
+++ b/packages/codev/src/commands/porch/prompts.ts
@@ -96,7 +96,12 @@ function loadPromptFile(workspaceRoot: string, protocolName: string, promptFile:
  */
 function resolvePrCreateCommand(workspaceRoot: string): string {
   const command = getForgeCommand('pr-create', loadForgeConfig(workspaceRoot));
-  return command ?? '# pr-create is disabled for this forge — open the PR manually';
+  // The disabled form must FAIL, not comment: a `# …` line is valid shell that
+  // exits 0, so an agent running the block would read "PR opened" from silence.
+  return (
+    command ??
+    "{ echo 'pr-create is disabled for this forge — open the PR manually' >&2; false; }"
+  );
 }
 
 /**

--- a/packages/codev/src/lib/forge-contracts.ts
+++ b/packages/codev/src/lib/forge-contracts.ts
@@ -139,6 +139,21 @@ export interface PrViewResult {
   deletions: number;
 }
 
+/**
+ * Output of the `pr-create` concept command.
+ *
+ * Inputs are environment variables, like every other concept:
+ * `CODEV_PR_TITLE` (required), `CODEV_PR_BODY` (required, may be empty), and
+ * the optional `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO`,
+ * `CODEV_PR_DRAFT`. A failed creation exits non-zero rather than emitting JSON.
+ */
+export interface PrCreateResult {
+  /** The created PR's number (`iid` on GitLab, `index` on Gitea). */
+  number: number;
+  /** The created PR's **browser/web** URL — never an API endpoint. */
+  url: string;
+}
+
 /** Output of the `pr-diff` concept command: raw diff text, not JSON. */
 // Returns diff text on stdout. Use `raw: true` option.
 

--- a/packages/codev/src/lib/forge-contracts.ts
+++ b/packages/codev/src/lib/forge-contracts.ts
@@ -143,9 +143,12 @@ export interface PrViewResult {
  * Output of the `pr-create` concept command.
  *
  * Inputs are environment variables, like every other concept:
- * `CODEV_PR_TITLE` (required), `CODEV_PR_BODY` (required, may be empty), and
- * the optional `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO`,
- * `CODEV_PR_DRAFT`. A failed creation exits non-zero rather than emitting JSON.
+ * `CODEV_PR_TITLE` (required), `CODEV_PR_BODY` (required — set it to `''` for
+ * an empty body; an *absent* one is rejected rather than silently posting a
+ * bodyless PR), and the optional `CODEV_PR_BASE`, `CODEV_PR_HEAD`,
+ * `CODEV_PR_REPO`, `CODEV_PR_DRAFT`. The gitea script also reads the optional
+ * `CODEV_PR_LOGIN` (tea's `--login`, for multi-login hosts). A failed creation
+ * exits non-zero rather than emitting JSON.
  */
 export interface PrCreateResult {
   /** The created PR's number (`iid` on GitLab, `index` on Gitea). */

--- a/packages/codev/src/lib/forge.ts
+++ b/packages/codev/src/lib/forge.ts
@@ -148,7 +148,7 @@ export interface ConceptResolution {
 }
 
 /**
- * Resolve all 15 concepts with their source and executable.
+ * Resolve every known concept with its source and executable.
  * Used by `codev doctor` for full concept reporting.
  */
 export function resolveAllConcepts(forgeConfig?: ForgeConfig | null): ConceptResolution[] {

--- a/packages/codev/src/lib/forge.ts
+++ b/packages/codev/src/lib/forge.ts
@@ -64,7 +64,7 @@ export interface ForgeCommandOptions {
 const KNOWN_CONCEPTS = [
   'issue-view', 'pr-list', 'issue-list', 'issue-search', 'issue-comment', 'pr-exists',
   'recently-closed', 'recently-merged', 'user-identity', 'team-activity',
-  'on-it-timestamps', 'pr-merge', 'pr-search', 'pr-view', 'pr-diff',
+  'on-it-timestamps', 'pr-create', 'pr-merge', 'pr-search', 'pr-view', 'pr-diff',
   'auth-status', 'repo-archive',
 ] as const;
 

--- a/packages/codev/src/lib/forge.ts
+++ b/packages/codev/src/lib/forge.ts
@@ -189,6 +189,9 @@ export function resolveAllConcepts(forgeConfig?: ForgeConfig | null): ConceptRes
  *
  * For inline commands: handles `if [ ... ]; then cmd ...` patterns and pipes.
  */
+/** Shell builtins and keywords that are never the executable a concept needs on PATH. */
+const SHELL_BUILTINS = ['if', 'then', 'else', 'fi', 'test', '[', '[[', 'set', 'export', 'readonly', 'local', 'shift', ':'];
+
 function extractExecutable(command: string): string | null {
   const trimmed = command.trim();
 
@@ -196,15 +199,25 @@ function extractExecutable(command: string): string | null {
   if (trimmed.endsWith('.sh') && existsSync(trimmed)) {
     try {
       const content = readFileSync(trimmed, 'utf-8');
+      // An explicit `# forge-executable: <tool>` declaration wins. The heuristic
+      // below reads the first substantive line, which is wrong for any script
+      // that opens with `set -e` or an input guard — it would tell `codev
+      // doctor` to look for `set` or `echo` instead of `gh`/`tea`/`glab`, and a
+      // missing forge CLI would go unreported (#1455).
+      const declared = content.match(/^#\s*forge-executable:\s*(\S+)/m);
+      if (declared) return declared[1];
       // Look for `exec <tool>` or first non-comment, non-shebang, non-blank line
       for (const line of content.split('\n')) {
         const l = line.trim();
         if (!l || l.startsWith('#') || l.startsWith('if') || l.startsWith('else') || l.startsWith('fi') || /^\w+=/.test(l)) continue;
         const execMatch = l.match(/^exec\s+(\S+)/);
         if (execMatch) return execMatch[1];
-        // First substantive command
+        // First substantive command. Shell builtins are skipped, not returned:
+        // a script opening with `set -e` would otherwise report `set` as its
+        // executable, and `codev doctor` would then warn that `set` is missing
+        // instead of checking for the real CLI (#1455).
         const token = l.split(/\s+/)[0];
-        if (token && !['if', 'then', 'else', 'fi', 'test', '[', '[['].includes(token)) {
+        if (token && !SHELL_BUILTINS.includes(token)) {
           return token;
         }
       }
@@ -222,7 +235,7 @@ function extractExecutable(command: string): string | null {
   const first = trimmed.split(/[|;]/).map(s => s.trim())[0];
   // Skip shell builtins
   const token = first.split(/\s+/)[0];
-  if (['if', 'test', '[', '[['].includes(token)) return null;
+  if (SHELL_BUILTINS.includes(token)) return null;
   return token || null;
 }
 

--- a/packages/codev/src/lib/forge.ts
+++ b/packages/codev/src/lib/forge.ts
@@ -127,11 +127,11 @@ function getProviderPresets(): Record<string, Record<string, string | null>> {
     github: getDefaultCommands(),
     gitlab: buildPresetFromScripts('gitlab', ['team-activity', 'on-it-timestamps']),
     gitea: buildPresetFromScripts('gitea', ['team-activity', 'on-it-timestamps', 'pr-search', 'pr-diff']),
-    // pr-create is explicitly disabled (not just "no script") — Linear has no PR
-    // concept of its own, and without this it silently falls through to the
-    // github default (`gh pr create`) instead of failing loudly. That's the
-    // exact silent-fallthrough bug class #1455 closes.
-    linear: buildPresetFromScripts('linear', ['team-activity', 'on-it-timestamps', 'pr-create']),
+    // Linear is a hybrid forge (spec 719): it owns *issues*, while every PR
+    // concept — pr-create included — deliberately falls through to the github
+    // default. Disabling pr-create here would leave Linear the one provider
+    // that can merge a PR but not open one.
+    linear: buildPresetFromScripts('linear', ['team-activity', 'on-it-timestamps']),
   };
   return _providerPresets;
 }
@@ -235,12 +235,17 @@ function extractExecutable(command: string): string | null {
   // Shell conditional: extract first command after "then"
   const thenMatch = trimmed.match(/then\s+(\S+)/);
   if (thenMatch) return thenMatch[1];
-  // Pipe: first command
-  const first = trimmed.split(/[|;]/).map(s => s.trim())[0];
-  // Skip shell builtins
-  const token = first.split(/\s+/)[0];
-  if (SHELL_BUILTINS.includes(token)) return null;
-  return token || null;
+  // First substantive segment of a pipe/sequence. Builtins are *skipped*, not
+  // returned as null: `doctor` treats a null executable as "nothing to check"
+  // (doctor.ts, `execInstalled`), so bailing at the first builtin would report
+  // `. env.sh; gh issue view "$1"` as healthy without ever checking for `gh` —
+  // the silent success #1455 is about, inside the reporter for it. This mirrors
+  // the script-file branch above, which also scans past builtins to the real CLI.
+  for (const segment of trimmed.split(/[|;]/)) {
+    const token = segment.trim().split(/\s+/)[0];
+    if (token && !SHELL_BUILTINS.includes(token)) return token;
+  }
+  return null;
 }
 
 // =============================================================================

--- a/packages/codev/src/lib/forge.ts
+++ b/packages/codev/src/lib/forge.ts
@@ -127,7 +127,11 @@ function getProviderPresets(): Record<string, Record<string, string | null>> {
     github: getDefaultCommands(),
     gitlab: buildPresetFromScripts('gitlab', ['team-activity', 'on-it-timestamps']),
     gitea: buildPresetFromScripts('gitea', ['team-activity', 'on-it-timestamps', 'pr-search', 'pr-diff']),
-    linear: buildPresetFromScripts('linear', ['team-activity', 'on-it-timestamps']),
+    // pr-create is explicitly disabled (not just "no script") — Linear has no PR
+    // concept of its own, and without this it silently falls through to the
+    // github default (`gh pr create`) instead of failing loudly. That's the
+    // exact silent-fallthrough bug class #1455 closes.
+    linear: buildPresetFromScripts('linear', ['team-activity', 'on-it-timestamps', 'pr-create']),
   };
   return _providerPresets;
 }
@@ -190,7 +194,7 @@ export function resolveAllConcepts(forgeConfig?: ForgeConfig | null): ConceptRes
  * For inline commands: handles `if [ ... ]; then cmd ...` patterns and pipes.
  */
 /** Shell builtins and keywords that are never the executable a concept needs on PATH. */
-const SHELL_BUILTINS = ['if', 'then', 'else', 'fi', 'test', '[', '[[', 'set', 'export', 'readonly', 'local', 'shift', ':'];
+const SHELL_BUILTINS = ['if', 'then', 'else', 'fi', 'test', '[', '[[', 'set', 'export', 'readonly', 'local', 'shift', ':', '.', 'source'];
 
 function extractExecutable(command: string): string | null {
   const trimmed = command.trim();


### PR DESCRIPTION
## Summary

`pr-create` is now a forge concept, so PR creation routes through the same dispatcher as the other 17 concepts instead of shelling out to `gh` unconditionally.

Fixes #1455

## Root cause

Four linked gaps, not one:

1. `packages/codev/src/lib/forge.ts` — `KNOWN_CONCEPTS` had no `pr-create`. Everything derives from that list (`getDefaultCommands`, `buildPresetFromScripts`, `resolveAllConcepts` for `codev doctor`, `validateForgeConfig`), so `getForgeCommand('pr-create', …)` returned `null` for every provider **and** a hand-written `forge["pr-create"]` override was reported by doctor as an unknown concept — and read by nothing.
2. No `pr-create.sh` in any provider directory.
3. `gh pr create` written literally into 7 prompt files per tree (14 total).
4. Nothing injected a resolved command into the PR-opening prompts, although the precedent existed for `pr-merge` (`porch/next.ts:227` and `:768`).

Reads and `pr-merge` route correctly, so a Gitea project looks fully configured right up to the one write that matters.

## The contract

The issue asked for agreement on the signature before anyone wrote it. This PR uses **environment variables in, JSON on stdout** — the shape every other concept already has:

| | |
|---|---|
| Inputs | `CODEV_PR_TITLE` (required), `CODEV_PR_BODY` (required — set it to `""` for an empty body; an *absent* one is rejected), `CODEV_PR_BASE`, `CODEV_PR_HEAD`, `CODEV_PR_REPO`, `CODEV_PR_DRAFT` (optional; gitea also reads `CODEV_PR_LOGIN`) |
| Output | `{"number": <int>, "url": "<web url>"}` — the browser URL, never an API endpoint |
| Failure | non-zero exit, diagnostics on stderr, no JSON |

The alternative — a CLI-compatible wrapper taking `--title/--body/--base/--head` on argv — would have preserved the existing prompt text verbatim, but `executeForgeCommand()` passes inputs as `CODEV_*` env and parses stdout, so an argv contract would make `pr-create` the one concept unreachable from TypeScript. Happy to flip it if you'd rather have the passthrough.

Deliberately **not** included: a `CODEV_PR_BODY_FILE` input. The issue's own testing note describes a shim that silently dropped `--body-file` and posted empty bodies at exit 0 for months; one way in is one thing to get wrong.

## What changed

- `forge.ts` — `pr-create` in `KNOWN_CONCEPTS` (one line; presets, doctor and config validation follow).
- `forge-contracts.ts` — `PrCreateResult`.
- `scripts/forge/github/pr-create.sh` — `gh pr create` with the flags it already took. Behaviour for GitHub users is unchanged.
- `scripts/forge/gitea/pr-create.sh` — `tea pulls create --description` (**not** `--body`). tea's rendered, line-wrapped, ANSI-decorated output goes to stderr; the new PR is then looked up by head branch through `tea pulls list --fields index,url,head --output json`, which is machine-readable, rather than parsed out of that view.
- `scripts/forge/gitlab/pr-create.sh` — **scope deviation, argued rather than chosen silently.** The issue asked for two scripts. Without a gitlab script the preset falls through to the GitHub default and runs `gh`, which is the bug this closes. It is marked ⚠️ UNVERIFIED in-file because `glab` is not installed in the authoring environment — same convention as the existing `gitea/issue-search.sh`. Say the word and I'll drop it.
- `porch/prompts.ts` — `{{pr_create_command}}` template variable, resolved per project config, falling back to "open the PR manually" when the concept is disabled.
- 14 prompt files across both trees now read:
  ```bash
  export CODEV_PR_TITLE="…"
  export CODEV_PR_BODY="$(cat <<'EOF'
  …
  EOF
  )"

  {{pr_create_command}}
  ```
  `export`, not an assignment prefix — see the CMAP section below. PIR moved off `--body-file` to `CODEV_PR_BODY="$(cat codev/reviews/….md)"`.
- `extractExecutable` honours a `# forge-executable: <tool>` declaration, so `codev doctor` reports the CLI a script actually needs rather than the first line of a guard clause.
- Docs: `codev/resources/commands/forge.md` and the byte-identical `.claude`/`.codex` forge SKILL.md pair.
- `bugfix-685-close-keyword.test.ts` — its PR-body-template regex now accepts `CODEV_PR_BODY=` alongside `--body`. Guard intent unchanged.

## Verification

**Live Forgejo, `tea` 0.14.2** — three scratch PRs, all closed and their branches deleted afterwards:

- Explicit base/head: the script printed `{"number":15,"url":"https://…/pulls/15"}` and nothing else on stdout. The body was then read **back from the server** over the REST API: 428 bytes sent, 428 received, byte-identical — `"quotes"`, `` `backticks` ``, `$VAR`, `\backslash`, a fenced code block, checkboxes and an em dash all intact. Server-side `base`, `head` and `title` matched the inputs. This is the assertion the issue asked for, not "exit 0".
- No `CODEV_PR_HEAD`: the `git rev-parse --abbrev-ref HEAD` default and tea's own base default both resolved correctly.
- Answering the issue's open question: on tea **0.14.2**, with a single configured login and an explicit `--head`, `tea pulls create` needs no `--repo`/`--login` and does not prompt. Both are still forwarded when set, for multi-login hosts and for the 0.11.x autodetect-prompt failure.

**This PR was opened with `scripts/forge/github/pr-create.sh`** — `CODEV_PR_REPO=cluesmith/codev`, `CODEV_PR_HEAD=pseudoseed:builder/bugfix-1455`.

**Regression tests** — `bugfix-1455-pr-create-concept.test.ts` (dispatcher routing per provider; the scripts' contract exercised against fake `gh`/`tea` on PATH, including the multi-line tricky body byte-for-byte, the `--description`-not-`--body` mapping, cross-repo `<user>:<branch>` head matching, and the failure paths) and `bugfix-1455-pr-create-prompt.test.ts` (porch renders the right command for github/gitea/override/disabled). Removing `pr-create` from `KNOWN_CONCEPTS` turns 7 of them red.

## Review: two CMAP rounds, four defects fixed

Round 1 — gemini APPROVE, codex REQUEST_CHANGES, claude REQUEST_CHANGES:

1. **Inline overrides received empty inputs** (codex). The prompts set the inputs as an assignment *prefix* (`CODEV_PR_TITLE=… <cmd>`). A script reading the environment works, but an inline override — the documented form, e.g. `"pr-merge": "glab mr merge \"$CODEV_PR_NUMBER\" --yes"` — has its `"$CODEV_PR_TITLE"` argument expanded by the calling shell *before* the assignment applies, so it got `""`. The prompts now `export`. Pinned by a test that renders the shipped prompt, extracts the bash block and **executes** it against an inline override.
2. **`codev doctor` reported `pr-create … set not found`** (claude). `extractExecutable` returns a script's first substantive command, which is `set -e` here — so doctor looked for `set` on PATH and could no longer tell a Gitea user that `tea` is missing. Fixed with the `# forge-executable:` declaration plus a shell-builtin skip list; verified against the built `dist`.
3. **The gitea lookup had no `--limit`** (claude), unlike every sibling gitea script. On a repo with more open PRs than tea's default page it would create the PR and then exit 1 claiming it couldn't find it. Now `--limit 200`.

Round 2 — gemini APPROVE, claude APPROVE, codex REQUEST_CHANGES:

4. **An absent body posted an empty PR** (codex). The scripts validated the title but not the body, and `--body ""` succeeds on every forge — so a caller who omitted the variable got a bodyless PR at exit 0, the same silent failure the issue's testing notes describe. The scripts now distinguish unset from deliberately empty and fail before reaching the forge CLI.

Also taken: the disabled-concept fallback used to render as a `#` comment (valid shell, exit 0, no PR) and now fails loudly; `CODEV_PR_LOGIN` is documented where it's read.

Round 3 — **gemini APPROVE, codex APPROVE, claude APPROVE**, with two cosmetic notes taken: `gitea/pr-create.sh` now accepts `.head` as either a string (tea 0.14.2) or the object-with-`.ref` shape sibling scripts assume, and the stale "15 concepts" counts in `forge.ts` and `arch.md` are corrected to 18. Re-verified live against Forgejo afterwards.

## Test plan

- [x] Regression tests added; they fail without the fix
- [x] `pnpm build` clean
- [x] Unit suite: 4891 passed / 0 failed (see the disclosure below)
- [x] CLI integration suite: 90 passed
- [x] Tower integration suite: 173 passed, 1 pre-existing failure unrelated to this change (`cli-tower-mode.e2e.test.ts` expects `http://localhost:…` and this machine's Tower binds `0.0.0.0`)
- [x] Live end-to-end against a real Forgejo

## Disclosure: one unrelated test is timing-sensitive on my machine

`spec-1280-measurement-instrument.test.ts` intermittently fails here with `Test timed out in 60000ms` — usually 1 test, sometimes 2, always `PHASE_ITERS is a linear comparison constant` and/or the determinism test. Both shell out to `scripts/measure-prompt-surface.sh` twice.

- That script takes **25–30 s per invocation** on this machine at ~17% CPU (process-spawn bound), against the **~2.0 s** recorded in `codev/state/bugfix-1323_thread.md` when the 60 s budgets were set. Two calls per test lands right on the budget.
- Nothing here touches it: this branch is 0 commits behind `upstream/main`, and both the test file and the script are byte-identical to main — so main fails identically on this machine.
- The whole suite passes when that file's runtime isn't competing with the rest (`vitest run` with output to a file, 4884 passed).

I deliberately did **not** raise those budgets in this PR — that's an unrelated test, and papering over a real performance signal inside a bugfix is the kind of scope creep a reviewer should reject. Worth its own issue if the numbers reproduce on your hardware.

## Out of scope, found while testing (no changes made)

Three pre-existing `gitea` read-concept bugs, all in #1137/#1146 territory rather than this one:

- `tea pulls view <n> --output json` ignores `<n>` and returns a **list** of all pulls, so `gitea/pr-view.sh`'s `jq '.url = (.html_url // .url)'` receives an array.
- `tea pulls list` rejects `--fields description`, so `gitea/pr-list.sh`'s `description → body` mapping can't populate.
- `tea pulls list --output json` returns `head` as a plain branch string, but `gitea/pr-exists.sh` filters on `.head.ref`.

Also: `gh pr edit --body-file` is still hardcoded in the PIR review prompt. `pr-edit` isn't a concept and adding one is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update (2026-08-14): gitea `pr-create` no longer looks the PR up

The gitea script created the PR with `tea pulls create` and then searched for it with `tea pulls list --limit 200`. That `--limit 200` was added here as a fix for a review defect, but it rests on an assumption the sibling PR #1146 disproves: **Gitea caps every list response at `max_response_items`, default 50** — `--limit 200` does not raise the cap, it silently truncates. On a busy repo the just-created PR falls off the first page and this script exited 1 for a PR that exists, inviting a duplicate retry.

Re-confirmed live against Forgejo 15.0.2, not inferred: `settings/api` reports `max_response_items: 50`, and a `?limit=200` request returned exactly **50** items on a list where paging at 50 returned **53**.

**Fix: delete the lookup rather than paginate it.** `tea api -X POST repos/{owner}/{repo}/pulls` returns the created PR — `number` and `html_url` — in its response body. Nothing to search, nothing to race, nothing to truncate, and the `<user>:<branch>` head-matching heuristic goes too (the API resolves an owner-qualified head itself).

Live testing turned up three defects in the obvious version of that change, each the same bug class as #1455 itself — an operation accepted and then silently not performed — so each is handled in code rather than noted as a caveat:

1. **`tea api` exits 0 on HTTP errors.** Since this replaces a lookup with a *single* call, trusting the exit code would reintroduce #1455's silent success inside the fix for it. The response is asserted to *be* a PR object — an object with a numeric `number` **and** a non-empty browser URL — or it fails loudly with the body. The case where `number` is present but the URL is not gets its own message naming the number and saying explicitly not to retry: the PR **was** created, and reading that as "nothing happened" is how duplicates get opened.
2. **The API requires `base`** (`[Base]: Required`), where `tea pulls create` defaulted it client-side. An unset `CODEV_PR_BASE` now resolves the repo's default branch explicitly.
3. **`draft: true` in the payload is silently ignored** (response comes back `draft: false`), so `CODEV_PR_DRAFT=1` would have been an accepted-and-ignored flag. Gitea's draft marker is a `WIP:` title prefix — what `tea pulls create --draft` does — now implemented and verified server-side.

Full detail, including the verified `{owner}`/`{repo}` placeholder behaviour and byte-exact body round-trip, is in the [reconcile comment](https://github.com/cluesmith/codev/pull/1458#issuecomment-5294360740).

### Testing

- The gitea half of `bugfix-1455-pr-create-concept.test.ts` is rewritten against a `tea api` stub. Every new case was run against the **previous** script first and fails there, so the pin is real — including an explicit assertion that no `pulls` / `list` / `--limit` call is made at all.
- Full `@cluesmith/codev` unit suite on this branch: **3218 passed, 126 failed** (67 files).
- Baseline, same suite on unmodified `upstream/main` in the same worktree: **3176 passed, 126 failed** — the *same* 67 files and *same* 126 tests. **Zero regressions**; this branch adds 42 passing tests. The pre-existing failures are `agent-farm` / `terminal` / `consolidate` (shellper sockets, SQLite state), environment-dependent: no built `dist/`, live Tower on the same state.
- All Gitea verification ran against scratch repo `pseudoseed/research`; every scratch PR closed, every scratch branch deleted. No `tea` token scope widened.

## Merge order with the sibling PR — verified, not assumed

#1146 and #1458 come from the same fork and both touch `packages/codev/scripts/forge/gitea/`, so the ordering question is fair. The answer:

### Either order is safe. There is no dependency and no conflict.

| Question | Answer | How it was checked |
|---|---|---|
| Do they conflict? | **No.** | `git merge-tree` on the two branch tips merges cleanly. The only file both touch is the builder thread log, which is the **identical blob** on both branches and auto-merges. |
| Must one merge first? | **No.** | #1458's `pr-create.sh` does not `source _lib.sh` and does not call `gitea_repo` or `tea_api_paged`. Nothing in it resolves against #1146. |
| Does the merged result hold together? | **Yes.** | In the merged tree, `_lib.sh` and `pr-view.sh` are byte-identical to #1146's versions and `pr-create.sh` byte-identical to #1458's — no silent blending. The `bugfix-693` invariant (every entry under each provider dir is a `*.sh`) still holds with `_lib.sh` present. |

### Does #1458 duplicate something #1146 makes shared?

**The paginator: no, and it shouldn't.** `_lib.sh#tea_api_paged` exists to walk a truncating *list* endpoint. `pr-create` no longer lists anything — it reads the new PR out of the create response — so there is no pagination for it to share. That is the point of the reconcile rather than an oversight.

**Repo resolution: yes, there are two paths, and this is worth a follow-up.**

- #1146's read concepts: `. _lib.sh` → `gitea_repo()`, which honours **`CODEV_REPO`**, else derives `owner/repo` from the origin remote, and fails fast naming `CODEV_REPO` as the remedy.
- #1458's `pr-create`: tea's own `{owner}`/`{repo}` placeholders, with **`CODEV_PR_REPO`** forwarded as `tea --repo`.

They were kept separate deliberately, for two reasons rather than by omission:

1. **Different contract.** `pr-create` takes `CODEV_PR_REPO`; the read concepts take `CODEV_REPO`. `gitea_repo()` reads the latter and takes no argument, so `pr-create` could not call it without changing its signature — which would mean editing a #1146 file from #1458 and creating exactly the merge-order coupling this avoids.
2. **`--repo` does more than fill a path.** It also supplies tea's repo/login context, verified working from a cwd whose remote is *not* a Gitea host. A path-only helper does not do that.

**Recommended follow-up (not done here, deliberately):** once both PRs have landed, unify the two behind one helper that takes the override variable as a parameter — e.g. `gitea_repo "$CODEV_PR_REPO"` — so there is one repo-resolution path with one error message. Doing it now would couple two independent PRs; doing it never leaves two paths that will drift. It is a small, mechanical change against a tree where both are already present.

The one ergonomic gap that split created *has* been closed in the meantime: an unresolvable repo used to surface from `pr-create` as a bare `404 page not found`, and now names `CODEV_PR_REPO` as the remedy, matching `gitea_repo()`'s fail-fast message.
