### PR TITLE
Fix #1502: bound test.yml jobs with timeout-minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ jobs:
   unit:
     name: Unit Tests
     runs-on: ubuntu-latest
+    # Healthy runs finish in ~2-3 min; bound well above that so a stall fails
+    # visibly instead of pending for GitHub's 6-hour default (see #1502).
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -115,6 +118,12 @@ jobs:
   canvas-browser:
     name: Artifact-Canvas Browser Tests
     runs-on: ubuntu-latest
+    # Root cause of #1502: `playwright install --with-deps` runs `apt-get update`,
+    # whose index fetch to archive.ubuntu.com intermittently stalls indefinitely
+    # (the fast azure.archive.ubuntu.com mirror is Ign-ored, and apt has no network
+    # timeout on the fallback fetch). Healthy runs finish in ~4 min; this bound turns
+    # a multi-hour silent stall into a fast, visible failure that a rerun clears.
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -144,6 +153,8 @@ jobs:
   integration:
     name: Tower Integration Tests
     runs-on: ubuntu-latest
+    # Healthy runs finish in ~2 min; bound above that so a stall fails visibly (#1502).
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -179,6 +190,8 @@ jobs:
   cli:
     name: CLI Integration Tests
     runs-on: ubuntu-latest
+    # Healthy runs finish in ~1 min; bound above that so a stall fails visibly (#1502).
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -214,6 +227,8 @@ jobs:
   package:
     name: Package Install Verification
     runs-on: ubuntu-latest
+    # Healthy runs finish in ~2 min; bound above that so a stall fails visibly (#1502).
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,11 +118,9 @@ jobs:
   canvas-browser:
     name: Artifact-Canvas Browser Tests
     runs-on: ubuntu-latest
-    # Root cause of #1502: `playwright install --with-deps` runs `apt-get update`,
-    # whose index fetch to archive.ubuntu.com intermittently stalls indefinitely
-    # (the fast azure.archive.ubuntu.com mirror is Ign-ored, and apt has no network
-    # timeout on the fallback fetch). Healthy runs finish in ~4 min; this bound turns
-    # a multi-hour silent stall into a fast, visible failure that a rerun clears.
+    # Backstop for #1502. The stall's root cause is removed below (see the install
+    # step), but every job stays bounded regardless: an unbounded job conceals its
+    # own failure, which is #1502's real lesson. Healthy runs finish in ~4 min.
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -140,9 +138,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # Root cause of #1502: `--with-deps` runs `apt-get update` to install Chromium's
+      # system libraries, and that apt index fetch intermittently stalls indefinitely
+      # (the fast azure.archive.ubuntu.com mirror is Ign-ored, and apt has no network
+      # timeout on the fallback to archive.ubuntu.com). Those libraries are already
+      # present on the ubuntu-latest image: the sibling dashboard-e2e workflow installs
+      # Chromium the same way without `--with-deps` and launches it successfully on
+      # every scheduled run. Dropping the flag removes the stalling apt phase entirely.
       - name: Install Playwright Chromium
         working-directory: packages/artifact-canvas
-        run: pnpm exec playwright install --with-deps chromium
+        run: pnpm exec playwright install chromium
 
       # Real-browser fragmentation regression suite (spec 1380): jsdom cannot express CSS
       # multi-column fragmentation, so the spike-derived invariants run against Chromium here.

--- a/codev/projects/bugfix-1502-ci-artifact-canvas-browser-tes/status.yaml
+++ b/codev/projects/bugfix-1502-ci-artifact-canvas-browser-tes/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1502
+title: ci-artifact-canvas-browser-tes
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-18T03:53:32.119Z'
+updated_at: '2026-08-18T03:53:32.120Z'

--- a/codev/projects/bugfix-1502-ci-artifact-canvas-browser-tes/status.yaml
+++ b/codev/projects/bugfix-1502-ci-artifact-canvas-browser-tes/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-08-18T04:04:03.885Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:53:32.119Z'
-updated_at: '2026-08-18T03:59:56.209Z'
+updated_at: '2026-08-18T04:04:03.886Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1502-ci-artifact-canvas-browser-tes/status.yaml
+++ b/codev/projects/bugfix-1502-ci-artifact-canvas-browser-tes/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1502
 title: ci-artifact-canvas-browser-tes
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,5 +11,5 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:53:32.119Z'
-updated_at: '2026-08-18T04:19:10.004Z'
+updated_at: '2026-08-18T04:21:06.285Z'
 pr_ready_for_human: false

--- a/codev/projects/bugfix-1502-ci-artifact-canvas-browser-tes/status.yaml
+++ b/codev/projects/bugfix-1502-ci-artifact-canvas-browser-tes/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1502
 title: ci-artifact-canvas-browser-tes
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:53:32.119Z'
-updated_at: '2026-08-18T03:56:59.649Z'
+updated_at: '2026-08-18T03:59:56.209Z'

--- a/codev/projects/bugfix-1502-ci-artifact-canvas-browser-tes/status.yaml
+++ b/codev/projects/bugfix-1502-ci-artifact-canvas-browser-tes/status.yaml
@@ -7,9 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-08-18T04:28:17.655Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:53:32.119Z'
-updated_at: '2026-08-18T04:21:06.285Z'
-pr_ready_for_human: false
+updated_at: '2026-08-18T04:28:17.655Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1502-ci-artifact-canvas-browser-tes/status.yaml
+++ b/codev/projects/bugfix-1502-ci-artifact-canvas-browser-tes/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1502
 title: ci-artifact-canvas-browser-tes
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:53:32.119Z'
-updated_at: '2026-08-18T03:53:32.120Z'
+updated_at: '2026-08-18T03:56:59.649Z'

--- a/codev/projects/bugfix-1502-ci-artifact-canvas-browser-tes/status.yaml
+++ b/codev/projects/bugfix-1502-ci-artifact-canvas-browser-tes/status.yaml
@@ -1,16 +1,15 @@
 id: bugfix-1502
 title: ci-artifact-canvas-browser-tes
 protocol: bugfix
-phase: pr
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
   pr:
     status: pending
-    requested_at: '2026-08-18T04:04:03.885Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:53:32.119Z'
-updated_at: '2026-08-18T04:04:03.886Z'
-pr_ready_for_human: true
+updated_at: '2026-08-18T04:19:10.004Z'
+pr_ready_for_human: false

--- a/codev/state/bugfix-1502_thread.md
+++ b/codev/state/bugfix-1502_thread.md
@@ -1,0 +1,62 @@
+# bugfix-1502 — CI: Artifact-Canvas Browser Tests hangs indefinitely
+
+## Investigate phase
+
+### What the issue + architect direction establish (verified against artifacts)
+- Stalling step is **`Install Playwright Chromium`** (`.github/workflows/test.yml:134-136`,
+  `pnpm exec playwright install --with-deps chromium`). The `Run artifact-canvas browser tests`
+  step never starts. Confirmed via job step state on two hung runs (issue comments).
+- **Zero `timeout-minutes`** anywhere in `.github/workflows/` (grepped all 5 workflow files).
+  GitHub's 6-hour default applies, which is why a stalled step reads as "running for hours".
+- Intermittent: run `32095039750` (pir-1498) passed the same job in **3m58s** while
+  `32093117702` (pir-1497) and `32085216485` (main #1493 merge) never finished.
+- Healthy duration reaches at least **3m58s**; the old "~1m09s baseline" is wrong — do NOT
+  size the timeout off it.
+- **Ruled out** (architect): playwright.config.ts webServer / `--strictPort 5199`. Tests never
+  start, so the webServer is never invoked.
+
+### Actions taken
+- Cancelled both hung runs (32093117702, 32085216485) — authorized by architect — to retrieve
+  the partial `Install Playwright Chromium` log (in-progress jobs return BlobNotFound).
+- Polling for both to conclude, then will fetch the job log.
+
+### Required fix
+- Add `timeout-minutes` to the `Artifact-Canvas Browser Tests` job, sized off healthy durations
+  (~4 min) with headroom. Converts a silent multi-hour stall into a fast visible failure.
+- Consider bounding the other jobs in test.yml too — argue either way in the PR.
+
+### ROOT CAUSE — confirmed from cancelled-run logs
+Both hung runs stalled at the **identical point** inside `Install Playwright Chromium`:
+the `apt-get update` that `playwright install --with-deps` runs to install Chromium's
+system libs.
+
+- pir-1497 (95579121785): last line `Get:7 https://archive.ubuntu.com/ubuntu noble-security
+  InRelease` at 02:50:02Z, then NOTHING until the cancel at 03:54:38Z (~64 min of silence).
+- main (95556232101): last line `Get:7 https://archive.ubuntu.com/ubuntu noble-security
+  InRelease` at 00:38:23Z, then NOTHING until cancel at 03:54:39Z (~3h of silence).
+
+Signature: the runner's fast `azure.archive.ubuntu.com` mirror is `Ign`-ored (unreachable),
+forcing fallback to public `archive.ubuntu.com`. The index fetch there stalls indefinitely.
+apt has no default network timeout on this fetch, and there is no `timeout-minutes` on the
+step/job/workflow, so GitHub's 6h default lets it pend for hours. Intermittent because it
+depends on that transient mirror/network condition.
+
+Narrowest supported claim: **the apt index-fetch phase of `--with-deps` stalls**. The tests
+never start (webServer/strictPort ruled out, correctly).
+
+### Fix decision (minimal, BUGFIX scope)
+- **Required + guaranteed**: add `timeout-minutes` to the canvas-browser job (healthy job
+  ~4min → bound 15, ~3.7x headroom). Converts silent multi-hour stall → fast visible failure.
+- **Defense in depth**: add bounds to the other 4 jobs too (all healthy 1–3min → 10min).
+  Argue in PR; a workflow with zero timeouts is one hiccup from the same stall.
+- **NOT doing** (argue in PR): dropping `--with-deps` (risks browser-launch breakage; the
+  intermittent hang can't be cheaply CI-verified away — trades a mitigated hang for a possible
+  breakage); caching `~/.cache/ms-playwright` (does NOT skip the apt phase, so wouldn't fix
+  THIS stall — it only removes the browser-binary download).
+
+### Regression test
+Parse `.github/workflows/test.yml` with `js-yaml` (already a codev dep) and assert each job
+carries a numeric `timeout-minutes`. Fails on current main (zero timeouts), passes with fix.
+Precedent: `packages/codev/src/__tests__/bugfix-566-dashboard-e2e-gh-token.test.ts`.
+
+Scope: 1 YAML edit + 1 test file. Well under 300 LOC. Fits BUGFIX.

--- a/codev/state/bugfix-1502_thread.md
+++ b/codev/state/bugfix-1502_thread.md
@@ -97,3 +97,14 @@ Amr asked whether a timeout is the best we can do. It is not.
   doesn't, it surfaces as a browser launch failure → restore --with-deps + rely on timeout, and
   say so. Not claiming certainty.
 - Re-running CMAP round 2 on the updated PR.
+
+## Verification + CMAP rounds 2/3
+- Canvas-browser CI on this PR (run 32098830832): SUCCESS in 45s. Install step (no --with-deps)
+  and browser-test step both green → Chromium launches without --with-deps. This is the
+  architect's cheap verification; it passed, so no fallback needed.
+- CMAP r2 (pre-assertion commit): gemini=APPROVE, claude=APPROVE, codex=REQUEST_CHANGES.
+  Codex's two points, both now resolved:
+    (1) regression test only guarded timeouts → added assertion that canvas install excludes
+        --with-deps (tamper-proven: fails when --with-deps reintroduced, passes without).
+    (2) canvas verification unchecked → verified green above.
+- CMAP r3 running on final commit (0bacf777, includes the new assertion) so all three see it.

--- a/codev/state/bugfix-1502_thread.md
+++ b/codev/state/bugfix-1502_thread.md
@@ -60,3 +60,15 @@ carries a numeric `timeout-minutes`. Fails on current main (zero timeouts), pass
 Precedent: `packages/codev/src/__tests__/bugfix-566-dashboard-e2e-gh-token.test.ts`.
 
 Scope: 1 YAML edit + 1 test file. Well under 300 LOC. Fits BUGFIX.
+
+## PR phase
+- PR #1507 opened. Fixes #1502.
+- CMAP (3-way, --issue 1502 needed to disambiguate from builder context):
+  - gemini = APPROVE (HIGH, no issues)
+  - codex  = COMMENT (HIGH) — nit: PR body said "four node-only jobs = 10" but `unit` is 15.
+             Fixed the PR body (description-only, no re-run needed).
+  - claude = APPROVE (HIGH). Non-blocking: other workflows (dashboard-e2e, e2e,
+             post-release-e2e, sdk-canary) remain unbounded — candidate follow-up issue to
+             raise with the architect (not self-filing, per scope discipline).
+- No REQUEST_CHANGES; the one actionable item (PR-body accuracy) is addressed.
+- Handing off at the pr gate; waiting for architect approval before merge.

--- a/codev/state/bugfix-1502_thread.md
+++ b/codev/state/bugfix-1502_thread.md
@@ -72,3 +72,10 @@ Scope: 1 YAML edit + 1 test file. Well under 300 LOC. Fits BUGFIX.
              raise with the architect (not self-filing, per scope discipline).
 - No REQUEST_CHANGES; the one actionable item (PR-body accuracy) is addressed.
 - Handing off at the pr gate; waiting for architect approval before merge.
+
+## Gate status
+- Architect posted integration-review APPROVE on PR #1507 (verified claims against artifacts).
+- Other-workflows unbounded gap filed by architect as #1509 (not folded into this PR).
+- Architect explicit: the pr gate is the OWNER's, not the architect's. Integration APPROVE is
+  NOT merge authorization. Holding at the pr gate; will not run `porch approve` or merge until
+  the owner gives the word, then follow the merge task from `porch next`.

--- a/codev/state/bugfix-1502_thread.md
+++ b/codev/state/bugfix-1502_thread.md
@@ -108,3 +108,12 @@ Amr asked whether a timeout is the best we can do. It is not.
         --with-deps (tamper-proven: fails when --with-deps reintroduced, passes without).
     (2) canvas verification unchecked → verified green above.
 - CMAP r3 running on final commit (0bacf777, includes the new assertion) so all three see it.
+
+## CMAP round 3 (final commit with assertion) — all APPROVE
+- gemini = APPROVE (HIGH, none)
+- codex  = APPROVE (HIGH, none) — flipped from REQUEST_CHANGES; both its points resolved.
+- claude = APPROVE (HIGH, none blocking). Actioned its non-blocking notes: ticked the satisfied
+  canvas checkbox in PR body; merged origin/main (branch was 8 behind) so CI validates integrated
+  state. Left its forward-compat note (timeout assertion vs a hypothetical `jobs.<id>.uses`
+  reusable-workflow job) unaddressed — speculative; all current jobs are `runs-on`.
+- Re-firing pr gate. Still the OWNER's gate — will not merge until his word.

--- a/codev/state/bugfix-1502_thread.md
+++ b/codev/state/bugfix-1502_thread.md
@@ -79,3 +79,21 @@ Scope: 1 YAML edit + 1 test file. Well under 300 LOC. Fits BUGFIX.
 - Architect explicit: the pr gate is the OWNER's, not the architect's. Integration APPROVE is
   NOT merge authorization. Holding at the pr gate; will not run `porch approve` or merge until
   the owner gives the word, then follow the merge task from `porch next`.
+
+## Reopened at architect's direction — stronger fix
+Amr asked whether a timeout is the best we can do. It is not.
+- Verified in-repo: dashboard-e2e.yml:42 runs `playwright install chromium` (NO --with-deps) on
+  ubuntu-latest, then launches Chromium (line 44-49). 8 consecutive successful scheduled runs on
+  main (08-10 → 08-17). So Chromium's system libs are already on the runner image and the apt
+  phase --with-deps triggers buys nothing.
+- Change: dropped --with-deps from test.yml install step → removes the SOLE log-confirmed stall
+  at its source. KEPT all timeout-minutes bounds as a backstop (not either-or): an unbounded job
+  conceals its own failure, which is #1502's real lesson.
+- --retries: argued AGAINST (not copied from sibling). Retries re-run failed tests not the
+  install step (wouldn't touch this stall), and the canvas suite is deterministic layout
+  invariants where a retry masks real regressions. Different character from dashboard-e2e's async
+  Tower/gh flows.
+- Verification is this PR's own canvas-browser CI run: if canvas needs a lib the dashboard
+  doesn't, it surfaces as a browser launch failure → restore --with-deps + rely on timeout, and
+  say so. Not claiming certainty.
+- Re-running CMAP round 2 on the updated PR.

--- a/packages/codev/src/__tests__/bugfix-1502-test-workflow-timeouts.test.ts
+++ b/packages/codev/src/__tests__/bugfix-1502-test-workflow-timeouts.test.ts
@@ -1,15 +1,17 @@
 /**
- * Regression test for bugfix #1502: Tests workflow jobs must carry a timeout bound.
+ * Regression test for bugfix #1502: the Tests workflow must not hang for hours.
  *
- * The `Artifact-Canvas Browser Tests` job intermittently hung for hours because
+ * The `Artifact-Canvas Browser Tests` job intermittently hung because
  * `playwright install --with-deps` runs an `apt-get update` whose index fetch to
  * archive.ubuntu.com can stall indefinitely, and no job in `test.yml` had a
  * `timeout-minutes`. GitHub's 6-hour default let the stall pend for hours, leaving
  * the PR check set permanently incomplete and blocking merges.
  *
- * The fix bounds every job so a stall fails fast and visibly instead of pending.
- * This test pins that invariant: each job in test.yml must declare a numeric
- * timeout-minutes below GitHub's 6-hour (360-minute) default.
+ * The fix is two-part, and this test pins both halves:
+ *   1. Remove the cause: the Chromium install must NOT pass `--with-deps` (its apt
+ *      phase is the sole stall; the runner image already carries Chromium's libs).
+ *   2. Keep a backstop: every job must declare a numeric `timeout-minutes` below
+ *      GitHub's 6-hour (360-minute) default, so any future stall fails fast.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -20,21 +22,24 @@ import * as yaml from 'js-yaml';
 const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
 const workflowPath = path.join(repoRoot, '.github/workflows/test.yml');
 
+interface WorkflowStep {
+  name?: string;
+  run?: string;
+}
+
 interface WorkflowJob {
   'timeout-minutes'?: number;
+  steps?: WorkflowStep[];
 }
 
 interface Workflow {
   jobs: Record<string, WorkflowJob>;
 }
 
+const workflow = yaml.load(fs.readFileSync(workflowPath, 'utf-8')) as Workflow;
+const jobEntries = Object.entries(workflow.jobs);
+
 describe('bugfix-1502: test.yml jobs carry a timeout bound', () => {
-  const workflow = yaml.load(
-    fs.readFileSync(workflowPath, 'utf-8'),
-  ) as Workflow;
-
-  const jobEntries = Object.entries(workflow.jobs);
-
   it('parses at least the known jobs', () => {
     expect(jobEntries.length).toBeGreaterThan(0);
     expect(workflow.jobs).toHaveProperty('canvas-browser');
@@ -55,4 +60,23 @@ describe('bugfix-1502: test.yml jobs carry a timeout bound', () => {
       expect(timeout).toBeLessThan(360);
     },
   );
+});
+
+describe('bugfix-1502: the Chromium install does not run the stalling apt phase', () => {
+  it('the canvas-browser install step does not pass --with-deps', () => {
+    const installStep = (workflow.jobs['canvas-browser'].steps ?? []).find(
+      (step) => step.run?.includes('playwright install'),
+    );
+    expect(
+      installStep,
+      'canvas-browser must have a "playwright install" step',
+    ).toBeDefined();
+    // `--with-deps` triggers the apt-get update that intermittently stalls (#1502).
+    // Chromium's system libraries are already present on the ubuntu-latest image
+    // (the dashboard-e2e workflow installs without it and launches Chromium fine).
+    // If a future runner image ever drops a library canvas needs, the fix is to
+    // restore --with-deps AND update this assertion with the reason — never to let
+    // the stalling phase back in silently.
+    expect(installStep?.run).not.toContain('--with-deps');
+  });
 });

--- a/packages/codev/src/__tests__/bugfix-1502-test-workflow-timeouts.test.ts
+++ b/packages/codev/src/__tests__/bugfix-1502-test-workflow-timeouts.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression test for bugfix #1502: Tests workflow jobs must carry a timeout bound.
+ *
+ * The `Artifact-Canvas Browser Tests` job intermittently hung for hours because
+ * `playwright install --with-deps` runs an `apt-get update` whose index fetch to
+ * archive.ubuntu.com can stall indefinitely, and no job in `test.yml` had a
+ * `timeout-minutes`. GitHub's 6-hour default let the stall pend for hours, leaving
+ * the PR check set permanently incomplete and blocking merges.
+ *
+ * The fix bounds every job so a stall fails fast and visibly instead of pending.
+ * This test pins that invariant: each job in test.yml must declare a numeric
+ * timeout-minutes below GitHub's 6-hour (360-minute) default.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as yaml from 'js-yaml';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+const workflowPath = path.join(repoRoot, '.github/workflows/test.yml');
+
+interface WorkflowJob {
+  'timeout-minutes'?: number;
+}
+
+interface Workflow {
+  jobs: Record<string, WorkflowJob>;
+}
+
+describe('bugfix-1502: test.yml jobs carry a timeout bound', () => {
+  const workflow = yaml.load(
+    fs.readFileSync(workflowPath, 'utf-8'),
+  ) as Workflow;
+
+  const jobEntries = Object.entries(workflow.jobs);
+
+  it('parses at least the known jobs', () => {
+    expect(jobEntries.length).toBeGreaterThan(0);
+    expect(workflow.jobs).toHaveProperty('canvas-browser');
+  });
+
+  it.each(jobEntries.map(([id]) => id))(
+    'job "%s" declares a bounded numeric timeout-minutes',
+    (jobId) => {
+      const timeout = workflow.jobs[jobId]['timeout-minutes'];
+      expect(
+        typeof timeout,
+        `job "${jobId}" must set timeout-minutes so a stall fails fast instead of ` +
+          `pending for GitHub's 6-hour default (see #1502)`,
+      ).toBe('number');
+      // Must be a real bound, not a value at or above GitHub's default that would
+      // never fire before the silent multi-hour stall the fix exists to prevent.
+      expect(timeout).toBeGreaterThan(0);
+      expect(timeout).toBeLessThan(360);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

The `Artifact-Canvas Browser Tests` job in the `Tests` workflow intermittently hung for hours
instead of concluding, leaving PR check sets permanently incomplete and blocking merges. This PR
**removes the stall at its source** by dropping `--with-deps` from the Playwright install, and
**keeps a per-job `timeout-minutes` backstop** so any future stall in any job fails fast instead
of pending for hours.

Fixes #1502

## Root Cause

Confirmed from the logs of two cancelled hung runs (`32093117702` on `builder/pir-1497`,
`32085216485` on `main`). Both stalled at the **identical point**: the `apt-get update` that
`pnpm exec playwright install --with-deps chromium` runs to install Chromium's system libraries.

```
Get:7 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
<... then nothing for ~1h and ~3h respectively, until cancellation ...>
```

The runner's fast `azure.archive.ubuntu.com` mirror is `Ign`-ored (unreachable), forcing fallback
to public `archive.ubuntu.com`, whose index fetch then stalls indefinitely. apt has no default
network timeout on that fetch, and no job in `test.yml` had a `timeout-minutes`, so GitHub's
6-hour default let the stall pend for hours. It is intermittent because it depends on that
transient mirror/network condition. The tests never start, so the `playwright.config.ts`
webServer / `--strictPort 5199` hypothesis is ruled out — the webServer is never invoked.

## Fix

**1. Remove the cause — drop `--with-deps` (`test.yml`, the install step).**
The stalling apt phase exists only to install Chromium's system libraries, and those libraries are
already present on the `ubuntu-latest` image. Proof lives in our own repo: the sibling
`dashboard-e2e.yml` workflow installs Chromium with the same command **minus** `--with-deps`
(`playwright install chromium`) on the same runner image, then launches Chromium for its
Playwright tests — and it has succeeded on `main` on every scheduled run from 2026-08-10 through
2026-08-17 (8 consecutive). So `--with-deps` buys nothing here except the apt phase that stalls.
Dropping it removes the stall's source rather than bounding it.

**2. Keep the backstop — `timeout-minutes` on every job (`test.yml`).**
`canvas-browser` and `unit` get 15 (healthy ~2–4 min); `integration`, `cli`, `package` get 10
(healthy 1–3 min). This is **not** traded away against the fix above. #1502's real lesson is that
an *unbounded* job conceals its own failure — it pends silently instead of failing — so every job
stays bounded regardless of this specific root cause. If any job ever stalls again for any reason,
it now fails visibly in minutes rather than pending for GitHub's 6-hour default.

### Considered and not done

- **`--retries` on `playwright test`** (as `dashboard-e2e` uses): not added. Retries re-run failed
  *tests*, not the *install* step, so they would not have touched #1502's stall. And the canvas
  browser suite asserts deterministic CSS-fragmentation invariants (protection rects, tall-block
  caps, per-fragment prose rects) — a retry there would mask a real layout regression rather than
  absorb infra flake. That is a different test character from `dashboard-e2e`'s async Tower/`gh`
  flows, where retries are justified.
- **Caching `~/.cache/ms-playwright`**: would not help — `--with-deps` ran `apt-get` regardless of
  the binary cache, so it never skipped the stalling phase. Moot now that `--with-deps` is gone.

## Test Plan

- [x] Regression test: `packages/codev/src/__tests__/bugfix-1502-test-workflow-timeouts.test.ts`
      parses `test.yml` and pins **both** halves of the fix: every job declares a bounded numeric
      `timeout-minutes` in `(0, 360)` (parameterized over the job list, so future jobs are covered
      too), and the canvas-browser install step does **not** pass `--with-deps`. Verified it fails
      both when a timeout is removed and when `--with-deps` is reintroduced; passes on the fix.
- [x] Build passes (`porch check`)
- [x] All tests pass (`porch check`)
- [x] This PR's `Artifact-Canvas Browser Tests` job installed Chromium **without** `--with-deps`
      and the browser launched — the canvas suite ran green in **45s** (vs ~4 min with the apt
      phase). Confirms the runner image carries every library canvas needs.

## Caveat

`dashboard-e2e` exercises the dashboard; this job exercises canvas rendering. If canvas needs a
system library the dashboard does not, dropping `--with-deps` surfaces it as a **browser launch
failure** in this PR's own `canvas-browser` job — cheap, immediate verification. If that happens,
the fix is to restore `--with-deps` and rely on the timeout backstop alone; that result is worth
knowing and is stated here honestly rather than claimed away. As with any intermittent failure, a
single green run does not *prove* the apt stall can never recur through some other path — which is
exactly why the timeout backstop stays.
