### PR TITLE
Dashboard: make the held-mail counter clickable, showing the held messages (from → to)

### DIFF
--- a/apps/web/__tests__/HeldCountBadge.test.tsx
+++ b/apps/web/__tests__/HeldCountBadge.test.tsx
@@ -341,6 +341,21 @@ describe('HeldCountBadge', () => {
     expect((await screen.findByTestId('held-empty')).textContent).toContain('Held mail cleared');
   });
 
+  it('says nothing is held when the held rows drain but a scheduled row remains', async () => {
+    // count -> 0 with a pre-due row still listed: the panel is NOT empty, but there is
+    // nothing HELD, and the Scheduled group's "not counted above" needs a line above it.
+    const now = Date.now();
+    const loadMessages = () => Promise.resolve([row({ id: 'sched', notBefore: now + 15_000 })]);
+    const { rerender } = render(<HeldCountBadge count={1} escalated={false} loadMessages={loadMessages} />);
+    await open();
+    rerender(<HeldCountBadge count={0} escalated={false} loadMessages={loadMessages} />);
+
+    const note = await screen.findByTestId('held-empty');
+    expect(note.textContent).toContain('scheduled');
+    expect(screen.queryByTestId('held-group-held')).toBeNull();
+    expect(screen.getByTestId('held-group-scheduled')).toBeTruthy();
+  });
+
   it('unmounts once the user closes a panel whose count already dropped to 0', async () => {
     const { rerender, container } = render(
       <HeldCountBadge count={1} escalated={false} loadMessages={noMessages} />,

--- a/apps/web/__tests__/HeldCountBadge.test.tsx
+++ b/apps/web/__tests__/HeldCountBadge.test.tsx
@@ -1,38 +1,410 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor, act } from '@testing-library/react';
+import type { HeldMessage } from '@cluesmith/codev-types';
 import { HeldCountBadge } from '../src/components/HeldCountBadge.js';
 
 afterEach(cleanup);
 
+/** A held row with sensible defaults; override only what a test cares about. */
+function row(over: Partial<HeldMessage> = {}): HeldMessage {
+  return {
+    id: 'row-1',
+    workspacePath: '/ws',
+    toAgent: 'cost',
+    fromAgent: 'architect',
+    reason: 'busy',
+    escalated: false,
+    createdAt: Date.now() - 90_000, // 1m ago
+    notBefore: null,
+    ...over,
+  };
+}
+
+const noMessages = () => Promise.resolve<HeldMessage[]>([]);
+
+/** Open the panel and wait for its first load to settle. */
+async function open(): Promise<HTMLElement> {
+  fireEvent.click(screen.getByTestId('held-badge'));
+  return screen.findByTestId('held-popover');
+}
+
 describe('HeldCountBadge', () => {
+  // ---------------------------------------------------------------- Spec 1313 contract
+  // These five predate Issue 1450 and must keep passing unchanged: the badge's
+  // count-only / zero-state / attention behaviour is not what the popover changed.
+
   it('renders nothing when the count is 0', () => {
-    const { container } = render(<HeldCountBadge count={0} escalated={false} />);
+    const { container } = render(<HeldCountBadge count={0} escalated={false} loadMessages={noMessages} />);
     expect(container.firstChild).toBeNull();
     expect(screen.queryByTestId('held-badge')).toBeNull();
   });
 
   it('renders nothing for a negative count (defensive)', () => {
-    const { container } = render(<HeldCountBadge count={-1} escalated={false} />);
+    const { container } = render(<HeldCountBadge count={-1} escalated={false} loadMessages={noMessages} />);
     expect(container.firstChild).toBeNull();
   });
 
   it('shows the held count when greater than 0', () => {
-    render(<HeldCountBadge count={3} escalated={false} />);
+    render(<HeldCountBadge count={3} escalated={false} loadMessages={noMessages} />);
     expect(screen.getByTestId('held-badge')).toBeTruthy();
     expect(screen.getByText('3 held')).toBeTruthy();
   });
 
   it('is not in the attention state when not escalated', () => {
-    render(<HeldCountBadge count={2} escalated={false} />);
+    render(<HeldCountBadge count={2} escalated={false} loadMessages={noMessages} />);
     const badge = screen.getByTestId('held-badge');
     expect(badge.className).not.toContain('held-badge--attention');
     expect(badge.querySelector('.held-dot--attention')).toBeNull();
   });
 
   it('enters the attention state (pulsing dot) when escalated', () => {
-    render(<HeldCountBadge count={1} escalated={true} />);
+    render(<HeldCountBadge count={1} escalated={true} loadMessages={noMessages} />);
     const badge = screen.getByTestId('held-badge');
     expect(badge.className).toContain('held-badge--attention');
     expect(badge.querySelector('.held-dot--attention')).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------- Issue 1450: affordance
+
+  it('is a button wired as a disclosure, collapsed by default', () => {
+    render(<HeldCountBadge count={1} escalated={false} loadMessages={noMessages} />);
+    const badge = screen.getByTestId('held-badge');
+    // A real <button> is what buys keyboard activation (Enter/Space) and focusability for
+    // free — the affordance is not just the underline.
+    expect(badge.tagName).toBe('BUTTON');
+    expect(badge.getAttribute('aria-expanded')).toBe('false');
+    expect(badge.getAttribute('aria-controls')).toBeTruthy();
+    // Disclosure pattern, not a dialog — see the component docstring.
+    expect(badge.getAttribute('aria-haspopup')).toBeNull();
+    expect(screen.queryByTestId('held-popover')).toBeNull();
+  });
+
+  it('points aria-controls at the panel it actually opens', async () => {
+    render(<HeldCountBadge count={1} escalated={false} loadMessages={noMessages} />);
+    const badge = screen.getByTestId('held-badge');
+    const panel = await open();
+    expect(panel.id).toBe(badge.getAttribute('aria-controls'));
+  });
+
+  it('opens the panel on click and loads the messages once', async () => {
+    const loadMessages = vi.fn(() => Promise.resolve([row()]));
+    render(<HeldCountBadge count={1} escalated={false} loadMessages={loadMessages} />);
+
+    await open();
+
+    expect(screen.getByTestId('held-badge').getAttribute('aria-expanded')).toBe('true');
+    expect(loadMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fetch until the panel is opened', () => {
+    const loadMessages = vi.fn(noMessages);
+    render(<HeldCountBadge count={1} escalated={false} loadMessages={loadMessages} />);
+    expect(loadMessages).not.toHaveBeenCalled();
+  });
+
+  it('closes again on a second click', async () => {
+    render(<HeldCountBadge count={1} escalated={false} loadMessages={() => Promise.resolve([row()])} />);
+    const badge = screen.getByTestId('held-badge');
+
+    await open();
+    fireEvent.click(badge);
+
+    expect(screen.queryByTestId('held-popover')).toBeNull();
+    expect(badge.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  // ---------------------------------------------------------------- Issue 1450: row rendering
+
+  it('renders each message as from → to', async () => {
+    render(
+      <HeldCountBadge
+        count={1}
+        escalated={false}
+        loadMessages={() => Promise.resolve([row({ fromAgent: 'architect', toAgent: 'cost' })])}
+      />,
+    );
+    await open();
+    expect(await screen.findByText('architect → cost')).toBeTruthy();
+  });
+
+  it('renders a missing sender as "?" (matching afx inbox)', async () => {
+    render(
+      <HeldCountBadge
+        count={1}
+        escalated={false}
+        loadMessages={() => Promise.resolve([row({ fromAgent: null, toAgent: 'cost' })])}
+      />,
+    );
+    await open();
+    expect(await screen.findByText('? → cost')).toBeTruthy();
+  });
+
+  it('renders age and reason, and marks an escalated row', async () => {
+    const now = Date.now();
+    render(
+      <HeldCountBadge
+        count={1}
+        escalated={true}
+        loadMessages={() =>
+          Promise.resolve([row({ createdAt: now - 120_000, reason: 'no-live-pty', escalated: true })])
+        }
+      />,
+    );
+    await open();
+
+    const rowEl = await screen.findByTestId('held-row');
+    expect(rowEl.textContent).toContain('2m');
+    expect(rowEl.textContent).toContain('no-live-pty');
+    expect(rowEl.textContent).toContain('!');
+    expect(rowEl.className).toContain('held-row--attention');
+  });
+
+  it('falls back to "held" when the row carries no reason', async () => {
+    render(
+      <HeldCountBadge count={1} escalated={false} loadMessages={() => Promise.resolve([row({ reason: null })])} />,
+    );
+    await open();
+    expect((await screen.findByTestId('held-row')).textContent).toContain('held');
+  });
+
+  // ------------------------------------------------- Issue 1450: the Held / Scheduled split
+  // The blocking finding from plan review: `heldCount` excludes pre-due `--delay` rows
+  // (heldSummaryForWorkspace filters not_before) while GET /api/inbox lists them
+  // (listHeld does not). The panel must render that difference, not hide it.
+
+  it('groups a pre-due row separately so the Held group matches the badge count', async () => {
+    const now = Date.now();
+    const due = row({ id: 'due', fromAgent: 'architect', toAgent: 'cost', notBefore: null });
+    const preDue = row({ id: 'pre', fromAgent: 'architect', toAgent: 'docs', notBefore: now + 15_000 });
+
+    // count=1 is what the server reports for these two rows: only `due` is eligible.
+    render(<HeldCountBadge count={1} escalated={false} loadMessages={() => Promise.resolve([due, preDue])} />);
+    await open();
+
+    const heldGroup = await screen.findByTestId('held-group-held');
+    const scheduledGroup = screen.getByTestId('held-group-scheduled');
+
+    // THE assertion: the group the user reads as "the held mail" is exactly the badge count.
+    expect(heldGroup.querySelectorAll('li')).toHaveLength(1);
+    expect(heldGroup.textContent).toContain('architect → cost');
+    expect(scheduledGroup.querySelectorAll('li')).toHaveLength(1);
+    expect(scheduledGroup.textContent).toContain('architect → docs');
+    expect(screen.getByText('Held (1)')).toBeTruthy();
+    expect(screen.getByText('Scheduled (1)')).toBeTruthy();
+  });
+
+  it('renders a scheduled row with a countdown and the "scheduled" reason, not an age', async () => {
+    // Pin the clock: the component samples `Date.now()` at render, so a countdown built from
+    // a real `Date.now()` in the fixture floors to 14s once a millisecond of test time has
+    // passed. Freezing it makes the assertion about the FORMAT, not about scheduling luck.
+    const now = 1_700_000_000_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+    try {
+      render(
+        <HeldCountBadge
+          count={1}
+          escalated={false}
+          loadMessages={() =>
+            Promise.resolve([row({ id: 'a', notBefore: null }), row({ id: 'b', notBefore: now + 15_000 })])
+          }
+        />,
+      );
+      await open();
+
+      const scheduled = await screen.findByTestId('held-group-scheduled');
+      expect(scheduled.textContent).toContain('→15s');
+      expect(scheduled.textContent).toContain('scheduled');
+      // Its own `reason` ('busy') is suppressed — a scheduled row is not stuck.
+      expect(scheduled.textContent).not.toContain('busy');
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('is absent entirely when the only row is scheduled (count 0) — the documented edge', () => {
+    // heldSummaryForWorkspace excludes pre-due rows, so heldCount is 0 and the badge does
+    // not render. `afx inbox` remains the surface for a scheduled-only state.
+    const { container } = render(
+      <HeldCountBadge count={0} escalated={false} loadMessages={() => Promise.resolve([row({ notBefore: Date.now() + 15_000 })])} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('omits a group entirely when it has no rows', async () => {
+    render(<HeldCountBadge count={1} escalated={false} loadMessages={() => Promise.resolve([row()])} />);
+    await open();
+
+    expect(await screen.findByTestId('held-group-held')).toBeTruthy();
+    expect(screen.queryByTestId('held-group-scheduled')).toBeNull();
+  });
+
+  // ---------------------------------------------------------------- Issue 1450: load states
+
+  it('shows an explicit empty state rather than a blank panel', async () => {
+    render(<HeldCountBadge count={1} escalated={false} loadMessages={noMessages} />);
+    await open();
+    expect((await screen.findByTestId('held-empty')).textContent).toContain('No held messages');
+  });
+
+  it('shows an error state when the fetch fails, not a silent empty list', async () => {
+    render(
+      <HeldCountBadge
+        count={1}
+        escalated={false}
+        loadMessages={() => Promise.reject(new Error('Failed to fetch held messages: 401'))}
+      />,
+    );
+    await open();
+
+    // A 401 must read as a failure, not as "nothing is held" — the two look identical
+    // otherwise, and one of them is a lie.
+    const err = await screen.findByTestId('held-error');
+    expect(err.textContent).toContain('401');
+    expect(screen.queryByTestId('held-empty')).toBeNull();
+  });
+
+  it('never renders a message body, even if the server sends one', async () => {
+    // Defence in depth for the Spec 1313 redaction rule: the projection carries no body,
+    // and the component must not surface one if a future/rogue payload includes it.
+    const withBody = { ...row(), body: 'SECRET-BODY-TEXT' } as unknown as HeldMessage;
+    render(<HeldCountBadge count={1} escalated={false} loadMessages={() => Promise.resolve([withBody])} />);
+    const panel = await open();
+    await screen.findByTestId('held-row');
+    expect(panel.textContent).not.toContain('SECRET-BODY-TEXT');
+  });
+
+  // ---------------------------------------------------------------- Issue 1450: lifecycle
+
+  it('discards a stale response from a fast open → close → open', async () => {
+    let call = 0;
+    const slowFirst = () => {
+      call++;
+      return call === 1
+        ? new Promise<HeldMessage[]>((r) =>
+            setTimeout(() => r([row({ id: 'stale', fromAgent: 'stale-from', toAgent: 'stale-to' })]), 50),
+          )
+        : Promise.resolve([row({ id: 'fresh', fromAgent: 'fresh-from', toAgent: 'fresh-to' })]);
+    };
+    render(<HeldCountBadge count={1} escalated={false} loadMessages={slowFirst} />);
+    const badge = screen.getByTestId('held-badge');
+
+    fireEvent.click(badge); // open  → slow request in flight
+    fireEvent.click(badge); // close
+    fireEvent.click(badge); // open  → fast request resolves first
+
+    expect(await screen.findByText('fresh-from → fresh-to')).toBeTruthy();
+
+    // Let the slow first response land; it must NOT overwrite the fresh data.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 120));
+    });
+    expect(screen.queryByText('stale-from → stale-to')).toBeNull();
+    expect(screen.getByText('fresh-from → fresh-to')).toBeTruthy();
+  });
+
+  it('refetches when the count changes while the panel is open', async () => {
+    const loadMessages = vi.fn(() => Promise.resolve([row()]));
+    const { rerender } = render(<HeldCountBadge count={1} escalated={false} loadMessages={loadMessages} />);
+
+    await open();
+    await waitFor(() => expect(loadMessages).toHaveBeenCalledTimes(1));
+
+    // The SSE-driven count moved — the open panel should follow, not go stale.
+    rerender(<HeldCountBadge count={2} escalated={false} loadMessages={loadMessages} />);
+    await waitFor(() => expect(loadMessages).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not refetch on an unrelated rerender', async () => {
+    const loadMessages = vi.fn(() => Promise.resolve([row()]));
+    const { rerender } = render(<HeldCountBadge count={1} escalated={false} loadMessages={loadMessages} />);
+
+    await open();
+    await waitFor(() => expect(loadMessages).toHaveBeenCalledTimes(1));
+
+    rerender(<HeldCountBadge count={1} escalated={true} loadMessages={loadMessages} />);
+    await act(async () => { await Promise.resolve(); });
+    expect(loadMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays mounted when the last held row is delivered while the panel is open', async () => {
+    const loadMessages = vi.fn(() => Promise.resolve<HeldMessage[]>([]));
+    const { rerender } = render(<HeldCountBadge count={1} escalated={false} loadMessages={loadMessages} />);
+
+    await open();
+
+    // useOverview polls every 2.5s; the last row clearing must not yank the button out from
+    // under the user's focus mid-interaction.
+    rerender(<HeldCountBadge count={0} escalated={false} loadMessages={loadMessages} />);
+
+    expect(screen.getByTestId('held-badge')).toBeTruthy();
+    expect(screen.getByTestId('held-popover')).toBeTruthy();
+    expect((await screen.findByTestId('held-empty')).textContent).toContain('Held mail cleared');
+  });
+
+  it('unmounts once the user closes a panel whose count already dropped to 0', async () => {
+    const { rerender, container } = render(
+      <HeldCountBadge count={1} escalated={false} loadMessages={noMessages} />,
+    );
+    await open();
+    rerender(<HeldCountBadge count={0} escalated={false} loadMessages={noMessages} />);
+
+    fireEvent.click(screen.getByTestId('held-badge')); // close
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('closes on Escape and returns focus to the button', async () => {
+    render(<HeldCountBadge count={1} escalated={false} loadMessages={() => Promise.resolve([row()])} />);
+    const badge = screen.getByTestId('held-badge');
+
+    await open();
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(screen.queryByTestId('held-popover')).toBeNull();
+    expect(document.activeElement).toBe(badge);
+  });
+
+  it('ignores unrelated keys while open', async () => {
+    render(<HeldCountBadge count={1} escalated={false} loadMessages={() => Promise.resolve([row()])} />);
+    await open();
+
+    fireEvent.keyDown(document, { key: 'a' });
+    expect(screen.getByTestId('held-popover')).toBeTruthy();
+  });
+
+  it('closes when clicking outside the badge', async () => {
+    render(
+      <div>
+        <HeldCountBadge count={1} escalated={false} loadMessages={() => Promise.resolve([row()])} />
+        <button type="button">elsewhere</button>
+      </div>,
+    );
+
+    await open();
+    fireEvent.mouseDown(screen.getByText('elsewhere'));
+
+    expect(screen.queryByTestId('held-popover')).toBeNull();
+  });
+
+  it('stays open when clicking inside the panel', async () => {
+    render(<HeldCountBadge count={1} escalated={false} loadMessages={() => Promise.resolve([row()])} />);
+    const panel = await open();
+
+    fireEvent.mouseDown(panel);
+
+    expect(screen.getByTestId('held-popover')).toBeTruthy();
+  });
+
+  it('detaches its document listeners on unmount', async () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    const { unmount } = render(
+      <HeldCountBadge count={1} escalated={false} loadMessages={() => Promise.resolve([row()])} />,
+    );
+    await open();
+    unmount();
+
+    const removed = removeSpy.mock.calls.map((c) => c[0]);
+    expect(removed).toContain('keydown');
+    expect(removed).toContain('mousedown');
+    removeSpy.mockRestore();
   });
 });

--- a/apps/web/__tests__/heldMail.test.ts
+++ b/apps/web/__tests__/heldMail.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { formatHeldAge, formatHeldDuration, isScheduled } from '../src/lib/heldMail.js';
+
+describe('formatHeldDuration', () => {
+  it('renders sub-minute deltas in seconds', () => {
+    expect(formatHeldDuration(0)).toBe('0s');
+    expect(formatHeldDuration(5_000)).toBe('5s');
+    expect(formatHeldDuration(59_000)).toBe('59s');
+  });
+
+  it('rolls over to minutes at 60s', () => {
+    expect(formatHeldDuration(60_000)).toBe('1m');
+    expect(formatHeldDuration(59 * 60_000)).toBe('59m');
+  });
+
+  it('rolls over to hours at 60m', () => {
+    expect(formatHeldDuration(60 * 60_000)).toBe('1h');
+    expect(formatHeldDuration(23 * 60 * 60_000)).toBe('23h');
+  });
+
+  it('rolls over to days at 24h', () => {
+    expect(formatHeldDuration(24 * 60 * 60_000)).toBe('1d');
+    expect(formatHeldDuration(3 * 24 * 60 * 60_000)).toBe('3d');
+  });
+
+  it('clamps a negative delta to 0s rather than rendering "-1s"', () => {
+    // Clock skew between the server's createdAt and the browser's Date.now() is real;
+    // a negative age must not leak into the UI.
+    expect(formatHeldDuration(-5_000)).toBe('0s');
+  });
+});
+
+describe('formatHeldAge', () => {
+  it('is the delta between now and createdAt', () => {
+    expect(formatHeldAge(1_000_000, 1_000_000 + 90_000)).toBe('1m');
+  });
+});
+
+describe('isScheduled', () => {
+  const now = 1_000_000;
+
+  it('is false for a deliver-ASAP row (null notBefore)', () => {
+    expect(isScheduled(null, now)).toBe(false);
+  });
+
+  it('is false for a row whose due time has passed', () => {
+    expect(isScheduled(now - 1, now)).toBe(false);
+  });
+
+  it('is false exactly at the due time (matches the SQL boundary not_before <= now)', () => {
+    // The count query uses `not_before <= now`, so a row due exactly now IS eligible and
+    // IS counted. This predicate must agree, or the Held group would drift from the badge.
+    expect(isScheduled(now, now)).toBe(false);
+  });
+
+  it('is true for a pre-due row', () => {
+    expect(isScheduled(now + 15_000, now)).toBe(true);
+  });
+});

--- a/apps/web/src/components/App.tsx
+++ b/apps/web/src/components/App.tsx
@@ -4,7 +4,7 @@ import { useTabs, type Tab } from '../hooks/useTabs.js';
 import { useMediaQuery } from '../hooks/useMediaQuery.js';
 import { useOverview } from '../hooks/useOverview.js';
 import { MOBILE_BREAKPOINT } from '../lib/constants.js';
-import { getTerminalWsPath, createFileTab, removeArchitect as removeArchitectApi } from '../lib/api.js';
+import { getTerminalWsPath, createFileTab, fetchInbox, removeArchitect as removeArchitectApi } from '../lib/api.js';
 import { readActiveArchitect, writeActiveArchitect } from '../lib/architectPersistence.js';
 import { SplitPane } from './SplitPane.js';
 import { TabBar } from './TabBar.js';
@@ -357,7 +357,11 @@ export function App() {
           {overviewTitle}
         </h1>
         <div className="header-controls">
-          <HeldCountBadge count={overview?.heldCount ?? 0} escalated={overview?.mailboxEscalated ?? false} />
+          <HeldCountBadge
+            count={overview?.heldCount ?? 0}
+            escalated={overview?.mailboxEscalated ?? false}
+            loadMessages={fetchInbox}
+          />
           {state?.version && <span className="header-version">v{state.version}</span>}
         </div>
       </header>

--- a/apps/web/src/components/HeldCountBadge.tsx
+++ b/apps/web/src/components/HeldCountBadge.tsx
@@ -1,41 +1,212 @@
 /**
- * Spec 1313 Phase 8: compact held-mail count indicator for the dashboard header.
+ * Spec 1313 Phase 8 / Issue 1450: the dashboard header's held-mail indicator.
  *
- * Read-only and count-only. It renders the number of currently-*held* (undelivered)
- * mailbox rows in the workspace, fed by `OverviewData.heldCount` (which the overview
- * refetches live on the `overview-changed` broadcast). When at least one held row has
- * crossed the escalation age (`OverviewData.mailboxEscalated`) the badge enters an
- * attention state — a pulsing amber dot — and clears back to normal when the row
- * resolves. Dismissal stays CLI-only (`afx inbox`); this surface never mutates state
- * (spec Decision 8). Renders nothing when the count is zero, so it stays out of the
- * way until there is held mail.
+ * Renders the number of currently-*held* (undelivered) mailbox rows in the workspace, fed by
+ * `OverviewData.heldCount` (which the overview refetches live on the `overview-changed`
+ * broadcast). When at least one held row has crossed the escalation age
+ * (`OverviewData.mailboxEscalated`) the badge enters an attention state — a pulsing amber dot —
+ * and clears back to normal when the row resolves. Renders nothing when the count is zero, so
+ * it stays out of the way until there is held mail.
  *
- * Presentational only (takes its data as props) so it unit-tests in isolation, mirroring
- * `CloudStatus`.
+ * Issue 1450 made it a **disclosure button**: clicking it opens a panel listing each held
+ * message as `from → to` with its age and why-held reason, so "2 held" stops sending the user
+ * to a terminal to find out who is stuck. Still strictly READ-ONLY — dismissal remains CLI-only
+ * (`afx inbox dismiss`, spec Decision 8), and the list carries no message bodies (the redaction
+ * rule; `afx inbox show <id>` is the body path).
+ *
+ * ## Held vs Scheduled — why the panel groups rows
+ *
+ * The badge count and the list come from DIFFERENT queries and legitimately disagree.
+ * `heldSummaryForWorkspace` (the count) requires `not_before IS NULL OR not_before <= now`, so a
+ * pre-due `--delay` send is "scheduled, not stuck" and does not inflate the attention count.
+ * `listHeld` (behind `GET /api/inbox`) has no such filter and returns every held row. So
+ * `count <= messages.length`, always.
+ *
+ * Rather than hide that, the panel groups: **Held (N)** — where N is exactly the badge count —
+ * and a secondary **Scheduled (M)** section for pre-due rows, with their due countdown. Each
+ * group renders only when non-empty, so the ordinary case (no `--delay` in flight) looks like a
+ * single plain list. This mirrors `afx inbox`, which lists both and labels the pre-due ones
+ * `scheduled`.
+ *
+ * Consequence worth knowing: with 0 due and 1 scheduled row the badge does not render at all,
+ * so a scheduled-only state is invisible here. That is the existing contract — the badge is an
+ * *attention* indicator — and `afx inbox` remains the surface that sees it.
+ *
+ * Presentational: it takes a `loadMessages` loader rather than importing `fetchInbox`, so it
+ * unit-tests in isolation with a fake loader, mirroring `CloudStatus`.
  */
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import type { HeldMessage } from '../lib/api.js';
+import { formatHeldAge, formatHeldDuration, isScheduled } from '../lib/heldMail.js';
+
 export interface HeldCountBadgeProps {
-  /** Count of currently-held rows across the workspace (`OverviewData.heldCount`). */
+  /** Count of currently-held ELIGIBLE rows across the workspace (`OverviewData.heldCount`). */
   count: number;
   /** True when at least one held row has crossed the escalation age. */
   escalated: boolean;
+  /**
+   * Fetches the workspace's held rows. Called on open, and again whenever `count` changes
+   * while open. Injected so the component stays presentational and testable.
+   */
+  loadMessages: () => Promise<HeldMessage[]>;
 }
 
-export function HeldCountBadge({ count, escalated }: HeldCountBadgeProps) {
-  if (count <= 0) {
+/** What the panel is currently showing. */
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'ready'; messages: HeldMessage[] };
+
+function HeldRow({ message, now }: { message: HeldMessage; now: number }) {
+  const scheduled = isScheduled(message.notBefore, now);
+  // `?` for a missing sender matches how `afx inbox` renders the same row.
+  const fromTo = `${message.fromAgent ?? '?'} → ${message.toAgent}`;
+  // A scheduled row shows its countdown to due time; a stuck one shows how long it has waited.
+  const when = scheduled
+    ? `→${formatHeldDuration(message.notBefore! - now)}`
+    : formatHeldAge(message.createdAt, now);
+  const reason = scheduled ? 'scheduled' : (message.reason ?? 'held');
+  return (
+    <li className={`held-row${message.escalated ? ' held-row--attention' : ''}`} data-testid="held-row">
+      <span className="held-row-addresses">{fromTo}</span>
+      <span className="held-row-meta">
+        {when} · {reason}
+        {message.escalated && !scheduled ? '!' : ''}
+      </span>
+    </li>
+  );
+}
+
+export function HeldCountBadge({ count, escalated, loadMessages }: HeldCountBadgeProps) {
+  const [open, setOpen] = useState(false);
+  const [state, setState] = useState<LoadState>({ kind: 'loading' });
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const panelId = useId();
+
+  // Discards a response whose request is no longer the current one. Without this, a fast
+  // open → close → open lands the FIRST (slower) response over the second's data; React 19
+  // does not warn about setState on an unmounted/stale path, so the bug would be silent.
+  const generationRef = useRef(0);
+
+  const load = useCallback(() => {
+    const generation = ++generationRef.current;
+    setState({ kind: 'loading' });
+    loadMessages().then(
+      (messages) => {
+        if (generationRef.current !== generation) return;
+        setState({ kind: 'ready', messages });
+      },
+      (err: unknown) => {
+        if (generationRef.current !== generation) return;
+        setState({ kind: 'error', message: err instanceof Error ? err.message : String(err) });
+      },
+    );
+  }, [loadMessages]);
+
+  // Load on open, and again when `count` changes while open. Refetch rather than snapshot:
+  // the count is SSE-driven, so a change means the mailbox actually moved — precisely when a
+  // user staring at the open panel would expect it to follow.
+  useEffect(() => {
+    if (!open) return;
+    load();
+  }, [open, count, load]);
+
+  // Escape closes and returns focus to the button (the disclosure pattern's keyboard contract).
+  // Click-outside closes without moving focus, since the user is already looking elsewhere.
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        buttonRef.current?.focus();
+      }
+    };
+    const onPointerDown = (e: MouseEvent) => {
+      if (!wrapperRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('mousedown', onPointerDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('mousedown', onPointerDown);
+    };
+  }, [open]);
+
+  // Normally the badge disappears at zero. But `useOverview` polls every 2.5s, so the last
+  // held row being delivered WHILE the panel is open would unmount the button mid-interaction
+  // and drop focus to <body>. So when open, stay mounted and say the mail cleared; the user's
+  // own close unmounts us. The closed-at-zero contract is unchanged.
+  if (count <= 0 && !open) {
     return null;
   }
+
   const label = `${count} held`;
   const title = escalated
-    ? `${count} held message${count === 1 ? '' : 's'} — at least one past the escalation age. Review with: afx inbox`
-    : `${count} held message${count === 1 ? '' : 's'} awaiting a clear prompt. Review with: afx inbox`;
+    ? `${count} held message${count === 1 ? '' : 's'} — at least one past the escalation age. Click to list them.`
+    : `${count} held message${count === 1 ? '' : 's'} awaiting a clear prompt. Click to list them.`;
+
+  // `now` is sampled per render rather than ticked on a timer: the panel is a triage glance,
+  // and every refetch re-renders anyway. A live-ticking age would be motion for its own sake.
+  const now = Date.now();
+  const messages = state.kind === 'ready' ? state.messages : [];
+  const heldRows = messages.filter((m) => !isScheduled(m.notBefore, now));
+  const scheduledRows = messages.filter((m) => isScheduled(m.notBefore, now));
+
   return (
-    <span
-      className={`held-badge${escalated ? ' held-badge--attention' : ''}`}
-      data-testid="held-badge"
-      title={title}
-    >
-      <span className={`held-dot${escalated ? ' held-dot--attention' : ''}`} />
-      {label}
-    </span>
+    <div className="held-badge-wrapper" ref={wrapperRef}>
+      <button
+        type="button"
+        ref={buttonRef}
+        className={`held-badge${escalated ? ' held-badge--attention' : ''}`}
+        data-testid="held-badge"
+        title={title}
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className={`held-dot${escalated ? ' held-dot--attention' : ''}`} />
+        {label}
+      </button>
+      {open && (
+        <div className="held-popover" id={panelId} data-testid="held-popover">
+          {state.kind === 'loading' && <p className="held-popover-note">Loading…</p>}
+          {state.kind === 'error' && (
+            <p className="held-popover-note held-popover-note--error" data-testid="held-error">
+              Could not load held messages: {state.message}
+            </p>
+          )}
+          {state.kind === 'ready' && messages.length === 0 && (
+            <p className="held-popover-note" data-testid="held-empty">
+              {count <= 0 ? 'Held mail cleared.' : 'No held messages.'}
+            </p>
+          )}
+          {heldRows.length > 0 && (
+            <section className="held-group">
+              <h2 className="held-group-title">Held ({heldRows.length})</h2>
+              <ul className="held-list" data-testid="held-group-held">
+                {heldRows.map((m) => (
+                  <HeldRow key={m.id} message={m} now={now} />
+                ))}
+              </ul>
+            </section>
+          )}
+          {scheduledRows.length > 0 && (
+            <section className="held-group held-group--scheduled">
+              <h2 className="held-group-title">Scheduled ({scheduledRows.length})</h2>
+              <p className="held-group-note">
+                Waiting for their due time — not counted above.
+              </p>
+              <ul className="held-list" data-testid="held-group-scheduled">
+                {scheduledRows.map((m) => (
+                  <HeldRow key={m.id} message={m} now={now} />
+                ))}
+              </ul>
+            </section>
+          )}
+          <p className="held-popover-foot">Dismiss with <code>afx inbox dismiss &lt;id&gt;</code></p>
+        </div>
+      )}
+    </div>
   );
 }

--- a/apps/web/src/components/HeldCountBadge.tsx
+++ b/apps/web/src/components/HeldCountBadge.tsx
@@ -80,6 +80,9 @@ function HeldRow({ message, now }: { message: HeldMessage; now: number }) {
 export function HeldCountBadge({ count, escalated, loadMessages }: HeldCountBadgeProps) {
   const [open, setOpen] = useState(false);
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
+  // In-flight flag, separate from `state`: a refetch keeps the previous rows rendered, so
+  // "is a request outstanding" can no longer be read off the state union.
+  const [busy, setBusy] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const panelId = useId();
@@ -89,20 +92,41 @@ export function HeldCountBadge({ count, escalated, loadMessages }: HeldCountBadg
   // does not warn about setState on an unmounted/stale path, so the bug would be silent.
   const generationRef = useRef(0);
 
+  // The loader is read through a ref so `load` (and therefore the fetch effect) does not
+  // depend on the prop's IDENTITY. App.tsx passes the module-level `fetchInbox`, which is
+  // stable — but an inline lambda from any future caller would change identity every render
+  // and turn the effect into a refetch loop. Behaviour should not hinge on a caller
+  // remembering to memoize.
+  const loaderRef = useRef(loadMessages);
+  useEffect(() => {
+    loaderRef.current = loadMessages;
+  }, [loadMessages]);
+
   const load = useCallback(() => {
     const generation = ++generationRef.current;
-    setState({ kind: 'loading' });
-    loadMessages().then(
+    setBusy(true);
+    // Keep already-loaded rows on screen while refetching rather than blanking to "Loading…".
+    // A refetch fires whenever `count` changes while the panel is open, and flashing the list
+    // away is exactly the wrong moment to do it — the user is watching to see what moved.
+    // `aria-busy` carries the in-flight state instead. Only a cold open shows the spinner.
+    setState((prev) => (prev.kind === 'ready' ? prev : { kind: 'loading' }));
+    loaderRef.current().then(
       (messages) => {
         if (generationRef.current !== generation) return;
+        setBusy(false);
         setState({ kind: 'ready', messages });
       },
       (err: unknown) => {
         if (generationRef.current !== generation) return;
+        setBusy(false);
+        // An error DOES replace the rows: once a refetch has failed, the previous list is no
+        // longer known to be current, and showing it as if it were would be a lie.
         setState({ kind: 'error', message: err instanceof Error ? err.message : String(err) });
       },
     );
-  }, [loadMessages]);
+    // No deps: the loader is reached through `loaderRef`, so `load` is stable for the
+    // lifetime of the component and the fetch effect fires only on open / count change.
+  }, []);
 
   // Load on open, and again when `count` changes while open. Refetch rather than snapshot:
   // the count is SSE-driven, so a change means the mailbox actually moved — precisely when a
@@ -168,17 +192,30 @@ export function HeldCountBadge({ count, escalated, loadMessages }: HeldCountBadg
         <span className={`held-dot${escalated ? ' held-dot--attention' : ''}`} />
         {label}
       </button>
+      {/* aria-live: the rows arrive asynchronously after the panel opens, so without it a
+          screen reader announces an empty container and never mentions the messages. */}
       {open && (
-        <div className="held-popover" id={panelId} data-testid="held-popover">
+        <div
+          className="held-popover"
+          id={panelId}
+          data-testid="held-popover"
+          aria-live="polite"
+          aria-busy={busy}
+        >
           {state.kind === 'loading' && <p className="held-popover-note">Loading…</p>}
           {state.kind === 'error' && (
             <p className="held-popover-note held-popover-note--error" data-testid="held-error">
               Could not load held messages: {state.message}
             </p>
           )}
-          {state.kind === 'ready' && messages.length === 0 && (
+          {/* Keyed on heldRows, not messages: when the held rows drain but a SCHEDULED row
+              remains, the panel is not empty yet there is still nothing held — and the
+              Scheduled group's "not counted above" needs something above it to refer to. */}
+          {state.kind === 'ready' && heldRows.length === 0 && (
             <p className="held-popover-note" data-testid="held-empty">
-              {count <= 0 ? 'Held mail cleared.' : 'No held messages.'}
+              {count <= 0 && messages.length > 0 ? 'No held messages — the rows below are scheduled.'
+                : count <= 0 ? 'Held mail cleared.'
+                : 'No held messages.'}
             </p>
           )}
           {heldRows.length > 0 && (
@@ -204,7 +241,10 @@ export function HeldCountBadge({ count, escalated, loadMessages }: HeldCountBadg
               </ul>
             </section>
           )}
-          <p className="held-popover-foot">Dismiss with <code>afx inbox dismiss &lt;id&gt;</code></p>
+          {/* Points at `afx inbox` rather than `afx inbox dismiss <id>`: dismissal needs a row
+              id, and this panel deliberately shows none (a full uuid would dominate the row
+              and this surface never mutates anyway). `afx inbox` is where the ids live. */}
+          <p className="held-popover-foot">Ids and dismissal: <code>afx inbox</code></p>
         </div>
       )}
     </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -894,6 +894,13 @@ body {
 /* Spec 1313 Phase 8: held-mail count indicator in the dashboard header. Count-only,
    read-only; enters an attention state (amber pulse, reusing @keyframes cloud-pulse)
    when a held row has crossed the escalation age. */
+/* Issue 1450: the badge is a disclosure button anchoring a popover. `.header-controls` is a
+   plain flex row with no positioning context, so the wrapper provides one. */
+.held-badge-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
 .held-badge {
   display: inline-flex;
   align-items: center;
@@ -901,11 +908,129 @@ body {
   font-size: 12px;
   color: var(--text-secondary);
   white-space: nowrap;
+  /* Button reset — this was a <span> until Issue 1450. */
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  cursor: pointer;
+  /* The affordance: dotted underline reads as "expands to reveal", not as a link. */
+  text-decoration: underline dotted;
+  text-underline-offset: 3px;
+}
+
+.held-badge:hover {
+  color: var(--text-primary);
+  text-decoration: underline solid;
+}
+
+.held-badge:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 3px;
 }
 
 .held-badge--attention {
   color: var(--status-waiting);
   font-weight: 600;
+}
+
+/* The popover sits at the 1000 tier (with the modal backdrop): xterm's WebGL/canvas panes
+   paint over anything at the lower 20/100 tiers. */
+.held-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 1000;
+  min-width: 280px;
+  max-width: 380px;
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 10px 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  font-size: 12px;
+  text-align: left;
+  cursor: default;
+}
+
+.held-popover-note {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.held-popover-note--error {
+  color: var(--status-error);
+}
+
+.held-group + .held-group {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border-color);
+}
+
+.held-group-title {
+  margin: 0 0 6px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.held-group-note {
+  margin: -2px 0 6px;
+  font-size: 11px;
+  font-style: italic;
+  color: var(--text-muted);
+}
+
+.held-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.held-row {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 4px 0;
+}
+
+.held-row + .held-row {
+  border-top: 1px solid var(--border-color);
+}
+
+.held-row-addresses {
+  color: var(--text-primary);
+  font-family: ui-monospace, monospace;
+  word-break: break-word;
+}
+
+.held-row-meta {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.held-row--attention .held-row-meta {
+  color: var(--status-waiting);
+  font-weight: 600;
+}
+
+.held-popover-foot {
+  margin: 10px 0 0;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-color);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.held-popover-foot code {
+  font-family: ui-monospace, monospace;
+  font-size: 11px;
 }
 
 .held-dot {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -91,6 +91,7 @@ export type {
   OverviewBacklogItem,
   OverviewRecentlyClosed,
   OverviewData,
+  HeldMessage,
   ProtocolStats,
   AnalyticsResponse,
 } from '@cluesmith/codev-types';
@@ -100,6 +101,7 @@ import type {
   AnalyticsResponse,
   TeamApiResponse,
   OverviewData,
+  HeldMessage,
   DashboardState,
 } from '@cluesmith/codev-types';
 
@@ -120,6 +122,23 @@ export async function fetchTeam(): Promise<TeamApiResponse> {
 export async function fetchOverview(): Promise<OverviewData> {
   const res = await fetch(apiUrl('api/overview'), { headers: getAuthHeaders() });
   if (!res.ok) throw new Error(`Failed to fetch overview: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Issue 1450: the workspace's currently-held mailbox rows — the payload behind the
+ * held-mail popover, and the same projection `afx inbox` renders.
+ *
+ * Hits the workspace-scoped `GET /api/inbox`, which resolves the workspace server-side from
+ * the `/workspace/<base64>/` URL prefix (the dashboard has no absolute workspace path of its
+ * own). Metadata only — never message bodies.
+ *
+ * Called lazily, on popover open, rather than folded into the 2.5s overview poll: this is a
+ * cold path that only matters when the user asks.
+ */
+export async function fetchInbox(): Promise<HeldMessage[]> {
+  const res = await fetch(apiUrl('api/inbox'), { headers: getAuthHeaders() });
+  if (!res.ok) throw new Error(`Failed to fetch held messages: ${res.status}`);
   return res.json();
 }
 

--- a/apps/web/src/lib/heldMail.ts
+++ b/apps/web/src/lib/heldMail.ts
@@ -1,0 +1,48 @@
+/**
+ * Issue 1450: age/countdown formatting for the dashboard's held-mail popover.
+ *
+ * Ported — deliberately, not imported — from the `afx inbox` CLI renderer
+ * (`packages/codev/src/agent-farm/commands/inbox.ts:77-90`). The web app must not import
+ * from `@cluesmith/codev-core` (server/client isolation, #1189), and `@cluesmith/codev-types`
+ * is a types-only devDependency, the wrong home for a runtime helper. Ten lines duplicated
+ * beats a boundary violation; keeping the output identical to the CLI's is what lets a
+ * reviewer check the popover against `afx inbox` row for row.
+ *
+ * Named `formatHeldAge` rather than `formatDuration` because
+ * `apps/web/src/lib/open-files-shells-utils.ts` already exports a `formatDuration` with
+ * DIFFERENT semantics (minute granularity, `<1m` floor) and existing callers. Two
+ * same-named formatters with different output in one `lib/` is a trap.
+ */
+
+/**
+ * Compact human duration ("5s", "3m", "2h", "1d") from a millisecond delta.
+ * Second-granularity, matching the CLI — held mail is often seconds old, and "<1m"
+ * would erase the distinction between "just held" and "held for most of a minute".
+ * Negative deltas clamp to `0s`.
+ */
+export function formatHeldDuration(ms: number): string {
+  const secs = Math.max(0, Math.floor(ms / 1000));
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+/** Compact human age ("5s", "3m", "2h", "1d") from an epoch-ms timestamp. */
+export function formatHeldAge(createdAt: number, now: number): string {
+  return formatHeldDuration(now - createdAt);
+}
+
+/**
+ * Is this row a pre-due `--delay` send — scheduled rather than stuck?
+ *
+ * The single predicate that splits the popover's two groups, and the same test the CLI
+ * applies (`inbox.ts:135`). A scheduled row is excluded from `OverviewData.heldCount` by
+ * `heldSummaryForWorkspace`, so grouping on exactly this predicate is what makes the
+ * "Held" group's length equal the badge count.
+ */
+export function isScheduled(notBefore: number | null, now: number): boolean {
+  return notBefore != null && notBefore > now;
+}

--- a/codev/plans/1450-dashboard-make-the-held-mail-c.md
+++ b/codev/plans/1450-dashboard-make-the-held-mail-c.md
@@ -321,16 +321,22 @@ The stub-server fallback from revision 1 is withdrawn as the primary path: it wo
 architect's steer, an **isolated second Tower**:
 
 1. Build the monorepo (including `apps/web`) from this worktree.
-2. Start a second Tower from the worktree build on a **non-default port**
-   (`afx tower start --port 14650`; `-p/--port` exists, `cli.ts:896`), with **`HOME` pointed at a
-   scratch directory** so `AGENT_FARM_DIR` (`packages/core/src/constants.ts:4` —
-   `resolve(homedir(), '.agent-farm')`, and `os.homedir()` honours `$HOME` on POSIX) resolves to
-   an **isolated `global.db`**. This matters beyond tidiness: a second Tower sharing the live
-   `~/.agent-farm/global.db` would run its own mailbox-delivery loop against the cohort's real
-   held mail. The shared Tower on 4100 is never restarted or repointed.
-3. Seed held rows the honest way — `afx send` against that Tower to an agent that cannot receive —
-   so the rows are real mailbox rows, not hand-inserted. Include one `--delay` row to exercise the
-   Scheduled group.
+2. Spawn **this worktree's built Tower directly** on a fresh private port —
+   `node dist/agent-farm/servers/tower-server.js 14700` with
+   `NODE_ENV=test` and `AF_TEST_DB=test-1450-14700.db`. That is the **purpose-built DB-isolation
+   seam** (`db/index.ts:117-127`: under `NODE_ENV=test`, `AF_TEST_DB` names the db file inside
+   `AGENT_FARM_DIR`), the same one `send-integration.e2e.test.ts:63` and pir-1365's
+   `spec-1365-e2e-evidence.mts` use. Ports 14500/14600/14650 are taken; 14700 is fresh.
+   Isolation matters beyond tidiness: a second Tower on the live `global.db` would run its own
+   mailbox-delivery loop against the cohort's real held mail — `AF_TEST_DB` is exactly what
+   prevents that. The shared Tower on 4100 is never restarted or repointed.
+   *(Revision 2 proposed redirecting `HOME` to move `AGENT_FARM_DIR`; the architect pointed at
+   this seam instead — it isolates the db without touching the environment's home, so it is
+   strictly better and is what pir-1365 actually did.)*
+3. Activate a scratch workspace (`POST /api/workspaces/<b64>/activate`), register a real
+   shellper-backed PTY (`POST /api/terminals`), and seed held rows the honest way — `POST /api/send`
+   to an agent whose composer is occupied, so the render gate holds them. Real mailbox rows, not
+   hand-inserted. Include one `--delay` row to exercise the Scheduled group.
 4. Navigate to the workspace dashboard; screenshot the header — the counter is **underlined** and
    reads as interactive.
 5. Click it; screenshot the open panel showing `from → to` per row with age and reason, and the
@@ -371,7 +377,9 @@ badge count.
 | NIT — pin `inbox/:id` and `/dismiss` 404s | Accepted; both added as tests, not just the POST case. |
 | NIT — rewrite the rejected-overview rationale | Accepted. `JSON.stringify`-churn argument withdrawn as weak; replaced with cached-aggregate cost, VSCode fanout, and the steer — and it now says what that alternative would have bought (one source of truth, i.e. the blocking finding) and why `/api/inbox` + grouping still wins. |
 
-**One note back:** I could not find pir-1365's artifacts in this worktree to follow the cited
-port-14650 precedent directly, so the isolated-Tower recipe above is reconstructed from the CLI
-(`afx tower start --port`) and the `AGENT_FARM_DIR` definition. If pir-1365 did something
-materially different, point me at it and I will match it.
+**Resolved after approval:** the architect pointed at pir-1365's actual recipe
+(`spec-1365-e2e-evidence.mts`). It did **not** redirect `HOME` — it spawns the worktree's built
+`tower-server.js` with `NODE_ENV=test` + `AF_TEST_DB`, the dedicated isolation seam at
+`db/index.ts:117-127`. The Playwright section above is updated to use that seam; the HOME
+redirect is withdrawn. The point it was protecting — the delivery loop must never see the
+cohort's live mail — is exactly what `AF_TEST_DB` guarantees.

--- a/codev/plans/1450-dashboard-make-the-held-mail-c.md
+++ b/codev/plans/1450-dashboard-make-the-held-mail-c.md
@@ -3,6 +3,11 @@
 Issue: [#1450](https://github.com/cluesmith/codev/issues/1450) — *Dashboard: make the held-mail
 counter clickable, showing the held messages (from → to)*
 
+> **Revision 2** — amended after the architect's plan review (claude lane, Medium tier,
+> REQUEST_CHANGES). The blocking finding was correct and I verified it myself; §"Held vs
+> Scheduled" is the design that replaces the wrong risk entry. All IMPORTANT items and NITs are
+> taken. Disposition list at the end.
+
 ## Understanding
 
 The dashboard header renders a count-only held-mail indicator. `HeldCountBadge`
@@ -33,15 +38,66 @@ resolves the workspace from the URL prefix. That is why calling the Tower-level
 `/api/inbox?workspace=<abs-path>` from the browser is not an option, and why the workspace-scoped
 branch (which passes `workspacePath` as an override) is the right seam.
 
+## Held vs Scheduled — the count and the list do not agree, by design
+
+*(This section replaces the incorrect risk entry in revision 1, which claimed pre-due rows
+"already inflate `heldCount`". They do not. Verified directly against `db/mailbox.ts`.)*
+
+Two different queries back the two surfaces, and they deliberately disagree:
+
+- **The badge count** comes from `heldSummaryForWorkspace` (`db/mailbox.ts:215-227`), whose SQL
+  filters `status = 'held' AND (not_before IS NULL OR not_before <= ?)`. Its docstring is
+  explicit: a pre-due `--delay` send is *"scheduled, not stuck"* and **must NOT inflate the
+  attention count/indicator**.
+- **The list** comes from `listHeld` (`db/mailbox.ts:113-124`), which `handleInboxList` calls and
+  which has **no `not_before` filter at all** — it returns every `held` row. The same docstring
+  confirms the intent: *"Pre-due rows are still visible in `afx inbox`, which lists ALL held rows
+  and labels these 'scheduled' — only the count/alarm surfaces exclude them."*
+
+So a naive popover would say "2 held" on the badge and list 3 rows. That is not a bug to paper
+over — it is an intentional split between an *attention* count and an *inventory* list, and the
+UI has to render the split rather than hide it.
+
+**Design (option (a) from the review — popover groups):**
+
+- The popover has two sections. **"Held (N)"** lists rows that are due (`notBefore == null ||
+  notBefore <= now`). **N is exactly the badge count**, so the number the user clicked and the
+  number of rows in the first group always match.
+- **"Scheduled (M)"** is a separate, visually-secondary section listing pre-due rows with their
+  due countdown (`→15s`), carrying one line of copy: *"Scheduled sends — waiting for their due
+  time, not counted above."*
+- Each group renders only when non-empty, so the common case (no `--delay` in flight) is a single
+  ungrouped-looking list.
+
+This also keeps the popover a faithful mirror of `afx inbox`, which shows both kinds and labels
+the pre-due ones `scheduled` (`commands/inbox.ts:135-137`).
+
+**Accepted edge case, stated rather than fixed:** with 0 due and 1 scheduled row, `heldCount` is
+0, the badge renders nothing, and the scheduled row is not reachable from the dashboard. That is
+the existing, deliberate contract — the badge is an *attention* indicator and a scheduled send is
+not attention-worthy. Surfacing it would mean rendering a badge whose count is 0, which
+contradicts `heldSummaryForWorkspace`'s stated purpose and the badge's own zero-state test.
+`afx inbox` remains the surface that sees scheduled-only state. If the architect wants that
+reachable from the dashboard, it is a separate change to what the badge *counts*, not to this
+popover.
+
+Pinned by test: seed 1 due + 1 pre-due row, render with `count={1}`, assert the "Held" group has
+exactly 1 row and the "Scheduled" group has exactly 1, and that the Held-group length equals the
+badge count.
+
 ## Proposed Change
 
 ### Server — reuse `handleInboxList` under the workspace prefix
 
-Give `handleInboxList` an optional `workspaceOverride` third parameter, exactly mirroring
+Give `handleInboxList` an optional `workspaceOverride` third parameter, mirroring
 `handleOverview(res, url, workspaceOverride?, ctx?)` (`tower-routes.ts:1108-1110`) and
-`handleAnalytics` (`:1382`). Resolution order becomes: explicit override → `?workspace=` →
-all workspaces. The Tower-level registration is unchanged, so `afx inbox` and any direct caller
-keep their exact current semantics.
+`handleAnalytics` (`:1382`). Resolution is `workspaceOverride ?? url.searchParams.get('workspace')`
+— **the override wins**, so a workspace-scoped call can never be redirected to another workspace
+by an attacker-supplied `?workspace=`. (`??` rather than `||` so an empty-string override is
+still an override rather than silently falling through.) The docstring will note that the
+override arrives already normalized by the prefix decoder (`tower-routes.ts:2476`), so
+`normalizeWorkspacePath` re-running on it is a safe no-op. The Tower-level registration is
+unchanged, so `afx inbox` and any direct caller keep their exact current semantics.
 
 Then add one branch to the workspace-scoped API dispatcher, next to the existing `overview` one:
 
@@ -55,18 +111,21 @@ if (req.method === 'GET' && apiPath === 'inbox') {
 ```
 
 Deliberately **exact-match `'inbox'` only**: `inbox/:id` (show, carries the body) and
-`inbox/:id/dismiss` (mutating) stay off the dashboard surface and keep 404-ing there. That
-preserves two Spec 1313 rules the current badge docstring already states — the redaction rule
-(bodies never leave the CLI/terminal path) and decision 8 (dismissal is CLI-only; this surface
-never mutates state). `afx inbox show <id>` remains the deep-dive path, as the issue itself
-allows.
+`inbox/:id/dismiss` (mutating) do not match and fall through to the dispatcher's 404, so they stay
+off the dashboard surface. That preserves two Spec 1313 rules the current badge docstring already
+states — the redaction rule (bodies never leave the CLI/terminal path) and decision 8 (dismissal
+is CLI-only; this surface never mutates state). `afx inbox show <id>` remains the deep-dive path,
+as the issue itself allows. Authentication needs no new work: the request passes through Tower's
+`isRequestAllowed` chokepoint before reaching the dispatcher, so the new branch inherits the
+shared-key check.
 
 ### Types — one shared projection type
 
 Add `HeldMessage` to `packages/types/src/api.ts` describing the `handleInboxList` projection.
 Both sides of the server/client boundary may import `codev-types` (arch invariant #1189), so the
 web app gets the shape without reaching into `codev-core`. The CLI's private `InboxRow`
-(`commands/inbox.ts:21-35`) is left alone — retyping it is a separate cleanup, not this issue.
+(`packages/codev/src/agent-farm/commands/inbox.ts:21-35`) is left alone — retyping it is a
+separate cleanup, not this issue.
 
 ### Web — the badge becomes a disclosure button with a popover
 
@@ -79,42 +138,63 @@ passes the real one. New shape:
 export interface HeldCountBadgeProps {
   count: number;
   escalated: boolean;
-  /** Fetches the workspace's held rows. Called lazily, on each open. */
+  /** Fetches the workspace's held rows. Called lazily, on open and on count change. */
   loadMessages: () => Promise<HeldMessage[]>;
 }
 ```
 
-Behaviour:
+**Affordance.** The `<span>` becomes a `<button type="button">` with a button-reset and
+`text-decoration: underline` (dotted, so it reads as a disclosure rather than a link),
+`cursor: pointer`, hover/`:focus-visible` states. Keeps `data-testid="held-badge"`, the
+`held-badge` / `held-badge--attention` classes, the dot, the `N held` label, and the existing
+`title`.
 
-- **Affordance.** The `<span>` becomes a `<button type="button">` with a button-reset and
-  `text-decoration: underline` (dotted, so it reads as a disclosure rather than a link),
-  `cursor: pointer`, hover/`:focus-visible` states. Keeps `data-testid="held-badge"`, the
-  `held-badge` / `held-badge--attention` classes, the dot, the `N held` label, and the existing
-  `title`. Still renders `null` at `count <= 0`.
-- **Disclosure.** `aria-haspopup="dialog"`, `aria-expanded`. Click toggles; the panel is a
-  `role="dialog"` with an accessible name. Escape closes and returns focus to the button;
-  click-outside closes.
-- **Lazy fetch.** `loadMessages()` runs on each open (the data is small, and re-opening is the
-  natural "is it still stuck?" gesture). Loading / error / empty states are all rendered — a
-  failed fetch says so rather than showing a silently empty list.
-- **Rows.** `from → to` is the primary line (`architect → cost`, `?` for a null `fromAgent`,
-  matching the CLI). A secondary line carries **age** and **reason**. A pre-due `--delay` row
-  (`notBefore > now`) renders `→15s` / `scheduled` exactly as the CLI does
-  (`commands/inbox.ts:129-133`) so a *scheduled* send is not misread as a *stuck* one. An
-  escalated row is marked (`!` plus the existing amber attention colour).
+**Disclosure semantics — WAI-ARIA disclosure, not dialog.** `<button aria-expanded aria-controls>`
+plus a plain container holding a real `<ul>`/`<li>` per group, so screen readers announce the row
+count. No `role="dialog"`, no `aria-haspopup` — a dialog role without moving focus into the panel
+is announced inconsistently, and this panel does not want to steal focus from the terminals.
+Escape closes and returns focus to the button; click-outside closes; a second click toggles.
 
-Age/duration formatting is a ~10-line reimplementation in a new
-`apps/web/src/lib/heldMail.ts` (`formatDuration` / `formatAge`, ported from
-`commands/inbox.ts:74-86`). It is **not** imported from `packages/codev` — the web app must not
-import server code across the isolation boundary.
+**Fetch lifecycle.** `loadMessages()` runs on open and again whenever `count` changes while open
+(the count is SSE-driven, so a change means the mailbox moved and the open panel should follow —
+snapshot-on-open would go stale in exactly the situation the user is watching). Every load is
+tagged with a **generation counter** incremented on each open/refetch; a response whose generation
+is not current is discarded. That kills the open→close→open stale-response race, which React 19
+will not warn about. Loading / error / empty states are all rendered — a failed fetch says so
+rather than showing a silently empty list.
+
+**Mid-open unmount.** The component returns `null` at `count <= 0`, and `useOverview` polls every
+2.5s — so delivery of the last held row while the panel is open would unmount the button and drop
+focus to `<body>`. Fix: **while `open` is true the component stays mounted even at `count <= 0`**,
+rendering a "held mail cleared" state in the panel until the user closes it; on close it unmounts
+normally. The closed-at-zero contract is untouched, so the existing zero-count test still passes
+unchanged.
+
+**Rows.** `from → to` is the primary line (`architect → cost`, `?` for a null `fromAgent`,
+matching the CLI). A secondary line carries **age** and **reason**. Escalated rows are marked
+(`!` plus the existing amber attention colour). Scheduled rows live in their own group with a
+countdown, per §"Held vs Scheduled".
+
+**Formatting.** A new `apps/web/src/lib/heldMail.ts` exports **`formatHeldAge`** (and a private
+second-granularity duration helper), ported from `packages/codev/src/agent-farm/commands/inbox.ts:77-90`
+— *not* imported, since the web app must not cross the server/client isolation boundary, and
+`codev-types` is a types-only devDependency, the wrong home for runtime helpers. It is named
+`formatHeldAge` rather than `formatDuration` because
+`apps/web/src/lib/open-files-shells-utils.ts:2-10` **already exports a `formatDuration`** with
+different (minute-granularity, `<1m`) semantics and existing callers. Two `formatDuration`s in one
+`lib/` would be a trap; extending the existing one would change behaviour for its current callers.
 
 `apps/web/src/lib/api.ts` gains `fetchInbox()`, using the existing `apiUrl()` + `getAuthHeaders()`
 helpers so the Tower shared-key header (GHSA-xvjp-7748-v88v) is sent like every other call.
 
-CSS in `apps/web/src/index.css` alongside the existing `.held-badge` block: button reset +
-underline, and a `.held-popover` panel — absolutely positioned under the header control,
-`max-height` + `overflow-y: auto` so a long list scrolls, and the same token palette
-(`--bg-*`, `--text-*`, `--status-waiting`) the confirmation modal uses.
+**Positioning and stacking.** `.header-controls` (`index.css:139-143`) is a plain flex row with
+**no `position: relative`**, so there is nothing for an absolutely-positioned panel to anchor to.
+The badge gets a `position: relative` wrapper, and `.held-popover` is absolutely positioned under
+it. The stylesheet's existing z-index tiers are 20 (`:457`), 100 (`:734`) and 1000 (`:239`, the
+modal backdrop); the popover sits at the **1000 tier**, because xterm's WebGL/canvas panes will
+otherwise paint over an unlayered panel. Panel styling reuses the token palette
+(`--bg-*`, `--text-*`, `--status-waiting`) the confirmation modal uses, with `max-height` +
+`overflow-y: auto` so a long list scrolls.
 
 ### Explicitly out of scope
 
@@ -122,6 +202,7 @@ underline, and a `.held-popover` panel — absolutely positioned under the heade
 - **Mobile** — `MobileLayout` does not render the badge today (only the desktop header at
   `App.tsx:355-361` does); this change does not add it.
 - **Dismiss / show-body from the UI** — Spec 1313 decision 8 and the redaction rule.
+- **Changing what the badge counts** — the scheduled-only edge case above.
 - **`codev-skeleton/` mirroring** — this touches product code (`apps/web`, `packages/codev`,
   `packages/types`), not framework files, so there is no skeleton twin to update.
 
@@ -129,7 +210,7 @@ underline, and a `.held-popover` panel — absolutely positioned under the heade
 
 **Server**
 
-- `packages/codev/src/agent-farm/servers/tower-routes.ts:2134` — `handleInboxList(res, url, workspaceOverride?)`; resolution order override → `?workspace=` → all. Update the docstring.
+- `packages/codev/src/agent-farm/servers/tower-routes.ts:2134` — `handleInboxList(res, url, workspaceOverride?)`; resolution `override ?? ?workspace= ?? all`. Docstring updated.
 - `packages/codev/src/agent-farm/servers/tower-routes.ts:~2698` — new `apiPath === 'inbox'` GET branch in the workspace-scoped dispatcher, beside the `overview` branch.
 
 **Types**
@@ -138,39 +219,54 @@ underline, and a `.held-popover` panel — absolutely positioned under the heade
 
 **Web**
 
-- `apps/web/src/components/HeldCountBadge.tsx` — `<span>` → `<button>`; disclosure state; popover render; `loadMessages` prop. Docstring updated (it currently asserts "Read-only and count-only" — still read-only, no longer count-only).
-- `apps/web/src/lib/heldMail.ts` — **new**; `formatDuration` / `formatAge`.
+- `apps/web/src/components/HeldCountBadge.tsx` — `<span>` → `<button>`; disclosure state, generation-guarded loader, grouped popover. Docstring updated (it currently asserts "Read-only and count-only" — still read-only, no longer count-only) and gains a note on the Held/Scheduled split.
+- `apps/web/src/lib/heldMail.ts` — **new**; `formatHeldAge`.
 - `apps/web/src/lib/api.ts` — **new** `fetchInbox(): Promise<HeldMessage[]>`; re-export `HeldMessage` alongside the other `codev-types` re-exports.
 - `apps/web/src/components/App.tsx:360` — pass `loadMessages={fetchInbox}`.
-- `apps/web/src/index.css:897-923` — extend `.held-badge` (button reset, underline, hover/focus); add `.held-popover` and row styles.
+- `apps/web/src/index.css:897-923` — extend `.held-badge` (button reset, underline, hover/focus); add the relative wrapper, `.held-popover` at the 1000 tier, and group/row styles.
 
 **Tests**
 
-- `apps/web/__tests__/HeldCountBadge.test.tsx` — extended (existing five cases kept).
+- `apps/web/__tests__/HeldCountBadge.test.tsx` — extended (existing five cases kept unchanged).
+- `apps/web/__tests__/heldMail.test.ts` — **new**.
 - `packages/codev/src/agent-farm/__tests__/inbox-routes.test.ts` — extended with the workspace-scoped route cases (harness already drives the real `handleRequest` against a real in-memory mailbox DB).
 
 ## Risks & Alternatives Considered
 
+- **Risk — the badge count and the list disagree.** Real and verified; see §"Held vs Scheduled".
+  Mitigated by grouping, not by hiding, and pinned by test.
 - **Risk — leaking message bodies into the dashboard.** Mitigation: the dashboard reuses the
   metadata-only `handleInboxList` projection verbatim, and the new branch exact-matches `'inbox'`
-  so `inbox/:id` (the only body-bearing route) is unreachable under the workspace prefix. A test
-  asserts the response carries no `body` key.
+  so `inbox/:id` (the only body-bearing route) is unreachable under the workspace prefix. Tests
+  assert the response carries no `body` key **and** that `GET .../api/inbox/<id>` and
+  `.../api/inbox/<id>/dismiss` both 404 under the workspace prefix — the non-reachability the
+  redaction argument depends on, pinned rather than assumed.
 - **Risk — the new branch accidentally exposes dismiss.** Mitigation: the branch is
-  `req.method === 'GET' && apiPath === 'inbox'`; `inbox/<id>/dismiss` does not match and falls
-  through to the dispatcher's 404. A test asserts a POST to `.../api/inbox` does not mutate.
+  `req.method === 'GET' && apiPath === 'inbox'`. A POST to `.../api/inbox` is tested to mutate
+  nothing.
 - **Risk — cross-workspace bleed.** `handleInboxList` with no workspace lists *every* workspace's
-  held rows. Passing `workspacePath` (already normalized to the stored realpath by the prefix
-  decoder, `tower-routes.ts:2476`) scopes it. A test seeds two workspaces and asserts only the
-  requested one comes back.
-- **Risk — a `--delay` row reads as "stuck".** Pre-due rows are held rows and already inflate
-  `heldCount`; the popover renders them as `scheduled` with a countdown, matching the CLI.
+  held rows. Passing `workspacePath` (already normalized by the prefix decoder,
+  `tower-routes.ts:2476`) scopes it, and `??` ordering means `?workspace=` cannot override it. A
+  test seeds two workspaces and asserts only the requested one comes back.
+- **Risk — stale response from a fast open→close→open.** Generation counter; tested with a slow
+  first promise.
+- **Risk — focus dropped when the last held row is delivered mid-open.** Component stays mounted
+  while open; tested.
+- **Risk — the popover painting under a terminal.** z-index at the 1000 tier; verified by a
+  Playwright screenshot taken with a terminal visible behind the open panel.
 - **Risk — regressing the existing badge contract.** The five existing unit tests
   (`data-testid`, zero/negative count, attention classes) are kept unchanged and must still pass.
-- **Alternative — fold a `heldMessages[]` array into `OverviewData`.** Rejected: `/api/overview`
-  is polled every 2.5s and its payload is `JSON.stringify`-compared for change detection
-  (`useOverview.ts:14-16`); carrying a list for a panel that is almost never open makes a hot path
-  pay for a cold feature. It would also push the same array into VSCode's overview cache. The
-  architect's steer was to reuse `/api/inbox`, and lazy-on-open is the cheaper shape.
+- **Alternative — fold a `heldMessages[]` array into `OverviewData`.** This is the alternative
+  that would have *dissolved* the blocking finding: badge and list would come from one source and
+  could not disagree. Rejected anyway, for three reasons. (1) `/api/overview` is a **cached
+  aggregate** — `overviewCache.getOverview` builds the whole payload including git/GitHub work, so
+  the held list would be recomputed on that schedule rather than when the user asks, and would be
+  served stale from cache. (2) The same payload feeds **VSCode's overview cache**, so every
+  consumer of the overview would carry a list only the dashboard popover reads. (3) The
+  architect's steer was to reuse `/api/inbox`. The grouped popover addresses the disagreement
+  directly and honestly, at the cost of one extra lazy fetch. *(Revision 1 justified this
+  rejection by `JSON.stringify` churn in `useOverview`; that argument was weak — held rows mostly
+  change when the count changes — and is withdrawn.)*
 - **Alternative — call the Tower-level `/api/inbox?workspace=<abs path>` from the browser.**
   Rejected: the dashboard has no absolute workspace path (all its calls are relative to the
   `/workspace/<base64>/` prefix and the server resolves the workspace). Teaching the client to
@@ -185,49 +281,97 @@ underline, and a `.held-popover` panel — absolutely positioned under the heade
 **Unit — web (`apps/web`, vitest + Testing Library)**
 
 - Existing five `HeldCountBadge` cases still pass unchanged.
-- Renders as a `<button>` with `aria-haspopup="dialog"` and `aria-expanded="false"`.
-- Click → `aria-expanded="true"`, `loadMessages` called once, popover in the DOM.
-- Popover renders `architect → cost` for a row `{fromAgent: 'architect', toAgent: 'cost'}`.
+- Renders as a `<button>` with `aria-expanded="false"` and an `aria-controls` target.
+- Click → `aria-expanded="true"`, `loadMessages` called once, panel in the DOM as a `<ul>`.
+- Panel renders `architect → cost` for a row `{fromAgent: 'architect', toAgent: 'cost'}`.
 - Null `fromAgent` renders `? → cost`.
-- Age and reason render (`busy`, and `!`/attention marking for `escalated: true`).
-- A pre-due `notBefore` row renders `scheduled` with a countdown, not an age.
+- Age and reason render; `escalated: true` gets the attention marking.
+- **Held/Scheduled split:** 1 due + 1 pre-due row with `count={1}` → "Held (1)" group has exactly
+  1 row, "Scheduled (1)" group has exactly 1, Held-group length === badge count.
+- A group with no rows is not rendered at all.
 - Empty result → an explicit "No held messages" state, not a blank panel.
 - Rejected loader → an error state, not a silent empty list.
+- **Stale-response race:** open → close → open with a slow first promise; only the second
+  response renders.
+- **Count change while open** triggers a refetch.
+- **Count → 0 while open** keeps the component mounted with a "cleared" state; closing unmounts it.
 - Escape closes and focus returns to the button; second click closes.
-- `apps/web/src/lib/heldMail.ts` — `formatDuration` boundaries (`59s` / `1m` / `60m` → `1h` / `24h` → `1d`).
+- `heldMail.test.ts` — `formatHeldAge` boundaries (`59s` / `1m` / `60m` → `1h` / `24h` → `1d`).
 
 **Unit — server (`packages/codev`, vitest, real in-memory mailbox DB)**
 
 - `GET /workspace/<b64>/api/inbox` returns that workspace's held rows only; a row seeded under a
-  second workspace is absent.
+  second workspace is absent. Seeding goes through `normalizeWorkspacePath` (or uses a
+  guaranteed-nonexistent path) because the harness's `WS` constant is realpath-resolved
+  (`utils/workspace-path.ts:19-26`) while the harness mocks `decodeWorkspacePath` as plain
+  base64url (`inbox-routes.test.ts:80-84`).
 - The projection carries `fromAgent`/`toAgent`/`reason`/`escalated`/`createdAt`/`notBefore` and
   **no `body`**.
+- Pre-due rows ARE listed (documenting `listHeld`'s no-filter behaviour the UI depends on).
 - A dismissed/delivered row is absent (only `held` rows list).
-- `POST /workspace/<b64>/api/inbox` does not dismiss anything.
-- The Tower-level `GET /api/inbox?workspace=…` behaviour is unchanged (regression guard on the
-  existing cases).
+- `GET /workspace/<b64>/api/inbox/<id>` → 404; `.../inbox/<id>/dismiss` → 404;
+  `POST .../api/inbox` dismisses nothing.
+- `?workspace=<other>` on a workspace-scoped call does **not** redirect the scope (override wins).
+- The Tower-level `GET /api/inbox?workspace=…` behaviour is unchanged (regression guard).
 
 **Manual — real browser via Playwright (required before dev-approval)**
 
-Per the architect's constraint, the changed UX is exercised in a real browser and screenshots are
-attached as evidence:
+The stub-server fallback from revision 1 is withdrawn as the primary path: it would exercise
+**zero server code**, and "`./api/inbox` 404s today" is the entire finding. Instead, per the
+architect's steer, an **isolated second Tower**:
 
-1. Build the web app from this worktree and serve it against a Tower whose `global.db` has held
-   rows (produced the honest way — `afx send` to a busy agent — so the rows are real mailbox rows,
-   not hand-inserted).
-2. Navigate to the workspace dashboard, screenshot the header: the counter is **underlined** and
+1. Build the monorepo (including `apps/web`) from this worktree.
+2. Start a second Tower from the worktree build on a **non-default port**
+   (`afx tower start --port 14650`; `-p/--port` exists, `cli.ts:896`), with **`HOME` pointed at a
+   scratch directory** so `AGENT_FARM_DIR` (`packages/core/src/constants.ts:4` —
+   `resolve(homedir(), '.agent-farm')`, and `os.homedir()` honours `$HOME` on POSIX) resolves to
+   an **isolated `global.db`**. This matters beyond tidiness: a second Tower sharing the live
+   `~/.agent-farm/global.db` would run its own mailbox-delivery loop against the cohort's real
+   held mail. The shared Tower on 4100 is never restarted or repointed.
+3. Seed held rows the honest way — `afx send` against that Tower to an agent that cannot receive —
+   so the rows are real mailbox rows, not hand-inserted. Include one `--delay` row to exercise the
+   Scheduled group.
+4. Navigate to the workspace dashboard; screenshot the header — the counter is **underlined** and
    reads as interactive.
-3. Click it; screenshot the open popover showing `from → to` per row, with age and reason.
-4. Verify keyboard path: Tab to the badge, Enter opens, Escape closes, focus returns.
-5. Verify the zero state: with no held mail the badge is absent entirely (unchanged behaviour).
-6. Check the browser console is clean (no 404 on `./api/inbox`, no React warnings).
+5. Click it; screenshot the open panel showing `from → to` per row with age and reason, and the
+   Held/Scheduled grouping.
+6. Screenshot the open panel **with a terminal visible behind it** — proves the z-index tier.
+7. **Network assertion:** capture the response for `GET .../api/inbox` and assert **status 200**.
+   A 401 renders as a benign-looking error state, so "the panel showed something" is not evidence
+   the route works.
+8. Keyboard path: Tab to the badge, Enter opens, Escape closes, focus returns.
+9. Zero state: with no held mail the badge is absent entirely (unchanged behaviour).
+10. Browser console clean — no 404 on `./api/inbox`, no React warnings.
 
-If a live held row cannot be produced in this worktree, I will fall back to driving the real
-built SPA in Playwright against a local stub serving the real `/api/inbox` projection shape, and
-I will **say so explicitly** in the dev-approval summary rather than implying a full-stack run.
+If the isolated Tower cannot be brought up in this worktree, the stub-backed run is a **last
+resort that explicitly does not verify the new route**, and I will label it exactly that way in
+the dev-approval summary rather than implying a full-stack run.
 
 **Reviewer's path at the `dev-approval` gate**
 
 Open the worktree dashboard, confirm the counter is underlined, click it, and check the listed
-`from → to` pairs against `afx inbox -w <workspace>` in a terminal — the two should agree row for
-row.
+`from → to` pairs against `afx inbox -w <workspace>` in a terminal. The **union** of the Held and
+Scheduled groups should match `afx inbox` row for row; the **Held group alone** should match the
+badge count.
+
+---
+
+## Review disposition (architect plan review, revision 1 → 2)
+
+| Item | Disposition |
+|---|---|
+| **BLOCKING** — pre-due/`heldCount` risk entry backwards | **Accepted; verified independently.** `heldSummaryForWorkspace` (`mailbox.ts:215-227`) filters `not_before`; `listHeld` (`:113-124`) does not. Wrong entry deleted, replaced by §"Held vs Scheduled" with option (a) grouping + the pinned test. The 0-due/1-scheduled edge is stated as accepted behaviour with the reason, not silently dropped. |
+| IMPORTANT 1 — duplicate `formatDuration`, wrong citation path | **Accepted.** Named `formatHeldAge`; existing `open-files-shells-utils.ts:2-10` `formatDuration` left alone (different granularity, existing callers). Citations corrected to `packages/codev/src/agent-farm/commands/inbox.ts` — formatters `:77-90`, `InboxRow :21-35`, scheduled rendering `:135-137`. |
+| IMPORTANT 2 — loader race + mid-open unmount | **Accepted.** Generation counter; refetch (not snapshot) on count change while open, with the reason; stay-mounted-while-open at count 0; both tested. |
+| IMPORTANT 3 — a11y half-pattern | **Accepted.** WAI-ARIA disclosure: `aria-expanded` + `aria-controls` + real `<ul>`; `role="dialog"`/`aria-haspopup` dropped; Escape + focus return kept. |
+| IMPORTANT 4 — positioning/stacking unspecified | **Accepted.** Relative wrapper; `.held-popover` at the 1000 tier (verified tiers 20/100/1000 at `index.css:457/734/239`; `.header-controls:139-143` confirmed to have no `position`). Playwright shot with a terminal behind. |
+| IMPORTANT 5 — Playwright fallback tests nothing | **Accepted, plus one addition.** Isolated second Tower on port 14650 via `afx tower start --port`; shared Tower never touched. **Added:** `HOME` redirected to a scratch dir so `AGENT_FARM_DIR` resolves to an isolated `global.db` — otherwise the second Tower would run a delivery loop against the cohort's live mailbox. 200-status network assertion added; stub demoted to a labelled last resort. |
+| NIT — `??` so override wins | Accepted, with the empty-string rationale and the already-normalized docstring note. |
+| NIT — server-test seeding through `normalizeWorkspacePath` | Accepted; `utils/workspace-path.ts:19-26` and the harness mock at `inbox-routes.test.ts:80-84` both confirmed. |
+| NIT — pin `inbox/:id` and `/dismiss` 404s | Accepted; both added as tests, not just the POST case. |
+| NIT — rewrite the rejected-overview rationale | Accepted. `JSON.stringify`-churn argument withdrawn as weak; replaced with cached-aggregate cost, VSCode fanout, and the steer — and it now says what that alternative would have bought (one source of truth, i.e. the blocking finding) and why `/api/inbox` + grouping still wins. |
+
+**One note back:** I could not find pir-1365's artifacts in this worktree to follow the cited
+port-14650 precedent directly, so the isolated-Tower recipe above is reconstructed from the CLI
+(`afx tower start --port`) and the `AGENT_FARM_DIR` definition. If pir-1365 did something
+materially different, point me at it and I will match it.

--- a/codev/plans/1450-dashboard-make-the-held-mail-c.md
+++ b/codev/plans/1450-dashboard-make-the-held-mail-c.md
@@ -1,0 +1,233 @@
+# PIR Plan: Clickable held-mail counter with a held-messages popover
+
+Issue: [#1450](https://github.com/cluesmith/codev/issues/1450) — *Dashboard: make the held-mail
+counter clickable, showing the held messages (from → to)*
+
+## Understanding
+
+The dashboard header renders a count-only held-mail indicator. `HeldCountBadge`
+(`apps/web/src/components/HeldCountBadge.tsx:31-40`) is an inert `<span>`: a dot, the text
+`N held`, and a `title` tooltip whose only remedy is *"Review with: afx inbox"*. It is mounted
+once, in the desktop header (`apps/web/src/components/App.tsx:360`), fed by
+`OverviewData.heldCount` / `mailboxEscalated`.
+
+So the user sees "2 held" and must drop to a terminal to learn *who is held from whom*. The ask
+is two things: (1) an affordance that reads as clickable, and (2) a panel on click listing each
+held message with at least `from → to`.
+
+### Verifying the issue's claims against current `main`
+
+The issue was written 2026-08-17; I re-checked every claim against the tree at
+`origin/main` (`9129ab81c`):
+
+| Issue claim | Verdict |
+|---|---|
+| The counter is inert text | **True.** `HeldCountBadge.tsx:31-40` — a `<span>` with a `title`, no handler, no affordance. Last touched by Spec 1313's `0bbea9de4`; nothing since. |
+| Finding out *what* is held needs `afx inbox -w <workspace>` | **True.** No dashboard surface lists held rows. |
+| "Data is already available server-side (the same store `afx inbox` reads)" | **True.** `GET /api/inbox` → `handleInboxList` (`tower-routes.ts:199`, impl `:2134`) projects exactly the CLI's fields: `id`, `workspacePath`, `toAgent`, `fromAgent`, `reason`, `escalated`, `createdAt`, `notBefore`. |
+| "a small read endpoint/**reuse of an existing one**" | **Needs one correction.** `GET /api/inbox` is registered only on the *Tower-level* route table. The dashboard is served under `/workspace/<base64-path>/` and calls its API with relative `./api/...` (`getApiBase()` returns `'./'`, `apps/web/src/lib/constants.ts`), which lands in the **workspace-scoped** dispatcher (`tower-routes.ts:2484-2723`). That dispatcher has no `inbox` branch, so `./api/inbox` currently 404s. The fix is a three-line branch that reuses `handleInboxList` — the same pattern `overview`, `analytics`, and `architects/:name` already use. No new handler, no new projection. |
+
+One more fact that shapes the design: **the dashboard does not know its own workspace path.**
+It never reads the encoded prefix out of `window.location` for API purposes — the server
+resolves the workspace from the URL prefix. That is why calling the Tower-level
+`/api/inbox?workspace=<abs-path>` from the browser is not an option, and why the workspace-scoped
+branch (which passes `workspacePath` as an override) is the right seam.
+
+## Proposed Change
+
+### Server — reuse `handleInboxList` under the workspace prefix
+
+Give `handleInboxList` an optional `workspaceOverride` third parameter, exactly mirroring
+`handleOverview(res, url, workspaceOverride?, ctx?)` (`tower-routes.ts:1108-1110`) and
+`handleAnalytics` (`:1382`). Resolution order becomes: explicit override → `?workspace=` →
+all workspaces. The Tower-level registration is unchanged, so `afx inbox` and any direct caller
+keep their exact current semantics.
+
+Then add one branch to the workspace-scoped API dispatcher, next to the existing `overview` one:
+
+```ts
+// GET /api/inbox — held mailbox rows for THIS workspace (Issue 1450). Reuses the
+// Tower-level handler with the workspace resolved from the /workspace/<base64>/ prefix,
+// the same way `overview` and `analytics` do. Metadata-only projection: never bodies.
+if (req.method === 'GET' && apiPath === 'inbox') {
+  return handleInboxList(res, url, workspacePath);
+}
+```
+
+Deliberately **exact-match `'inbox'` only**: `inbox/:id` (show, carries the body) and
+`inbox/:id/dismiss` (mutating) stay off the dashboard surface and keep 404-ing there. That
+preserves two Spec 1313 rules the current badge docstring already states — the redaction rule
+(bodies never leave the CLI/terminal path) and decision 8 (dismissal is CLI-only; this surface
+never mutates state). `afx inbox show <id>` remains the deep-dive path, as the issue itself
+allows.
+
+### Types — one shared projection type
+
+Add `HeldMessage` to `packages/types/src/api.ts` describing the `handleInboxList` projection.
+Both sides of the server/client boundary may import `codev-types` (arch invariant #1189), so the
+web app gets the shape without reaching into `codev-core`. The CLI's private `InboxRow`
+(`commands/inbox.ts:21-35`) is left alone — retyping it is a separate cleanup, not this issue.
+
+### Web — the badge becomes a disclosure button with a popover
+
+`HeldCountBadge` keeps its presentational character (its docstring calls that out explicitly, and
+it is why the component unit-tests in isolation), but gains disclosure state and a **`loadMessages`
+loader prop** rather than importing `fetchInbox` directly. Tests inject a fake loader; `App.tsx`
+passes the real one. New shape:
+
+```ts
+export interface HeldCountBadgeProps {
+  count: number;
+  escalated: boolean;
+  /** Fetches the workspace's held rows. Called lazily, on each open. */
+  loadMessages: () => Promise<HeldMessage[]>;
+}
+```
+
+Behaviour:
+
+- **Affordance.** The `<span>` becomes a `<button type="button">` with a button-reset and
+  `text-decoration: underline` (dotted, so it reads as a disclosure rather than a link),
+  `cursor: pointer`, hover/`:focus-visible` states. Keeps `data-testid="held-badge"`, the
+  `held-badge` / `held-badge--attention` classes, the dot, the `N held` label, and the existing
+  `title`. Still renders `null` at `count <= 0`.
+- **Disclosure.** `aria-haspopup="dialog"`, `aria-expanded`. Click toggles; the panel is a
+  `role="dialog"` with an accessible name. Escape closes and returns focus to the button;
+  click-outside closes.
+- **Lazy fetch.** `loadMessages()` runs on each open (the data is small, and re-opening is the
+  natural "is it still stuck?" gesture). Loading / error / empty states are all rendered — a
+  failed fetch says so rather than showing a silently empty list.
+- **Rows.** `from → to` is the primary line (`architect → cost`, `?` for a null `fromAgent`,
+  matching the CLI). A secondary line carries **age** and **reason**. A pre-due `--delay` row
+  (`notBefore > now`) renders `→15s` / `scheduled` exactly as the CLI does
+  (`commands/inbox.ts:129-133`) so a *scheduled* send is not misread as a *stuck* one. An
+  escalated row is marked (`!` plus the existing amber attention colour).
+
+Age/duration formatting is a ~10-line reimplementation in a new
+`apps/web/src/lib/heldMail.ts` (`formatDuration` / `formatAge`, ported from
+`commands/inbox.ts:74-86`). It is **not** imported from `packages/codev` — the web app must not
+import server code across the isolation boundary.
+
+`apps/web/src/lib/api.ts` gains `fetchInbox()`, using the existing `apiUrl()` + `getAuthHeaders()`
+helpers so the Tower shared-key header (GHSA-xvjp-7748-v88v) is sent like every other call.
+
+CSS in `apps/web/src/index.css` alongside the existing `.held-badge` block: button reset +
+underline, and a `.held-popover` panel — absolutely positioned under the header control,
+`max-height` + `overflow-y: auto` so a long list scrolls, and the same token palette
+(`--bg-*`, `--text-*`, `--status-waiting`) the confirmation modal uses.
+
+### Explicitly out of scope
+
+- **VSCode** (`apps/vscode/src/mailbox-indicators.ts`) — the issue is titled *Dashboard*.
+- **Mobile** — `MobileLayout` does not render the badge today (only the desktop header at
+  `App.tsx:355-361` does); this change does not add it.
+- **Dismiss / show-body from the UI** — Spec 1313 decision 8 and the redaction rule.
+- **`codev-skeleton/` mirroring** — this touches product code (`apps/web`, `packages/codev`,
+  `packages/types`), not framework files, so there is no skeleton twin to update.
+
+## Files to Change
+
+**Server**
+
+- `packages/codev/src/agent-farm/servers/tower-routes.ts:2134` — `handleInboxList(res, url, workspaceOverride?)`; resolution order override → `?workspace=` → all. Update the docstring.
+- `packages/codev/src/agent-farm/servers/tower-routes.ts:~2698` — new `apiPath === 'inbox'` GET branch in the workspace-scoped dispatcher, beside the `overview` branch.
+
+**Types**
+
+- `packages/types/src/api.ts` — new exported `HeldMessage` interface (the metadata-only projection); export it from the package index if that file enumerates exports.
+
+**Web**
+
+- `apps/web/src/components/HeldCountBadge.tsx` — `<span>` → `<button>`; disclosure state; popover render; `loadMessages` prop. Docstring updated (it currently asserts "Read-only and count-only" — still read-only, no longer count-only).
+- `apps/web/src/lib/heldMail.ts` — **new**; `formatDuration` / `formatAge`.
+- `apps/web/src/lib/api.ts` — **new** `fetchInbox(): Promise<HeldMessage[]>`; re-export `HeldMessage` alongside the other `codev-types` re-exports.
+- `apps/web/src/components/App.tsx:360` — pass `loadMessages={fetchInbox}`.
+- `apps/web/src/index.css:897-923` — extend `.held-badge` (button reset, underline, hover/focus); add `.held-popover` and row styles.
+
+**Tests**
+
+- `apps/web/__tests__/HeldCountBadge.test.tsx` — extended (existing five cases kept).
+- `packages/codev/src/agent-farm/__tests__/inbox-routes.test.ts` — extended with the workspace-scoped route cases (harness already drives the real `handleRequest` against a real in-memory mailbox DB).
+
+## Risks & Alternatives Considered
+
+- **Risk — leaking message bodies into the dashboard.** Mitigation: the dashboard reuses the
+  metadata-only `handleInboxList` projection verbatim, and the new branch exact-matches `'inbox'`
+  so `inbox/:id` (the only body-bearing route) is unreachable under the workspace prefix. A test
+  asserts the response carries no `body` key.
+- **Risk — the new branch accidentally exposes dismiss.** Mitigation: the branch is
+  `req.method === 'GET' && apiPath === 'inbox'`; `inbox/<id>/dismiss` does not match and falls
+  through to the dispatcher's 404. A test asserts a POST to `.../api/inbox` does not mutate.
+- **Risk — cross-workspace bleed.** `handleInboxList` with no workspace lists *every* workspace's
+  held rows. Passing `workspacePath` (already normalized to the stored realpath by the prefix
+  decoder, `tower-routes.ts:2476`) scopes it. A test seeds two workspaces and asserts only the
+  requested one comes back.
+- **Risk — a `--delay` row reads as "stuck".** Pre-due rows are held rows and already inflate
+  `heldCount`; the popover renders them as `scheduled` with a countdown, matching the CLI.
+- **Risk — regressing the existing badge contract.** The five existing unit tests
+  (`data-testid`, zero/negative count, attention classes) are kept unchanged and must still pass.
+- **Alternative — fold a `heldMessages[]` array into `OverviewData`.** Rejected: `/api/overview`
+  is polled every 2.5s and its payload is `JSON.stringify`-compared for change detection
+  (`useOverview.ts:14-16`); carrying a list for a panel that is almost never open makes a hot path
+  pay for a cold feature. It would also push the same array into VSCode's overview cache. The
+  architect's steer was to reuse `/api/inbox`, and lazy-on-open is the cheaper shape.
+- **Alternative — call the Tower-level `/api/inbox?workspace=<abs path>` from the browser.**
+  Rejected: the dashboard has no absolute workspace path (all its calls are relative to the
+  `/workspace/<base64>/` prefix and the server resolves the workspace). Teaching the client to
+  decode its own prefix would duplicate server-side knowledge that the existing
+  `architects/:name` and `overview` routes deliberately keep on the server.
+- **Alternative — a full modal instead of a popover.** Rejected: this is a triage glance, not a
+  task. A modal steals focus from the terminals, which is the opposite of what "does it matter?"
+  wants.
+
+## Test Plan
+
+**Unit — web (`apps/web`, vitest + Testing Library)**
+
+- Existing five `HeldCountBadge` cases still pass unchanged.
+- Renders as a `<button>` with `aria-haspopup="dialog"` and `aria-expanded="false"`.
+- Click → `aria-expanded="true"`, `loadMessages` called once, popover in the DOM.
+- Popover renders `architect → cost` for a row `{fromAgent: 'architect', toAgent: 'cost'}`.
+- Null `fromAgent` renders `? → cost`.
+- Age and reason render (`busy`, and `!`/attention marking for `escalated: true`).
+- A pre-due `notBefore` row renders `scheduled` with a countdown, not an age.
+- Empty result → an explicit "No held messages" state, not a blank panel.
+- Rejected loader → an error state, not a silent empty list.
+- Escape closes and focus returns to the button; second click closes.
+- `apps/web/src/lib/heldMail.ts` — `formatDuration` boundaries (`59s` / `1m` / `60m` → `1h` / `24h` → `1d`).
+
+**Unit — server (`packages/codev`, vitest, real in-memory mailbox DB)**
+
+- `GET /workspace/<b64>/api/inbox` returns that workspace's held rows only; a row seeded under a
+  second workspace is absent.
+- The projection carries `fromAgent`/`toAgent`/`reason`/`escalated`/`createdAt`/`notBefore` and
+  **no `body`**.
+- A dismissed/delivered row is absent (only `held` rows list).
+- `POST /workspace/<b64>/api/inbox` does not dismiss anything.
+- The Tower-level `GET /api/inbox?workspace=…` behaviour is unchanged (regression guard on the
+  existing cases).
+
+**Manual — real browser via Playwright (required before dev-approval)**
+
+Per the architect's constraint, the changed UX is exercised in a real browser and screenshots are
+attached as evidence:
+
+1. Build the web app from this worktree and serve it against a Tower whose `global.db` has held
+   rows (produced the honest way — `afx send` to a busy agent — so the rows are real mailbox rows,
+   not hand-inserted).
+2. Navigate to the workspace dashboard, screenshot the header: the counter is **underlined** and
+   reads as interactive.
+3. Click it; screenshot the open popover showing `from → to` per row, with age and reason.
+4. Verify keyboard path: Tab to the badge, Enter opens, Escape closes, focus returns.
+5. Verify the zero state: with no held mail the badge is absent entirely (unchanged behaviour).
+6. Check the browser console is clean (no 404 on `./api/inbox`, no React warnings).
+
+If a live held row cannot be produced in this worktree, I will fall back to driving the real
+built SPA in Playwright against a local stub serving the real `/api/inbox` projection shape, and
+I will **say so explicitly** in the dev-approval summary rather than implying a full-stack run.
+
+**Reviewer's path at the `dev-approval` gate**
+
+Open the worktree dashboard, confirm the counter is underlined, click it, and check the listed
+`from → to` pairs against `afx inbox -w <workspace>` in a terminal — the two should agree row for
+row.

--- a/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
+++ b/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
@@ -10,12 +10,13 @@ gates:
     requested_at: '2026-08-18T03:18:45.785Z'
     approved_at: '2026-08-18T03:34:52.094Z'
   dev-approval:
-    status: pending
+    status: approved
     requested_at: '2026-08-18T03:50:13.800Z'
+    approved_at: '2026-08-18T04:03:07.050Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:14:21.212Z'
-updated_at: '2026-08-18T03:50:13.801Z'
+updated_at: '2026-08-18T04:03:07.051Z'

--- a/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
+++ b/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
@@ -16,10 +16,10 @@ gates:
   pr:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-08-18T03:14:21.212Z'
-updated_at: '2026-08-18T04:06:13.523Z'
+updated_at: '2026-08-18T04:06:20.144Z'
 pr_history:
   - phase: review
     pr_number: 1510

--- a/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
+++ b/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
@@ -7,6 +7,7 @@ current_plan_phase: null
 gates:
   plan-approval:
     status: pending
+    requested_at: '2026-08-18T03:18:45.785Z'
   dev-approval:
     status: pending
   pr:
@@ -15,4 +16,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:14:21.212Z'
-updated_at: '2026-08-18T03:14:21.213Z'
+updated_at: '2026-08-18T03:18:45.786Z'

--- a/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
+++ b/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
@@ -18,10 +18,10 @@ gates:
     requested_at: '2026-08-18T04:15:40.636Z'
     approved_at: '2026-08-18T04:17:21.430Z'
 iteration: 1
-build_complete: false
+build_complete: true
 history: []
 started_at: '2026-08-18T03:14:21.212Z'
-updated_at: '2026-08-18T04:17:21.430Z'
+updated_at: '2026-08-18T04:17:28.829Z'
 pr_history:
   - phase: review
     pr_number: 1510

--- a/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
+++ b/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
@@ -11,10 +11,11 @@ gates:
     approved_at: '2026-08-18T03:34:52.094Z'
   dev-approval:
     status: pending
+    requested_at: '2026-08-18T03:50:13.800Z'
   pr:
     status: pending
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:14:21.212Z'
-updated_at: '2026-08-18T03:35:41.209Z'
+updated_at: '2026-08-18T03:50:13.801Z'

--- a/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
+++ b/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
@@ -1,7 +1,7 @@
 id: '1450'
 title: dashboard-make-the-held-mail-c
 protocol: pir
-phase: implement
+phase: review
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -19,4 +19,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:14:21.212Z'
-updated_at: '2026-08-18T04:03:07.051Z'
+updated_at: '2026-08-18T04:03:08.492Z'

--- a/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
+++ b/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
@@ -19,4 +19,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:14:21.212Z'
-updated_at: '2026-08-18T04:03:08.492Z'
+updated_at: '2026-08-18T04:06:13.523Z'
+pr_history:
+  - phase: review
+    pr_number: 1510
+    branch: builder/pir-1450
+    created_at: '2026-08-18T04:06:13.523Z'

--- a/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
+++ b/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
@@ -6,8 +6,9 @@ plan_phases: []
 current_plan_phase: null
 gates:
   plan-approval:
-    status: pending
+    status: approved
     requested_at: '2026-08-18T03:18:45.785Z'
+    approved_at: '2026-08-18T03:34:52.094Z'
   dev-approval:
     status: pending
   pr:
@@ -16,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:14:21.212Z'
-updated_at: '2026-08-18T03:18:45.786Z'
+updated_at: '2026-08-18T03:34:52.094Z'

--- a/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
+++ b/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
@@ -1,0 +1,18 @@
+id: '1450'
+title: dashboard-make-the-held-mail-c
+protocol: pir
+phase: plan
+plan_phases: []
+current_plan_phase: null
+gates:
+  plan-approval:
+    status: pending
+  dev-approval:
+    status: pending
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-18T03:14:21.212Z'
+updated_at: '2026-08-18T03:14:21.213Z'

--- a/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
+++ b/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
@@ -1,7 +1,7 @@
 id: '1450'
 title: dashboard-make-the-held-mail-c
 protocol: pir
-phase: review
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -21,7 +21,7 @@ iteration: 1
 build_complete: true
 history: []
 started_at: '2026-08-18T03:14:21.212Z'
-updated_at: '2026-08-18T04:17:28.829Z'
+updated_at: '2026-08-18T04:17:30.488Z'
 pr_history:
   - phase: review
     pr_number: 1510

--- a/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
+++ b/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
@@ -14,16 +14,17 @@ gates:
     requested_at: '2026-08-18T03:50:13.800Z'
     approved_at: '2026-08-18T04:03:07.050Z'
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-08-18T04:15:40.636Z'
+    approved_at: '2026-08-18T04:17:21.430Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:14:21.212Z'
-updated_at: '2026-08-18T04:15:40.636Z'
+updated_at: '2026-08-18T04:17:21.430Z'
 pr_history:
   - phase: review
     pr_number: 1510
     branch: builder/pir-1450
     created_at: '2026-08-18T04:06:13.523Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
+++ b/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
@@ -1,7 +1,7 @@
 id: '1450'
 title: dashboard-make-the-held-mail-c
 protocol: pir
-phase: plan
+phase: implement
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -17,4 +17,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T03:14:21.212Z'
-updated_at: '2026-08-18T03:34:52.094Z'
+updated_at: '2026-08-18T03:35:41.209Z'

--- a/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
+++ b/codev/projects/1450-dashboard-make-the-held-mail-c/status.yaml
@@ -15,13 +15,15 @@ gates:
     approved_at: '2026-08-18T04:03:07.050Z'
   pr:
     status: pending
+    requested_at: '2026-08-18T04:15:40.636Z'
 iteration: 1
-build_complete: true
+build_complete: false
 history: []
 started_at: '2026-08-18T03:14:21.212Z'
-updated_at: '2026-08-18T04:06:20.144Z'
+updated_at: '2026-08-18T04:15:40.636Z'
 pr_history:
   - phase: review
     pr_number: 1510
     branch: builder/pir-1450
     created_at: '2026-08-18T04:06:13.523Z'
+pr_ready_for_human: true

--- a/codev/resources/arch.md
+++ b/codev/resources/arch.md
@@ -1839,7 +1839,9 @@ rather than reconcile it — `afx inbox` labels pre-due rows `scheduled`, and th
 groups `Held (N)` (N === the badge count) above a separate `Scheduled (M)`. The corollary is that
 with 0 due and 1 scheduled row the badge does not render at all, so a scheduled-only state is
 visible **only** in `afx inbox`; changing that means changing what the badge counts, not how the
-list is filtered. Terminal rows (delivered/superseded/dismissed) are pruned after `mailbox.retentionDays` (default 30) by the drainer; **held rows are never pruned**. Cron delivers through the same gate via `deliverCronMessage` (`cron-delivery.ts`) with a per-task supersede key (a newer run replaces the older *held* row) and logs the real outcome.
+list is filtered.
+
+Terminal rows (delivered/superseded/dismissed) are pruned after `mailbox.retentionDays` (default 30) by the drainer; **held rows are never pruned**. Cron delivers through the same gate via `deliverCronMessage` (`cron-delivery.ts`) with a per-task supersede key (a newer run replaces the older *held* row) and logs the real outcome.
 
 #### Address Resolution
 

--- a/codev/resources/arch.md
+++ b/codev/resources/arch.md
@@ -660,6 +660,30 @@ As of v2.0.0 (Spec 0090 Phase 4), Agent Farm uses a **Tower Single Daemon** arch
 4. **Tower serves React dashboard directly**: No separate dashboard-server processes - Tower serves `/workspace/<encoded>/` routes
 5. **WebSocket paths include workspace context**: Format is `/workspace/<base64url>/ws/terminal/<id>`
 
+##### Two route tables, and why a "working" endpoint can still 404 for the dashboard (Issue 1450)
+
+`tower-routes.ts` dispatches HTTP through **two independent tables**, and registering in one
+does not register in the other:
+
+| | Tower-level `ROUTES` map (~`:180`) | Workspace-scoped dispatcher (`handleWorkspaceRoutes`) |
+|---|---|---|
+| URL | `/api/<thing>` | `/workspace/<base64url>/api/<thing>` |
+| Callers | CLI (`afx …` via the Tower client), direct HTTP | **The React dashboard** |
+| Workspace | from `?workspace=`, else "first known" | decoded + normalized from the URL prefix |
+
+The dashboard's `getApiBase()` returns `'./'`, so every call it makes is **relative** and lands
+in the second table. It never decodes its own workspace path — the server resolves it from the
+prefix, which is why workspace-scoped handlers take a `workspaceOverride` argument
+(`handleOverview`, `handleAnalytics`, `handleInboxList`) that **wins over** `?workspace=` so a
+query param cannot redirect a scoped call to another workspace's data.
+
+Consequence: a CLI-facing endpoint being live and tested says nothing about whether the
+dashboard can reach it. `GET /api/inbox` had backed `afx inbox` since Spec 1313 while
+`./api/inbox` 404'd for the dashboard. When wiring a dashboard feature to an existing endpoint,
+check the workspace-scoped dispatcher, not just the `ROUTES` map. The exact-vs-prefix match
+there is also a security boundary: matching `'inbox'` exactly keeps `inbox/:id` (body-bearing)
+and `inbox/:id/dismiss` (mutating) unreachable from the browser surface.
+
 #### State Split Problem & Reconciliation
 
 **WARNING**: The system has a known state split between:
@@ -1803,7 +1827,19 @@ Spec 1313 replaced Spec 403's in-memory, timer-based, force-flushing `SendBuffer
 
 #### Escalation & visibility (never delivery)
 
-A held row past the escalation age (`DEFAULT_ESCALATION_MS`, default 60s; `.codev/config.json` `mailbox.escalationSeconds`) is flagged `escalated` and emits the `mailbox-escalation` SSE event — **visibility only, never a delivery trigger**. Every held-state change (hold/deliver/supersede/dismiss) fires `overview-changed` so the dashboard/VSCode held-count indicators stay live (`setMailboxBroadcaster(broadcastNotification)` wires the boot-time drainer, which has no `RouteContext`, into the SSE fan-out). `afx inbox` lists held rows (workspace-scoped; metadata only, never bodies), `afx inbox show <id>` displays a single row including its body (the one body-surfacing CLI view; works on a row of any status), and `afx inbox dismiss <id>` soft-marks a row dismissed (any workspace operator; CLI-only). Terminal rows (delivered/superseded/dismissed) are pruned after `mailbox.retentionDays` (default 30) by the drainer; **held rows are never pruned**. Cron delivers through the same gate via `deliverCronMessage` (`cron-delivery.ts`) with a per-task supersede key (a newer run replaces the older *held* row) and logs the real outcome.
+A held row past the escalation age (`DEFAULT_ESCALATION_MS`, default 60s; `.codev/config.json` `mailbox.escalationSeconds`) is flagged `escalated` and emits the `mailbox-escalation` SSE event — **visibility only, never a delivery trigger**. Every held-state change (hold/deliver/supersede/dismiss) fires `overview-changed` so the dashboard/VSCode held-count indicators stay live (`setMailboxBroadcaster(broadcastNotification)` wires the boot-time drainer, which has no `RouteContext`, into the SSE fan-out). `afx inbox` lists held rows (workspace-scoped; metadata only, never bodies), `afx inbox show <id>` displays a single row including its body (the one body-surfacing CLI view; works on a row of any status), and `afx inbox dismiss <id>` soft-marks a row dismissed (any workspace operator; CLI-only).
+
+**The held COUNT and the held LIST disagree by design — do not "fix" it (Issue 1450).** The
+count (`heldSummaryForWorkspace`, behind `OverviewData.heldCount` and every badge/alarm surface)
+filters `not_before IS NULL OR not_before <= now`; the list (`listHeld`, behind `GET /api/inbox`)
+has **no** `not_before` filter. So a pre-due `--delay` send is listed but not counted, and
+`heldCount <= inbox.length` always. This is deliberate: a scheduled send is "scheduled, not
+stuck" and must not raise an attention indicator. Any surface rendering both must show the split
+rather than reconcile it — `afx inbox` labels pre-due rows `scheduled`, and the dashboard popover
+groups `Held (N)` (N === the badge count) above a separate `Scheduled (M)`. The corollary is that
+with 0 due and 1 scheduled row the badge does not render at all, so a scheduled-only state is
+visible **only** in `afx inbox`; changing that means changing what the badge counts, not how the
+list is filtered. Terminal rows (delivered/superseded/dismissed) are pruned after `mailbox.retentionDays` (default 30) by the drainer; **held rows are never pruned**. Cron delivers through the same gate via `deliverCronMessage` (`cron-delivery.ts`) with a per-task supersede key (a newer run replaces the older *held* row) and logs the real outcome.
 
 #### Address Resolution
 

--- a/codev/resources/lessons-learned.md
+++ b/codev/resources/lessons-learned.md
@@ -283,6 +283,20 @@ Generalizable wisdom extracted from review documents, ordered by impact. Updated
   Playwright spec while the unit and browser suites both passed, because Playwright transpiles
   per file with no project-wide type check. Run `check-types` after the last **file** is added,
   not after the last logic change.
+- [From #1450] **A browser assertion can pass while proving nothing — assert its precondition in
+  the same test.** A z-index check did `elementFromPoint` at the popover's centre and confirmed
+  the popover was on top: green, and worthless, because `document.querySelector('.xterm')` had
+  returned the *left* pane's terminal, which can never overlap a top-right panel. The hazard
+  (xterm's WebGL canvas painting over an unlayered element) was never exercised. The fix is to
+  assert the setup, not just the property: "a terminal genuinely overlaps this rect" **and then**
+  "the panel wins at every sampled point". Same shape as the #1401 guard lesson — if a check
+  cannot distinguish the bug from its absence, it is decoration.
+- [From #1450] Two Playwright mechanics worth knowing on this dashboard: `waitUntil:
+  'networkidle'` can **never** fire (the SSE stream at `/api/events` stays open for the page's
+  lifetime — use `domcontentloaded` plus an explicit element wait), and a lazily-fetched panel
+  must be waited on by its *loaded* content, or assertions read the "Loading…" state instead.
+  Also assert the **status code** of the endpoint under test: an auth failure renders as a tidy
+  error state that looks like a working UI, so "the panel showed something" is not evidence.
 - [From #1380] jsdom cannot express CSS layout (fragmentation, multicol, client rects) — for
   layout-dependent features, commit a real-browser (Playwright) fixture **alongside the first
   layout CSS**, and have it assert invariants (fragment-rect counts, reachability), not the

--- a/codev/reviews/1450-dashboard-make-the-held-mail-c.md
+++ b/codev/reviews/1450-dashboard-make-the-held-mail-c.md
@@ -1,0 +1,171 @@
+# PIR Review: Clickable held-mail counter with a held-messages popover
+
+Fixes #1450
+
+## Summary
+
+The dashboard header's held-mail counter ("2 held") was inert text, so learning *what* was held
+meant dropping to `afx inbox` in a terminal. It is now a disclosure button — dotted underline,
+`aria-expanded`/`aria-controls` — that opens a panel listing each held message as `from → to`
+with its age and why-held reason. Server-side this reuses the existing `handleInboxList` behind a
+new workspace-scoped `GET /api/inbox` branch; no new handler and no new projection, so the
+metadata-only redaction rule and CLI-only dismissal (Spec 1313 decision 8) are untouched.
+
+The one genuinely subtle part is that **the badge count and the list disagree by design** — see
+*Things to Look At*.
+
+## Files Changed
+
+- `apps/web/src/components/HeldCountBadge.tsx` (+219 / -…) — span → disclosure button, grouped popover, generation-guarded lazy fetch
+- `apps/web/src/index.css` (+125 / -0) — underline affordance, popover panel, z-index tier
+- `apps/web/src/lib/heldMail.ts` (+48 / -0) — new; `formatHeldAge` / `formatHeldDuration` / `isScheduled`
+- `apps/web/src/lib/api.ts` (+19 / -0) — `fetchInbox`
+- `apps/web/src/components/App.tsx` (+8 / -3) — wire `loadMessages`
+- `packages/codev/src/agent-farm/servers/tower-routes.ts` (+30 / -3) — `workspaceOverride` param + workspace-scoped branch
+- `packages/types/src/api.ts` (+46 / -0) — `HeldMessage`
+- `packages/types/src/index.ts` (+1 / -0) — export it
+- `apps/web/__tests__/HeldCountBadge.test.tsx` (+386 / -…) — 20 new cases, 5 originals kept unchanged
+- `apps/web/__tests__/heldMail.test.ts` (+59 / -0) — new
+- `packages/codev/src/agent-farm/__tests__/inbox-routes.test.ts` (+168 / -0) — 13 new route cases
+- `packages/codev/scripts/issue-1450-dashboard-evidence.mts` (+370 / -0) — new; real-browser evidence harness
+- `codev/plans/1450-dashboard-make-the-held-mail-c.md`, `codev/state/pir-1450_thread.md`, `codev/resources/arch.md`, `codev/resources/lessons-learned.md` — artifacts and governance
+
+## Commits
+
+- `b6c15774e` [PIR #1450] Plan draft
+- `934e9354e` [PIR #1450] Plan revised: Held/Scheduled split, a11y disclosure pattern, isolated-Tower Playwright
+- `5a782c0b7` [PIR #1450] Plan: use AF_TEST_DB isolation seam for the evidence Tower (not a HOME redirect)
+- `d70e3503f` [PIR #1450] feat: clickable held-mail counter with a held-messages popover
+
+## Test Results
+
+- `pnpm build`: ✓ pass
+- `pnpm test` (`@cluesmith/codev`): ✓ 4916 passed, 48 skipped, **0 failures**
+- `apps/web` (`pnpm --filter @cluesmith/codev-web test`): ✓ 371 passed, 1 skipped, 33 files — **37 new tests**
+  - Note: the root `test` script runs only the `codev` package; web tests need the filtered command.
+- **Manual, real browser**: `packages/codev/scripts/issue-1450-dashboard-evidence.mts` — 23/23 checks
+  in headless Chromium against an isolated Tower (worktree build, port 14700, `NODE_ENV=test` +
+  `AF_TEST_DB`). Real workspace, real shellper PTYs painted with an occupied composer, real
+  `POST /api/send` held by the render gate, real built SPA. Asserts the underline affordance,
+  `aria-expanded` toggling, `from → to` rows, the Held/Scheduled grouping,
+  `GET .../api/inbox` returning **200**, Held-group length === badge count, popover stacking over
+  a live terminal, and Escape-closes-with-focus-return.
+- **Human review at the `dev-approval` gate**: the reviewer exercised an interactive instance of
+  that same environment personally (2 held + 1 scheduled fixture) and approved.
+
+## Architecture Updates
+
+Routed **COLD only** (`codev/resources/arch.md`). Neither hot file was touched: both are at their
+10-entry cap, and nothing here is a cross-cutting invariant worth displacing an existing entry —
+these are subsystem facts about Tower's routing and the mailbox, which is what the cold archive is
+for.
+
+Two additions:
+
+1. **Agent Farm Internals → "Two route tables, and why a 'working' endpoint can still 404 for the
+   dashboard."** `tower-routes.ts` dispatches through two independent tables — the Tower-level
+   `ROUTES` map (`/api/<thing>`, used by the CLI) and `handleWorkspaceRoutes`
+   (`/workspace/<b64>/api/<thing>`, used by the dashboard, whose `getApiBase()` returns `'./'`).
+   Registering in one does not register in the other, which is exactly why this issue existed:
+   `GET /api/inbox` had backed `afx inbox` since Spec 1313 while `./api/inbox` 404'd for the
+   dashboard. Also records why workspace-scoped handlers take a `workspaceOverride` that **wins
+   over** `?workspace=`, and that the exact-vs-prefix match is a security boundary.
+2. **Mailbox section** — the count/list asymmetry, written as "do not 'fix' it" (details below),
+   including the corollary that a scheduled-only state is invisible to the badge by design.
+
+## Lessons Learned Updates
+
+Routed **COLD only** (`codev/resources/lessons-learned.md` → Testing). Both entries are about
+browser-test technique — useful, but not the always-injected kind, and the hot file is at cap.
+
+1. **A browser assertion can pass while proving nothing — assert its precondition in the same
+   test.** My z-index check confirmed the popover was on top at its centre point and was green
+   and worthless: `querySelector('.xterm')` had returned the *left* pane's terminal, which can
+   never overlap a top-right panel, so the actual hazard (xterm's WebGL canvas painting over an
+   unlayered element) was never exercised. The fix asserts the setup — "a terminal genuinely
+   overlaps this rect" — before asserting the property. Same shape as #1401's guard lesson.
+2. **Two Playwright mechanics specific to this dashboard**: `waitUntil: 'networkidle'` can never
+   fire (the SSE stream at `/api/events` stays open for the page's lifetime), and a lazily-fetched
+   panel must be waited on by its *loaded* content or assertions read the "Loading…" state. Plus:
+   assert the **status code** of the endpoint under test, because an auth failure renders as a
+   tidy error state that looks like a working UI.
+
+## Things to Look At During PR Review
+
+**1. The Held/Scheduled split — the part that took two attempts to get right.**
+My first plan asserted that pre-due `--delay` rows "already inflate `heldCount`". That was
+backwards, and the architect's review caught it. Verified against `db/mailbox.ts`:
+
+- `heldSummaryForWorkspace` (`:215-227`) — the badge count — filters
+  `not_before IS NULL OR not_before <= now`.
+- `listHeld` (`:113-124`) — behind `GET /api/inbox` — has **no** such filter.
+
+So `heldCount <= inbox.length`, always, deliberately: a scheduled send is "scheduled, not stuck"
+and must not raise an attention indicator. A naive popover would say "2 held" and list 3 rows. The
+panel therefore **groups**: `Held (N)` where N is exactly the badge count, above a secondary
+`Scheduled (M)` with a countdown and explanatory copy. Groups render only when non-empty, so the
+ordinary case looks like one plain list. Pinned by a unit test (1 due + 1 pre-due at `count={1}`)
+and re-verified live in the browser run, which reproduced exactly that fixture.
+
+**2. Accepted edge case, not an oversight.** With 0 due and 1 scheduled row, `heldCount` is 0, the
+badge does not render, and that row is unreachable from the dashboard. That is the existing
+contract — the badge is an *attention* indicator — and `afx inbox` remains the surface that sees
+it. Surfacing it would mean rendering a badge whose count is 0. Documented on the component, on
+the `HeldMessage` type, and in arch.md; changing it is a change to what the badge counts.
+
+**3. The exact-match on `'inbox'` is load-bearing.** `inbox/:id` returns the message **body** and
+`inbox/:id/dismiss` mutates. Both must stay unreachable under the workspace prefix for the
+"metadata-only, read-only" claim to hold. Three tests pin that (both 404, and the row survives a
+POST) rather than leaving it to inspection.
+
+**4. `formatHeldAge`, not `formatDuration`.** `apps/web/src/lib/open-files-shells-utils.ts:2-10`
+already exports a `formatDuration` with different semantics (minute granularity, `<1m` floor) and
+existing callers. The new helper is second-granularity to match `afx inbox`, so it is separately
+named rather than merged — two same-named formatters with different output in one `lib/` is a
+trap. It is a deliberate ~10-line port, not an import: the web app must not cross the
+server/client isolation boundary (#1189), and `codev-types` is a types-only devDependency.
+
+**5. Fetch lifecycle.** Loads on open and on `count` change while open (the count is SSE-driven, so
+a change means the mailbox moved). Each load carries a generation counter; stale responses are
+discarded — React 19 would not warn about the open→close→open race. And while the panel is open
+the component stays mounted even at `count <= 0`, because `useOverview` polls every 2.5s and the
+last row being delivered would otherwise unmount the button and drop focus to `<body>`. The
+closed-at-zero contract is unchanged, so the original zero-state tests pass untouched.
+
+**6. Not a dialog.** Deliberately the WAI-ARIA *disclosure* pattern (`aria-expanded` +
+`aria-controls` + a real `<ul>`), not `role="dialog"` — a dialog role without moving focus in is
+announced inconsistently, and this panel should not steal focus from the terminals.
+
+## How to Test Locally
+
+- **View diff**: VSCode sidebar → right-click builder `pir-1450` → **Review Diff**
+- **Run the browser evidence** (needs an out-of-tree Playwright; see the script header):
+  ```bash
+  pnpm build
+  npm install playwright-core --prefix /tmp/pw
+  PW_CORE=/tmp/pw/node_modules/playwright-core \
+  PW_CHROMIUM=~/.cache/ms-playwright/chromium-*/chrome-linux64/chrome \
+  node --experimental-strip-types packages/codev/scripts/issue-1450-dashboard-evidence.mts
+  ```
+  It stands up and tears down its own isolated Tower on port 14700; the live Tower on 4100 and the
+  real `global.db` are never touched.
+- **What to verify**:
+  - The counter is underlined and reads as interactive; clicking opens the panel.
+  - Rows show `from → to` (a null sender renders `?`, matching `afx inbox`), with age and reason.
+  - With a `--delay` send in flight, `Held (N)` matches the badge and `Scheduled (M)` is separate.
+  - Escape closes and returns focus to the counter; click-outside closes; a terminal behind the
+    panel does not paint over it.
+  - On a normally-running dashboard, the union of both groups matches `afx inbox -w <workspace>`
+    row for row, and the Held group alone matches the badge count.
+
+## Flaky Tests
+
+None. No pre-existing failures were encountered in the full suite (4916 passed), so nothing was
+skipped or quarantined.
+
+## Scope Note
+
+Out of scope and unchanged, per the plan: VSCode's `mailbox-indicators.ts` (the issue is titled
+*Dashboard*); mobile (`MobileLayout` does not render the badge today); dismiss/show-body from the
+UI (Spec 1313 decision 8 and the redaction rule); and `codev-skeleton/` (this is product code, not
+framework files, so there is no skeleton twin to mirror).

--- a/codev/reviews/1450-dashboard-make-the-held-mail-c.md
+++ b/codev/reviews/1450-dashboard-make-the-held-mail-c.md
@@ -36,11 +36,13 @@ The one genuinely subtle part is that **the badge count and the list disagree by
 - `934e9354e` [PIR #1450] Plan revised: Held/Scheduled split, a11y disclosure pattern, isolated-Tower Playwright
 - `5a782c0b7` [PIR #1450] Plan: use AF_TEST_DB isolation seam for the evidence Tower (not a HOME redirect)
 - `d70e3503f` [PIR #1450] feat: clickable held-mail counter with a held-messages popover
+- `7483bcce9` [PIR #1450] Review + retrospective
+- `2cb2b3623` [PIR #1450] Address 3-way consult + architect integration review
 
 ## Test Results
 
 - `pnpm build`: ✓ pass
-- `pnpm test` (`@cluesmith/codev`): ✓ 4916 passed, 48 skipped, **0 failures**
+- `pnpm test` (`@cluesmith/codev`): ✓ 4917 passed, 48 skipped, **0 failures**
 - `apps/web` (`pnpm --filter @cluesmith/codev-web test`): ✓ 33 files — **37 new web tests** (27 component + 10 formatter)
   - Note: the root `test` script runs only the `codev` package; web tests need the filtered command.
 - **49 new tests total** across the three files (27 + 10 + 12).

--- a/codev/reviews/1450-dashboard-make-the-held-mail-c.md
+++ b/codev/reviews/1450-dashboard-make-the-held-mail-c.md
@@ -24,9 +24,9 @@ The one genuinely subtle part is that **the badge count and the list disagree by
 - `packages/codev/src/agent-farm/servers/tower-routes.ts` (+30 / -3) — `workspaceOverride` param + workspace-scoped branch
 - `packages/types/src/api.ts` (+46 / -0) — `HeldMessage`
 - `packages/types/src/index.ts` (+1 / -0) — export it
-- `apps/web/__tests__/HeldCountBadge.test.tsx` (+386 / -…) — 20 new cases, 5 originals kept unchanged
-- `apps/web/__tests__/heldMail.test.ts` (+59 / -0) — new
-- `packages/codev/src/agent-farm/__tests__/inbox-routes.test.ts` (+168 / -0) — 13 new route cases
+- `apps/web/__tests__/HeldCountBadge.test.tsx` — 32 cases total: 5 originals kept unchanged, **27 new**
+- `apps/web/__tests__/heldMail.test.ts` — new, **10 cases**
+- `packages/codev/src/agent-farm/__tests__/inbox-routes.test.ts` — **12 new** route cases (14 → 26 in the file)
 - `packages/codev/scripts/issue-1450-dashboard-evidence.mts` (+370 / -0) — new; real-browser evidence harness
 - `codev/plans/1450-dashboard-make-the-held-mail-c.md`, `codev/state/pir-1450_thread.md`, `codev/resources/arch.md`, `codev/resources/lessons-learned.md` — artifacts and governance
 
@@ -41,8 +41,9 @@ The one genuinely subtle part is that **the badge count and the list disagree by
 
 - `pnpm build`: ✓ pass
 - `pnpm test` (`@cluesmith/codev`): ✓ 4916 passed, 48 skipped, **0 failures**
-- `apps/web` (`pnpm --filter @cluesmith/codev-web test`): ✓ 371 passed, 1 skipped, 33 files — **37 new tests**
+- `apps/web` (`pnpm --filter @cluesmith/codev-web test`): ✓ 33 files — **37 new web tests** (27 component + 10 formatter)
   - Note: the root `test` script runs only the `codev` package; web tests need the filtered command.
+- **49 new tests total** across the three files (27 + 10 + 12).
 - **Manual, real browser**: `packages/codev/scripts/issue-1450-dashboard-evidence.mts` — 23/23 checks
   in headless Chromium against an isolated Tower (worktree build, port 14700, `NODE_ENV=test` +
   `AF_TEST_DB`). Real workspace, real shellper PTYs painted with an occupied composer, real
@@ -158,9 +159,31 @@ announced inconsistently, and this panel should not steal focus from the termina
   - On a normally-running dashboard, the union of both groups matches `afx inbox -w <workspace>`
     row for row, and the Held group alone matches the badge count.
 
+## Post-Consultation Fixes
+
+The 3-way consult and the architect's integration review both landed as non-blocking
+(APPROVE / COMMENT / APPROVE). Every finding was verified against the files before acting; all
+were real and all are fixed in `dd7a6b1` (see the PR's commit list).
+
+| Finding | Source | Disposition |
+|---|---|---|
+| `handleInboxList`'s docstring claimed an empty `workspaceOverride` stays scoped, but `rawWorkspace ? … : undefined` widened it to **all workspaces** | Codex + architect (3) | **Real.** Unreachable today (the dispatcher 400s a missing/relative prefix first), but the comment promised a guarantee the code did not make. Made the code true rather than weakening the comment: a scoped call with a blank override now scopes to `''`, which matches no rows. The safe failure for a scoped call is zero rows, never every row. |
+| Review file's test counts were wrong | Codex | **Real.** Recounted from the merge-base: **27** new component + **10** formatter + **12** route = **49**, not the 37 originally claimed. Corrected above. |
+| `count → 0` with scheduled rows left the panel with no "cleared" notice, and `Scheduled`'s "not counted above" had nothing above it | Codex | **Real.** The notice now keys on `heldRows.length === 0` rather than `messages.length === 0`, with copy that distinguishes "cleared" from "nothing held, rows below are scheduled". |
+| arch.md edit swallowed the pre-existing pruning/cron sentences into the new count-vs-list paragraph | Claude + architect (2) | **Real** — content survived but read as part of the Held/Scheduled discussion. Paragraph break restored. (Second splice of this kind in this project; the first was caught in `packages/types/src/api.ts` before commit.) |
+| `loadMessages` prop identity drove the refetch effect — an inline lambda from a future caller would loop | Claude + architect (4) | **Real footgun.** Latched in a ref; `load` now has empty deps, so behaviour no longer depends on a caller remembering to memoize. |
+| Popover lacked `aria-live`, so asynchronously-loaded rows were never announced | Claude | **Real.** Added `aria-live="polite"` + `aria-busy`. |
+| Footer said `afx inbox dismiss <id>` but no id is rendered anywhere | Claude | **Real.** Reworded to `Ids and dismissal: afx inbox`. Rendering a full uuid per row would dominate the row, and this surface never mutates. |
+| Server projection was untyped — `HeldMessage` was client-side decoration only | architect (1) | **Real.** Annotated `const projected: HeldMessage[]`, so a drifting projection (dropped field, or a `body` slipping in) fails the server build. |
+| Keep prior rows during refetch instead of blanking to "Loading…" | architect (5), optional | **Taken.** A refetch fires on every `count` change while open; flashing the list away is the worst moment to do it. `aria-busy` carries the in-flight state; only a cold open shows the spinner. An **error** still replaces the rows — once a refetch fails, the old list is no longer known to be current. |
+| `HeldMessage` jsdoc typo `/api/inbox:id` | architect (6) | **Not reproduced.** The jsdoc already reads `GET /api/inbox/:id` (`packages/types/src/api.ts:597`). No change made. |
+
+Re-verified after the fixes: `pnpm build` ✓, web suite ✓ (373 passed), route suite ✓ (26 passed),
+and the browser evidence re-run ✓ **23/23**.
+
 ## Flaky Tests
 
-None. No pre-existing failures were encountered in the full suite (4916 passed), so nothing was
+None. No pre-existing failures were encountered in the full suite, so nothing was
 skipped or quarantined.
 
 ## Scope Note

--- a/codev/reviews/1450-dashboard-make-the-held-mail-c.md
+++ b/codev/reviews/1450-dashboard-make-the-held-mail-c.md
@@ -163,7 +163,7 @@ announced inconsistently, and this panel should not steal focus from the termina
 
 The 3-way consult and the architect's integration review both landed as non-blocking
 (APPROVE / COMMENT / APPROVE). Every finding was verified against the files before acting; all
-were real and all are fixed in `dd7a6b1` (see the PR's commit list).
+were real and all are fixed in `2cb2b3623` (see the PR's commit list).
 
 | Finding | Source | Disposition |
 |---|---|---|

--- a/codev/state/pir-1450_thread.md
+++ b/codev/state/pir-1450_thread.md
@@ -62,3 +62,65 @@ JSON.stringify-diffed — a hot path shouldn't carry a cold panel's list).
   to saying so explicitly rather than implying a full-stack run.
 
 Plan committed, `plan-approval` gate pending.
+
+## Plan review round 1 (2026-08-18) — REQUEST_CHANGES, amended
+
+Architect ran a claude-lane Medium-tier plan review. Security axis came back clean
+(`isRequestAllowed` covers the new branch for free; `inbox/:id` + `/dismiss` fall through to 404;
+no body in the projection; prefix-decoded `workspacePath` scopes correctly). Ten file:line
+citations checked out.
+
+### The blocking finding — I had it backwards, and it mattered
+
+My revision-1 risk entry claimed pre-due `--delay` rows "already inflate `heldCount`". **Wrong,
+and verified wrong myself against `db/mailbox.ts`:**
+
+- `heldSummaryForWorkspace` (`:215-227`) filters `AND (not_before IS NULL OR not_before <= ?)`.
+  Docstring is explicit: pre-due sends "must NOT inflate the attention count".
+- `listHeld` (`:113-124`), which `handleInboxList` calls, has **no `not_before` filter** — every
+  held row.
+
+So badge count ≤ list length, always, by design. A naive popover would say "2 held" and list 3.
+This is not a bug to paper over — it's an intentional split between an *attention count* and an
+*inventory list*, and the same docstring says `afx inbox` deliberately shows both and labels the
+pre-due ones "scheduled".
+
+Took option (a): popover groups "Held (N)" (N === badge count exactly) + a secondary
+"Scheduled (M)" section with explanatory copy. Keeps the panel a faithful mirror of `afx inbox`
+while making the badge number verifiable at a glance. Groups render only when non-empty, so the
+common case looks like one plain list.
+
+Accepted edge case, stated not hidden: 0 due + 1 scheduled → heldCount 0 → badge absent → that
+row unreachable from the dashboard. That's the existing contract (badge = attention). Changing it
+means changing what the badge *counts*, which is a different issue.
+
+**Lesson for me:** I asserted a data-flow claim about two SQL queries without opening either.
+"Verify reviewer/plan claims against the actual file" cuts both ways — it applies to my own plan
+claims before I write them down.
+
+### Other dispositions (all accepted)
+
+1. `formatDuration` duplicate — `open-files-shells-utils.ts:2-10` already exports one at minute
+   granularity with existing callers. Naming mine `formatHeldAge`; not extending theirs. Also
+   fixed citations (I'd dropped the `agent-farm/` path segment).
+2. Loader race + mid-open unmount — generation counter; refetch on count-change while open; stay
+   mounted while open at count 0 so focus isn't dropped to `<body>` when the last row delivers.
+3. A11y — switched from the `role="dialog"` half-pattern to WAI-ARIA disclosure
+   (`aria-expanded` + `aria-controls` + real `<ul>`). Escape/focus-return kept.
+4. Positioning/stacking — `.header-controls:139-143` confirmed to have no `position`; z-index
+   tiers confirmed 20/100/1000. Relative wrapper + popover at the 1000 tier, else xterm WebGL
+   paints over it.
+5. Playwright — my stub fallback was rightly called out as testing *none* of the change, when
+   "`./api/inbox` 404s today" IS the finding. Switched to an isolated second Tower
+   (`afx tower start --port 14650`). **Added beyond the steer:** redirect `HOME` to a scratch dir
+   so `AGENT_FARM_DIR` (`packages/core/src/constants.ts:4`, `resolve(homedir(), ...)`) gives it
+   its own `global.db` — a second Tower on the live global.db would run a delivery loop against
+   the cohort's real held mail. Plus a 200-status network assertion (a 401 renders as a
+   benign-looking error state).
+
+Nits all taken: `??` so the override wins; test seeding through `normalizeWorkspacePath`; pin the
+`inbox/:id` and `/dismiss` 404s; rewrote the rejected-overview rationale (my JSON.stringify-churn
+argument was weak — real reasons are cached-aggregate cost + VSCode overview fanout + the steer).
+
+Open note back to architect: couldn't find pir-1365's artifacts in this worktree, so the
+isolated-Tower recipe is reconstructed from the CLI rather than copied from that precedent.

--- a/codev/state/pir-1450_thread.md
+++ b/codev/state/pir-1450_thread.md
@@ -195,3 +195,44 @@ for the page's lifetime. Used `domcontentloaded`.
 - No pre-existing failures encountered, so nothing to quarantine.
 
 Awaiting `dev-approval`. PR gets parked open at the end — maintainer merges.
+
+## dev-approval (2026-08-18)
+
+Human asked to exercise the UX personally before deciding, so I stood up an INTERACTIVE version of
+the evidence environment (same AF_TEST_DB isolation, port 14700, Tower detached via
+`spawn({detached:true})` + `unref()` so it outlived my turn) seeded with 2 held + 1 scheduled, and
+left it running.
+
+Two things worth recording from that:
+
+- **`MAX_DELAY_SECONDS` is 3600** (`delayed-send.ts:102`). The architect asked for "a long
+  notBefore so the scheduled row doesn't come due mid-inspection"; one hour is the product's cap on
+  `--delay`, so that wasn't available. Said so rather than quietly seeding something shorter.
+- **My first seeding run silently produced only 2 rows.** The 7-day send was rejected with a 400
+  and my helper swallowed the response. Fixed the helper to throw on `!res.ok` — a fixture that
+  comes up short without saying so is worse than one that fails loudly.
+- Started the interactive session on a **fresh** db name: my four evidence runs had left ~12 stale
+  held rows in `test-1450-14700.db`, which would have shown the reviewer a pile of junk instead of
+  the fixture.
+
+Approved. Torn down and verified: pid gone, 14700 closed, fixture db + scratch workspaces removed,
+live Tower on 4100 still listening, `global.db` timestamp unchanged. Also deleted my stale
+`test-1450-14700.db` litter.
+
+## Review phase (2026-08-18)
+
+Retrospective written. Governance routed **COLD only** — both hot files are at their 10-entry cap
+and nothing here justifies displacing an existing entry:
+
+- `arch.md` — (1) the **two route tables** fact under Agent Farm Internals: Tower-level `ROUTES`
+  vs `handleWorkspaceRoutes`, why a CLI-live endpoint can still 404 for the dashboard, and why
+  `workspaceOverride` must win over `?workspace=`. This is the root of the whole issue and would
+  bite the next person wiring a dashboard feature to an "existing" endpoint. (2) the
+  count-vs-list asymmetry in the mailbox section, framed as "do not fix it".
+- `lessons-learned.md` → Testing — (1) a browser assertion can pass while proving nothing; assert
+  the precondition (my z-index check). (2) `networkidle` never fires against an SSE-holding page;
+  wait on loaded content, and assert the status code because auth failures render as tidy error
+  states.
+
+Next: open the PR, record with porch, `porch done` triggers the single 3-way consult, then the
+`pr` gate. **Park it open — never merge, never close #1450.** We are not maintainers here.

--- a/codev/state/pir-1450_thread.md
+++ b/codev/state/pir-1450_thread.md
@@ -296,6 +296,15 @@ Final state: PR #1510 OPEN, issue #1450 OPEN, branch `builder/pir-1450` pushed, 
 No `porch done --merged` recorded, because nothing was merged — recording it would put a false
 lifecycle event in `status.yaml`.
 
+### PENDING — post-merge follow-through
+
+Architect confirmed: leave `status.yaml` at `verified` / created-but-not-merged. **When the
+maintainer merges PR #1510, run `porch done 1450 --merged 1510`** to close the lifecycle record.
+Nothing else is owed. Do not merge or close anything yourself — we are contributors here, not
+maintainers.
+
+(Recorded here rather than only in the session, so a crash-and-relaunch doesn't lose it.)
+
 ### What I'd tell the next builder on this code
 
 - The whole issue existed because `tower-routes.ts` has **two** route tables and `GET /api/inbox`

--- a/codev/state/pir-1450_thread.md
+++ b/codev/state/pir-1450_thread.md
@@ -234,5 +234,48 @@ and nothing here justifies displacing an existing entry:
   wait on loaded content, and assert the status code because auth failures render as tidy error
   states.
 
-Next: open the PR, record with porch, `porch done` triggers the single 3-way consult, then the
-`pr` gate. **Park it open — never merge, never close #1450.** We are not maintainers here.
+PR #1510 opened and recorded with porch. `Fixes #1450` kept per architect (matches program
+precedent and the #1483 two-phase signal — the issue closing exactly at maintainer merge is the
+intended semantics).
+
+## Consult round (2026-08-18) — APPROVE / COMMENT / APPROVE, all non-blocking
+
+Gemini APPROVE, Codex COMMENT, Claude APPROVE; plus the architect's own integration review
+(COMMENT). Nine distinct findings, **every one real**, all fixed. Verified each against the files
+before acting rather than taking the summaries at face value — which mattered, because the one I
+could *not* reproduce was the architect's jsdoc typo (`/api/inbox:id`); the file already read
+`/api/inbox/:id`, so I reported "not reproduced" instead of making a cosmetic no-op edit.
+
+The two that actually mattered:
+
+1. **`handleInboxList` doc/code disagreement (Codex + architect).** My docstring bragged that an
+   empty `workspaceOverride` stays scoped. It didn't — `rawWorkspace ? … : undefined` turned it
+   into an all-workspaces query. Unreachable today (the dispatcher 400s a missing prefix), but I
+   had written a security guarantee the code did not make. Fixed by making the code true rather
+   than softening the comment: a scoped call with a blank override scopes to `''`, matching no
+   rows. Needed a narrow `export` of the handler to test it, since the branch is unreachable
+   through `handleRequest` — documented as a test seam at the export.
+2. **My review file's test counts were wrong.** Claimed 20 new component tests / 37 total; the
+   real numbers from the merge-base are 27 + 10 + 12 = **49**. I had eyeballed rather than
+   counted. Corrected. A retrospective is durable team knowledge — wrong numbers in it are worse
+   than no numbers.
+
+Also fixed: arch.md paragraph splice (the pruning/cron sentences got glued onto my new
+paragraph — **second splice of this kind this project**, after the api.ts docstring; I should
+reread the surrounding block after every insertion into prose, not just after code edits);
+`loadMessages` identity driving the refetch effect (latched in a ref, so an inline lambda from a
+future caller can't cause a refetch loop); missing `aria-live`; a footer naming an id the panel
+never renders; the untyped server projection (now `const projected: HeldMessage[]`, so drift
+fails the build); and blanking to "Loading…" on refetch (now keeps rows, `aria-busy` carries the
+in-flight state — but an *error* still replaces them, because a failed refetch means the old list
+is no longer known to be current).
+
+One self-inflicted detour: my `aria-live` edit put a JSX comment as a sibling expression inside
+`{open && ( … )}`, which doesn't parse. Caught by the build immediately.
+
+Re-verified after all fixes: build ✓, full suite **4917 passed / 0 failures**, web 373, routes 26,
+and the **browser evidence re-run 23/23** — the component changed, so re-running it was not
+optional.
+
+Sitting at the `pr` gate. **Park it open — never merge, never close #1450.** We are not
+maintainers here.

--- a/codev/state/pir-1450_thread.md
+++ b/codev/state/pir-1450_thread.md
@@ -279,3 +279,29 @@ optional.
 
 Sitting at the `pr` gate. **Park it open — never merge, never close #1450.** We are not
 maintainers here.
+
+## Protocol complete (2026-08-18)
+
+`pr` gate approved by the human; `porch next 1450` reports `status: complete`, `phase: verified`.
+
+**Deliberately did NOT run the protocol's final task.** Porch's completion task says "Merge the
+pull request" — that is the PIR default for a repo the cohort owns. It does not apply here: we
+are contributors to cluesmith/codev, not maintainers, and the architect's standing instruction
+across four separate messages was park / never merge / never close #1450. A standing instruction
+from the human beats a protocol default, and merging is both irreversible and outward-facing.
+`Fixes #1450` in the PR body closes the issue at the maintainer's merge, which is the intended
+two-phase signal (#1483 precedent).
+
+Final state: PR #1510 OPEN, issue #1450 OPEN, branch `builder/pir-1450` pushed, worktree clean.
+No `porch done --merged` recorded, because nothing was merged — recording it would put a false
+lifecycle event in `status.yaml`.
+
+### What I'd tell the next builder on this code
+
+- The whole issue existed because `tower-routes.ts` has **two** route tables and `GET /api/inbox`
+  was only in the CLI-facing one. Check `handleWorkspaceRoutes` before assuming the dashboard can
+  reach an endpoint. Now in arch.md.
+- `heldCount` and `GET /api/inbox` disagree on purpose. Don't "fix" it. Also in arch.md.
+- The evidence script (`packages/codev/scripts/issue-1450-dashboard-evidence.mts`) is reusable for
+  any dashboard change: isolated Tower via `AF_TEST_DB`, real PTYs, real render gate, real SPA. It
+  needs an out-of-tree `playwright-core` via `PW_CORE`/`PW_CHROMIUM`.

--- a/codev/state/pir-1450_thread.md
+++ b/codev/state/pir-1450_thread.md
@@ -124,3 +124,74 @@ argument was weak — real reasons are cached-aggregate cost + VSCode overview f
 
 Open note back to architect: couldn't find pir-1365's artifacts in this worktree, so the
 isolated-Tower recipe is reconstructed from the CLI rather than copied from that precedent.
+
+**Resolved:** architect pointed at `spec-1365-e2e-evidence.mts`. pir-1365 did NOT redirect HOME —
+it spawns the built `tower-server.js` with `NODE_ENV=test` + `AF_TEST_DB`, the dedicated seam at
+`db/index.ts:117-127`. Strictly better than my HOME idea (isolates the db without touching the
+environment's home), so the plan was amended before implementing. Plan gate approved on rev 2.
+
+## Implement phase (2026-08-18)
+
+Shipped. Server + types + web + tests + a real-browser evidence script.
+
+### Shape of the change
+
+- `handleInboxList(res, url, workspaceOverride?)` — `??` ordering so the override WINS over
+  `?workspace=`; the Tower-level registration is untouched.
+- New `apiPath === 'inbox'` GET branch in the workspace-scoped dispatcher. **Exact match**, so
+  `inbox/:id` (body) and `inbox/:id/dismiss` (mutating) fall through to 404 and stay off the
+  dashboard. Three tests pin that non-reachability — it's what the redaction argument rests on.
+- `HeldMessage` in `packages/types`, with the Held-vs-Scheduled asymmetry documented ON the type
+  and a cross-reference added to `OverviewData.heldCount`. The next person to wire a UI to these
+  two fields shouldn't have to rediscover it from SQL.
+- Badge → disclosure button (dotted underline, `aria-expanded` + `aria-controls`, real `<ul>`),
+  generation-guarded lazy fetch, grouped popover, stays mounted while open at count 0.
+
+### Things worth recording
+
+- **`user-event` is not a dependency here.** I wrote the first test pass against it out of habit;
+  the repo convention is `fireEvent` from `@testing-library/react`. Rewrote rather than add a
+  devDependency for one test file.
+- **A `cd` in a Bash call persists across calls.** I cd'd into `apps/web/src` for a sed-style
+  edit and then spent two tool calls confused about why `apps/web/__tests__` "didn't exist".
+  Use absolute paths or cd back in the same command.
+- **Nearly wrote to main's tree.** An Edit call with a path missing the `.builders/pir-1450/`
+  segment was blocked by the guard. The nesting hazard in the role doc is real.
+- My first `heldCount` docstring edit spliced a note into the MIDDLE of the neighbouring
+  `queuedFeedback` comment, breaking its sentence. Caught on reread and moved.
+
+### Evidence (the part that actually proves this works)
+
+`packages/codev/scripts/issue-1450-dashboard-evidence.mts` — 23/23 checks, committed.
+
+Isolated Tower on **14700**, `NODE_ENV=test` + `AF_TEST_DB=test-1450-14700.db`, so the cohort's
+live `global.db` is never touched and no second delivery loop runs against their held mail.
+Real workspace, real shellper PTYs painted with an occupied composer, real `POST /api/send`
+held by the render gate, real built SPA in real Chromium.
+
+The run produced the exact scenario the blocking finding predicted: **badge says "2 held" while
+the mailbox has 3 rows**, and the popover renders `Held (2)` + `Scheduled (1)`. The
+`heldRows === badgeCount` assertion is in the script.
+
+`playwright-core` isn't a repo dependency — installed out-of-tree in the scratchpad and passed
+via `PW_CORE`/`PW_CHROMIUM` rather than adding a heavy devDependency for one script.
+
+Two flaws in my *own* evidence surfaced and were fixed rather than papered over:
+1. The z-index check used `querySelector('.xterm')`, which returned the LEFT pane's architect
+   terminal — never overlapping a top-right popover. The check passed while proving nothing.
+   Now it opens a builder terminal in the right pane, checks every mounted `.xterm`, and asserts
+   a terminal genuinely overlaps before testing what paints on top.
+2. Panel text was read before the lazy fetch resolved, so it was asserting against "Loading…".
+
+Also: `waitUntil: 'networkidle'` can never fire on this dashboard — the SSE stream stays open
+for the page's lifetime. Used `domcontentloaded`.
+
+### Test results
+
+- Full `pnpm test` (@cluesmith/codev): **4916 passed**, 48 skipped, 0 failures.
+- `apps/web`: **371 passed**, 1 skipped, 0 failures (33 files). Note the root `test` script only
+  runs the codev package — web tests need `pnpm --filter @cluesmith/codev-web test`.
+- New: 20 web component tests, 4 formatter tests, 13 route tests.
+- No pre-existing failures encountered, so nothing to quarantine.
+
+Awaiting `dev-approval`. PR gets parked open at the end — maintainer merges.

--- a/codev/state/pir-1450_thread.md
+++ b/codev/state/pir-1450_thread.md
@@ -1,0 +1,64 @@
+# pir-1450 — Dashboard: clickable held-mail counter
+
+## Plan phase (2026-08-17)
+
+Issue #1450: make the header's "N held" counter clickable and show the held messages
+(from → to) in a popover.
+
+### Architect spawn constraints (received mid-turn)
+
+1. We are **not** cluesmith/codev maintainers — PR gets parked open at the end. Never merge,
+   never close #1450.
+2. Issue body is dated 2026-08-17 and main has moved — verify its claims first.
+3. Dashboard UI → must be exercised in a real browser via Playwright, screenshots as evidence,
+   before dev-approval.
+4. Orientation given: `HeldCountBadge.tsx` is count-only; `GET /api/inbox` (`handleInboxList`,
+   tower-routes.ts:199) already serves the rows — prefer reusing it over a new endpoint.
+
+### What the investigation found
+
+Verified against `origin/main` @ `9129ab81c`:
+
+- `HeldCountBadge.tsx:31-40` is an inert `<span>` + `title` tooltip. Untouched since Spec 1313's
+  `0bbea9de4`. Issue claim holds.
+- `handleInboxList` (`tower-routes.ts:2134`) projects exactly what `afx inbox` renders — id,
+  workspacePath, to/fromAgent, reason, escalated, createdAt, notBefore. **No body** (Spec 1313
+  redaction rule).
+- **One correction to the issue's framing:** `GET /api/inbox` is registered only on the
+  *Tower-level* route table. The dashboard is served under `/workspace/<base64>/` and calls
+  `./api/...` (relative — `getApiBase()` returns `'./'`), which lands in the *workspace-scoped*
+  dispatcher (`tower-routes.ts:2484-2723`). That dispatcher has no `inbox` branch → `./api/inbox`
+  currently 404s. So "reuse the existing endpoint" needs a 3-line workspace-scoped branch, the
+  same pattern `overview` / `analytics` / `architects/:name` already use. Still reuse, not a new
+  handler.
+- **The dashboard does not know its own workspace path.** It never decodes the URL prefix for API
+  purposes; the server resolves it. That rules out calling the Tower-level
+  `/api/inbox?workspace=<abs>` from the browser, and makes the `workspaceOverride` param the right
+  seam.
+- `MobileLayout` never renders the badge — desktop header only (`App.tsx:355-361`). Out of scope.
+
+### Design chosen
+
+- Server: `handleInboxList(res, url, workspaceOverride?)` mirroring `handleOverview`; new
+  `apiPath === 'inbox'` GET branch under the workspace prefix. Exact-match so `inbox/:id` (body)
+  and `inbox/:id/dismiss` (mutating) stay unreachable from the dashboard — keeps the redaction
+  rule and decision-8 (dismissal is CLI-only) intact.
+- Types: shared `HeldMessage` in `packages/types` (both sides may import codev-types).
+- Web: badge → `<button>` with dotted underline, `aria-haspopup="dialog"` + `aria-expanded`,
+  owns disclosure state, takes a `loadMessages` **loader prop** (keeps it unit-testable in
+  isolation, which its docstring explicitly cares about). Lazy fetch on each open. Pre-due
+  `--delay` rows render `scheduled` + countdown like the CLI so they aren't misread as stuck.
+- Age formatting reimplemented in `apps/web/src/lib/heldMail.ts` — the web app must NOT import
+  `packages/codev` across the server/client isolation boundary.
+
+Rejected: folding `heldMessages[]` into `OverviewData` (that payload polls every 2.5s and is
+JSON.stringify-diffed — a hot path shouldn't carry a cold panel's list).
+
+### Open items for implement phase
+
+- Playwright: no `.codev/config.json` in this worktree and vite's dev proxy points at :4200
+  (legacy dashboard-server port). Need to work out the real serving path at implement time.
+  Plan states the fallback honestly (drive the real built SPA against a local stub) and commits
+  to saying so explicitly rather than implying a full-stack run.
+
+Plan committed, `plan-approval` gate pending.

--- a/packages/codev/scripts/issue-1450-dashboard-evidence.mts
+++ b/packages/codev/scripts/issue-1450-dashboard-evidence.mts
@@ -1,0 +1,370 @@
+/**
+ * Issue #1450 — dev-approval evidence for the clickable held-mail counter.
+ *
+ * This is a DASHBOARD change, so "tests pass" is not evidence: the affordance, the popover,
+ * its grouping and its stacking only exist in a browser. This script produces that browser
+ * run against a real, ISOLATED Tower and saves screenshots.
+ *
+ * ## Why a second Tower, and why it is safe
+ *
+ * `afx dev` deliberately reuses the live Tower's ports, and restarting the live Tower kills
+ * every builder session — neither is acceptable from inside a builder worktree. So this
+ * follows the pattern `send-integration.e2e.test.ts` and pir-1365's evidence script use:
+ * spawn THIS worktree's built `tower-server.js` on a private port with
+ * `NODE_ENV=test` + `AF_TEST_DB`, which redirects the mailbox to its own db file inside
+ * `~/.agent-farm/` (`db/index.ts` getGlobalDbPath). That isolation is load-bearing, not
+ * tidiness: a second Tower reading the real `global.db` would run its own mailbox-delivery
+ * loop against the cohort's live held mail. The shared Tower on 4100 is never touched.
+ *
+ * ## What is real here
+ *
+ * Nothing about the path under test is stubbed. Real Tower process, real SQLite mailbox,
+ * real `POST /api/send` going through the render gate (which HOLDS, because the recipient's
+ * composer is painted occupied), real `GET /workspace/<b64>/api/inbox` — the route this
+ * issue adds — and the real built SPA driven by a real Chromium.
+ *
+ * The `GET .../api/inbox` response status is asserted to be 200. That assertion is the point:
+ * the route is key-authenticated, and a 401 renders in the popover as a tidy error state that
+ * looks like a working UI. "The panel showed something" is not evidence.
+ *
+ * ## Running it
+ *
+ *   pnpm build
+ *   node --experimental-strip-types packages/codev/scripts/issue-1450-dashboard-evidence.mts
+ *
+ * Needs a Playwright browser driver. `playwright-core` is not a dependency of this repo (it
+ * would be a heavy devDependency for one script), so point PW_CORE at an installed copy and
+ * PW_CHROMIUM at a browser binary:
+ *
+ *   npm install playwright-core --prefix /tmp/pw
+ *   PW_CORE=/tmp/pw/node_modules/playwright-core \
+ *   PW_CHROMIUM=~/.cache/ms-playwright/chromium-*\/chrome-linux64/chrome \
+ *   node --experimental-strip-types packages/codev/scripts/issue-1450-dashboard-evidence.mts
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { resolve } from 'node:path';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import net from 'node:net';
+
+const PORT = 14700; // private to this script (14500 / 14600 / 14650 are taken)
+const BASE = `http://localhost:${PORT}`;
+const TOWER = resolve(import.meta.dirname, '../dist/agent-farm/servers/tower-server.js');
+// Defaults outside the repo so a bare run cannot leave untracked PNGs in the working tree.
+const SHOTS = process.env.SHOT_DIR || resolve(tmpdir(), 'codev-evidence-1450');
+
+const ESC = '\x1b';
+const RULE = '─'.repeat(22);
+const CLEAR = `${ESC}[2J${ESC}[H`;
+/** An OCCUPIED composer: a draft at normal intensity → the render gate HOLDS the send. */
+const DRAFT_COMPOSER = `${CLEAR}❯ ${ESC}[0mdeploy the hotfix to prod\r\n${RULE}\r\n`;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+let failures = 0;
+let checks = 0;
+function check(ok: boolean, label: string, detail = ''): void {
+  checks++;
+  if (!ok) failures++;
+  console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`);
+}
+function section(title: string): void {
+  console.log(`\n${'='.repeat(78)}\n${title}\n${'='.repeat(78)}`);
+}
+
+/** The shared local key Tower expects on API calls (advisory GHSA-xvjp-7748-v88v). */
+const KEY = readFileSync(resolve(homedir(), '.agent-farm', 'local-key'), 'utf-8').trim();
+const AUTH = { 'codev-tower-key': KEY };
+
+// ---------------------------------------------------------------- Tower lifecycle
+
+async function portListening(port: number): Promise<boolean> {
+  return new Promise((r) => {
+    const s = new net.Socket();
+    s.setTimeout(1000);
+    s.on('connect', () => { s.destroy(); r(true); });
+    s.on('timeout', () => { s.destroy(); r(false); });
+    s.on('error', () => r(false));
+    s.connect(port, '127.0.0.1');
+  });
+}
+
+async function startTower(): Promise<ChildProcess> {
+  if (!existsSync(TOWER)) throw new Error(`Tower build missing at ${TOWER} — run \`pnpm build\` first.`);
+  const proc = spawn('node', [TOWER, String(PORT)], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    // THE isolation seam — see the header. Without AF_TEST_DB this would attach to the
+    // cohort's live global.db and start delivering their held mail.
+    env: { ...process.env, NODE_ENV: 'test', AF_TEST_DB: `test-1450-${PORT}.db` },
+  });
+  let stderr = '';
+  proc.stderr?.on('data', (d: Buffer) => (stderr += d.toString()));
+  for (let i = 0; i < 75; i++) {
+    if (await portListening(PORT)) return proc;
+    await sleep(200);
+  }
+  proc.kill();
+  throw new Error(`Tower did not start on ${PORT}. stderr:\n${stderr}`);
+}
+
+async function stopTower(proc: ChildProcess | null): Promise<void> {
+  if (!proc) return;
+  proc.kill('SIGTERM');
+  await new Promise<void>((r) => {
+    proc.on('exit', () => r());
+    setTimeout(() => { proc.kill('SIGKILL'); r(); }, 3000);
+  });
+}
+
+// ---------------------------------------------------------------- workspace + terminals
+
+const enc = (p: string) => Buffer.from(p).toString('base64url');
+
+function makeWorkspace(): string {
+  const base = resolve(homedir(), '.agent-farm', 'test-workspaces');
+  mkdirSync(base, { recursive: true });
+  const ws = mkdtempSync(resolve(base, 'issue1450-'));
+  for (const d of ['codev', '.agent-farm', '.codev']) mkdirSync(resolve(ws, d), { recursive: true });
+  writeFileSync(
+    resolve(ws, '.codev', 'config.json'),
+    JSON.stringify({ shell: { architect: 'sh -c "sleep 3600"', builder: 'bash', shell: 'bash' } }),
+  );
+  // Lets `resolveProfileForSession` recover a harness for the wrapped launch, so sends are
+  // held for `busy` (an occupied composer) rather than short-circuiting on `no-profile`.
+  writeFileSync(resolve(ws, '.builder-start.sh'), '#!/usr/bin/env bash\nexec claude --dangerously-skip-permissions\n');
+  return ws;
+}
+
+async function activate(ws: string): Promise<void> {
+  for (let i = 0; i < 30; i++) {
+    const res = await fetch(`${BASE}/api/workspaces/${enc(ws)}/activate`, { method: 'POST', headers: AUTH });
+    if (res.ok) break;
+    await sleep(500);
+  }
+  for (let i = 0; i < 60; i++) {
+    const list = await (await fetch(`${BASE}/api/workspaces`, { headers: AUTH })).json();
+    if (list.workspaces?.some((w: { path: string }) => w.path === ws)) return;
+    await sleep(500);
+  }
+  throw new Error('workspace never activated');
+}
+
+/** A real shellper-backed PTY that echoes its input, so a composer can be painted onto it. */
+async function registerEchoTerminal(ws: string, roleId: string): Promise<string> {
+  const res = await fetch(`${BASE}/api/terminals`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...AUTH },
+    body: JSON.stringify({
+      command: 'sh',
+      args: ['-c', 'stty raw -echo 2>/dev/null; exec cat'],
+      cwd: ws, cols: 110, rows: 32,
+      workspacePath: ws, type: 'builder', roleId, persistent: true,
+    }),
+  });
+  if (res.status !== 201) throw new Error(`terminal register failed for ${roleId}: ${res.status}`);
+  return (await res.json()).id;
+}
+
+async function paint(terminalId: string, screen: string): Promise<void> {
+  await fetch(`${BASE}/api/terminals/${terminalId}/write`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...AUTH },
+    body: JSON.stringify({ data: screen }),
+  });
+  await sleep(250);
+}
+
+async function send(ws: string, to: string, message: string, options: Record<string, unknown> = {}) {
+  const res = await fetch(`${BASE}/api/send`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...AUTH },
+    body: JSON.stringify({ to, workspace: ws, from: 'architect', message, options }),
+  });
+  return { status: res.status, body: await res.json().catch(() => ({})) };
+}
+
+// ---------------------------------------------------------------- main
+
+async function main(): Promise<void> {
+  mkdirSync(SHOTS, { recursive: true });
+
+  // playwright-core is CJS: an ESM `import()` of it puts the exports on `.default`, and a
+  // bare directory path needs its entry file spelled out. Accept either shape so PW_CORE can
+  // be a package name, a directory, or a file.
+  const pwCore = process.env.PW_CORE || 'playwright-core';
+  const candidates = pwCore.endsWith('.js') || !pwCore.startsWith('/')
+    ? [pwCore]
+    : [`${pwCore}/index.js`, pwCore];
+  let chromium: any;
+  for (const candidate of candidates) {
+    try {
+      const mod: any = await import(candidate);
+      chromium = mod.chromium ?? mod.default?.chromium;
+      if (chromium) break;
+    } catch { /* try the next shape */ }
+  }
+  if (!chromium) {
+    console.error(
+      `\nCould not load playwright-core from "${pwCore}".\n` +
+      `Install it out-of-tree and set PW_CORE / PW_CHROMIUM — see this file's header.\n`,
+    );
+    process.exit(2);
+  }
+
+  let tower: ChildProcess | null = null;
+  try {
+    section('SETUP — isolated Tower, workspace, held mail');
+    tower = await startTower();
+    check(true, `Tower up on ${PORT} with AF_TEST_DB=test-1450-${PORT}.db (live global.db untouched)`);
+
+    const ws = makeWorkspace();
+    await activate(ws);
+    check(true, `workspace activated`, ws);
+
+    // Two recipients with OCCUPIED composers → the gate holds every send.
+    const cost = await registerEchoTerminal(ws, 'cost');
+    const docs = await registerEchoTerminal(ws, 'docs');
+    await paint(cost, DRAFT_COMPOSER);
+    await paint(docs, DRAFT_COMPOSER);
+
+    const r1 = await send(ws, 'cost', 'the cost report needs a second look');
+    const r2 = await send(ws, 'docs', 'please refresh the install docs');
+    // A pre-due --delay row: scheduled, NOT counted by heldCount. This is the row that makes
+    // the badge count and the list length disagree, which the popover has to group.
+    const r3 = await send(ws, 'cost', 'nightly summary', { deliverAfter: 3600 });
+
+    check(r1.body.held === true, 'send → cost was HELD (occupied composer)', String(r1.body.reason ?? ''));
+    check(r2.body.held === true, 'send → docs was HELD', String(r2.body.reason ?? ''));
+    check(r3.status === 200, 'delayed send accepted', `status ${r3.status}`);
+
+    const inbox = await (await fetch(`${BASE}/api/inbox?workspace=${encodeURIComponent(ws)}`, { headers: AUTH })).json();
+    console.log(`  inbox rows: ${JSON.stringify(inbox.map((r: any) => `${r.fromAgent}→${r.toAgent}${r.notBefore ? ' (scheduled)' : ''}`))}`);
+    check(inbox.length >= 2, 'held rows are in the mailbox', `${inbox.length} rows`);
+
+    section('BROWSER — the real built SPA in Chromium');
+    const browser = await chromium.launch({
+      headless: true,
+      ...(process.env.PW_CHROMIUM ? { executablePath: process.env.PW_CHROMIUM } : {}),
+    });
+    const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+
+    // Capture the status of the route this issue adds. A 401 renders as a benign-looking
+    // error state, so the status is the assertion that matters.
+    const inboxStatuses: number[] = [];
+    page.on('response', (res) => {
+      if (new URL(res.url()).pathname.endsWith('/api/inbox')) inboxStatuses.push(res.status());
+    });
+    const consoleErrors: string[] = [];
+    page.on('console', (m) => { if (m.type() === 'error') consoleErrors.push(m.text()); });
+
+    // NOT `networkidle`: the dashboard holds an SSE stream (/api/events) open for its
+    // lifetime, so the network never goes idle and the wait would always time out.
+    await page.goto(`${BASE}/workspace/${enc(ws)}/`, { waitUntil: 'domcontentloaded' });
+
+    // 1 — the counter, closed. The affordance must be visible without interacting.
+    const badge = page.getByTestId('held-badge');
+    await badge.waitFor({ state: 'visible', timeout: 20_000 });
+    check(true, 'held badge is rendered', await badge.textContent() ?? '');
+    const decoration = await badge.evaluate((el) => getComputedStyle(el).textDecorationLine);
+    check(decoration.includes('underline'), 'counter is underlined (reads as clickable)', decoration);
+    check(await badge.evaluate((el) => el.tagName) === 'BUTTON', 'counter is a real <button>');
+    check(await badge.getAttribute('aria-expanded') === 'false', 'starts collapsed (aria-expanded=false)');
+    await page.screenshot({ path: `${SHOTS}/1-counter-closed.png` });
+
+    // 2 — click it open.
+    await badge.click();
+    const popover = page.getByTestId('held-popover');
+    await popover.waitFor({ state: 'visible', timeout: 10_000 });
+    check(await badge.getAttribute('aria-expanded') === 'true', 'aria-expanded flips to true on open');
+
+    // The fetch is lazy, so the panel renders "Loading…" before the rows. Wait for the
+    // loaded content, or the text assertions below race the request and read the spinner.
+    await page.getByTestId('held-group-held').waitFor({ state: 'visible', timeout: 15_000 });
+    const panelText = (await popover.textContent()) ?? '';
+    check(panelText.includes('architect → cost'), 'panel lists architect → cost');
+    check(panelText.includes('architect → docs'), 'panel lists architect → docs');
+    check(panelText.includes('Held ('), 'panel has a Held group');
+    check(panelText.includes('Scheduled ('), 'panel has a Scheduled group for the pre-due row');
+    await page.screenshot({ path: `${SHOTS}/2-popover-open.png` });
+
+    // THE network assertion.
+    check(inboxStatuses.length > 0, 'GET .../api/inbox was actually requested', JSON.stringify(inboxStatuses));
+    check(inboxStatuses.every((s) => s === 200), 'GET .../api/inbox returned 200 (not a 401 masquerading as empty)', JSON.stringify(inboxStatuses));
+
+    // The Held group must equal the badge count — the plan's blocking-finding invariant.
+    const badgeCount = parseInt((await badge.textContent())?.trim() ?? '0', 10);
+    const heldRows = await page.getByTestId('held-group-held').locator('li').count();
+    check(heldRows === badgeCount, 'Held group length === badge count', `held=${heldRows} badge=${badgeCount}`);
+    const schedRows = await page.getByTestId('held-group-scheduled').locator('li').count();
+    check(schedRows >= 1, 'scheduled row is listed separately, not counted', `scheduled=${schedRows}`);
+
+    // 3 — stacking against a REAL terminal. The hazard this guards is xterm's WebGL/canvas
+    // renderer painting over an unlayered panel, so the check is only meaningful with a
+    // terminal actually mounted underneath the popover — not the Work view. Open a builder
+    // terminal tab in the right pane first, then reopen the popover on top of it.
+    await page.keyboard.press('Escape');
+    await popover.waitFor({ state: 'detached', timeout: 5000 });
+
+    await page.getByRole('tab', { name: /cost/ }).first().click();
+    await page.locator('.xterm-screen, .xterm canvas').first().waitFor({ state: 'visible', timeout: 20_000 });
+    await sleep(600); // let the renderer paint before we measure what is on top
+
+    await badge.click();
+    await popover.waitFor({ state: 'visible', timeout: 10_000 });
+
+    const stacking = await popover.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      // Sample several points across the panel, not just the centre: a canvas can win at
+      // one coordinate and lose at another.
+      const points: Array<[number, number]> = [
+        [r.left + r.width / 2, r.top + 10],
+        [r.left + r.width / 2, r.top + r.height / 2],
+        [r.left + r.width / 2, r.bottom - 10],
+        [r.left + 10, r.top + r.height / 2],
+        [r.right - 10, r.top + r.height / 2],
+      ];
+      const covered = points.filter(([x, y]) => {
+        const hit = document.elementFromPoint(x, y);
+        return hit ? el.contains(hit) : false;
+      }).length;
+      // Is there genuinely a terminal painted behind it? Check EVERY mounted .xterm, not
+      // just the first — the left pane holds an architect terminal that never overlaps the
+      // top-right popover, and querying only that one would silently under-report.
+      const overlapsTerminal = Array.from(document.querySelectorAll('.xterm')).some((term) => {
+        const b = term.getBoundingClientRect();
+        if (b.width === 0 || b.height === 0) return false; // hidden/kept-alive tab
+        return b.left < r.right && b.right > r.left && b.top < r.bottom && b.bottom > r.top;
+      });
+      return { covered, total: points.length, overlapsTerminal };
+    });
+    check(stacking.overlapsTerminal, 'a terminal is mounted behind the popover (the check is real)');
+    check(
+      stacking.covered === stacking.total,
+      'popover paints over the terminal at every sampled point (z-index tier holds)',
+      `${stacking.covered}/${stacking.total}`,
+    );
+    await page.screenshot({ path: `${SHOTS}/3-popover-over-terminal.png`, fullPage: false });
+
+    // 4 — keyboard: Escape closes and focus returns to the button.
+    await page.keyboard.press('Escape');
+    await popover.waitFor({ state: 'detached', timeout: 5000 });
+    const focusIsBadge = await page.evaluate(() =>
+      document.activeElement?.getAttribute('data-testid') === 'held-badge');
+    check(focusIsBadge, 'Escape closes and returns focus to the counter');
+
+    check(consoleErrors.length === 0, 'browser console clean', consoleErrors.slice(0, 3).join(' | '));
+
+    await browser.close();
+
+    section(`RESULT — ${checks - failures}/${checks} checks passed; screenshots in ${SHOTS}`);
+  } finally {
+    await stopTower(tower);
+  }
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/codev/src/agent-farm/__tests__/inbox-routes.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/inbox-routes.test.ts
@@ -13,7 +13,7 @@ import { EventEmitter } from 'node:events';
 import Database from 'better-sqlite3';
 import { GLOBAL_SCHEMA } from '../db/schema.js';
 import * as mailbox from '../db/mailbox.js';
-import { handleRequest } from '../servers/tower-routes.js';
+import { handleRequest, handleInboxList } from '../servers/tower-routes.js';
 import type { RouteContext } from '../servers/tower-routes.js';
 
 // The one db seam tower-routes uses: return a real in-memory DB, reseeded per test.
@@ -407,6 +407,19 @@ describe('GET /workspace/<b64>/api/inbox (Issue 1450)', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].id).toBe(mine.id);
     expect(rows[0].workspacePath).toBe(WS);
+  });
+
+  it('an EMPTY override scopes to nothing rather than widening to every workspace', async () => {
+    // Defensive: the dispatcher 400s a missing prefix, so a blank override is unreachable
+    // from the route today. But "unreachable" is a property of the caller, and the safe
+    // failure for a scoped call is zero rows, never every workspace's held mail.
+    seedHeld();
+    seedHeld({ workspacePath: '/home/user/other-project', toAgent: 'other-1' });
+
+    const res = makeRes();
+    handleInboxList(res, new URL('http://localhost/api/inbox'), '');
+
+    expect(JSON.parse(res._body)).toEqual([]);
   });
 
   it('lists pre-due --delay rows too, so the popover can group them as scheduled', async () => {

--- a/packages/codev/src/agent-farm/__tests__/inbox-routes.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/inbox-routes.test.ts
@@ -332,3 +332,171 @@ describe('GET /api/inbox/:id', () => {
     expect(res._statusCode).toBe(405);
   });
 });
+
+// ============================================================================
+// Issue 1450 — the WORKSPACE-SCOPED inbox route (/workspace/<b64>/api/inbox)
+//
+// The dashboard is served under /workspace/<base64-path>/ and calls its API with relative
+// `./api/...`, which lands in the workspace-scoped dispatcher rather than the Tower-level
+// route table. Before this change that dispatcher had no `inbox` branch, so the held-mail
+// popover's fetch 404'd. These tests pin the branch's scoping, its read-only-ness, and the
+// non-reachability that the redaction argument depends on.
+//
+// `WS` ('/home/user/project') does not exist on disk, so `normalizeWorkspacePath` falls back
+// to `resolve()` and returns it unchanged — the seeded rows and the decoded prefix agree.
+// The harness mocks `decodeWorkspacePath` as plain base64url (see the preamble).
+// ============================================================================
+
+/** The dashboard's URL for a workspace's held mail. */
+function wsInboxUrl(workspace: string, suffix = ''): string {
+  return `/workspace/${Buffer.from(workspace).toString('base64url')}/api/inbox${suffix}`;
+}
+
+describe('GET /workspace/<b64>/api/inbox (Issue 1450)', () => {
+  it('lists the held rows for the workspace named in the URL prefix', async () => {
+    const row = seedHeld();
+    const res = makeRes();
+    await handleRequest(makeReq('GET', wsInboxUrl(WS)), res, makeCtx());
+
+    expect(res._statusCode).toBe(200);
+    const rows = JSON.parse(res._body) as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: row.id,
+      workspacePath: WS,
+      toAgent: 'spir-1',
+      fromAgent: 'architect',
+      reason: 'busy',
+      escalated: false,
+    });
+  });
+
+  it('never surfaces the message body (Spec 1313 redaction rule)', async () => {
+    seedHeld();
+    const res = makeRes();
+    await handleRequest(makeReq('GET', wsInboxUrl(WS)), res, makeCtx());
+
+    expect(res._body).not.toContain('SECRET BODY');
+    expect(JSON.parse(res._body)[0]).not.toHaveProperty('body');
+  });
+
+  it('scopes to the URL workspace — another workspace\'s held mail is excluded', async () => {
+    const mine = seedHeld();
+    seedHeld({ workspacePath: '/home/user/other-project', toAgent: 'other-1' });
+
+    const res = makeRes();
+    await handleRequest(makeReq('GET', wsInboxUrl(WS)), res, makeCtx());
+
+    const rows = JSON.parse(res._body) as Array<{ id: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(mine.id);
+  });
+
+  it('ignores ?workspace= — the prefix wins, so a query param cannot redirect the scope', async () => {
+    const mine = seedHeld();
+    seedHeld({ workspacePath: '/home/user/other-project', toAgent: 'other-1' });
+
+    const res = makeRes();
+    await handleRequest(
+      makeReq('GET', `${wsInboxUrl(WS)}?workspace=${encodeURIComponent('/home/user/other-project')}`),
+      res,
+      makeCtx(),
+    );
+
+    const rows = JSON.parse(res._body) as Array<{ id: string; workspacePath: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(mine.id);
+    expect(rows[0].workspacePath).toBe(WS);
+  });
+
+  it('lists pre-due --delay rows too, so the popover can group them as scheduled', async () => {
+    // This is the asymmetry Issue 1450's popover has to render: `listHeld` (this route) has
+    // no not_before filter, while `heldSummaryForWorkspace` (the badge count) does. The
+    // count is therefore a LOWER BOUND on this list's length, by design.
+    const due = seedHeld({ toAgent: 'due-agent' });
+    const preDue = seedHeld({ toAgent: 'scheduled-agent', notBefore: 9_999_999_999_999 });
+
+    const res = makeRes();
+    await handleRequest(makeReq('GET', wsInboxUrl(WS)), res, makeCtx());
+
+    const rows = JSON.parse(res._body) as Array<{ id: string; notBefore: number | null }>;
+    expect(rows.map((r) => r.id).sort()).toEqual([due.id, preDue.id].sort());
+    expect(rows.find((r) => r.id === preDue.id)?.notBefore).toBe(9_999_999_999_999);
+
+    // And the count surface excludes it — the two numbers legitimately differ.
+    expect(mailbox.heldSummaryForWorkspace(holder.db, WS, 2000).total).toBe(1);
+  });
+
+  it('omits rows that are no longer held', async () => {
+    const kept = seedHeld({ toAgent: 'kept' });
+    const dismissed = seedHeld({ toAgent: 'gone' });
+    mailbox.dismiss(holder.db, dismissed.id, 5000);
+
+    const res = makeRes();
+    await handleRequest(makeReq('GET', wsInboxUrl(WS)), res, makeCtx());
+
+    const rows = JSON.parse(res._body) as Array<{ id: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(kept.id);
+  });
+
+  it('returns an empty list (not an error) when nothing is held', async () => {
+    const res = makeRes();
+    await handleRequest(makeReq('GET', wsInboxUrl(WS)), res, makeCtx());
+    expect(res._statusCode).toBe(200);
+    expect(JSON.parse(res._body)).toEqual([]);
+  });
+
+  // -------------------------------------------------------------- non-reachability
+  // The branch matches 'inbox' EXACTLY. These three assertions are what let the dashboard
+  // be described as a metadata-only, read-only surface: the body route and the mutating
+  // route simply do not exist under the workspace prefix.
+
+  it('does not expose the body-bearing single-row route under the workspace prefix', async () => {
+    const row = seedHeld();
+    const res = makeRes();
+    await handleRequest(makeReq('GET', wsInboxUrl(WS, `/${row.id}`)), res, makeCtx());
+
+    expect(res._statusCode).toBe(404);
+    expect(res._body).not.toContain('SECRET BODY');
+  });
+
+  it('does not expose dismiss under the workspace prefix — and the row survives', async () => {
+    const row = seedHeld();
+    const res = makeRes();
+    await handleRequest(makeReq('POST', wsInboxUrl(WS, `/${row.id}/dismiss`)), res, makeCtx());
+
+    expect(res._statusCode).toBe(404);
+    expect(mailbox.listHeld(holder.db, WS)).toHaveLength(1); // still held, not dismissed
+  });
+
+  it('rejects a non-GET method on the list route without mutating anything', async () => {
+    seedHeld();
+    const res = makeRes();
+    await handleRequest(makeReq('POST', wsInboxUrl(WS)), res, makeCtx());
+
+    expect(res._statusCode).toBe(404); // no POST branch → falls through to the API 404
+    expect(mailbox.listHeld(holder.db, WS)).toHaveLength(1);
+  });
+
+  it('leaves the Tower-level route behaviour unchanged (regression guard)', async () => {
+    const mine = seedHeld();
+    seedHeld({ workspacePath: '/home/user/other-project', toAgent: 'other-1' });
+
+    // Explicit ?workspace= still scopes...
+    const scoped = makeRes();
+    await handleRequest(
+      makeReq('GET', `/api/inbox?workspace=${encodeURIComponent(WS)}`),
+      scoped,
+      makeCtx(),
+    );
+    const scopedRows = JSON.parse(scoped._body) as Array<{ id: string }>;
+    expect(scopedRows).toHaveLength(1);
+    expect(scopedRows[0].id).toBe(mine.id);
+
+    // ...and omitting it still lists every workspace (the direct-caller convenience).
+    const all = makeRes();
+    await handleRequest(makeReq('GET', '/api/inbox'), all, makeCtx());
+    expect(JSON.parse(all._body)).toHaveLength(2);
+  });
+});

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -27,7 +27,7 @@ import { version } from '../../version.js';
 const execAsync = promisify(exec);
 import type { SessionManager } from '../../terminal/session-manager.js';
 import type { PtySessionInfo } from '../../terminal/pty-session.js';
-import type { BuilderSpawnedPayload, DashboardState, ArchitectState, TowerVersionInfo } from '@cluesmith/codev-types';
+import type { BuilderSpawnedPayload, DashboardState, ArchitectState, TowerVersionInfo, HeldMessage } from '@cluesmith/codev-types';
 import { getBuilders, setArchitectByName } from '../state.js';
 import { DEFAULT_COLS, defaultSessionOptions } from '../../terminal/index.js';
 import type { SSEClient, WorkspaceTerminals } from './tower-types.js';
@@ -2134,23 +2134,43 @@ async function handleSend(
  * Issue 1450: `workspaceOverride` lets the workspace-scoped route
  * (`/workspace/<base64>/api/inbox`, which backs the dashboard's held-mail popover) pass the
  * workspace resolved from the URL prefix, exactly as `handleOverview` / `handleAnalytics` do.
- * The override WINS over `?workspace=` (`??`, so even an empty-string override is honored
- * rather than falling through) — a workspace-scoped call must never be redirected to another
- * workspace's held mail by a query parameter. The override arrives already normalized by the
- * prefix decoder, so `normalizeWorkspacePath` re-running on it is a safe no-op.
+ * The override arrives already normalized by the prefix decoder, so `normalizeWorkspacePath`
+ * re-running on it is a safe no-op.
+ *
+ * Two separate widening hazards are closed here, because a scoped caller must never receive
+ * another workspace's held mail:
+ *   - `??` (not `||`) means `?workspace=` can never take effect once an override was passed.
+ *   - An EMPTY override does not fall through to the unscoped all-workspaces listing; it
+ *     scopes to a path that matches nothing. Today the dispatcher 400s a missing prefix so
+ *     this is unreachable, but "unreachable" is a property of the caller, not of this
+ *     function, and the safe failure for a scoped call is zero rows, never every row.
+ * The all-workspaces listing therefore remains reachable only when NO override was passed —
+ * the Tower-level route without `?workspace=`, the direct-caller convenience the CLI never uses.
  *
  * NOTE: this lists ALL held rows, including pre-due `--delay` rows, while the badge count
  * (`heldSummaryForWorkspace`) excludes them — see the `HeldMessage` type for why the two
  * legitimately disagree.
  */
-function handleInboxList(res: http.ServerResponse, url: URL, workspaceOverride?: string): void {
+// Exported as a narrow test seam (Issue 1450): the empty-override branch below cannot be
+// reached through `handleRequest` — the workspace dispatcher rejects a missing or non-absolute
+// prefix with a 400 before this runs — so the only way to pin that guard's behaviour is to call
+// the handler directly. Production callers go through the two route tables, not this export.
+export function handleInboxList(res: http.ServerResponse, url: URL, workspaceOverride?: string): void {
+  const scoped = workspaceOverride !== undefined;
   const rawWorkspace = workspaceOverride ?? url.searchParams.get('workspace');
   // Normalize to the stored realpath key (mailbox workspace_path is normalized at
   // enqueue — tower-routes handleSend / holdAndRespond — matching overview.ts). Without
   // this a symlinked workspace root would miss its own held rows.
-  const workspace = rawWorkspace ? normalizeWorkspacePath(rawWorkspace) : undefined;
+  // `scoped ? '' : undefined` on the empty branch: '' matches no workspace_path, so a scoped
+  // call with a blank override returns nothing rather than widening to every workspace.
+  const workspace = rawWorkspace
+    ? normalizeWorkspacePath(rawWorkspace)
+    : (scoped ? '' : undefined);
   const rows = listHeldMailbox(getGlobalDb(), workspace);
-  const projected = rows.map((r) => ({
+  // Annotated, not inferred: `HeldMessage` is the shared contract this route owes its
+  // clients, so a projection that drifts from it (a dropped field, or a `body` slipping in)
+  // fails the server build rather than only surprising the dashboard at runtime.
+  const projected: HeldMessage[] = rows.map((r) => ({
     id: r.id,
     workspacePath: r.workspace_path,
     toAgent: r.to_agent,

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -2130,9 +2130,21 @@ async function handleSend(
  * redaction rule): id, addresses, why-held reason, escalation flag, and enqueue time —
  * the message BODY is deliberately never surfaced here (it travels only over the live
  * terminal stream on delivery). `escalated` is normalized from SQLite's 0/1 to a bool.
+ *
+ * Issue 1450: `workspaceOverride` lets the workspace-scoped route
+ * (`/workspace/<base64>/api/inbox`, which backs the dashboard's held-mail popover) pass the
+ * workspace resolved from the URL prefix, exactly as `handleOverview` / `handleAnalytics` do.
+ * The override WINS over `?workspace=` (`??`, so even an empty-string override is honored
+ * rather than falling through) — a workspace-scoped call must never be redirected to another
+ * workspace's held mail by a query parameter. The override arrives already normalized by the
+ * prefix decoder, so `normalizeWorkspacePath` re-running on it is a safe no-op.
+ *
+ * NOTE: this lists ALL held rows, including pre-due `--delay` rows, while the badge count
+ * (`heldSummaryForWorkspace`) excludes them — see the `HeldMessage` type for why the two
+ * legitimately disagree.
  */
-function handleInboxList(res: http.ServerResponse, url: URL): void {
-  const rawWorkspace = url.searchParams.get('workspace');
+function handleInboxList(res: http.ServerResponse, url: URL, workspaceOverride?: string): void {
+  const rawWorkspace = workspaceOverride ?? url.searchParams.get('workspace');
   // Normalize to the stored realpath key (mailbox workspace_path is normalized at
   // enqueue — tower-routes handleSend / holdAndRespond — matching overview.ts). Without
   // this a symlinked workspace root would miss its own held rows.
@@ -2698,6 +2710,20 @@ async function handleWorkspaceRoutes(
     // GET /api/overview - Work view overview data (Spec 0126 Phase 4)
     if (req.method === 'GET' && apiPath === 'overview') {
       return handleOverview(res, url, workspacePath, ctx);
+    }
+
+    // GET /api/inbox - held mailbox rows for THIS workspace (Issue 1450). Backs the
+    // dashboard's clickable held-mail counter. Reuses the Tower-level handler with the
+    // workspace resolved from the /workspace/<base64>/ prefix, the same way `overview`
+    // and `analytics` above do — the dashboard calls relative `./api/...` and has no
+    // absolute workspace path of its own to pass as `?workspace=`.
+    //
+    // Deliberately an EXACT match on 'inbox', not a prefix: `inbox/:id` (which returns the
+    // message BODY) and `inbox/:id/dismiss` (which mutates) do not match, fall through to
+    // the 404 below, and so stay off the dashboard surface. That is what keeps this read
+    // path inside Spec 1313's redaction rule and decision 8 (dismissal is CLI-only).
+    if (req.method === 'GET' && apiPath === 'inbox') {
+      return handleInboxList(res, url, workspacePath);
     }
 
     // POST /api/overview/refresh - Invalidate overview cache (Spec 0126 Phase 4)

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -307,6 +307,12 @@ export interface OverviewData {
    * Spec 1313: count of currently-*held* mailbox rows across this workspace (all
    * recipient agents — builders and architects). Drives the dashboard/VSCode
    * held-count indicator. Count only, never message bodies. 0 when nothing is held.
+   *
+   * Issue 1450: this counts ELIGIBLE held rows only — a pre-due `--delay` send is
+   * excluded (`heldSummaryForWorkspace`). `GET /api/inbox` lists ALL held rows,
+   * pre-due ones included, so this number is a LOWER BOUND on that list's length.
+   * See `HeldMessage` for the full explanation; any surface showing both must
+   * render the difference rather than assume they agree.
    */
   heldCount: number;
   /**
@@ -580,6 +586,46 @@ export interface ProtocolStats {
   count: number;
   avgWallClockHours: number | null;
   avgAgentTimeHours: number | null;
+}
+
+/**
+ * Issue 1450: one currently-*held* mailbox row as `GET /api/inbox` projects it —
+ * the payload behind `afx inbox` and the dashboard's held-mail popover.
+ *
+ * **Metadata only, never the body** (Spec 1313 redaction rule). The message body
+ * travels only over the live terminal stream on delivery, or through the separate
+ * single-row `GET /api/inbox/:id` that backs `afx inbox show <id>`. Nothing that
+ * consumes this type can leak a body, because no body is here to leak.
+ *
+ * **Held vs scheduled — these rows do NOT all count toward `OverviewData.heldCount`.**
+ * The list comes from `listHeld`, which returns every `status = 'held'` row. The count
+ * comes from `heldSummaryForWorkspace`, which additionally requires
+ * `not_before IS NULL OR not_before <= now` — a pre-due `--delay` send is "scheduled,
+ * not stuck" and deliberately does not inflate the attention count. So
+ * `heldCount <= inbox.length`, always, by design. A UI showing both must group them
+ * (`afx inbox` labels pre-due rows `scheduled`) rather than pretend the numbers match.
+ */
+export interface HeldMessage {
+  /** Mailbox row id — the handle `afx inbox show|dismiss <id>` takes. */
+  id: string;
+  /** Normalized (realpath) workspace root the row was enqueued under. */
+  workspacePath: string;
+  /** Recipient agent (builder roleId or architect name). */
+  toAgent: string;
+  /** Sending agent; `null` for rows with no recorded sender (rendered as `?`). */
+  fromAgent: string | null;
+  /** Why the render gate held it: `'busy' | 'no-profile' | 'no-live-pty'`; `null` if unset. */
+  reason: string | null;
+  /** True once the row has crossed the escalation age. A pre-due row never escalates. */
+  escalated: boolean;
+  /** Enqueue time, epoch ms — the basis for the displayed age. */
+  createdAt: number;
+  /**
+   * Due time of a pre-due delayed (`--delay`) send, epoch ms; `null` = deliver ASAP.
+   * `notBefore > now` marks the row SCHEDULED: excluded from `heldCount`, rendered
+   * with a countdown rather than an age.
+   */
+  notBefore: number | null;
 }
 
 export interface AnalyticsResponse {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -57,6 +57,7 @@ export {
   type OverviewBacklogItem,
   type OverviewRecentlyClosed,
   type OverviewData,
+  type HeldMessage,
   type IssueView,
   type PRView,
   type IssueSearchItem,


### PR DESCRIPTION
# PIR Review: Clickable held-mail counter with a held-messages popover

Fixes #1450

## Summary

The dashboard header's held-mail counter ("2 held") was inert text, so learning *what* was held
meant dropping to `afx inbox` in a terminal. It is now a disclosure button — dotted underline,
`aria-expanded`/`aria-controls` — that opens a panel listing each held message as `from → to`
with its age and why-held reason. Server-side this reuses the existing `handleInboxList` behind a
new workspace-scoped `GET /api/inbox` branch; no new handler and no new projection, so the
metadata-only redaction rule and CLI-only dismissal (Spec 1313 decision 8) are untouched.

The one genuinely subtle part is that **the badge count and the list disagree by design** — see
*Things to Look At*.

## Files Changed

- `apps/web/src/components/HeldCountBadge.tsx` (+219 / -…) — span → disclosure button, grouped popover, generation-guarded lazy fetch
- `apps/web/src/index.css` (+125 / -0) — underline affordance, popover panel, z-index tier
- `apps/web/src/lib/heldMail.ts` (+48 / -0) — new; `formatHeldAge` / `formatHeldDuration` / `isScheduled`
- `apps/web/src/lib/api.ts` (+19 / -0) — `fetchInbox`
- `apps/web/src/components/App.tsx` (+8 / -3) — wire `loadMessages`
- `packages/codev/src/agent-farm/servers/tower-routes.ts` (+30 / -3) — `workspaceOverride` param + workspace-scoped branch
- `packages/types/src/api.ts` (+46 / -0) — `HeldMessage`
- `packages/types/src/index.ts` (+1 / -0) — export it
- `apps/web/__tests__/HeldCountBadge.test.tsx` — 32 cases total: 5 originals kept unchanged, **27 new**
- `apps/web/__tests__/heldMail.test.ts` — new, **10 cases**
- `packages/codev/src/agent-farm/__tests__/inbox-routes.test.ts` — **12 new** route cases (14 → 26 in the file)
- `packages/codev/scripts/issue-1450-dashboard-evidence.mts` (+370 / -0) — new; real-browser evidence harness
- `codev/plans/1450-dashboard-make-the-held-mail-c.md`, `codev/state/pir-1450_thread.md`, `codev/resources/arch.md`, `codev/resources/lessons-learned.md` — artifacts and governance

## Commits

- `b6c15774e` [PIR #1450] Plan draft
- `934e9354e` [PIR #1450] Plan revised: Held/Scheduled split, a11y disclosure pattern, isolated-Tower Playwright
- `5a782c0b7` [PIR #1450] Plan: use AF_TEST_DB isolation seam for the evidence Tower (not a HOME redirect)
- `d70e3503f` [PIR #1450] feat: clickable held-mail counter with a held-messages popover
- `7483bcce9` [PIR #1450] Review + retrospective
- `2cb2b3623` [PIR #1450] Address 3-way consult + architect integration review

## Test Results

- `pnpm build`: ✓ pass
- `pnpm test` (`@cluesmith/codev`): ✓ 4917 passed, 48 skipped, **0 failures**
- `apps/web` (`pnpm --filter @cluesmith/codev-web test`): ✓ 33 files — **37 new web tests** (27 component + 10 formatter)
  - Note: the root `test` script runs only the `codev` package; web tests need the filtered command.
- **49 new tests total** across the three files (27 + 10 + 12).
- **Manual, real browser**: `packages/codev/scripts/issue-1450-dashboard-evidence.mts` — 23/23 checks
  in headless Chromium against an isolated Tower (worktree build, port 14700, `NODE_ENV=test` +
  `AF_TEST_DB`). Real workspace, real shellper PTYs painted with an occupied composer, real
  `POST /api/send` held by the render gate, real built SPA. Asserts the underline affordance,
  `aria-expanded` toggling, `from → to` rows, the Held/Scheduled grouping,
  `GET .../api/inbox` returning **200**, Held-group length === badge count, popover stacking over
  a live terminal, and Escape-closes-with-focus-return.
- **Human review at the `dev-approval` gate**: the reviewer exercised an interactive instance of
  that same environment personally (2 held + 1 scheduled fixture) and approved.

## Architecture Updates

Routed **COLD only** (`codev/resources/arch.md`). Neither hot file was touched: both are at their
10-entry cap, and nothing here is a cross-cutting invariant worth displacing an existing entry —
these are subsystem facts about Tower's routing and the mailbox, which is what the cold archive is
for.

Two additions:

1. **Agent Farm Internals → "Two route tables, and why a 'working' endpoint can still 404 for the
   dashboard."** `tower-routes.ts` dispatches through two independent tables — the Tower-level
   `ROUTES` map (`/api/<thing>`, used by the CLI) and `handleWorkspaceRoutes`
   (`/workspace/<b64>/api/<thing>`, used by the dashboard, whose `getApiBase()` returns `'./'`).
   Registering in one does not register in the other, which is exactly why this issue existed:
   `GET /api/inbox` had backed `afx inbox` since Spec 1313 while `./api/inbox` 404'd for the
   dashboard. Also records why workspace-scoped handlers take a `workspaceOverride` that **wins
   over** `?workspace=`, and that the exact-vs-prefix match is a security boundary.
2. **Mailbox section** — the count/list asymmetry, written as "do not 'fix' it" (details below),
   including the corollary that a scheduled-only state is invisible to the badge by design.

## Lessons Learned Updates

Routed **COLD only** (`codev/resources/lessons-learned.md` → Testing). Both entries are about
browser-test technique — useful, but not the always-injected kind, and the hot file is at cap.

1. **A browser assertion can pass while proving nothing — assert its precondition in the same
   test.** My z-index check confirmed the popover was on top at its centre point and was green
   and worthless: `querySelector('.xterm')` had returned the *left* pane's terminal, which can
   never overlap a top-right panel, so the actual hazard (xterm's WebGL canvas painting over an
   unlayered element) was never exercised. The fix asserts the setup — "a terminal genuinely
   overlaps this rect" — before asserting the property. Same shape as #1401's guard lesson.
2. **Two Playwright mechanics specific to this dashboard**: `waitUntil: 'networkidle'` can never
   fire (the SSE stream at `/api/events` stays open for the page's lifetime), and a lazily-fetched
   panel must be waited on by its *loaded* content or assertions read the "Loading…" state. Plus:
   assert the **status code** of the endpoint under test, because an auth failure renders as a
   tidy error state that looks like a working UI.

## Things to Look At During PR Review

**1. The Held/Scheduled split — the part that took two attempts to get right.**
My first plan asserted that pre-due `--delay` rows "already inflate `heldCount`". That was
backwards, and the architect's review caught it. Verified against `db/mailbox.ts`:

- `heldSummaryForWorkspace` (`:215-227`) — the badge count — filters
  `not_before IS NULL OR not_before <= now`.
- `listHeld` (`:113-124`) — behind `GET /api/inbox` — has **no** such filter.

So `heldCount <= inbox.length`, always, deliberately: a scheduled send is "scheduled, not stuck"
and must not raise an attention indicator. A naive popover would say "2 held" and list 3 rows. The
panel therefore **groups**: `Held (N)` where N is exactly the badge count, above a secondary
`Scheduled (M)` with a countdown and explanatory copy. Groups render only when non-empty, so the
ordinary case looks like one plain list. Pinned by a unit test (1 due + 1 pre-due at `count={1}`)
and re-verified live in the browser run, which reproduced exactly that fixture.

**2. Accepted edge case, not an oversight.** With 0 due and 1 scheduled row, `heldCount` is 0, the
badge does not render, and that row is unreachable from the dashboard. That is the existing
contract — the badge is an *attention* indicator — and `afx inbox` remains the surface that sees
it. Surfacing it would mean rendering a badge whose count is 0. Documented on the component, on
the `HeldMessage` type, and in arch.md; changing it is a change to what the badge counts.

**3. The exact-match on `'inbox'` is load-bearing.** `inbox/:id` returns the message **body** and
`inbox/:id/dismiss` mutates. Both must stay unreachable under the workspace prefix for the
"metadata-only, read-only" claim to hold. Three tests pin that (both 404, and the row survives a
POST) rather than leaving it to inspection.

**4. `formatHeldAge`, not `formatDuration`.** `apps/web/src/lib/open-files-shells-utils.ts:2-10`
already exports a `formatDuration` with different semantics (minute granularity, `<1m` floor) and
existing callers. The new helper is second-granularity to match `afx inbox`, so it is separately
named rather than merged — two same-named formatters with different output in one `lib/` is a
trap. It is a deliberate ~10-line port, not an import: the web app must not cross the
server/client isolation boundary (#1189), and `codev-types` is a types-only devDependency.

**5. Fetch lifecycle.** Loads on open and on `count` change while open (the count is SSE-driven, so
a change means the mailbox moved). Each load carries a generation counter; stale responses are
discarded — React 19 would not warn about the open→close→open race. And while the panel is open
the component stays mounted even at `count <= 0`, because `useOverview` polls every 2.5s and the
last row being delivered would otherwise unmount the button and drop focus to `<body>`. The
closed-at-zero contract is unchanged, so the original zero-state tests pass untouched.

**6. Not a dialog.** Deliberately the WAI-ARIA *disclosure* pattern (`aria-expanded` +
`aria-controls` + a real `<ul>`), not `role="dialog"` — a dialog role without moving focus in is
announced inconsistently, and this panel should not steal focus from the terminals.

## How to Test Locally

- **View diff**: VSCode sidebar → right-click builder `pir-1450` → **Review Diff**
- **Run the browser evidence** (needs an out-of-tree Playwright; see the script header):
  ```bash
  pnpm build
  npm install playwright-core --prefix /tmp/pw
  PW_CORE=/tmp/pw/node_modules/playwright-core \
  PW_CHROMIUM=~/.cache/ms-playwright/chromium-*/chrome-linux64/chrome \
  node --experimental-strip-types packages/codev/scripts/issue-1450-dashboard-evidence.mts
  ```
  It stands up and tears down its own isolated Tower on port 14700; the live Tower on 4100 and the
  real `global.db` are never touched.
- **What to verify**:
  - The counter is underlined and reads as interactive; clicking opens the panel.
  - Rows show `from → to` (a null sender renders `?`, matching `afx inbox`), with age and reason.
  - With a `--delay` send in flight, `Held (N)` matches the badge and `Scheduled (M)` is separate.
  - Escape closes and returns focus to the counter; click-outside closes; a terminal behind the
    panel does not paint over it.
  - On a normally-running dashboard, the union of both groups matches `afx inbox -w <workspace>`
    row for row, and the Held group alone matches the badge count.

## Post-Consultation Fixes

The 3-way consult and the architect's integration review both landed as non-blocking
(APPROVE / COMMENT / APPROVE). Every finding was verified against the files before acting; all
were real and all are fixed in `2cb2b3623` (see the PR's commit list).

| Finding | Source | Disposition |
|---|---|---|
| `handleInboxList`'s docstring claimed an empty `workspaceOverride` stays scoped, but `rawWorkspace ? … : undefined` widened it to **all workspaces** | Codex + architect (3) | **Real.** Unreachable today (the dispatcher 400s a missing/relative prefix first), but the comment promised a guarantee the code did not make. Made the code true rather than weakening the comment: a scoped call with a blank override now scopes to `''`, which matches no rows. The safe failure for a scoped call is zero rows, never every row. |
| Review file's test counts were wrong | Codex | **Real.** Recounted from the merge-base: **27** new component + **10** formatter + **12** route = **49**, not the 37 originally claimed. Corrected above. |
| `count → 0` with scheduled rows left the panel with no "cleared" notice, and `Scheduled`'s "not counted above" had nothing above it | Codex | **Real.** The notice now keys on `heldRows.length === 0` rather than `messages.length === 0`, with copy that distinguishes "cleared" from "nothing held, rows below are scheduled". |
| arch.md edit swallowed the pre-existing pruning/cron sentences into the new count-vs-list paragraph | Claude + architect (2) | **Real** — content survived but read as part of the Held/Scheduled discussion. Paragraph break restored. (Second splice of this kind in this project; the first was caught in `packages/types/src/api.ts` before commit.) |
| `loadMessages` prop identity drove the refetch effect — an inline lambda from a future caller would loop | Claude + architect (4) | **Real footgun.** Latched in a ref; `load` now has empty deps, so behaviour no longer depends on a caller remembering to memoize. |
| Popover lacked `aria-live`, so asynchronously-loaded rows were never announced | Claude | **Real.** Added `aria-live="polite"` + `aria-busy`. |
| Footer said `afx inbox dismiss <id>` but no id is rendered anywhere | Claude | **Real.** Reworded to `Ids and dismissal: afx inbox`. Rendering a full uuid per row would dominate the row, and this surface never mutates. |
| Server projection was untyped — `HeldMessage` was client-side decoration only | architect (1) | **Real.** Annotated `const projected: HeldMessage[]`, so a drifting projection (dropped field, or a `body` slipping in) fails the server build. |
| Keep prior rows during refetch instead of blanking to "Loading…" | architect (5), optional | **Taken.** A refetch fires on every `count` change while open; flashing the list away is the worst moment to do it. `aria-busy` carries the in-flight state; only a cold open shows the spinner. An **error** still replaces the rows — once a refetch fails, the old list is no longer known to be current. |
| `HeldMessage` jsdoc typo `/api/inbox:id` | architect (6) | **Not reproduced.** The jsdoc already reads `GET /api/inbox/:id` (`packages/types/src/api.ts:597`). No change made. |

Re-verified after the fixes: `pnpm build` ✓, web suite ✓ (373 passed), route suite ✓ (26 passed),
and the browser evidence re-run ✓ **23/23**.

## Flaky Tests

None. No pre-existing failures were encountered in the full suite, so nothing was
skipped or quarantined.

## Scope Note

Out of scope and unchanged, per the plan: VSCode's `mailbox-indicators.ts` (the issue is titled
*Dashboard*); mobile (`MobileLayout` does not render the badge today); dismiss/show-body from the
UI (Spec 1313 decision 8 and the redaction rule); and `codev-skeleton/` (this is product code, not
framework files, so there is no skeleton twin to mirror).
