### PR TITLE
[Air #1489] records: porch completion state + builder thread close-out

### DIFF
--- a/codev/projects/1489-rename-afx-reset-to-afx-refres/status.yaml
+++ b/codev/projects/1489-rename-afx-reset-to-afx-refres/status.yaml
@@ -1,7 +1,7 @@
 id: '1489'
 title: rename-afx-reset-to-afx-refres
 protocol: air
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,7 +13,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-17T23:42:08.661Z'
-updated_at: '2026-08-18T00:15:13.619Z'
+updated_at: '2026-08-18T00:17:04.000Z'
 pr_history:
   - phase: pr
     pr_number: 1490

--- a/codev/projects/1489-rename-afx-reset-to-afx-refres/status.yaml
+++ b/codev/projects/1489-rename-afx-reset-to-afx-refres/status.yaml
@@ -13,10 +13,12 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-17T23:42:08.661Z'
-updated_at: '2026-08-18T00:14:17.045Z'
+updated_at: '2026-08-18T00:15:13.619Z'
 pr_history:
   - phase: pr
     pr_number: 1490
     branch: builder/air-1489
     created_at: '2026-08-18T00:02:38.562Z'
+    merged: true
+    merged_at: '2026-08-18T00:15:13.619Z'
 pr_ready_for_human: false

--- a/codev/state/air-1489_thread.md
+++ b/codev/state/air-1489_thread.md
@@ -82,3 +82,35 @@ text, but assembly end-to-end remains covered by the orchestrator tests rather t
 **`afx db reset` still exists** and is legitimately destructive (Claude's minor note #2). No
 collision with the top-level registration — commander scopes it under `db` — but "reset is
 deprecated" is now marginally ambiguous in the help surface. Left alone.
+
+## 2026-08-18 — Backfill, gate, merge
+
+Human decision (relayed by the architect): approve **with backfill first**.
+
+Backfilled `## afx interrupt` and `## afx refresh` into both skeleton skill files, lifted
+**verbatim** from the root skill files updated earlier in the PR so the adopter-facing copies cannot
+drift from what shipped. Then closed the hole that hid the drift: the docs test's `SKILL_DOCS`
+covered only the ROOT `.claude`/`.codex` trees, so it now asserts the skeleton twins too — both
+commands present, `## afx reset` absent, deprecation line present, copies byte-identical. Confirmed
+non-vacuous against `git show HEAD:<file>` before trusting it (a docs test that cannot fail is
+worse than no docs test).
+
+CI was revalidated against the **exact new head SHA** `1c0a59eda`, not a stale rollup — 7/7 success
+— and the PR head was re-checked to still equal that SHA before approving the gate. `porch approve
+1489 pr` needed the explicit `--a-human-explicitly-approved-this` flag.
+
+`gh pr merge 1490 --merge` was refused: `reviewDecision=REVIEW_REQUIRED`, `main` requires 1
+approving review and I authored the PR. **Did not reach for `--admin`** — that is the owner's call.
+Waleed admin-merged at 00:14:52Z as merge commit `10eef2d62` (verified 2 parents: a true merge, not
+a squash). Issue #1489 auto-closed via `Closes #1489`.
+
+Verified on `origin/main` after the merge: all four skill trees carry refresh + interrupt with zero
+stale `## afx reset` headings, and the only surviving `afx reset` strings outside historical
+artifacts are the intentional deprecation notice and the test that asserts the heading's absence.
+
+Protocol complete (phase `verified`). **Worktree deliberately left in place** — cleanup awaits the
+owner's word.
+
+> Note: this final entry post-dates the merge, so it lives on `builder/air-1489` only, not on
+> `main`. Everything decision-relevant in it is also captured in the merged commit messages and the
+> merged test.


### PR DESCRIPTION
## Summary

Records-only follow-up to #1490 (`afx reset` → `afx refresh`, merged as `10eef2d6`). It lands the
three commits that were stranded on `builder/air-1489` because they were created *after* that PR
merged — nothing here changes behaviour.

Refs #1489

## What's in it

| Commit | What |
|---|---|
| `chore(porch): 1489 PR #1490 merged` | `status.yaml` — records the merge on `pr_history` |
| `chore(porch): 1489 protocol complete` | `status.yaml` — `phase: pr` → `phase: verified` |
| `docs: close out builder thread` | final `codev/state/air-1489_thread.md` entry |

Two files, +36/−2:

- `codev/projects/1489-rename-afx-reset-to-afx-refres/status.yaml`
- `codev/state/air-1489_thread.md`

Both `status.yaml` changes were written by porch (`porch done --merged`, then `porch done`), not by
hand.

## Why it's a separate PR

Porch's completion records and the closing thread entry can only exist once the feature PR is
merged, so they cannot ride along in it. Same pattern as the records PRs for 1370/1372 and 1280.

## The thread entry

Covers the part of the work that post-dates #1490's body: the skeleton skill-tree backfill and the
docs-test gap that hid it, CI revalidation against the exact head SHA `1c0a59eda` rather than a
stale rollup, the `REVIEW_REQUIRED` self-approval wall (and the deliberate decision not to reach
for `--admin`), and the post-merge verification on `origin/main`.

## Test Plan

- [x] Cherry-picked onto a fresh branch off `origin/main`; all three applied cleanly
- [x] `git diff origin/main...HEAD` matches the stranded set exactly — two files, no strays
- [x] No source, test, or doc-content changes — records only

## Review Notes

Documentation and state records only. Merge word is Waleed's; I am not attempting it.