### PR TITLE
[Air #1489] feat: rename `afx reset` to `afx refresh` (deprecated `reset` alias)

### DIFF
--- a/.claude/skills/afx/SKILL.md
+++ b/.claude/skills/afx/SKILL.md
@@ -111,13 +111,13 @@ afx interrupt 0042
 afx send 0042 "That producer died — stop waiting and report."
 ```
 
-## afx reset
+## afx refresh
 
-Resets a builder's context: save working state → `/clear` → re-orient. Use when a builder's context window
+Refreshes a builder's context: save working state → `/clear` → re-orient. Use when a builder's context window
 is exhausted; `afx spawn --resume` reattaches the *same* conversation and does **not** give it a fresh one.
 
 ```
-afx reset <builder>
+afx refresh <builder>
 ```
 
 | Flag | Description |
@@ -133,13 +133,16 @@ afx reset <builder>
 
 Every gate fails safe: if the state file never arrives, carries a stale nonce, is a stub, is still being
 written, or the builder will not go quiet, the command **aborts without clearing** and exits non-zero,
-naming the gate. Requires a harness with in-session reset (Claude Code); others abort loudly.
+naming the gate. Requires a harness with in-session context clearing (Claude Code); others abort loudly.
+
+`afx reset` is a deprecated alias: it still works, prints a one-line notice to stderr, and will be removed
+in a future release.
 
 ```bash
-afx reset 0042 --dry-run                  # inspect first — touches nothing
-afx reset 0042
-afx reset 0042 --note "PR #90 merged while you were mid-phase. Rebase first."
-afx reset 0042 --interrupt-first          # builder is wedged mid-turn
+afx refresh 0042 --dry-run                # inspect first — touches nothing
+afx refresh 0042
+afx refresh 0042 --note "PR #90 merged while you were mid-phase. Rebase first."
+afx refresh 0042 --interrupt-first        # builder is wedged mid-turn
 ```
 
 ## afx cleanup

--- a/.codex/skills/afx/SKILL.md
+++ b/.codex/skills/afx/SKILL.md
@@ -111,13 +111,13 @@ afx interrupt 0042
 afx send 0042 "That producer died — stop waiting and report."
 ```
 
-## afx reset
+## afx refresh
 
-Resets a builder's context: save working state → `/clear` → re-orient. Use when a builder's context window
+Refreshes a builder's context: save working state → `/clear` → re-orient. Use when a builder's context window
 is exhausted; `afx spawn --resume` reattaches the *same* conversation and does **not** give it a fresh one.
 
 ```
-afx reset <builder>
+afx refresh <builder>
 ```
 
 | Flag | Description |
@@ -133,13 +133,16 @@ afx reset <builder>
 
 Every gate fails safe: if the state file never arrives, carries a stale nonce, is a stub, is still being
 written, or the builder will not go quiet, the command **aborts without clearing** and exits non-zero,
-naming the gate. Requires a harness with in-session reset (Claude Code); others abort loudly.
+naming the gate. Requires a harness with in-session context clearing (Claude Code); others abort loudly.
+
+`afx reset` is a deprecated alias: it still works, prints a one-line notice to stderr, and will be removed
+in a future release.
 
 ```bash
-afx reset 0042 --dry-run                  # inspect first — touches nothing
-afx reset 0042
-afx reset 0042 --note "PR #90 merged while you were mid-phase. Rebase first."
-afx reset 0042 --interrupt-first          # builder is wedged mid-turn
+afx refresh 0042 --dry-run                # inspect first — touches nothing
+afx refresh 0042
+afx refresh 0042 --note "PR #90 merged while you were mid-phase. Rebase first."
+afx refresh 0042 --interrupt-first        # builder is wedged mid-turn
 ```
 
 ## afx cleanup

--- a/codev-skeleton/.claude/skills/afx/SKILL.md
+++ b/codev-skeleton/.claude/skills/afx/SKILL.md
@@ -69,6 +69,60 @@ afx send 0042 "PR approved, please merge"
 afx send 0585 "check the test output" --file /tmp/test-results.txt
 ```
 
+## afx interrupt
+
+Sends an ESC keystroke to a builder's PTY — the only thing that reaches it **mid-turn**.
+
+```
+afx interrupt <builder>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--no-enter` | Send ESC alone, without the trailing Enter |
+
+A builder chaining foreground waits inside one turn queues every `afx send` unread — including your order
+to stop. ESC ends the turn so the queue processes. Distinct from `afx send --interrupt` (Ctrl+C).
+
+```bash
+afx interrupt 0042
+afx send 0042 "That producer died — stop waiting and report."
+```
+
+## afx refresh
+
+Refreshes a builder's context: save working state → `/clear` → re-orient. Use when a builder's context window
+is exhausted; `afx spawn --resume` reattaches the *same* conversation and does **not** give it a fresh one.
+
+```
+afx refresh <builder>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Print what would be sent; write nothing to the builder |
+| `--note <text>` | Extra context appended to the re-orientation |
+| `--file <path>` | Append file content (48KB max, read from *your* filesystem) |
+| `--interrupt-first` | ESC before the save request, for a builder already wedged |
+| `--mode <strict\|soft>` | Override mode if it cannot be detected |
+| `--timeout <seconds>` | Wait for the save-state receipt (default 300) |
+| `--min-bytes <n>` | Minimum state-file size to accept (default 1000) |
+| `--quiet-window <ms>` | Terminal silence counting as turn-ended (default 1500) |
+
+Every gate fails safe: if the state file never arrives, carries a stale nonce, is a stub, is still being
+written, or the builder will not go quiet, the command **aborts without clearing** and exits non-zero,
+naming the gate. Requires a harness with in-session context clearing (Claude Code); others abort loudly.
+
+`afx reset` is a deprecated alias: it still works, prints a one-line notice to stderr, and will be removed
+in a future release.
+
+```bash
+afx refresh 0042 --dry-run                # inspect first — touches nothing
+afx refresh 0042
+afx refresh 0042 --note "PR #90 merged while you were mid-phase. Rebase first."
+afx refresh 0042 --interrupt-first        # builder is wedged mid-turn
+```
+
 ## afx cleanup
 
 Removes a builder's worktree and branch after work is done.

--- a/codev-skeleton/.codex/skills/afx/SKILL.md
+++ b/codev-skeleton/.codex/skills/afx/SKILL.md
@@ -69,6 +69,60 @@ afx send 0042 "PR approved, please merge"
 afx send 0585 "check the test output" --file /tmp/test-results.txt
 ```
 
+## afx interrupt
+
+Sends an ESC keystroke to a builder's PTY — the only thing that reaches it **mid-turn**.
+
+```
+afx interrupt <builder>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--no-enter` | Send ESC alone, without the trailing Enter |
+
+A builder chaining foreground waits inside one turn queues every `afx send` unread — including your order
+to stop. ESC ends the turn so the queue processes. Distinct from `afx send --interrupt` (Ctrl+C).
+
+```bash
+afx interrupt 0042
+afx send 0042 "That producer died — stop waiting and report."
+```
+
+## afx refresh
+
+Refreshes a builder's context: save working state → `/clear` → re-orient. Use when a builder's context window
+is exhausted; `afx spawn --resume` reattaches the *same* conversation and does **not** give it a fresh one.
+
+```
+afx refresh <builder>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Print what would be sent; write nothing to the builder |
+| `--note <text>` | Extra context appended to the re-orientation |
+| `--file <path>` | Append file content (48KB max, read from *your* filesystem) |
+| `--interrupt-first` | ESC before the save request, for a builder already wedged |
+| `--mode <strict\|soft>` | Override mode if it cannot be detected |
+| `--timeout <seconds>` | Wait for the save-state receipt (default 300) |
+| `--min-bytes <n>` | Minimum state-file size to accept (default 1000) |
+| `--quiet-window <ms>` | Terminal silence counting as turn-ended (default 1500) |
+
+Every gate fails safe: if the state file never arrives, carries a stale nonce, is a stub, is still being
+written, or the builder will not go quiet, the command **aborts without clearing** and exits non-zero,
+naming the gate. Requires a harness with in-session context clearing (Claude Code); others abort loudly.
+
+`afx reset` is a deprecated alias: it still works, prints a one-line notice to stderr, and will be removed
+in a future release.
+
+```bash
+afx refresh 0042 --dry-run                # inspect first — touches nothing
+afx refresh 0042
+afx refresh 0042 --note "PR #90 merged while you were mid-phase. Rebase first."
+afx refresh 0042 --interrupt-first        # builder is wedged mid-turn
+```
+
 ## afx cleanup
 
 Removes a builder's worktree and branch after work is done.

--- a/codev-skeleton/resources/commands/agent-farm.md
+++ b/codev-skeleton/resources/commands/agent-farm.md
@@ -501,12 +501,12 @@ afx send 0042 "That producer died — stop waiting and report."
 
 ---
 
-### afx reset
+### afx refresh
 
-Reset a builder's context: have it save its working state, clear the conversation, then re-orient it.
+Refresh a builder's context: have it save its working state, clear the conversation, then re-orient it.
 
 ```bash
-afx reset <builder> [options]
+afx refresh <builder> [options]
 ```
 
 **Arguments:**
@@ -522,10 +522,13 @@ afx reset <builder> [options]
 - `--min-bytes <n>` - Minimum state-file size to accept as substantive (default 1000)
 - `--quiet-window <ms>` - Terminal silence that counts as turn-ended (default 1500)
 
+**Deprecated alias:** `afx reset` still runs this command and prints a one-line notice to stderr.
+It will be removed in a future release — use `afx refresh`.
+
 **Description:**
 
 Long-running builders exhaust their context window. `afx spawn --resume` reattaches the *same*
-conversation, so a deep session resumes deep — it does not give the builder a fresh window. `afx reset`
+conversation, so a deep session resumes deep — it does not give the builder a fresh window. `afx refresh`
 does, without losing what the builder knows.
 
 The sequence:
@@ -533,7 +536,7 @@ The sequence:
 1. Assemble the re-orientation and write it to `.builder-reorient.md` in the worktree.
 2. Ask the builder to write its complete working state to `.builder-state.md`, stamped with a one-time
    nonce.
-3. Wait for that file and **verify** it: correct nonce (not a stale file from an earlier reset),
+3. Wait for that file and **verify** it: correct nonce (not a stale file from an earlier refresh),
    substantive size, and stable across two observations (not still being written).
 4. Wait for the terminal to fall silent, so the clear is not typed mid-turn. If it does not settle, send
    **one** ESC and wait again.
@@ -556,19 +559,19 @@ then `afx spawn <id> --resume`).
 
 ```bash
 # See exactly what would be sent, without touching the builder
-afx reset 0042 --dry-run
+afx refresh 0042 --dry-run
 
-# Standard reset
-afx reset 0042
+# Standard refresh
+afx refresh 0042
 
 # Add context that post-dates the builder's saved state
-afx reset 0042 --note "PR #90 merged while you were mid-phase. Rebase before continuing."
+afx refresh 0042 --note "PR #90 merged while you were mid-phase. Rebase before continuing."
 
 # The builder is wedged mid-turn and not reading messages
-afx reset 0042 --interrupt-first
+afx refresh 0042 --interrupt-first
 
 # A builder that legitimately needs longer to write its state
-afx reset 0042 --timeout 600
+afx refresh 0042 --timeout 600
 ```
 
 ---

--- a/codev-skeleton/roles/builder.md
+++ b/codev-skeleton/roles/builder.md
@@ -72,7 +72,7 @@ nobody can redirect, and you will not notice, because from inside it everything 
 Never chain foreground poll loops.
 
 If you are wedged anyway, the architect can end your turn with `afx interrupt <your-id>`, or
-`afx reset <your-id>` to have you save state and re-orient. Worth knowing so you can suggest
+`afx refresh <your-id>` to have you save state and re-orient. Worth knowing so you can suggest
 them.
 
 ## PRs

--- a/codev/projects/1489-rename-afx-reset-to-afx-refres/status.yaml
+++ b/codev/projects/1489-rename-afx-reset-to-afx-refres/status.yaml
@@ -6,16 +6,17 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-08-18T00:04:31.636Z'
+    approved_at: '2026-08-18T00:14:17.044Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-17T23:42:08.661Z'
-updated_at: '2026-08-18T00:04:31.637Z'
+updated_at: '2026-08-18T00:14:17.045Z'
 pr_history:
   - phase: pr
     pr_number: 1490
     branch: builder/air-1489
     created_at: '2026-08-18T00:02:38.562Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/1489-rename-afx-reset-to-afx-refres/status.yaml
+++ b/codev/projects/1489-rename-afx-reset-to-afx-refres/status.yaml
@@ -1,7 +1,7 @@
 id: '1489'
 title: rename-afx-reset-to-afx-refres
 protocol: air
-phase: implement
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-17T23:42:08.661Z'
-updated_at: '2026-08-17T23:42:08.662Z'
+updated_at: '2026-08-17T23:55:50.468Z'

--- a/codev/projects/1489-rename-afx-reset-to-afx-refres/status.yaml
+++ b/codev/projects/1489-rename-afx-reset-to-afx-refres/status.yaml
@@ -11,4 +11,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-17T23:42:08.661Z'
-updated_at: '2026-08-17T23:55:50.468Z'
+updated_at: '2026-08-18T00:02:38.563Z'
+pr_history:
+  - phase: pr
+    pr_number: 1490
+    branch: builder/air-1489
+    created_at: '2026-08-18T00:02:38.562Z'

--- a/codev/projects/1489-rename-afx-reset-to-afx-refres/status.yaml
+++ b/codev/projects/1489-rename-afx-reset-to-afx-refres/status.yaml
@@ -7,13 +7,15 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-08-18T00:04:31.636Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-17T23:42:08.661Z'
-updated_at: '2026-08-18T00:02:38.563Z'
+updated_at: '2026-08-18T00:04:31.637Z'
 pr_history:
   - phase: pr
     pr_number: 1490
     branch: builder/air-1489
     created_at: '2026-08-18T00:02:38.562Z'
+pr_ready_for_human: true

--- a/codev/projects/1489-rename-afx-reset-to-afx-refres/status.yaml
+++ b/codev/projects/1489-rename-afx-reset-to-afx-refres/status.yaml
@@ -1,0 +1,14 @@
+id: '1489'
+title: rename-afx-reset-to-afx-refres
+protocol: air
+phase: implement
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-17T23:42:08.661Z'
+updated_at: '2026-08-17T23:42:08.662Z'

--- a/codev/resources/commands/agent-farm.md
+++ b/codev/resources/commands/agent-farm.md
@@ -692,12 +692,12 @@ afx send 0042 "That producer died — stop waiting and report."
 
 ---
 
-### afx reset
+### afx refresh
 
-Reset a builder's context: have it save its working state, clear the conversation, then re-orient it.
+Refresh a builder's context: have it save its working state, clear the conversation, then re-orient it.
 
 ```bash
-afx reset <builder> [options]
+afx refresh <builder> [options]
 ```
 
 **Arguments:**
@@ -713,10 +713,13 @@ afx reset <builder> [options]
 - `--min-bytes <n>` - Minimum state-file size to accept as substantive (default 1000)
 - `--quiet-window <ms>` - Terminal silence that counts as turn-ended (default 1500)
 
+**Deprecated alias:** `afx reset` still runs this command and prints a one-line notice to stderr.
+It will be removed in a future release — use `afx refresh`.
+
 **Description:**
 
 Long-running builders exhaust their context window. `afx spawn --resume` reattaches the *same*
-conversation, so a deep session resumes deep — it does not give the builder a fresh window. `afx reset`
+conversation, so a deep session resumes deep — it does not give the builder a fresh window. `afx refresh`
 does, without losing what the builder knows.
 
 The sequence:
@@ -724,7 +727,7 @@ The sequence:
 1. Assemble the re-orientation and write it to `.builder-reorient.md` in the worktree.
 2. Ask the builder to write its complete working state to `.builder-state.md`, stamped with a one-time
    nonce.
-3. Wait for that file and **verify** it: correct nonce (not a stale file from an earlier reset),
+3. Wait for that file and **verify** it: correct nonce (not a stale file from an earlier refresh),
    substantive size, and stable across two observations (not still being written).
 4. Wait for the terminal to fall silent, so the clear is not typed mid-turn. If it does not settle, send
    **one** ESC and wait again.
@@ -747,19 +750,19 @@ then `afx spawn <id> --resume`).
 
 ```bash
 # See exactly what would be sent, without touching the builder
-afx reset 0042 --dry-run
+afx refresh 0042 --dry-run
 
-# Standard reset
-afx reset 0042
+# Standard refresh
+afx refresh 0042
 
 # Add context that post-dates the builder's saved state
-afx reset 0042 --note "PR #90 merged while you were mid-phase. Rebase before continuing."
+afx refresh 0042 --note "PR #90 merged while you were mid-phase. Rebase before continuing."
 
 # The builder is wedged mid-turn and not reading messages
-afx reset 0042 --interrupt-first
+afx refresh 0042 --interrupt-first
 
 # A builder that legitimately needs longer to write its state
-afx reset 0042 --timeout 600
+afx refresh 0042 --timeout 600
 ```
 
 ---

--- a/codev/roles/builder.md
+++ b/codev/roles/builder.md
@@ -72,7 +72,7 @@ nobody can redirect, and you will not notice, because from inside it everything 
 Never chain foreground poll loops.
 
 If you are wedged anyway, the architect can end your turn with `afx interrupt <your-id>`, or
-`afx reset <your-id>` to have you save state and re-orient. Worth knowing so you can suggest
+`afx refresh <your-id>` to have you save state and re-orient. Worth knowing so you can suggest
 them.
 
 ## PRs

--- a/codev/state/air-1489_thread.md
+++ b/codev/state/air-1489_thread.md
@@ -1,0 +1,51 @@
+# air-1489 — Rename `afx reset` → `afx refresh`
+
+Protocol: AIR (strict). Issue #1489. No spec/plan/review files by design — the review goes in
+the PR body.
+
+## 2026-08-17 — Implement
+
+### Scope calls I made (the issue left these to my discretion)
+
+**Internal file/directory names stay `reset*`.** `commands/reset.ts`, `commands/reset/`,
+`ResetOptions`, `runReset`, `ResetPreflightError`, `formatResetReport` are untouched. Issue point 5
+explicitly allows this and warns against ballooning the diff; renaming the directory would have
+turned a ~250-line naming change into a several-hundred-line move with no user-visible benefit.
+The one exception is the **exported command entry point**, `reset()` → `refresh()`, because that is
+the symbol the CLI wires the canonical command to and reading `await reset(...)` under an
+`afx refresh` registration is exactly the confusion the rename exists to remove.
+
+**The builder-facing header changed too: "CONTEXT RESET" → "CONTEXT REFRESH".** Issue point 3 only
+names `--dry-run` output, log lines and error messages. But the save request and the re-orientation
+frame are read by an *agent* under the same vocabulary the issue is trying to fix, and #1470's
+automatic flow is "builder context refresh". Leaving the payloads saying RESET would have split the
+vocabulary at exactly the point where it matters most. Side benefit: `confirmClear`'s pattern is
+`/context (?:cleared|reset)/i`, and the old `CONTEXT RESET INCOMING` header collided with it (a real
+false-positive, fixed structurally in Spec 1273 by only scanning post-clear output). The new header
+no longer collides — but the orchestrator test deliberately **keeps** a colliding line in
+`PRE_CLEAR_BUFFER` so the window logic is not allowed to start depending on that luck.
+
+**The nonce marker `<!-- codev-reset: … -->` stays.** It is a wire format between the command and
+the builder within a single run, and it appears in state files that may already exist on disk.
+Renaming it buys nothing and would make a live builder's stale-file detection read oddly.
+
+### The alias
+
+`afx reset` and `afx refresh` are registered as two commands over one shared action body
+(`registerRefresh` in `cli.ts`), canonical name first so `--help` leads with it. Commander's
+`.alias()` was rejected: it gives no way to tell which spelling the caller typed, and the deprecated
+spelling has to announce itself. The notice goes to **stderr** via `process.stderr.write` —
+`logger.warn` writes to stdout, which carries the run report.
+
+### Sweep
+
+`grep -rn "afx reset"` across the repo is clean except for (a) the deprecation lines that mention it
+on purpose, and (b) `codev/specs/`, `codev/plans/`, `codev/reviews/`, `codev/projects/`,
+`codev/state/` — historical artifacts of Spec 1273 and friends, which are records of what was
+written at the time and are not rewritten.
+
+### Environment note
+
+The worktree ships without `node_modules`; `pnpm install --frozen-lockfile` plus
+`pnpm --filter "@cluesmith/codev^..." build` were needed before vitest could resolve
+`@cluesmith/codev-sdk/tower-client`.

--- a/codev/state/air-1489_thread.md
+++ b/codev/state/air-1489_thread.md
@@ -49,3 +49,36 @@ written at the time and are not rewritten.
 The worktree ships without `node_modules`; `pnpm install --frozen-lockfile` plus
 `pnpm --filter "@cluesmith/codev^..." build` were needed before vitest could resolve
 `@cluesmith/codev-sdk/tower-client`.
+
+## 2026-08-17 — PR #1490 + CMAP
+
+`gemini=APPROVE (HIGH)`, `codex=COMMENT (HIGH)`, `claude=APPROVE (HIGH)`. **No blocking findings.**
+
+Codex's only note is diff size (693 lines) against AIR's nominal ~300 — it says explicitly this is
+"not blocking", and the production-code delta is small; the bulk is comment rewrites, docs, the
+alias test suite and this thread file. Claude independently re-ran the affected suites (6 files /
+197 tests green) and re-verified the sweep, and both it and Codex endorsed the `CONTEXT REFRESH`
+payload rename that I had flagged as the debatable call.
+
+### Verified reviewer claims rather than taking them on trust
+
+**Claude's finding #1 is real.** `codev-skeleton/.claude/skills/afx/SKILL.md` and its `.codex` twin
+have no `afx reset`/`afx interrupt` section at all — their headings stop at `afx cron`, and the file
+was last touched by #1143, well before Spec 1273. So there was nothing in the skeleton skill trees
+for this PR to rename, and the issue's sweep is complete by its own terms; but **adopters will never
+discover `afx refresh`**. The docs test's `SKILL_DOCS` only covers the root `.claude`/`.codex`
+trees, which is why the drift is invisible. Backfilling a whole missing section is Spec 1273 work,
+not a rename — flagged to the architect for a follow-up issue rather than widened into this PR.
+
+**The reviewers' suggested live `--dry-run` could not run from here.** I first confirmed by reading
+`runReset` that `dryRun` returns before `fs.write`, before the optional interrupt and before any
+terminal send — genuinely zero-write, so self-targeting was safe. But `afx refresh air-1489
+--dry-run` fails at the registry lookup: from inside a worktree the workspace resolves to the
+worktree path, and `afx status` reports "Workspace: not active in tower". Pre-existing scoping,
+untouched by this change, and running afx from the main workspace root is not a builder's call. So
+the attempt did exercise the real resolve path under the new name and emitted the renamed error
+text, but assembly end-to-end remains covered by the orchestrator tests rather than a live run.
+
+**`afx db reset` still exists** and is legitimately destructive (Claude's minor note #2). No
+collision with the top-level registration — commander scopes it under `db` — but "reset is
+deprecated" is now marginally ambiguous in the help surface. Left alone.

--- a/packages/codev/src/agent-farm/__tests__/air-1489-refresh-rename.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/air-1489-refresh-rename.test.ts
@@ -1,0 +1,176 @@
+/**
+ * `afx reset` → `afx refresh` rename — Issue #1489.
+ *
+ * The rename exists because "reset" reads as "throw work away", which is the
+ * opposite of what this command guarantees: every gate aborts *without*
+ * clearing. So the canonical spelling is `refresh`, and `reset` survives one
+ * release as an alias that announces its own deprecation.
+ *
+ * Both halves of that need pinning. An alias that silently works is one nobody
+ * migrates off; an alias that stops working is a breaking change nobody
+ * announced. These tests hold the alias to exactly one behaviour: identical run,
+ * one line of notice, on stderr.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { mockRefresh } = vi.hoisted(() => ({ mockRefresh: vi.fn() }));
+
+vi.mock('../commands/reset.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../commands/reset.js')>();
+  return { ...actual, refresh: mockRefresh };
+});
+
+describe('Issue #1489 — the deprecation notice', () => {
+  it('names both spellings and says the alias is going away', async () => {
+    const { RESET_ALIAS_NOTICE } = await import('../commands/reset.js');
+
+    expect(RESET_ALIAS_NOTICE).toBe(
+      'afx reset has been renamed to afx refresh; this alias will be removed in a future release',
+    );
+  });
+
+  it('goes to stderr, so it cannot contaminate the run report on stdout', async () => {
+    // The report is what an architect reads (and occasionally pipes) to decide
+    // whether the builder was cleared. A deprecation line in that stream is
+    // noise at best and a parse break at worst.
+    const { warnResetAlias, RESET_ALIAS_NOTICE } = await import('../commands/reset.js');
+
+    const errWrites: string[] = [];
+    const outWrites: string[] = [];
+    const err = vi.spyOn(process.stderr, 'write').mockImplementation(chunk => {
+      errWrites.push(String(chunk));
+      return true;
+    });
+    const out = vi.spyOn(process.stdout, 'write').mockImplementation(chunk => {
+      outWrites.push(String(chunk));
+      return true;
+    });
+    try {
+      warnResetAlias();
+    } finally {
+      // Collected into arrays rather than asserted off the spies: `mockRestore`
+      // clears recorded calls as well as restoring the original.
+      err.mockRestore();
+      out.mockRestore();
+    }
+
+    expect(errWrites).toEqual([`${RESET_ALIAS_NOTICE}\n`]);
+    expect(outWrites).toEqual([]);
+  });
+});
+
+describe('Issue #1489 — CLI surface', () => {
+  let stderr: string[];
+  let restore: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRefresh.mockResolvedValue(undefined);
+    stderr = [];
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(chunk => {
+      stderr.push(String(chunk));
+      return true;
+    });
+    restore = () => spy.mockRestore();
+  });
+
+  afterEach(() => restore());
+
+  it('runs the refresh command under its canonical name, silently', async () => {
+    const { runAgentFarm } = await import('../cli.js');
+
+    await runAgentFarm(['refresh', '1273', '--note', 'rebase first']);
+
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+    expect(mockRefresh.mock.calls[0][0]).toMatchObject({
+      builder: '1273',
+      note: 'rebase first',
+    });
+    expect(stderr.join('')).not.toMatch(/renamed/);
+  });
+
+  it('still runs under the deprecated `reset` spelling, with the same arguments', async () => {
+    const { runAgentFarm } = await import('../cli.js');
+
+    await runAgentFarm(['reset', '1273', '--note', 'rebase first']);
+
+    // Identical call, not a degraded one: the alias is a spelling, not a mode.
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+    expect(mockRefresh.mock.calls[0][0]).toMatchObject({
+      builder: '1273',
+      note: 'rebase first',
+    });
+  });
+
+  it('prints the deprecation notice once when the alias is used', async () => {
+    const { runAgentFarm } = await import('../cli.js');
+    const { RESET_ALIAS_NOTICE } = await import('../commands/reset.js');
+
+    await runAgentFarm(['reset', '1273']);
+
+    const emitted = stderr.filter(line => line.includes(RESET_ALIAS_NOTICE));
+    expect(emitted).toHaveLength(1);
+  });
+
+  it('forwards every safety-gate flag through the alias unchanged', async () => {
+    // The alias shares one action body with the canonical command. If it ever
+    // grows its own copy, the flag validation that guards R2/R4 could drift on
+    // one side and silently disable a gate for whoever still types `reset`.
+    const { runAgentFarm } = await import('../cli.js');
+
+    await runAgentFarm([
+      'reset',
+      '1273',
+      '--dry-run',
+      '--interrupt-first',
+      '--mode',
+      'soft',
+      '--timeout',
+      '600',
+      '--min-bytes',
+      '2000',
+      '--quiet-window',
+      '3000',
+    ]);
+
+    expect(mockRefresh.mock.calls[0][0]).toMatchObject({
+      builder: '1273',
+      dryRun: true,
+      interruptFirst: true,
+      mode: 'soft',
+      timeout: 600,
+      minBytes: 2000,
+      quietWindow: 3000,
+    });
+  });
+
+  it('lists refresh as a command and marks reset deprecated in --help', async () => {
+    // Help text is where the next architect learns which spelling to type.
+    const { runAgentFarm } = await import('../cli.js');
+    const out: string[] = [];
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation(chunk => {
+      out.push(String(chunk));
+      return true;
+    });
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit');
+    }) as never);
+
+    try {
+      await runAgentFarm(['--help']);
+    } catch {
+      // Commander exits after printing help.
+    } finally {
+      spy.mockRestore();
+      exit.mockRestore();
+    }
+
+    const help = out.join('');
+    expect(help).toMatch(/^\s+refresh \[options\] \[builder\]/m);
+    expect(help).toMatch(/^\s+reset \[options\] \[builder\]/m);
+    // The canonical spelling must come first, so a skim lands on it.
+    expect(help.indexOf('refresh [options]')).toBeLessThan(help.indexOf('reset [options]'));
+    expect(help).toMatch(/\[deprecated\] Alias for 'afx refresh'/);
+  });
+});

--- a/packages/codev/src/agent-farm/__tests__/bugfix-1267-launch-loop.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-1267-launch-loop.test.ts
@@ -141,12 +141,12 @@ describe('buildLaunchLoop — clean exit reruns fresh (Bugfix #1267)', () => {
     expect(invocations[1]).toBe('--append-system-prompt|two words|');
   });
 
-  // `afx reset` refuses to type into a builder whose harness it cannot name, and
+  // `afx refresh` refuses to type into a builder whose harness it cannot name, and
   // it names it by scanning `.builder-start.sh` for a command-position harness
   // binary. The dual-launcher shape adds `codev_launch=…` / `"$codev_launch"`
   // lines that scanner has never seen — this is the guard that they neither
   // shadow the real harness line nor get mistaken for one.
-  it('stays identifiable to afx reset harness detection', () => {
+  it('stays identifiable to afx refresh harness detection', () => {
     const loop = buildLaunchLoop(
       "claude --model opus --resume 'abc'",
       `claude --model opus --append-system-prompt "$(cat '/wt/.builder-role.md')"`,

--- a/packages/codev/src/agent-farm/__tests__/pir-1233-session-launch-loop.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/pir-1233-session-launch-loop.test.ts
@@ -231,7 +231,7 @@ done
 });
 
 describe('PIR #1233 — downstream consumers of the generated script', () => {
-  it('afx reset still identifies the claude harness from the session-aware script', () => {
+  it('afx refresh still identifies the claude harness from the session-aware script', () => {
     const loop = buildLoop('claude');
     const script = `#!/bin/bash\ncd '${dir}'\n${loop}`;
     const fs = {

--- a/packages/codev/src/agent-farm/__tests__/pty-last-data-at.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/pty-last-data-at.test.ts
@@ -100,7 +100,7 @@ describe('PtySession.lastDataAt (Spec 467)', () => {
  * Spec 1273: the tracking above has existed since Spec 467, but only as an
  * in-process getter — it never reached `info`, which is what
  * `GET /api/terminals/:id` serialises. Without it on the wire, a client cannot
- * measure output quiescence and `afx reset` would have to *assume* a builder's
+ * measure output quiescence and `afx refresh` would have to *assume* a builder's
  * turn had ended before typing `/clear` into its terminal. Invariant R4 requires
  * measuring instead of assuming, so these tests pin the field's presence on the
  * serialised shape, not merely on the class.
@@ -161,7 +161,7 @@ describe('PtySession.info.lastDataAt (Spec 1273 — quiescence on the wire)', ()
 /**
  * PtySessionInfo.writable (Spec 1273)
  *
- * `afx reset` preflights on this field so it refuses a terminal it cannot write
+ * `afx refresh` preflights on this field so it refuses a terminal it cannot write
  * to before touching anything. That only works if `writable` is actually
  * SERIALISED — the getter existed since #1198 but never reached `info`, so no
  * client could see it.

--- a/packages/codev/src/agent-farm/__tests__/spawn-worktree.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/spawn-worktree.test.ts
@@ -377,7 +377,7 @@ describe('spawn-worktree', () => {
       expect(launcherBody(script!, 'entry')).toBe("claude --resume 'abc-1234-uuid'");
       expect(script).not.toContain('--resume,');
       expect(script).toContain('while true');
-      // Resume never rewrites the prompt file: `afx reset` reads the spawn-time
+      // Resume never rewrites the prompt file: `afx refresh` reads the spawn-time
       // `## Mode:` heading out of it, and it cannot be regenerated faithfully.
       const writeCalls = vi.mocked(writeFileSync).mock.calls;
       const promptCall = writeCalls.find(

--- a/packages/codev/src/agent-farm/__tests__/spec-1273-reset-command.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/spec-1273-reset-command.test.ts
@@ -1,5 +1,5 @@
 /**
- * `afx reset` command surface — Spec 1273, phase 6.
+ * `afx refresh` command surface — Spec 1273, phase 6 (renamed from `reset` by #1489).
  *
  * The orchestrator tests prove the state machine's ordering. These prove the
  * WRAPPER: that the right things are bound to the right ports and the target is
@@ -111,7 +111,7 @@ const BUILDER = {
   taskText: undefined,
 };
 
-describe('afx reset — command surface (Spec 1273)', () => {
+describe('afx refresh — command surface (Spec 1273)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsRunning.mockResolvedValue(true);
@@ -137,30 +137,30 @@ describe('afx reset — command surface (Spec 1273)', () => {
   // ==========================================================================
 
   it('resolves the target through the shared resolver, not an exact-id lookup', async () => {
-    // `getBuilder` matches the id EXACTLY. Using it meant `afx reset 1273`
+    // `getBuilder` matches the id EXACTLY. Using it meant `afx refresh 1273`
     // failed against a builder registered as `aspir-1273` while `afx send 1273`
     // reached it fine — a command the architect cannot address the way they
     // already type addresses is one that gets typed wrong under pressure.
-    const { reset } = await import('../commands/reset.js');
+    const { refresh } = await import('../commands/reset.js');
 
-    await reset({ builder: '1273' });
+    await refresh({ builder: '1273' });
 
     expect(mockFindBuilderById).toHaveBeenCalledWith('1273');
   });
 
   it('aborts when the target cannot be resolved or is ambiguous', async () => {
     mockFindBuilderById.mockReturnValue(null);
-    const { reset } = await import('../commands/reset.js');
+    const { refresh } = await import('../commands/reset.js');
 
-    await expect(reset({ builder: 'nope' })).rejects.toThrow(/FATAL/);
+    await expect(refresh({ builder: 'nope' })).rejects.toThrow(/FATAL/);
     expect(mockRunReset).not.toHaveBeenCalled();
   });
 
   it('refuses a registry row missing the worktree or branch', async () => {
     mockFindBuilderById.mockReturnValue({ ...BUILDER, worktree: '' });
-    const { reset } = await import('../commands/reset.js');
+    const { refresh } = await import('../commands/reset.js');
 
-    await expect(reset({ builder: '1273' })).rejects.toThrow(/incomplete registry row/);
+    await expect(refresh({ builder: '1273' })).rejects.toThrow(/incomplete registry row/);
     expect(mockRunReset).not.toHaveBeenCalled();
   });
 
@@ -169,8 +169,8 @@ describe('afx reset — command surface (Spec 1273)', () => {
   // ==========================================================================
 
   it('binds /clear to Tower\'s raw channel, and ESC to its escape channel', async () => {
-    const { reset } = await import('../commands/reset.js');
-    await reset({ builder: '1273' });
+    const { refresh } = await import('../commands/reset.js');
+    await refresh({ builder: '1273' });
 
     const terminal = mockRunReset.mock.calls[0][0].terminal;
 
@@ -191,8 +191,8 @@ describe('afx reset — command surface (Spec 1273)', () => {
   });
 
   it('sends the save request and re-orientation as formatted messages', async () => {
-    const { reset } = await import('../commands/reset.js');
-    await reset({ builder: '1273' });
+    const { refresh } = await import('../commands/reset.js');
+    await refresh({ builder: '1273' });
 
     const terminal = mockRunReset.mock.calls[0][0].terminal;
     await terminal.sendMessage('save your state');
@@ -207,8 +207,8 @@ describe('afx reset — command surface (Spec 1273)', () => {
     // "unobservable" and refuses to clear; collapsing it to 0 at this boundary
     // would defeat that check before the orchestrator ever saw it.
     mockGetTerminal.mockResolvedValue({ id: 'term-1', status: 'running' });
-    const { reset } = await import('../commands/reset.js');
-    await reset({ builder: '1273' });
+    const { refresh } = await import('../commands/reset.js');
+    await refresh({ builder: '1273' });
 
     const terminal = mockRunReset.mock.calls[0][0].terminal;
     await expect(terminal.observe()).resolves.toEqual({ exists: true, lastDataAt: undefined });
@@ -223,8 +223,8 @@ describe('afx reset — command surface (Spec 1273)', () => {
       total: 2,
       hasMore: false,
     });
-    const { reset } = await import('../commands/reset.js');
-    await reset({ builder: '1273' });
+    const { refresh } = await import('../commands/reset.js');
+    await refresh({ builder: '1273' });
 
     const terminal = mockRunReset.mock.calls[0][0].terminal;
     expect(terminal.readOutput).toBeDefined();
@@ -238,8 +238,8 @@ describe('afx reset — command surface (Spec 1273)', () => {
     // Confirmation is advisory: an older Tower or a 404 must degrade to
     // "unconfirmed", never fail the reset that already succeeded.
     mockGetTerminalOutput.mockResolvedValue(null);
-    const { reset } = await import('../commands/reset.js');
-    await reset({ builder: '1273' });
+    const { refresh } = await import('../commands/reset.js');
+    await refresh({ builder: '1273' });
 
     const terminal = mockRunReset.mock.calls[0][0].terminal;
     await expect(terminal.readOutput()).resolves.toBeNull();
@@ -247,8 +247,8 @@ describe('afx reset — command surface (Spec 1273)', () => {
 
   it('reports a non-running terminal as absent', async () => {
     mockGetTerminal.mockResolvedValue({ id: 'term-1', status: 'exited' });
-    const { reset } = await import('../commands/reset.js');
-    await reset({ builder: '1273' });
+    const { refresh } = await import('../commands/reset.js');
+    await refresh({ builder: '1273' });
 
     const terminal = mockRunReset.mock.calls[0][0].terminal;
     await expect(terminal.observe()).resolves.toEqual({ exists: false });
@@ -262,22 +262,22 @@ describe('afx reset — command surface (Spec 1273)', () => {
     // The flag is documented in seconds; the orchestrator takes ms. An
     // unconverted 300 would make the receipt wait 0.3s instead of 5 minutes and
     // abort against every real builder.
-    const { reset } = await import('../commands/reset.js');
-    await reset({ builder: '1273', timeout: 300 });
+    const { refresh } = await import('../commands/reset.js');
+    await refresh({ builder: '1273', timeout: 300 });
 
     expect(mockRunReset.mock.calls[0][0].receiptTimeoutMs).toBe(300_000);
   });
 
   it('passes --note through as the addendum', async () => {
-    const { reset } = await import('../commands/reset.js');
-    await reset({ builder: '1273', note: 'Ignore the stale PR comment.' });
+    const { refresh } = await import('../commands/reset.js');
+    await refresh({ builder: '1273', note: 'Ignore the stale PR comment.' });
 
     expect(mockRunReset.mock.calls[0][0].addendum).toBe('Ignore the stale PR comment.');
   });
 
   it('forwards --dry-run and --interrupt-first', async () => {
-    const { reset } = await import('../commands/reset.js');
-    await reset({ builder: '1273', dryRun: true, interruptFirst: true });
+    const { refresh } = await import('../commands/reset.js');
+    await refresh({ builder: '1273', dryRun: true, interruptFirst: true });
 
     const opts = mockRunReset.mock.calls[0][0];
     expect(opts.dryRun).toBe(true);
@@ -290,24 +290,24 @@ describe('afx reset — command surface (Spec 1273)', () => {
 
   it('rejects a gate-disabling numeric option before runReset is called', async () => {
     // The CLI layer validates first, but the wrapper is also reachable
-    // programmatically, and `reset()` must not forward a value that would
+    // programmatically, and `refresh()` must not forward a value that would
     // silently switch off R2 or R4. The orchestrator's own guard is what
     // enforces it; this asserts the wrapper does not swallow that refusal and
     // report success anyway.
     mockRunReset.mockRejectedValue(
       Object.assign(new Error('Invalid quietWindowMs: -1.'), { name: 'ResetPreflightError' }),
     );
-    const { reset } = await import('../commands/reset.js');
+    const { refresh } = await import('../commands/reset.js');
 
-    await expect(reset({ builder: '1273', quietWindow: -1 })).rejects.toThrow(/FATAL/);
+    await expect(refresh({ builder: '1273', quietWindow: -1 })).rejects.toThrow(/FATAL/);
   });
 
   it('omits an unset numeric option rather than passing NaN or zero', async () => {
     // `options.timeout ? ... : undefined` on an absent flag must yield
     // undefined so the orchestrator's own default applies. Passing 0 or NaN
     // here would disable the gate the default exists to enforce.
-    const { reset } = await import('../commands/reset.js');
-    await reset({ builder: '1273' });
+    const { refresh } = await import('../commands/reset.js');
+    await refresh({ builder: '1273' });
 
     const opts = mockRunReset.mock.calls[0][0];
     expect(opts.receiptTimeoutMs).toBeUndefined();
@@ -326,9 +326,9 @@ describe('afx reset — command surface (Spec 1273)', () => {
       saveRequest: 'save request text',
     });
     const previous = process.exitCode;
-    const { reset } = await import('../commands/reset.js');
+    const { refresh } = await import('../commands/reset.js');
 
-    await reset({ builder: '1273' });
+    await refresh({ builder: '1273' });
 
     expect(process.exitCode).toBe(1);
     process.exitCode = previous;

--- a/packages/codev/src/agent-farm/__tests__/spec-1273-reset-context.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/spec-1273-reset-context.test.ts
@@ -621,7 +621,7 @@ describe('mode resolution for the ad-hoc task lane (Spec 1273 F2)', () => {
   }
 
   it('defaults a no-porch builder to soft instead of hard-erroring', () => {
-    // Before this, `afx reset <task-builder>` could not run at all without an
+    // Before this, `afx refresh <task-builder>` could not run at all without an
     // explicit --mode: task spawns never render the `## Mode:` line.
     const ctx = resolveBuilderContext({
       fs: taskWorktree(),

--- a/packages/codev/src/agent-farm/__tests__/spec-1273-reset-orchestrator.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/spec-1273-reset-orchestrator.test.ts
@@ -130,12 +130,14 @@ function makeFs(script: {
 const CURRENT_NONCE = { value: '' };
 
 /**
- * What the terminal already contains before the clear: reset's own messages.
+ * What the terminal already contains before the clear: the refresh's own messages.
  *
- * Deliberately includes the save request's "CONTEXT RESET INCOMING" header,
- * because that string matches the confirmation pattern. If the window logic
- * regresses, these lines leak into the check and confirmation goes true for the
- * wrong reason — which is exactly the bug this models.
+ * The first line deliberately matches the confirmation pattern. Until #1489 the
+ * save request literally opened "CONTEXT RESET INCOMING", which is how this
+ * false-positive was found; the header now reads "CONTEXT REFRESH" and no longer
+ * collides. The window logic must not depend on that luck — anything in the
+ * pre-clear window has to be excluded by construction — so the fixture keeps a
+ * colliding line.
  */
 const PRE_CLEAR_BUFFER = [
   'CONTEXT RESET INCOMING — save your working state now.',
@@ -263,7 +265,7 @@ describe('Spec 1273 — reset orchestrator: happy path', () => {
     // Two messages: the save request, then the re-orientation.
     expect(terminal.messages).toHaveLength(2);
     expect(terminal.messages[0]).toContain('.builder-state.md');
-    expect(terminal.messages[1]).toContain('CONTEXT RESET');
+    expect(terminal.messages[1]).toContain('CONTEXT REFRESH');
   });
 
   it('delivers /clear down the RAW channel, never the escape channel', async () => {
@@ -273,7 +275,7 @@ describe('Spec 1273 — reset orchestrator: happy path', () => {
     // escape channel sends an interrupt instead of typing `/clear`. Every
     // observable signal would still look like success: the send returns ok, the
     // terminal goes quiet (an ESC ends the turn), the re-orientation arrives.
-    // The only thing that would not happen is the reset.
+    // The only thing that would not happen is the clear.
     const terminal = makeTerminal({ quietness: QUIET });
     const result = await runReset(baseOptions({ terminal }) as never);
 
@@ -295,16 +297,16 @@ describe('Spec 1273 — reset orchestrator: happy path', () => {
     expect(names(result.steps)).not.toContain('clear-confirmed');
   });
 
-  it('does NOT match reset\'s own save-request text still sitting in the buffer', async () => {
-    // The save request opens with "CONTEXT RESET INCOMING", which matches the
-    // confirmation pattern. It is in the buffer on every run because reset put
-    // it there moments earlier. Scanning the whole buffer therefore confirmed
-    // the clear using reset's own words — the second false-positive in this
-    // check, after the echoed `/clear`.
+  it('does NOT match text already sitting in the buffer before the clear', async () => {
+    // Pre-#1489 the save request opened with "CONTEXT RESET INCOMING", which
+    // matches the confirmation pattern, and it was in the buffer on every run
+    // because the command put it there moments earlier. Scanning the whole
+    // buffer therefore confirmed the clear using the command's own words — the
+    // second false-positive in this check, after the echoed `/clear`.
     //
     // The fix is structural rather than a better regex: only output produced
-    // AFTER the clear is considered, so anything reset wrote is excluded by
-    // construction. PRE_CLEAR_BUFFER carries that exact header.
+    // AFTER the clear is considered, so anything the command wrote is excluded
+    // by construction. PRE_CLEAR_BUFFER carries a line that would still match.
     const terminal = makeTerminal({ quietness: QUIET, recentOutput: '> ' });
     const result = await runReset(baseOptions({ terminal }) as never);
 
@@ -635,7 +637,7 @@ describe('Spec 1273 — CLI-facing behaviour', () => {
     // Not even the long-form file: a dry run must not alter the worktree either.
     expect(fs.writes).toHaveLength(0);
     // But it still proves assembly succeeded — that is the point of the run.
-    expect(result.payload?.inline).toContain('CONTEXT RESET');
+    expect(result.payload?.inline).toContain('CONTEXT REFRESH');
   });
 
   it('places the addendum in the delivered payload', async () => {

--- a/packages/codev/src/agent-farm/__tests__/spec-1273-wait-discipline-docs.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/spec-1273-wait-discipline-docs.test.ts
@@ -29,6 +29,12 @@ const COMMAND_DOCS = [
   'codev-skeleton/resources/commands/agent-farm.md',
 ];
 const SKILL_DOCS = ['.claude/skills/afx/SKILL.md', '.codex/skills/afx/SKILL.md'];
+// The skeleton twins — what ADOPTERS install, as opposed to the two above, which
+// only this workspace's agents ever read.
+const SKELETON_SKILL_DOCS = [
+  'codev-skeleton/.claude/skills/afx/SKILL.md',
+  'codev-skeleton/.codex/skills/afx/SKILL.md',
+];
 
 describe('Spec 1273 phase 7 — wait discipline reaches the builder role doc', () => {
   for (const doc of ROLE_DOCS) {
@@ -125,6 +131,40 @@ describe('Spec 1273 phase 7 — both skill trees, not just the Claude one', () =
 
   it('keeps the two skill trees byte-identical', () => {
     const [claude, codex] = SKILL_DOCS.map(read);
+    expect(claude).toBe(codex);
+  });
+});
+
+describe('#1489 — the SKELETON skill trees, which are what adopters install', () => {
+  // Found during #1489 and fixed there. Spec 1273 added `afx interrupt` and the
+  // context-refresh command to the four doc trees it knew about, but the two
+  // skeleton skill files were not among them: they sat at a pre-1273 revision
+  // whose headings stopped at `afx cron`. Nothing failed, because the assertions
+  // above only ever looked at the ROOT skill trees — so adopters could not
+  // discover either command, and no test could see that they could not.
+  //
+  // This is the same class of defect the file was written to catch, one tree
+  // further out. Asserting the skeleton copies closes the gap.
+  for (const doc of SKELETON_SKILL_DOCS) {
+    it(`${doc} lists afx refresh and afx interrupt`, () => {
+      expect(existsSync(resolve(REPO, doc))).toBe(true);
+      const text = read(doc);
+      expect(text).toContain('## afx refresh');
+      expect(text).toContain('## afx interrupt');
+    });
+
+    it(`${doc} leads with refresh and marks reset deprecated, not the reverse`, () => {
+      // An adopter reading this file must come away typing `afx refresh`. A
+      // stale copy that documents `afx reset` as the command would teach the
+      // spelling we are retiring.
+      const text = read(doc);
+      expect(text).not.toContain('## afx reset');
+      expect(text).toMatch(/`afx reset` is a deprecated alias/);
+    });
+  }
+
+  it('keeps the two skeleton skill trees byte-identical', () => {
+    const [claude, codex] = SKELETON_SKILL_DOCS.map(read);
     expect(claude).toBe(codex);
   });
 });

--- a/packages/codev/src/agent-farm/__tests__/spec-1273-wait-discipline-docs.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/spec-1273-wait-discipline-docs.test.ts
@@ -58,7 +58,7 @@ describe('Spec 1273 phase 7 — wait discipline reaches the builder role doc', (
       it('names the escape hatch so a stuck builder knows it can be reached', () => {
         const text = read(doc);
         expect(text).toContain('afx interrupt');
-        expect(text).toContain('afx reset');
+        expect(text).toContain('afx refresh');
       });
     });
   }
@@ -76,13 +76,13 @@ describe('Spec 1273 phase 7 — wait discipline reaches the builder role doc', (
 describe('Spec 1273 phase 7 — both commands are documented where they are looked up', () => {
   for (const doc of COMMAND_DOCS) {
     describe(doc, () => {
-      it('documents afx reset and afx interrupt', () => {
+      it('documents afx refresh and afx interrupt', () => {
         const text = read(doc);
-        expect(text).toContain('### afx reset');
+        expect(text).toContain('### afx refresh');
         expect(text).toContain('### afx interrupt');
       });
 
-      it('documents every reset flag the CLI accepts', () => {
+      it('documents every refresh flag the CLI accepts', () => {
         // Kept in sync with cli.ts's registration by hand; a flag that exists
         // and is undocumented is a flag nobody uses.
         const text = read(doc);
@@ -112,13 +112,13 @@ describe('Spec 1273 phase 7 — both commands are documented where they are look
 
 describe('Spec 1273 phase 7 — both skill trees, not just the Claude one', () => {
   for (const doc of SKILL_DOCS) {
-    it(`${doc} lists afx reset and afx interrupt`, () => {
+    it(`${doc} lists afx refresh and afx interrupt`, () => {
       // The repo maintains parallel Claude and Codex skill trees. Updating only
       // the Claude one leaves Codex-driven agents unable to discover the
-      // commands — they would have no reason to believe reset exists.
+      // commands — they would have no reason to believe refresh exists.
       expect(existsSync(resolve(REPO, doc))).toBe(true);
       const text = read(doc);
-      expect(text).toContain('## afx reset');
+      expect(text).toContain('## afx refresh');
       expect(text).toContain('## afx interrupt');
     });
   }

--- a/packages/codev/src/agent-farm/__tests__/tower-routes.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tower-routes.test.ts
@@ -1018,7 +1018,7 @@ describe('tower-routes', () => {
 
   describe('GET /api/terminals/:id (Spec 1273 — lastDataAt on the wire)', () => {
     // Testing `session.info` alone would not pin this: the whole point of the
-    // phase is that the field reaches a *client*, so afx reset can measure
+    // phase is that the field reaches a *client*, so afx refresh can measure
     // output quiescence instead of assuming a builder's turn has ended before
     // typing /clear into its terminal. This asserts the serialised response.
     it('serialises lastDataAt as an epoch-ms number', async () => {

--- a/packages/codev/src/agent-farm/cli.ts
+++ b/packages/codev/src/agent-farm/cli.ts
@@ -508,57 +508,77 @@ export async function runAgentFarm(args: string[]): Promise<void> {
       }
     });
 
-  // Reset command (Spec 1273) — save-state → /clear → re-orient
-  program
-    .command('reset [builder]')
-    .description('Reset a builder\'s context: save working state, clear, then re-orient')
-    .option('--note <text>', 'Extra context to append to the re-orientation')
-    .option('--file <path>', 'Append file content to the re-orientation (48KB max)')
-    .option('--dry-run', 'Print what would be sent; write nothing to the builder')
-    .option('--interrupt-first', 'Send ESC before the save request (for a builder wedged mid-turn)')
-    .option('--mode <mode>', 'Override the builder mode (strict|soft) if it cannot be detected')
-    .option('--timeout <seconds>', 'How long to wait for the save-state receipt')
-    .option('--min-bytes <n>', 'Minimum state-file size to accept as substantive')
-    .option('--quiet-window <ms>', 'Terminal silence that counts as turn-ended')
-    .action(async (builder, options) => {
-      const { reset } = await import('./commands/reset.js');
-      try {
-        if (options.mode && options.mode !== 'strict' && options.mode !== 'soft') {
-          logger.error(`--mode must be 'strict' or 'soft', got '${options.mode}'`);
-          process.exit(1);
-        }
-        // Every one of these tunes a SAFETY GATE, so a bad value does not
-        // degrade the run — it disables a protection while still reporting
-        // success. `--quiet-window -1` makes the quiescence check pass
-        // instantly (R4 gone), `--min-bytes -1` accepts any state file however
-        // empty (R2's substance floor gone), and a non-numeric `--timeout`
-        // yields NaN, whose comparisons are all false, so the receipt wait
-        // never expires and the command hangs. Reject at the boundary.
-        const positiveInt = (raw: string | undefined, flag: string): number | undefined => {
-          if (raw === undefined) return undefined;
-          const parsed = Number(raw);
-          if (!Number.isInteger(parsed) || parsed <= 0) {
-            logger.error(`${flag} must be a positive integer, got '${raw}'`);
+  // Refresh command (Spec 1273; renamed from `reset` by #1489) —
+  // save-state → /clear → re-orient.
+  //
+  // Registered TWICE, canonical name first so `--help` leads with it. Commander's
+  // `.alias()` would hide which spelling the caller typed, and the deprecated
+  // spelling has to announce itself — so the alias is its own registration over
+  // the same builder.
+  const registerRefresh = (name: string, description: string, deprecated: boolean) => {
+    program
+      .command(`${name} [builder]`)
+      .description(description)
+      .option('--note <text>', 'Extra context to append to the re-orientation')
+      .option('--file <path>', 'Append file content to the re-orientation (48KB max)')
+      .option('--dry-run', 'Print what would be sent; write nothing to the builder')
+      .option('--interrupt-first', 'Send ESC before the save request (for a builder wedged mid-turn)')
+      .option('--mode <mode>', 'Override the builder mode (strict|soft) if it cannot be detected')
+      .option('--timeout <seconds>', 'How long to wait for the save-state receipt')
+      .option('--min-bytes <n>', 'Minimum state-file size to accept as substantive')
+      .option('--quiet-window <ms>', 'Terminal silence that counts as turn-ended')
+      .action(async (builder, options) => {
+        const { refresh, warnResetAlias } = await import('./commands/reset.js');
+        if (deprecated) warnResetAlias();
+        try {
+          if (options.mode && options.mode !== 'strict' && options.mode !== 'soft') {
+            logger.error(`--mode must be 'strict' or 'soft', got '${options.mode}'`);
             process.exit(1);
           }
-          return parsed;
-        };
-        await reset({
-          builder,
-          note: options.note,
-          file: options.file,
-          dryRun: options.dryRun,
-          interruptFirst: options.interruptFirst,
-          mode: options.mode,
-          timeout: positiveInt(options.timeout, '--timeout'),
-          minBytes: positiveInt(options.minBytes, '--min-bytes'),
-          quietWindow: positiveInt(options.quietWindow, '--quiet-window'),
-        });
-      } catch (error) {
-        logger.error(error instanceof Error ? error.message : String(error));
-        process.exit(1);
-      }
-    });
+          // Every one of these tunes a SAFETY GATE, so a bad value does not
+          // degrade the run — it disables a protection while still reporting
+          // success. `--quiet-window -1` makes the quiescence check pass
+          // instantly (R4 gone), `--min-bytes -1` accepts any state file however
+          // empty (R2's substance floor gone), and a non-numeric `--timeout`
+          // yields NaN, whose comparisons are all false, so the receipt wait
+          // never expires and the command hangs. Reject at the boundary.
+          const positiveInt = (raw: string | undefined, flag: string): number | undefined => {
+            if (raw === undefined) return undefined;
+            const parsed = Number(raw);
+            if (!Number.isInteger(parsed) || parsed <= 0) {
+              logger.error(`${flag} must be a positive integer, got '${raw}'`);
+              process.exit(1);
+            }
+            return parsed;
+          };
+          await refresh({
+            builder,
+            note: options.note,
+            file: options.file,
+            dryRun: options.dryRun,
+            interruptFirst: options.interruptFirst,
+            mode: options.mode,
+            timeout: positiveInt(options.timeout, '--timeout'),
+            minBytes: positiveInt(options.minBytes, '--min-bytes'),
+            quietWindow: positiveInt(options.quietWindow, '--quiet-window'),
+          });
+        } catch (error) {
+          logger.error(error instanceof Error ? error.message : String(error));
+          process.exit(1);
+        }
+      });
+  };
+
+  registerRefresh(
+    'refresh',
+    'Refresh a builder\'s context: save working state, clear, then re-orient',
+    false,
+  );
+  registerRefresh(
+    'reset',
+    '[deprecated] Alias for \'afx refresh\'; will be removed in a future release',
+    true,
+  );
 
   // Bench command - consultation benchmarking
   program

--- a/packages/codev/src/agent-farm/commands/reset.ts
+++ b/packages/codev/src/agent-farm/commands/reset.ts
@@ -1,5 +1,5 @@
 /**
- * `afx reset` — the command surface over the reset state machine (Spec 1273).
+ * `afx refresh` — the command surface over the refresh state machine (Spec 1273).
  *
  * This file is deliberately thin. It does three things and nothing else:
  * resolves the target, binds REAL implementations to the orchestrator's ports,
@@ -7,7 +7,7 @@
  * lives in `reset/index.ts`, where it is testable without Tower, a PTY, or a
  * live builder.
  *
- * That split is the point. The dangerous part of reset is the ordering, and
+ * That split is the point. The dangerous part of a refresh is the ordering, and
  * ordering is only provable if the thing that decides it has no I/O in it.
  *
  * Addressing, workspace detection and sender identity are reused verbatim from
@@ -41,13 +41,33 @@ import type { ResetOptions } from '../types.js';
 /** Same cap `afx send --file` enforces. One rule for architect-supplied files. */
 const MAX_FILE_SIZE = 48 * 1024;
 
-export async function reset(options: ResetOptions): Promise<void> {
+/**
+ * The one-line notice `afx reset` prints before doing the work (#1489).
+ *
+ * Exported so the deprecation is pinned by a test rather than by whoever
+ * happens to read the CLI wiring: an alias that stops announcing itself is an
+ * alias nobody migrates off, and this one is scheduled for removal.
+ */
+export const RESET_ALIAS_NOTICE =
+  'afx reset has been renamed to afx refresh; this alias will be removed in a future release';
+
+/**
+ * Announce the deprecated spelling on **stderr**.
+ *
+ * stdout carries the run report, which is read by humans and occasionally piped;
+ * a deprecation line does not belong in it.
+ */
+export function warnResetAlias(): void {
+  process.stderr.write(`${RESET_ALIAS_NOTICE}\n`);
+}
+
+export async function refresh(options: ResetOptions): Promise<void> {
   const target = options.builder;
   if (!target) {
-    fatal('Must specify a builder. Usage: afx reset <builder>');
+    fatal('Must specify a builder. Usage: afx refresh <builder>');
   }
 
-  logger.header('Builder Context Reset');
+  logger.header('Builder Context Refresh');
 
   const workspace = detectWorkspaceRoot() ?? undefined;
 
@@ -59,23 +79,23 @@ export async function reset(options: ResetOptions): Promise<void> {
   }
 
   // `findBuilderById`, NOT `getBuilder`: the latter matches the id EXACTLY, so
-  // `afx reset 1273` would fail against a builder registered as `aspir-1273`
-  // while `afx send 1273` reached it fine. Reset must resolve targets the same
-  // way every other builder-addressed command does — a reset that cannot be
-  // addressed the way the architect already types addresses is a reset that
+  // `afx refresh 1273` would fail against a builder registered as `aspir-1273`
+  // while `afx send 1273` reached it fine. Refresh must resolve targets the same
+  // way every other builder-addressed command does — a refresh that cannot be
+  // addressed the way the architect already types addresses is one that
   // gets typed wrong under pressure. `findBuilderById` also reports AMBIGUOUS
   // with the candidate list rather than silently picking one.
   const builder = findBuilderById(target);
   if (!builder) {
     fatal(
       `No builder '${target}' in this workspace (or the id is ambiguous — see above). ` +
-        `Check 'afx status'. Reset needs the registry row for the worktree and branch.`,
+        `Check 'afx status'. Refresh needs the registry row for the worktree and branch.`,
     );
   }
   if (!builder.worktree || !builder.branch) {
     fatal(
       `Builder '${target}' has an incomplete registry row (worktree='${builder.worktree}', ` +
-        `branch='${builder.branch}'). Refusing to reset against unresolved state.`,
+        `branch='${builder.branch}'). Refusing to refresh against unresolved state.`,
     );
   }
 
@@ -145,14 +165,14 @@ export async function reset(options: ResetOptions): Promise<void> {
     console.log(formatResetReport(result));
 
     if (result.outcome === 'aborted') {
-      // Non-zero: an aborted reset is a failure the caller must see, even though
+      // Non-zero: an aborted refresh is a failure the caller must see, even though
       // it is the SAFE outcome. Silence here would let a script treat "refused
       // to clear" as "cleared".
       process.exitCode = 1;
       return;
     }
 
-    logger.success(`Builder ${target} reset and re-oriented.`);
+    logger.success(`Builder ${target} refreshed and re-oriented.`);
     logger.info(`State file: ${result.statePath} (${result.stateBytes} bytes)`);
   } catch (err) {
     if (err instanceof ResetPreflightError) {
@@ -297,9 +317,9 @@ function buildAddendum(options: ResetOptions): string | undefined {
 /**
  * Fetch issue metadata for the long form, best-effort.
  *
- * A forge outage must not block a reset: phase 5 renders an explicit "could not
+ * A forge outage must not block a refresh: phase 5 renders an explicit "could not
  * be fetched" gap with a `gh issue view` recovery line, which is strictly better
- * than aborting a reset the architect needs, and strictly better than silently
+ * than aborting a refresh the architect needs, and strictly better than silently
  * omitting requirements.
  */
 async function fetchIssuePayload(

--- a/packages/codev/src/agent-farm/commands/reset/constants.ts
+++ b/packages/codev/src/agent-farm/commands/reset/constants.ts
@@ -1,5 +1,5 @@
 /**
- * Tunable parameters for `afx reset` (Spec 1273).
+ * Tunable parameters for `afx refresh` (Spec 1273).
  *
  * Every value here is overridable from the CLI. The defaults are grounded in
  * the one verified manual reset (shannon workspace, 2026-07-27), not guessed.

--- a/packages/codev/src/agent-farm/commands/reset/context.ts
+++ b/packages/codev/src/agent-farm/commands/reset/context.ts
@@ -1,5 +1,5 @@
 /**
- * Builder context resolution for `afx reset` (Spec 1273, phase 4).
+ * Builder context resolution for `afx refresh` (Spec 1273, phase 4).
  *
  * Invariant R3 requires a re-orientation carrying protocol, mode, worktree,
  * branch, project identity and porch re-entry. The first draft of the plan
@@ -140,7 +140,7 @@ export class ContextResolutionError extends Error {
  * one project directory. **This repo commits porch history to `main`**, so every
  * worktree inherits every project ever run — 203 of them at the time of writing.
  * The alphabetically-first is `0087-porch-timeout-termination-retries`, whose
- * protocol is `spider`, so `afx reset` resolved protocol "spider" for *every*
+ * protocol is `spider`, so `afx refresh` resolved protocol "spider" for *every*
  * builder and died on `Protocol "spider" has no builder-prompt.md`. It failed
  * loudly, which is why nothing was corrupted — but it failed for every lane.
  *
@@ -577,7 +577,7 @@ export function resolveBuilderContext(options: ResolveContextOptions): ResolvedB
   }
   if (!mode && isBareTask) {
     // A `--task` spawn writes a bare prompt with no `## Mode:` heading, so this
-    // lane could never auto-detect and every `afx reset <task>` hard-errored.
+    // lane could never auto-detect and every `afx refresh <task>` hard-errored.
     //
     // Defaulting to SOFT is not a guess dressed up as a fact: "strict" means
     // *porch orchestrates this builder*, and a builder with no porch project
@@ -615,7 +615,7 @@ export function resolveBuilderContext(options: ResolveContextOptions): ResolvedB
   }
   if (!harness.supportsContextReset) {
     throw new ContextResolutionError(
-      `Harness '${harnessName}' has no in-session context reset, so 'afx reset' cannot clear this ` +
+      `Harness '${harnessName}' has no in-session context reset, so 'afx refresh' cannot clear this ` +
         `builder's context. Only the claude harness supports it today. ` +
         `To give this builder a fresh window, stop it and respawn without --resume.`,
     );

--- a/packages/codev/src/agent-farm/commands/reset/index.ts
+++ b/packages/codev/src/agent-farm/commands/reset/index.ts
@@ -1,5 +1,5 @@
 /**
- * Reset orchestrator — the `afx reset` state machine (Spec 1273).
+ * Reset orchestrator — the `afx refresh` state machine (Spec 1273).
  *
  * Composes the verified parts from phases 1–5 into the flow the architect ran by
  * hand on 2026-07-27: request save-state → verify the receipt → wait for the
@@ -141,12 +141,12 @@ export interface TerminalPort {
    * Recent terminal output plus the buffer's total line count, for best-effort
    * clear confirmation. Null when this Tower cannot serve it.
    *
-   * `total` is what makes confirmation trustworthy. Reset writes into this same
-   * terminal — the save request, the re-orientation — so any pattern matched
-   * against the whole buffer eventually collides with reset's OWN text. (It did,
-   * twice: first the echoed `/clear`, then the save request's "CONTEXT RESET
-   * INCOMING" header.) Snapshotting `total` before the clear lets the check read
-   * only what the harness emitted AFTERWARDS.
+   * `total` is what makes confirmation trustworthy. A refresh writes into this
+   * same terminal — the save request, the re-orientation — so any pattern matched
+   * against the whole buffer eventually collides with its OWN text. (It did,
+   * twice: first the echoed `/clear`, then the save request's header, which read
+   * "CONTEXT RESET INCOMING" before #1489.) Snapshotting `total` before the clear
+   * lets the check read only what the harness emitted AFTERWARDS.
    */
   readOutput?(): Promise<{ lines: string[]; total: number } | null>;
 }
@@ -311,7 +311,7 @@ export async function runReset(options: RunResetOptions): Promise<ResetResult> {
   if (!context.harness.supportsContextReset) {
     throw new ResetPreflightError(
       `Builder '${context.builderId}' runs under the '${context.harnessName}' harness, ` +
-        `which has no in-session context reset. Reset is a no-op there — there is no ` +
+        `which has no in-session context reset. Refresh is a no-op there — there is no ` +
         `substitute mechanism. Use the boundary-recycle pattern instead: let the builder ` +
         `finish, then respawn with 'afx spawn <id> --resume'.`,
     );
@@ -320,7 +320,7 @@ export async function runReset(options: RunResetOptions): Promise<ResetResult> {
   const observed = await terminal.observe();
   if (!observed.exists) {
     throw new ResetPreflightError(
-      `Builder '${context.builderId}' has no live terminal. Reset writes to a running ` +
+      `Builder '${context.builderId}' has no live terminal. Refresh writes to a running ` +
         `session; there is nothing to clear. Check 'afx status'.`,
     );
   }
@@ -336,7 +336,7 @@ export async function runReset(options: RunResetOptions): Promise<ResetResult> {
   if (observed.writable === false) {
     throw new ResetPreflightError(
       `Builder '${context.builderId}' has a terminal that is not accepting input ` +
-        `(its process connection is down — #1198). Reset would send a save request that ` +
+        `(its process connection is down — #1198). Refresh would send a save request that ` +
         `is silently dropped. Nothing has been touched. Check Tower logs, or retry once ` +
         `the session reconnects.`,
     );
@@ -363,7 +363,7 @@ export async function runReset(options: RunResetOptions): Promise<ResetResult> {
   } catch (err) {
     if (err instanceof ReorientationAssemblyError) {
       throw new ResetPreflightError(
-        `Refusing to reset: ${err.message} The builder has not been touched.`,
+        `Refusing to refresh: ${err.message} The builder has not been touched.`,
       );
     }
     throw err;
@@ -698,9 +698,9 @@ async function confirmClear(terminal: TerminalPort, totalBeforeClear: number): P
     const output = await terminal.readOutput();
     if (!output) return false;
 
-    // Consider ONLY lines produced after the clear was sent. Everything reset
-    // itself wrote is at or before `totalBeforeClear`, so this excludes reset's
-    // own text by construction rather than by hoping the pattern avoids it.
+    // Consider ONLY lines produced after the clear was sent. Everything the
+    // refresh itself wrote is at or before `totalBeforeClear`, so this excludes
+    // its own text by construction rather than by hoping the pattern avoids it.
     const newLineCount = output.total - totalBeforeClear;
     if (newLineCount <= 0) return false;
     const fresh = output.lines.slice(-newLineCount).join('\n');

--- a/packages/codev/src/agent-farm/commands/reset/receipt.ts
+++ b/packages/codev/src/agent-farm/commands/reset/receipt.ts
@@ -1,7 +1,7 @@
 /**
  * The reset receipt gate — invariant R2 (Spec 1273).
  *
- * `afx reset` clears a builder's context, which is irreversible. The manual
+ * `afx refresh` clears a builder's context, which is irreversible. The manual
  * version of this flow guarded that step by eyeballing the state file ("ours was
  * 203 lines"). This module replaces the eyeball with evidence: a state file is
  * accepted only if it proves it is *this run's* save, is substantive, and has
@@ -75,7 +75,7 @@ export function nonceMarker(nonce: string): string {
  */
 export function buildSaveRequest(nonce: string, statePath: string): string {
   return [
-    'CONTEXT RESET INCOMING — save your working state now.',
+    'CONTEXT REFRESH INCOMING — save your working state now.',
     '',
     `Write your complete working state to \`${statePath}\` (untracked; do not stage or commit it).`,
     '',
@@ -95,7 +95,7 @@ export function buildSaveRequest(nonce: string, statePath: string): string {
     '5. **Open questions** — decisions you deferred, and what they hinge on.',
     '6. **Standing orders** — instructions from the architect you are still bound by,',
     '   including anything you were told NOT to do.',
-    '7. **Next concrete action** — the single thing to do first after the reset.',
+    '7. **Next concrete action** — the single thing to do first after the refresh.',
     '',
     'Do not summarise for brevity. A save that omits a standing order or a receipt',
     'costs more than a long file does. When the file is written, stop and wait.',
@@ -194,7 +194,7 @@ export function describeReceiptFailure(
     case 'missing':
       return `${statePath} was never written. The builder may not have read the request (if it is wedged mid-turn, retry with --interrupt-first).`;
     case 'wrong-nonce':
-      return `${statePath} exists (${observation.bytes} bytes) but does not carry this run's nonce — it is stale, left by an earlier reset. Refusing to clear on superseded state.`;
+      return `${statePath} exists (${observation.bytes} bytes) but does not carry this run's nonce — it is stale, left by an earlier refresh. Refusing to clear on superseded state.`;
     case 'too-small':
       return `${statePath} carries the nonce but is only ${observation.bytes} bytes (minimum ${minBytes}). That is a stub, not a working-state save. Override with --min-bytes if this is genuinely all there was.`;
     case 'still-growing':

--- a/packages/codev/src/agent-farm/commands/reset/reorient.ts
+++ b/packages/codev/src/agent-farm/commands/reset/reorient.ts
@@ -105,7 +105,7 @@ export class ReorientationAssemblyError extends Error {
  * silently shipping a frame that is missing it.
  */
 export const REQUIRED_INLINE_MARKERS = [
-  'CONTEXT RESET',
+  'CONTEXT REFRESH',
   'You are a Builder',
   // The spec requires the identity block to name WHICH role document governs
   // the builder, not merely that one does.
@@ -213,7 +213,7 @@ function buildInline(options: AssembleOptions): string {
   const { context: c, statePath, addendum } = options;
 
   const lines: string[] = [
-    '## CONTEXT RESET — re-orientation',
+    '## CONTEXT REFRESH — re-orientation',
     '',
     'Your conversation history was cleared. Everything you knew that was not written',
     'down is gone. Do not try to recall it; read the files below instead.',
@@ -381,9 +381,9 @@ function assembleLongFormDocument(options: AssembleOptions, promptBody: string):
   const { context: c, statePath, addendum, buildResumeNotice, issue } = options;
 
   const header = [
-    '<!-- Written by `afx reset` (Spec 1273). Untracked; regenerated on every reset. -->',
+    '<!-- Written by `afx refresh` (Spec 1273). Untracked; regenerated on every refresh. -->',
     '',
-    '# Re-orientation after context reset',
+    '# Re-orientation after context refresh',
     '',
     `Your conversation history was cleared deliberately, to give you a fresh window`,
     `without losing your working state. This file restores the protocol framing a`,

--- a/packages/codev/src/agent-farm/commands/spawn-worktree.ts
+++ b/packages/codev/src/agent-farm/commands/spawn-worktree.ts
@@ -1051,7 +1051,7 @@ export async function startBuilderSession(
 
   // Write the initial prompt to a file the launch command reads back.
   //
-  // Issue #1267: a resume must NOT rewrite it. `afx reset` reads the literal
+  // Issue #1267: a resume must NOT rewrite it. `afx refresh` reads the literal
   // `## Mode: STRICT|SOFT` heading out of this file as spawn-time ground truth
   // (reset/context.ts: modeFromBuilderPrompt) precisely *because* `--resume`
   // never regenerates it — `resolveMode` cannot recover a spawn-time `--soft`

--- a/packages/codev/src/agent-farm/servers/gate-profiles.ts
+++ b/packages/codev/src/agent-farm/servers/gate-profiles.ts
@@ -123,7 +123,7 @@ export interface AppIdentity {
  * launches — a builder run through `.builder-start.sh` whose `command` is the
  * shell, not the agent — resolve to `null` here; the delivery wiring (Phase 4)
  * supplies the resolved agent command for those (it already reads the launch
- * script to identify the harness, as `afx reset` does). Fail-safe by
+ * script to identify the harness, as `afx refresh` does). Fail-safe by
  * construction: an unresolved identity is held and surfaced, never guessed.
  */
 export function resolveProfile(identity: AppIdentity): GateProfile | null {

--- a/packages/codev/src/agent-farm/servers/mailbox-wiring.ts
+++ b/packages/codev/src/agent-farm/servers/mailbox-wiring.ts
@@ -143,7 +143,7 @@ export function resolveAgentForSession(
  * The classifier profile for a session, resolving the wrapped-launch case. A real
  * builder runs through `.builder-start.sh`, so `session.command` is the shell, not
  * the agent, and the pure {@link resolveProfile} returns `null`. We then read the
- * launch script (exactly as `afx reset` does) to recover the underlying harness
+ * launch script (exactly as `afx refresh` does) to recover the underlying harness
  * command and resolve against that. Still `null` → the delivery holds `no-profile`
  * (fail-safe by construction: an unknown agent is held and surfaced, never guessed
  * — this is what correctly trips on wrapper/boot/relaunch screens too).

--- a/packages/codev/src/agent-farm/servers/session-submit.ts
+++ b/packages/codev/src/agent-farm/servers/session-submit.ts
@@ -9,7 +9,7 @@
  * soon as the write was *scheduled*. So an awaited send resolved before its own
  * message had been submitted.
  *
- * In production (`afx reset`, 2026-07-31) that gap swallowed a `/clear`
+ * In production (`afx refresh`, 2026-07-31) that gap swallowed a `/clear`
  * entirely. Reset awaited the raw write of `/clear`, then wrote the
  * re-orientation — landing inside the 50ms window, into the same composer,
  * ahead of the Enter. One Enter then submitted both as a single message

--- a/packages/codev/src/agent-farm/types.ts
+++ b/packages/codev/src/agent-farm/types.ts
@@ -189,7 +189,7 @@ export interface InterruptOptions {
 }
 
 /**
- * Options for `afx reset` — save-state → /clear → re-orient (Spec 1273).
+ * Options for `afx refresh` — save-state → /clear → re-orient (Spec 1273).
  *
  * The timing knobs exist because the safe failure of every gate is "abort
  * without clearing". A builder that legitimately needs longer than a default

--- a/packages/codev/src/agent-farm/utils/harness.ts
+++ b/packages/codev/src/agent-farm/utils/harness.ts
@@ -46,11 +46,11 @@ export interface HarnessProvider {
 
   /**
    * Whether this harness can clear its conversation context in-session, without
-   * restarting the process (Spec 1273 — `afx reset`).
+   * restarting the process (Spec 1273 — `afx refresh`).
    *
    * Optional, and absence means "no": a harness that has not declared support
    * must not be reset, and defaulting to unsupported is the safe direction. Only
-   * Claude declares it today (`/clear`), which is why `afx reset` refuses other
+   * Claude declares it today (`/clear`), which is why `afx refresh` refuses other
    * harnesses loudly rather than improvising a substitute mechanism.
    */
   supportsContextReset?: boolean;
@@ -216,7 +216,7 @@ export const OPENCODE_HARNESS: HarnessProvider = {
 };
 
 /**
- * Exported for Spec 1273: `afx reset` identifies a running builder's harness from
+ * Exported for Spec 1273: `afx refresh` identifies a running builder's harness from
  * its launch script and must check `supportsContextReset` before typing into the
  * terminal. It needs the name→provider map, not just the workspace default.
  */

--- a/packages/codev/src/terminal/pty-session.ts
+++ b/packages/codev/src/terminal/pty-session.ts
@@ -70,7 +70,7 @@ export interface PtySessionInfo {
    *
    * Serialised alongside `status` because the two disagree in the case that
    * matters: a session whose shellper connection died reports status 'running'
-   * until teardown while every write to it is dropped (#1198). `afx reset`
+   * until teardown while every write to it is dropped (#1198). `afx refresh`
    * preflights on this so it refuses a terminal it cannot write to BEFORE
    * touching anything, rather than discovering it on the first send.
    */
@@ -81,7 +81,7 @@ export interface PtySessionInfo {
    * Serialised by `GET /api/terminals/:id`, which makes output quiescence
    * *measurable* by a client: an agent mid-turn emits continuously (spinner
    * frames, streamed tokens), so a stretch with no advance means the turn ended.
-   * `afx reset` uses this to avoid typing into a terminal that is still working.
+   * `afx refresh` uses this to avoid typing into a terminal that is still working.
    */
   lastDataAt: number;
 }


### PR DESCRIPTION
## Summary

`afx reset` becomes **`afx refresh`**. Same behaviour, same flags, same safety gates — the name
was the problem. `afx reset` survives one release as an alias that announces its own deprecation.

Closes #1489

## Why

"reset" carries git-adjacent muscle memory for "throw work away", which is the exact opposite of
what this command guarantees: the nonce check, the min-bytes floor and the quiet-window check all
**abort without clearing**. A name that reads as destructive works against a command built to be
safe. "refresh" says what happens — same state, fresh context window — and it matches the
vocabulary of the automatic flow in #1470.

## What Changed

**CLI.** `refresh` and `reset` are registered as two commands over one shared action body
(`registerRefresh` in `cli.ts`), canonical name first so `--help` leads with it. Commander's
`.alias()` was rejected: it gives no way to tell which spelling the caller typed, and the
deprecated spelling has to announce itself. Sharing one action body is deliberate — if the alias
ever grew its own copy, the flag validation that guards R2/R4 could drift on one side and silently
disable a safety gate for whoever still types `reset`.

**The notice goes to stderr.** `logger.warn` writes to stdout, and stdout carries the run report
that tells an architect whether the builder was cleared. Verified against the built CLI:

```
$ afx reset no-such-builder 2>&1 1>/dev/null
afx reset has been renamed to afx refresh; this alias will be removed in a future release

$ afx refresh no-such-builder 2>&1 1>/dev/null
(nothing)
```

**User-facing strings.** Header (`Builder Context Refresh`), usage line, success line
(`Builder X refreshed and re-oriented`), preflight refusals (`Refusing to refresh: …`,
`Refresh needs the registry row …`), and the harness refusal (`'afx refresh' cannot clear this …`).

**Docs, both trees + both skill trees.** `codev/resources/commands/agent-farm.md`,
`codev-skeleton/resources/commands/agent-farm.md`, `codev/roles/builder.md`,
`codev-skeleton/roles/builder.md`, `.claude/skills/afx/SKILL.md`, `.codex/skills/afx/SKILL.md` —
each with an explicit deprecated-alias line. The byte-identical-twin assertions still pass.

## Key Decisions

**1. Internal file and directory names stay `reset*`.** `commands/reset.ts`, `commands/reset/`,
`ResetOptions`, `runReset`, `ResetPreflightError`, `formatResetReport` are untouched — issue point 5
allows this and warns against ballooning the diff. The one exception is the exported command entry
point, `reset()` → `refresh()`, because that is the symbol the canonical command wires to, and
reading `await reset(...)` under an `afx refresh` registration is the confusion this rename exists
to remove.

**2. The builder-facing payloads changed too: `CONTEXT RESET` → `CONTEXT REFRESH`.** This goes
slightly past the letter of issue point 3, which names only dry-run output, log lines and error
messages. The reasoning: the save request and the re-orientation frame are read by an *agent* under
exactly the vocabulary the issue is fixing, and #1470's automatic flow is "builder context refresh".
Leaving the payloads saying RESET would split the vocabulary at the point where it matters most.
Flagging it explicitly since it is a judgement call — happy to revert this half if you'd rather keep
the payloads frozen.

There is a side benefit. `confirmClear` matches `/context (?:cleared|reset)/i`, and the old
`CONTEXT RESET INCOMING` header collided with it — a real false-positive, fixed structurally in
Spec 1273 by scanning only post-clear output. The new header no longer collides, but the
orchestrator test deliberately **keeps** a colliding line in `PRE_CLEAR_BUFFER` so the window logic
is not allowed to start depending on that luck.

**3. The nonce marker `<!-- codev-reset: … -->` stays.** It is a wire format between the command and
the builder within a single run, and it appears in `.builder-state.md` files that may already exist
on disk. Renaming it buys nothing and would make stale-file detection read oddly against a state
file written before this lands.

**4. Historical artifacts are not rewritten.** `grep -rn "afx reset"` is clean except for the
deprecation lines that mention it on purpose and `codev/specs/`, `codev/plans/`, `codev/reviews/`,
`codev/projects/`, `codev/state/` — records of what was written at the time.

## Test Plan

- [x] New suite `air-1489-refresh-rename.test.ts` (7 tests): notice wording; stderr-only and never
      stdout; canonical name runs silently; alias runs with **identical** arguments; notice emitted
      exactly once; every safety-gate flag forwarded through the alias unchanged; `--help` lists
      both with `refresh` first and `reset` marked `[deprecated]`.
- [x] Existing Spec 1273 suites pass against the new names (command surface, orchestrator, receipt,
      wait-discipline docs).
- [x] `tsc --noEmit` clean; `pnpm build` passes.
- [x] Full suite: 246 files passed, 3 skipped, 4863 tests passed, 0 failed.
- [x] Built CLI exercised by hand: `--help` ordering, alias notice on stderr only, `refresh` silent,
      `Must specify a builder. Usage: afx refresh <builder>`.

## Review Notes

- **Decision 2 is the one worth a second opinion** — whether the builder-facing `CONTEXT REFRESH`
  payload rename is in scope, or should stay `CONTEXT RESET`.
- The live headline path (an actual refresh against a running builder) was **not** re-run; this
  change does not touch the state machine, and self-targeting a dry-run from inside my own worktree
  seemed like unnecessary risk. Payload assembly is covered by the orchestrator tests.
- The worktree needed `pnpm install` plus a full `pnpm --filter @cluesmith/codev build` before
  vitest was green — 12 unrelated files fail without the built `skeleton/` directory. Not caused by
  this change, but worth knowing if you run the suite in a fresh worktree.

---

## CMAP

`gemini=APPROVE (HIGH)` · `codex=COMMENT (HIGH)` · `claude=APPROVE (HIGH)` — **no blocking findings.**

Both Codex and Claude independently endorsed **Decision 2** (the `CONTEXT REFRESH` payload rename)
that I'd flagged above as the debatable call, so I've left it in. Claude added three supporting
reasons: no doc anywhere references the old header, the nonce wire format is unchanged so
pre-#1489 state files are still correctly detected as stale, and the rename removes a latent
collision with `confirmClear`'s `/context (?:cleared|reset)/i`. Claude also re-ran the affected
suites itself (6 files / 197 tests green) rather than trusting the numbers in this body.

Codex's one note is diff size (693 lines vs AIR's nominal ~300), which it calls "not blocking" —
the production-code delta is small; the bulk is comment rewrites, docs, the alias test suite and
the builder thread.

### Follow-up worth filing (pre-existing, not caused by this PR)

`codev-skeleton/.claude/skills/afx/SKILL.md` and its `.codex` twin have **no `afx reset` /
`afx interrupt` section at all** — I verified this: their headings stop at `afx cron`, and the
files were last touched by #1143, well before Spec 1273. So there was nothing in the skeleton
skill trees for this PR to rename and the issue's sweep is complete by its own terms, but
**adopters will never discover `afx refresh`**. The docs test's `SKILL_DOCS` covers only the root
`.claude`/`.codex` trees, which is why the drift is invisible. Backfilling a missing section is
Spec 1273 work rather than a rename, so I left it out of this PR — happy to file the issue or do
it here if you'd rather.

### On the live headline-path check

I confirmed by reading `runReset` that `--dry-run` returns before `fs.write`, before the optional
interrupt and before any terminal send, so a self-targeted dry run was genuinely zero-write. It
still can't complete from inside a worktree: the registry lookup fails because the workspace
resolves to the worktree path (`afx status` → "Workspace: not active in tower"). Pre-existing
scoping, untouched here. The attempt did exercise the real resolve path under the new name and
emitted the renamed error text; assembly stays covered by the orchestrator tests.

Minor, left alone: `afx db reset` still exists and is legitimately destructive, so "reset is
deprecated" is marginally ambiguous in the help surface — but there's no collision, since commander
scopes it under `db`.
