### PR TITLE
[Air #1505] Stream Deck: bare Scroll on the dial when no builder is selected

### DIFF
--- a/apps/streamdeck/src/__tests__/actions.test.ts
+++ b/apps/streamdeck/src/__tests__/actions.test.ts
@@ -680,15 +680,25 @@ describe('encoders', () => {
     expect(ctx.sent).toEqual([{ verb: 'feedback-selection', args: [], ws: '/work/alpha' }]);
   });
 
-  it('ScrollNav empty state: line 2 reads "No builder" and the press is a silent no-op', async () => {
+  it('ScrollNav empty state: line 1 is a bare "Scroll" (no delivery mode), line 2 reads "No builder", press is a silent no-op (#1505)', async () => {
     const ctx = makeStore();
     ctx.store.overview = { builders: [], pendingPRs: [], backlog: [], recentlyClosed: [] } as never;
     const action = { isDial: () => true, setFeedback: vi.fn() };
     const nav = new ScrollNav(ctx.store);
     nav.onWillAppear({ action, payload: {} } as never);
-    expect(action.setFeedback.mock.calls.at(-1)?.[0]).toMatchObject({ title: 'Scroll · send', value: 'No builder' });
+    // With nothing selected the press is inert, so line 1 must not name a delivery mode it
+    // cannot fire: neither `send` nor `queue`, just the bare axis.
+    expect(action.setFeedback.mock.calls.at(-1)?.[0]).toEqual({ title: 'Scroll', value: 'No builder' });
     await nav.onDialDown();
     expect(ctx.sent).toHaveLength(0); // inert: no feedback-selection with nothing selected
+  });
+
+  it('ScrollNav empty state: the queue delivery mode does NOT leak into line 1 (#1505)', () => {
+    const ctx = makeStore();
+    ctx.store.overview = { builders: [], pendingPRs: [], backlog: [], recentlyClosed: [], feedbackMode: 'queue' } as never;
+    const action = { isDial: () => true, setFeedback: vi.fn() };
+    new ScrollNav(ctx.store).onWillAppear({ action, payload: {} } as never);
+    expect(action.setFeedback.mock.calls.at(-1)?.[0]).toEqual({ title: 'Scroll', value: 'No builder' });
   });
 
   it('ScrollNav re-renders line 2 on a store change (subscription wired)', () => {

--- a/apps/streamdeck/src/__tests__/actions.test.ts
+++ b/apps/streamdeck/src/__tests__/actions.test.ts
@@ -701,6 +701,18 @@ describe('encoders', () => {
     expect(action.setFeedback.mock.calls.at(-1)?.[0]).toEqual({ title: 'Scroll', value: 'No builder' });
   });
 
+  it('ScrollNav empty state: rotation still relays the scroll verb with the workspace path — the half-live premise the bare "Scroll" rests on (#1505)', async () => {
+    const ctx = makeStore();
+    ctx.store.overview = { builders: [], pendingPRs: [], backlog: [], recentlyClosed: [] } as never;
+    const nav = new ScrollNav(ctx.store);
+    // The press is inert with nothing selected, but rotation is NOT: relaying `scroll` needs
+    // only the workspace path, never a builder. If a future edit early-returns onDialRotate on
+    // no builder (mirroring onDialDown), the dial goes fully inert and the bare "Scroll" line 1
+    // becomes a lie — this guard fails first.
+    await nav.onDialRotate(dial(1) as never);
+    expect(ctx.sent).toEqual([{ verb: 'scroll', args: [{ to: 'down', by: 'line', value: 3, revealCursor: false }], ws: '/work/alpha' }]);
+  });
+
   it('ScrollNav re-renders line 2 on a store change (subscription wired)', () => {
     const ctx = makeStore();
     const action = { isDial: () => true, setFeedback: vi.fn() };

--- a/apps/streamdeck/src/actions.ts
+++ b/apps/streamdeck/src/actions.ts
@@ -1081,10 +1081,21 @@ export class ScrollNav extends SingletonAction {
    *  which is neither. The qualifier names where the dial DOES work rather than reading as
    *  a fault. (#1501 would restore ROTATION on a canvas via a canvas viewport-scroll
    *  command, but the press stays diff-bound by design, so this does not simply collapse
-   *  back to `send`/`queue` when #1501 lands — the two gestures have different scopes.) */
+   *  back to `send`/`queue` when #1501 lands — the two gestures have different scopes.)
+   *
+   *  With NO builder selected the press is inert too (`onDialDown` returns early), so the
+   *  delivery-mode qualifier is suppressed and line 1 reads a bare `Scroll` (#1505) — the
+   *  same canvas-branch rule that the qualifier appears only where the gesture it names is
+   *  live. Rotation still works with nothing selected (relaying `scroll` needs only the
+   *  workspace path), so the axis word stays honest; only the qualifier drops. */
   private renderTo(action: DialAction): void {
+    const b = this.store.selectedBuilder();
+    if (!b) {
+      void action.setFeedback({ title: 'Scroll', value: selectedBuilderLine(this.store) });
+      return;
+    }
     let qualifier: string;
-    if (reviewMode(this.store.selectedBuilder()) === 'canvas') {
+    if (reviewMode(b) === 'canvas') {
       qualifier = 'editor only';
     } else if (this.store.feedbackMode() === 'queue') {
       qualifier = 'queue';

--- a/apps/streamdeck/src/actions.ts
+++ b/apps/streamdeck/src/actions.ts
@@ -43,7 +43,15 @@ async function ack(action: KeyAction, ok: boolean): Promise<void> {
 
 // ── Verb keypads ──────────────────────────────────────────────────────────
 
-/** A keypad that fires one canonical verb (overridable via settings). */
+/**
+ * A keypad that fires one canonical verb (overridable via settings).
+ *
+ * VerbKey keys have no RUNTIME face: this base never calls `setImage`, so the key's manifest
+ * `Image` IS its hardware face (#1459). Subclasses that need a composed face (an icon plus a
+ * label, e.g. DevServerAction) render it themselves in `onWillAppear`, and for those the
+ * manifest image is only the placeholder the deck shows until that first render lands. So an
+ * unstyled VerbKey shows its static manifest icon; a compositing one overwrites it on appear.
+ */
 abstract class VerbKey extends SingletonAction<VerbSettings> {
   protected abstract readonly defaultVerb: string;
   constructor(protected readonly store: CodevStore) {

--- a/codev/projects/1505-stream-deck-scroll-dial-names-/status.yaml
+++ b/codev/projects/1505-stream-deck-scroll-dial-names-/status.yaml
@@ -6,16 +6,17 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-08-18T04:01:36.881Z'
+    approved_at: '2026-08-18T04:10:15.565Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:57:22.238Z'
-updated_at: '2026-08-18T04:01:36.882Z'
+updated_at: '2026-08-18T04:10:15.566Z'
 pr_history:
   - phase: pr
     pr_number: 1508
     branch: builder/air-1505
     created_at: '2026-08-18T04:01:25.967Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/1505-stream-deck-scroll-dial-names-/status.yaml
+++ b/codev/projects/1505-stream-deck-scroll-dial-names-/status.yaml
@@ -7,13 +7,15 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-08-18T04:01:36.881Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:57:22.238Z'
-updated_at: '2026-08-18T04:01:25.968Z'
+updated_at: '2026-08-18T04:01:36.882Z'
 pr_history:
   - phase: pr
     pr_number: 1508
     branch: builder/air-1505
     created_at: '2026-08-18T04:01:25.967Z'
+pr_ready_for_human: true

--- a/codev/projects/1505-stream-deck-scroll-dial-names-/status.yaml
+++ b/codev/projects/1505-stream-deck-scroll-dial-names-/status.yaml
@@ -11,4 +11,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:57:22.238Z'
-updated_at: '2026-08-18T04:00:55.341Z'
+updated_at: '2026-08-18T04:01:25.968Z'
+pr_history:
+  - phase: pr
+    pr_number: 1508
+    branch: builder/air-1505
+    created_at: '2026-08-18T04:01:25.967Z'

--- a/codev/projects/1505-stream-deck-scroll-dial-names-/status.yaml
+++ b/codev/projects/1505-stream-deck-scroll-dial-names-/status.yaml
@@ -1,0 +1,14 @@
+id: '1505'
+title: stream-deck-scroll-dial-names-
+protocol: air
+phase: implement
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-18T03:57:22.238Z'
+updated_at: '2026-08-18T03:57:22.239Z'

--- a/codev/projects/1505-stream-deck-scroll-dial-names-/status.yaml
+++ b/codev/projects/1505-stream-deck-scroll-dial-names-/status.yaml
@@ -1,7 +1,7 @@
 id: '1505'
 title: stream-deck-scroll-dial-names-
 protocol: air
-phase: implement
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:57:22.238Z'
-updated_at: '2026-08-18T03:57:22.239Z'
+updated_at: '2026-08-18T04:00:55.341Z'

--- a/codev/state/air-1505_thread.md
+++ b/codev/state/air-1505_thread.md
@@ -1,0 +1,27 @@
+# air-1505 — Stream Deck: Scroll dial names a delivery mode with no builder selected
+
+## Task (AIR, strict)
+Issue #1505: with no builder selected the Scroll dial's touchstrip still read
+`Scroll · send` / `Scroll · queue` while its press is inert (`onDialDown` returns early
+when nothing is selected). Line 1 named a delivery mode a gesture could not fire.
+Ride-along fix folded into the next `apps/streamdeck/src/actions.ts` touch (the #1454 pattern).
+
+## What I did
+- `ScrollNav.renderTo` (`apps/streamdeck/src/actions.ts`): when `selectedBuilder()` is
+  undefined, suppress the delivery-mode qualifier and render a bare `Scroll` on line 1.
+  Rotation still works with nothing selected (relaying `scroll` needs only the workspace
+  path), so the axis word stays honest; only the qualifier drops. Mirrors the canvas
+  branch's rule (#1498) that the qualifier appears only where the gesture it names is live.
+  Reused the already-fetched `selectedBuilder()` result instead of calling it twice.
+- Updated the existing empty-state test to assert the bare `Scroll` title, and added a
+  second guard proving the `queue` delivery mode does not leak into line 1 when nothing
+  is selected.
+
+## Verification
+- `apps/streamdeck` check-types: 0 errors (had to build `@cluesmith/codev-types` +
+  `@cluesmith/codev-sdk` first — their dist wasn't present in a fresh worktree; the
+  `codev-sdk/controller` module-not-found errors were purely that, not my change).
+- `apps/streamdeck` build (esbuild): exit 0.
+- `apps/streamdeck` vitest: 239 passed.
+
+Scope: `apps/streamdeck` only, no wire or VS Code involvement. Well under 300 LOC.

--- a/codev/state/air-1505_thread.md
+++ b/codev/state/air-1505_thread.md
@@ -25,3 +25,26 @@ Ride-along fix folded into the next `apps/streamdeck/src/actions.ts` touch (the 
 - `apps/streamdeck` vitest: 239 passed.
 
 Scope: `apps/streamdeck` only, no wire or VS Code involvement. Well under 300 LOC.
+
+## Architect review round 1 (PR #1508 → REQUEST_CHANGES, batched into one push)
+Two gaps, both in `actions.ts`, fixed together (a second push restarts all seven checks, #1462):
+- **Gap 1 / #1459**: added a doc comment to the `VerbKey` base class recording that its keys
+  have no runtime face — the manifest `Image` IS the hardware face; compositing subclasses
+  (e.g. `DevServerAction`) render their own face in `onWillAppear` and treat the manifest
+  image as the pre-render placeholder. PR body gains `Closes #1459` so both issues close on merge.
+- **Gap 2**: the "rotation still works with nothing selected" claim (the reason we chose a bare
+  `Scroll` over `editor only`) was asserted in prose but tested nowhere — the only rotate test
+  used a fixture WITH builders. Added a behaviour guard: with an empty overview, `onDialRotate`
+  still relays the `scroll` verb with the workspace path. This pins the premise, distinct from
+  the queue-leak test which pins RENDERING. Catches a future `onDialRotate` early-return that
+  would make the dial fully inert while line 1 still names a live axis.
+
+Re-verified: check-types 0 errors, vitest 240 passed (+1). Reported new head SHA to architect.
+Not merging — owner's word, and the architect still owes a hardware deck check.
+
+## User report: scrolling doesn't work in spec/plan (canvas) review mode
+That is issue #1501, OPEN and separate — out of this lane's scope. The Scroll dial correctly
+RELAYS `scroll`, but VS Code applies it to the focused text editor, and a spec/plan opens in
+the artifact-canvas webview (not a text editor), so nothing scrolls there. #1505 only fixed the
+LABEL (bare `Scroll` with no builder); restoring canvas rotation needs a new canvas
+viewport-scroll command spanning wire + VS Code, which #1501 tracks. Flagged, did not expand scope.


### PR DESCRIPTION
## Summary

Closes #1505 and #1459 — two small `apps/streamdeck/src/actions.ts` items batched into one lane.

**#1505** — with **no builder selected**, the Scroll dial's touchstrip still read `Scroll · send` / `Scroll · queue` while its press is inert (`onDialDown` returns early when `selectedBuilder()` is undefined). Line 1 named a delivery mode for a gesture that cannot fire. This suppresses the delivery-mode qualifier in the empty state so line 1 reads a bare `Scroll`, mirroring the canvas branch's rule (#1498) that the qualifier appears only where the gesture it names is live.

**#1459** — a doc comment on the `VerbKey` base class recording that its keys draw no runtime face: the manifest `Image` IS the hardware face, and compositing subclasses (e.g. `DevServerAction`) render their own face in `onWillAppear`, treating the manifest image as the pre-render placeholder.

## What changed

- **`ScrollNav.renderTo`** (#1505): when `selectedBuilder()` is undefined, render a bare `Scroll` on line 1 with no `· send` / `· queue` qualifier. The existing `canvas` / `queue` / `send` branch is untouched and now runs only when a builder is selected. Reused the already-fetched builder handle instead of calling `selectedBuilder()` twice.
- **`VerbKey` doc comment** (#1459): records the no-runtime-face contract described above.
- **Tests** (`apps/streamdeck/src/__tests__/actions.test.ts`):
  - updated the empty-state guard to assert the bare `Scroll` title (`toEqual`);
  - added a **rendering** guard that the `queue` delivery mode does not leak into line 1 when nothing is selected;
  - added a **behaviour** guard that with an empty overview `onDialRotate` still relays the `scroll` verb with the workspace path — pinning the "rotation is still live with no builder" premise that justifies a bare `Scroll` over `editor only`. Distinct from the rendering guard; catches a future `onDialRotate` early-return that would make the dial fully inert while line 1 still names a live axis.

## Why line 1 (not line 2)

Line 2 already reads `No builder`, so the absent target is stated. The remaining inconsistency was line 1 claiming a *live delivery mode* on a dead press. Rotation genuinely still works with nothing selected (`onDialRotate` relays `scroll` with only the workspace path), so the axis word `Scroll` stays — only the delivery-mode qualifier, which describes the inert press, is dropped. This closes the last place on the dial where the strip claimed a live mode for an inert gesture — the principle #1498 established.

## Not in scope

Rotation does **not** scroll a spec/plan under review (canvas webview, not a text editor): the dial relays `scroll` correctly, but VS Code applies it to the focused text editor, so nothing moves on a canvas. That is tracked separately as **#1501** (needs a new canvas viewport-scroll command spanning wire + VS Code) and is deliberately out of this lane.

## Review notes

- Scope: `apps/streamdeck` only. No wire protocol or VS Code involvement. Well under the AIR 300-LOC ceiling.
- **Verification**: `apps/streamdeck` check-types 0 errors, esbuild build exit 0, vitest 240 passed.
- No changelog entry: this is a Stream Deck plugin fix, not the VS Code extension, so neither `packages/vscode/CHANGELOG.md` nor `docs/releases/UNRELEASED.md` applies.

AIR protocol: no spec/plan/review files; the review lives in this PR body.
