### PR TITLE
[PIR #1463 follow-up] Review/arch: capture the key reuse lesson (avoid live-architect dependency; resolve() = structural safeguard)

### DIFF
--- a/codev/projects/1463-stream-deck-key-to-open-the-ar/status.yaml
+++ b/codev/projects/1463-stream-deck-key-to-open-the-ar/status.yaml
@@ -21,10 +21,12 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-15T02:54:37.170Z'
-updated_at: '2026-08-15T08:45:59.435Z'
+updated_at: '2026-08-15T08:50:09.703Z'
 pr_history:
   - phase: review
     pr_number: 1466
     branch: builder/pir-1463
     created_at: '2026-08-15T08:13:46.320Z'
+    merged: true
+    merged_at: '2026-08-15T08:50:09.703Z'
 pr_ready_for_human: false

--- a/codev/resources/arch.md
+++ b/codev/resources/arch.md
@@ -2054,7 +2054,11 @@ The deck is a remote and VSCode is the screen, bound by **one shared selection**
   live-architect view) — one policy, one home. Two accepted residuals follow from the fire-and-forget
   relay: in `main` mode when `main` is absent VSCode opens the first live architect while the face still
   reads `Main`; and a live registration behind a dead PTY resolves fine. The face renders the resolved
-  architect name (the safeguard shown before a press). Paired-renamed with the builder key
+  architect name (the safeguard shown before a press), and because `resolve()` is shared by the
+  press path and the render path, that safeguard is **structural** — face and action can't drift,
+  there is one resolution. The lesson for the next key: **avoiding** the live-architect dependency
+  (fire a name, delegate policy to VSCode) beat handling it — the registry failure modes are simply
+  not this key's problem. Don't reach for `OverviewData.architects`. Paired-renamed with the builder key
   (`Open Builder Terminal` / `Open Architect Terminal`); **the Elgato UUID is the stable identity**, so
   renaming `Name`/face never orphans an already-placed key. Prerequisite: #1406 (spawn mis-attribution)
   can make `builder` mode summon the wrong architect until fixed.

--- a/codev/reviews/1463-stream-deck-key-to-open-the-ar.md
+++ b/codev/reviews/1463-stream-deck-key-to-open-the-ar.md
@@ -63,6 +63,23 @@ live-architect view) entirely** — dropping the first-live fallback and a store
 reader that would have coupled the deck to a transiently-wrong view. The bullet also
 records the two accepted residuals and the UUID-stability property (below).
 
+### Design note for the next key-author (read this before reaching for `OverviewData.architects`)
+
+Two properties are the point of this key, and the default instinct — read the live
+architect list on the deck — would have thrown both away:
+
+- **Avoiding the live-architect dependency beat handling it carefully.** Because the
+  deck fires a *name* and delegates `main`-else-first to VS Code, the three registry
+  failure modes — an empty architect list, a transiently-missing `main`, and a live
+  row behind a dead PTY — are simply **not this key's problem**, rather than being
+  mitigated by it. There is no live-view code on the deck to get the mitigation
+  wrong. Reaching for `OverviewData.architects` would have re-imported all three.
+- **The wrong-architect safeguard is structural, not conventional.** `resolve()` is
+  shared by the press path (`onKeyDown`) and `renderTo`, so the face and the action
+  **cannot drift apart** — there is exactly one resolution, and the name you see is
+  the name you'll open. It's not "remember to keep the face in sync with the press";
+  it's one function, so there's nothing to keep in sync.
+
 ## Lessons Learned Updates
 
 **HOT (`lessons-critical.md`): none** — the core reuse decision ("delegate the

--- a/codev/state/pir-1463_thread.md
+++ b/codev/state/pir-1463_thread.md
@@ -149,3 +149,20 @@ SEPARATE issue **#1465** (reframed to lead with the correctness bug), credited t
 me. 1463 stays as-is; added a one-line Row-1 placement caveat + #1465 pointer to
 the plan's README-guidance section (documentation, not a fold-in). Architect
 endorsed the reshape and the Main-mode residual wording. Gate still pending (Amr).
+
+## Merged + complete (2026-08-15)
+
+PR #1466 opened; 3-way consult all APPROVE (one non-blocking claude note: rename
+was outside the plan's file list — ratified). pr gate approved by Amr. First
+`gh pr merge --merge` hit the review-required branch-protection wall (BLOCKED /
+REVIEW_REQUIRED); went quiet per merge-window hygiene (#1462). Architect merged
+via admin — merge commit 0cc416ff7, seven checks green, mergedAt
+2026-08-15T08:49:14Z. Verified state=MERGED against that SHA; ran
+`porch done 1463 --merged 1466` → protocol COMPLETE (phase verified).
+
+Follow-up (doc-only, PR #TBD): architect asked to add the key reuse lesson to the
+review artifact + arch.md — (1) AVOIDING the live-architect dependency beat
+handling it (fire a name, delegate main-else-first to VSCode → the 3 registry
+failure modes aren't this key's problem); (2) resolve() shared by press + render
+makes the wrong-architect safeguard STRUCTURAL, not conventional. Subject to the
+same review-required wall.


### PR DESCRIPTION
Doc-only follow-up to #1466 (merged). Adds the reuse lesson the architect asked to preserve in the durable artifacts, for the next person adding a Stream Deck key:

- **Avoiding the live-architect dependency beat handling it carefully.** The deck fires a *name* and delegates `main`-else-first to VS Code, so the three registry failure modes (empty list, transiently-missing `main`, live row behind a dead PTY) are simply not this key's problem rather than mitigated by it — reaching for `OverviewData.architects` would re-import all three.
- **The wrong-architect safeguard is structural, not conventional.** `resolve()` is shared by the press path (`onKeyDown`) and `renderTo`, so face and action cannot drift — one resolution, the name you see is the name you open.

Added to `codev/reviews/1463-*.md` and the `arch.md` Stream Deck integration bullet. No code change.

Refs #1463.