### PR TITLE
Fix #1519: authenticate the Playwright dashboard-e2e harness to Tower

### DIFF
--- a/codev/projects/bugfix-1519-dashboard-e2e-red-on-main-sinc/status.yaml
+++ b/codev/projects/bugfix-1519-dashboard-e2e-red-on-main-sinc/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1519
 title: dashboard-e2e-red-on-main-sinc
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T09:53:20.690Z'
-updated_at: '2026-08-18T09:57:05.723Z'
+updated_at: '2026-08-18T10:03:24.597Z'

--- a/codev/projects/bugfix-1519-dashboard-e2e-red-on-main-sinc/status.yaml
+++ b/codev/projects/bugfix-1519-dashboard-e2e-red-on-main-sinc/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-08-18T10:28:15.191Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T09:53:20.690Z'
-updated_at: '2026-08-18T10:03:24.597Z'
+updated_at: '2026-08-18T10:28:15.191Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1519-dashboard-e2e-red-on-main-sinc/status.yaml
+++ b/codev/projects/bugfix-1519-dashboard-e2e-red-on-main-sinc/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1519
 title: dashboard-e2e-red-on-main-sinc
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T09:53:20.690Z'
-updated_at: '2026-08-18T09:53:20.691Z'
+updated_at: '2026-08-18T09:57:05.723Z'

--- a/codev/projects/bugfix-1519-dashboard-e2e-red-on-main-sinc/status.yaml
+++ b/codev/projects/bugfix-1519-dashboard-e2e-red-on-main-sinc/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1519
+title: dashboard-e2e-red-on-main-sinc
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-18T09:53:20.690Z'
+updated_at: '2026-08-18T09:53:20.691Z'

--- a/codev/state/bugfix-1519_thread.md
+++ b/codev/state/bugfix-1519_thread.md
@@ -83,3 +83,30 @@ Validation caveat for PR: dashboard-e2e is schedule-only, so PR CI can't turn it
 Did NOT run the Playwright suite locally (it would target the LIVE :4100 Tower / real
 architect sessions — architect's caution). Will note in the PR that validation was via the
 vitest regression test + a dispatched `workflow_dispatch` run of dashboard-e2e.yml.
+
+## PR phase — CMAP round 1 + revision
+
+PR #1520 opened. CMAP round 1: gemini=APPROVE (HIGH), claude=APPROVE (HIGH),
+codex=REQUEST_CHANGES (HIGH). Codex's real point: global `use.extraHTTPHeaders` attaches
+the key to EVERY origin, not just Tower — broader than a real client (same-origin only) and
+a latent cross-origin key-disclosure vector. (Verified no cross-origin browser request exists
+in the suite today, so not an active leak — but the issue's own lesson is "don't defer the
+auth fast-follow," so I scoped it now rather than punting.)
+
+Revision (round 2): scoped the key to Tower-bound traffic only, one source of truth.
+- NEW `e2e/tower-key.ts` (pure, no Playwright import): `towerAuthHeaders()` + `towerWsProtocols()`.
+- NEW `e2e/tower-auth.ts`: Playwright fixtures — `request` fixture is a Tower-scoped keyed
+  APIRequestContext; browser page fetches rely on same-origin injection (shipped behavior).
+- `playwright.config.ts`: REMOVED global `extraHTTPHeaders` (no all-origins header).
+- Direct-API tests import the scoped `test` from `./tower-auth.js`; `page.request` sites
+  (tower-integration, work-view-backlog) pass `{ headers: towerAuthHeaders() }` explicitly.
+- `dashboard-terminals.test.ts` WS uses `towerWsProtocols()` (consolidation, claude#2).
+- `global-setup.ts`: extracted `waitForArchitectReady()` (testable), imports the shared helper.
+- Regression test strengthened: pins launch (A), state poll (A), request-header token (B),
+  WS subprotocol token (C); uses `toBe(ensureLocalKey())` not a hex regex (claude#1: avoids
+  CODEV_TOWER_KEY false-fail). 5 assertions; reverting either global-setup key → 2 fail.
+
+Net result: the key never touches a non-Tower origin — mirrors the shipped same-origin design.
+Also filed-for-architect (do NOT self-file): claude#6 suggests a `pull_request` paths-filtered
+trigger so this schedule-only suite gets a real gate (closes the class, not just the instance).
+Re-running CMAP on the revised PR before notifying.

--- a/codev/state/bugfix-1519_thread.md
+++ b/codev/state/bugfix-1519_thread.md
@@ -110,3 +110,27 @@ Net result: the key never touches a non-Tower origin — mirrors the shipped sam
 Also filed-for-architect (do NOT self-file): claude#6 suggests a `pull_request` paths-filtered
 trigger so this schedule-only suite gets a real gate (closes the class, not just the instance).
 Re-running CMAP on the revised PR before notifying.
+
+## PR phase — CMAP round 2 + end-to-end validation
+
+Round 2 (on the scoped revision): gemini=APPROVE (HIGH), codex=REQUEST_CHANGES (HIGH),
+claude=COMMENT (HIGH). Both non-gemini reviews converged on two things:
+1. PR body was stale (still described the discarded global-`extraHTTPHeaders` approach).
+   → Rewrote the PR body to describe the scoped design + validation.
+2. The vitest lane pins the setup HTTP paths + token correctness but NOT the Playwright
+   fixture / WebSocket *wiring* (Playwright-only). Both reviewers offered "run the workflow"
+   as the accepted alternative. → Dispatched `dashboard-e2e.yml` on the branch.
+
+Plus claude minors (all applied): hardcoded `'30000ms'` → named constant; scoped `request`
+fixture now preserves `baseURL`; regression-test docstring corrected to state exactly what it
+pins vs. what the Playwright run proves.
+
+**End-to-end validation: `dashboard-e2e.yml` GREEN on the final commit 6b03415c3** —
+run https://github.com/cluesmith/codev/actions/runs/32126675026 (Playwright step: success).
+This is the real dashboard-e2e suite against a fresh keyed Tower, so it proves the fixture,
+`page.request`, and WebSocket wiring that vitest can't — the fix works end-to-end, and the
+schedule-only suite that was red is now green.
+
+Round-2 verdicts are final (post-round-2 changes were cosmetic polish, not substantial → no
+round 3). codex's REQUEST_CHANGES points are both resolved (PR body rewritten; wiring proven
+by the green run). Notifying architect and firing the `pr` gate.

--- a/codev/state/bugfix-1519_thread.md
+++ b/codev/state/bugfix-1519_thread.md
@@ -1,0 +1,85 @@
+# bugfix-1519 — Dashboard E2E red on main since #1421
+
+Issue: the schedule-only **Playwright** dashboard-e2e suite makes keyless Tower
+requests. #1421 put every non-public Tower route behind the shared local key; its
+in-PR fix keyed only the **vitest** harness (`vitest-e2e-setup.ts` + `towerWsProtocols`),
+which the Playwright harness never touches. First scheduled run after merge → 27 failed.
+
+## Investigate phase — findings
+
+Auth model (verified in `packages/codev/src/agent-farm/utils/server-utils.ts`):
+- Public (keyless GET): `/health`, `/api/version`, `/`, `/index.html`, and the SPA shell
+  under `/workspace/<enc>/` (static assets only). Every `api/`/`ws/`/`file` subpath is keyed.
+- HTTP key: `codev-tower-key` header. WS key: `codev-key.<key>` subprotocol
+  (`terminalWsProtocols()` in `packages/types/src/websocket.ts`).
+- **Injection path is HEALTHY** (`tower-routes.ts:injectWebKey`): both the front page
+  (`tower.html`) and SPA `index.html` are served with `window.__CODEV_TOWER_KEY__` set.
+  So real-UI `page.goto` tests get a keyed shell and the SPA presents the key. The
+  architect's datum (front-page h1 passed, `.instance` list failed) is explained by the
+  **setup** failure below, not an injection bug.
+
+Root-cause call sites (all in the Playwright harness — none in the workflow yaml):
+
+- **A. Harness setup cascade** — `e2e/global-setup.ts` uses node global `fetch`
+  (NOT a Playwright context, so `use.extraHTTPHeaders` won't reach it) for keyless
+  `POST /api/launch` and `GET /workspace/<enc>/api/state`. Both now 401 → workspace never
+  activated → no architect terminal / no instances → `element(s) not found` across the
+  WHOLE suite. This is the dominant failure.
+- **B. Direct-API tests** — `request.get/post/delete` and `page.request.*` to `/api/state`,
+  `/api/team`, `/api/overview`, `/api/tabs/*` in dashboard-bugs, dashboard-terminals,
+  team-tab, tower-integration, work-view-backlog → keyless → 401.
+- **C. Raw WS tests** — `dashboard-terminals.test.ts:70,101` do `new WebSocket(url)` inside
+  `page.evaluate` with no subprotocol → keyless handshake → rejected.
+- **D. `page.route('**/api/state', route.fetch())`** (architect-pane-layout, spec-823,
+  team-tab, spec-1313) — replays the browser's own (key-injected) request, and merges
+  onto `{}` if base 401s. Resilient; not the cause. Extra-header fix makes them doubly safe.
+
+Workflow check (`.github/workflows/dashboard-e2e.yml`): NO keyless curl/API setup steps —
+Tower start + activation happen entirely inside Playwright's webServer + global-setup.
+So the architect's "category 2" (workflow setup) is clean.
+
+## Planned fix (implement phase) — ~3 files, well under 300 LOC
+
+1. `playwright.config.ts`: add `use.extraHTTPHeaders = { [TOWER_KEY_HEADER]: ensureLocalKey() }`.
+   One place keys every `request.*` / `page.request.*` / navigation — mirrors how
+   `vitest-e2e-setup.ts` wrapped fetch once instead of threading 90 call sites. Fixes B (+D).
+2. `e2e/global-setup.ts`: key its two raw-fetch calls (launch + state poll) with the header.
+   Fixes A. `launchWorkspaceWithRetry` already takes an injectable `fetchFn` — good for testing.
+3. `dashboard-terminals.test.ts`: build subprotocol from `window.__CODEV_TOWER_KEY__` in the
+   two `page.evaluate` WS opens (mirror the real dashboard client). Fixes C.
+
+Regression test (vitest, runs in REQUIRED CI so it can actually gate):
+- Assert `global-setup` attaches `codev-tower-key` to its launch/state requests (capture via
+  mock `fetchFn`), and that `playwright.config.ts` `use.extraHTTPHeaders` carries a 64-hex key.
+  Fails without the fix, passes with it.
+
+Validation note: the suite is schedule-only, so PR CI can't prove it. Local `reuseExistingServer`
+targets the LIVE :4100 Tower (architect's caution — do NOT start a second :4100 / drive the live
+one). Will validate via the vitest regression test + a dispatched `workflow_dispatch` run (or an
+isolated non-4100 Tower if feasible) and state the method in the PR.
+
+Scope verdict: focused, no architecture change → stays in BUGFIX.
+
+## Fix phase — implemented
+
+Changes (all product code under `packages/codev`, no skeleton mirror):
+1. `playwright.config.ts` — `use.extraHTTPHeaders = { [TOWER_KEY_HEADER]: ensureLocalKey() }`.
+   Keys every `request.*` / `page.request.*` / navigation in one place. Fixes B (+ hardens D).
+2. `e2e/global-setup.ts` — new exported `towerAuthHeaders()`; attach it to the launch POST
+   and the state-poll GET (both run outside Playwright contexts). Fixes A (the cascade).
+3. `e2e/dashboard-terminals.test.ts` — offer `terminalWsProtocols(ensureLocalKey())` as the
+   subprotocol on the two raw `new WebSocket()` opens in `page.evaluate`. Fixes C.
+4. NEW `__tests__/bugfix-1519-e2e-auth.test.ts` — vitest regression test (runs in REQUIRED CI):
+   asserts the launch POST and the config both present a 64-hex `codev-tower-key`.
+
+Verification:
+- Regression test: 3/3 pass with fix; reverting the two source changes → 2 fail (proves it pins).
+- Targeted `tsc` on all 4 changed files: clean.
+- `pnpm build` (codev): pass.
+- Adjacent suites (bugfix-1519 + bugfix-773 + request-auth): 42/42 pass.
+- Full default `pnpm vitest run`: running in background.
+
+Validation caveat for PR: dashboard-e2e is schedule-only, so PR CI can't turn it green.
+Did NOT run the Playwright suite locally (it would target the LIVE :4100 Tower / real
+architect sessions — architect's caution). Will note in the PR that validation was via the
+vitest regression test + a dispatched `workflow_dispatch` run of dashboard-e2e.yml.

--- a/packages/codev/playwright.config.ts
+++ b/packages/codev/playwright.config.ts
@@ -5,9 +5,20 @@
  *
  * The webServer option auto-starts tower on port 4100.
  * If tower is already running locally, it reuses the existing server.
+ *
+ * Tower enforces request authentication (advisory GHSA-xvjp-7748-v88v): every
+ * non-public route requires the shared local key (`~/.agent-farm/local-key`)
+ * presented as the `codev-tower-key` header. The `use.extraHTTPHeaders` below
+ * injects it into every request Playwright makes — the `request` fixture,
+ * `page.request`, and page navigations — so this harness authenticates the way
+ * a real client does, mirroring what `vitest-e2e-setup.ts` did for the vitest
+ * harness. (Raw WebSocket opens and `global-setup.ts`'s node-`fetch` calls run
+ * outside Playwright's request contexts and carry the key separately.)
  */
 
 import { defineConfig } from '@playwright/test';
+import { ensureLocalKey } from '@cluesmith/codev-core/auth';
+import { TOWER_KEY_HEADER } from '@cluesmith/codev-types';
 
 const port = Number(process.env.TOWER_TEST_PORT || '4100');
 
@@ -18,6 +29,9 @@ export default defineConfig({
   globalSetup: './src/agent-farm/__tests__/e2e/global-setup.ts',
   use: {
     baseURL: `http://localhost:${port}`,
+    extraHTTPHeaders: {
+      [TOWER_KEY_HEADER]: ensureLocalKey(),
+    },
   },
   webServer: {
     command: `node dist/agent-farm/servers/tower-server.js ${port}`,

--- a/packages/codev/playwright.config.ts
+++ b/packages/codev/playwright.config.ts
@@ -8,17 +8,16 @@
  *
  * Tower enforces request authentication (advisory GHSA-xvjp-7748-v88v): every
  * non-public route requires the shared local key (`~/.agent-farm/local-key`)
- * presented as the `codev-tower-key` header. The `use.extraHTTPHeaders` below
- * injects it into every request Playwright makes — the `request` fixture,
- * `page.request`, and page navigations — so this harness authenticates the way
- * a real client does, mirroring what `vitest-e2e-setup.ts` did for the vitest
- * harness. (Raw WebSocket opens and `global-setup.ts`'s node-`fetch` calls run
- * outside Playwright's request contexts and carry the key separately.)
+ * presented as the `codev-tower-key` header. Authentication is scoped to
+ * Tower-bound traffic rather than installed as an all-origins
+ * `use.extraHTTPHeaders`, so the key is never disclosed to a cross-origin
+ * request: direct-API tests use the Tower-scoped `request` fixture from
+ * `tower-auth.ts`, browser page fetches use the key Tower injects into the
+ * shell same-origin, and raw WebSocket / `page.request` / `global-setup.ts`
+ * calls carry the key explicitly via `tower-key.ts`.
  */
 
 import { defineConfig } from '@playwright/test';
-import { ensureLocalKey } from '@cluesmith/codev-core/auth';
-import { TOWER_KEY_HEADER } from '@cluesmith/codev-types';
 
 const port = Number(process.env.TOWER_TEST_PORT || '4100');
 
@@ -29,9 +28,6 @@ export default defineConfig({
   globalSetup: './src/agent-farm/__tests__/e2e/global-setup.ts',
   use: {
     baseURL: `http://localhost:${port}`,
-    extraHTTPHeaders: {
-      [TOWER_KEY_HEADER]: ensureLocalKey(),
-    },
   },
   webServer: {
     command: `node dist/agent-farm/servers/tower-server.js ${port}`,

--- a/packages/codev/src/agent-farm/__tests__/bugfix-1519-e2e-auth.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-1519-e2e-auth.test.ts
@@ -10,29 +10,38 @@
  * workspace never activated, and the suite went red with `element(s) not
  * found` the first time its schedule fired after merge.
  *
- * These assertions pin the harness to presenting the key the way a real client
- * does. They fail against the pre-fix harness (no key header) and pass with it.
+ * These assertions pin the shared auth tokens (`tower-key.ts`) that the harness
+ * now presents on every Tower-bound path: HTTP setup calls (A), the direct-API
+ * request fixture / `page.request` calls (B), and raw WebSocket opens (C). They
+ * fail against the pre-fix harness and pass with it. The tokens are keyed to
+ * Tower only — never installed as an all-origins header — so the key is never
+ * disclosed to a cross-origin request.
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { TOWER_KEY_HEADER } from '@cluesmith/codev-types';
-import { launchWorkspaceWithRetry, towerAuthHeaders } from './e2e/global-setup.js';
-import playwrightConfig from '../../../playwright.config.js';
-
-const HEX_64 = /^[0-9a-f]{64}$/;
+import { ensureLocalKey } from '@cluesmith/codev-core/auth';
+import { TOWER_KEY_HEADER, WS_KEY_PROTOCOL_PREFIX } from '@cluesmith/codev-types';
+import { towerAuthHeaders, towerWsProtocols } from './e2e/tower-key.js';
+import { launchWorkspaceWithRetry, waitForArchitectReady } from './e2e/global-setup.js';
 
 function headerOf(init: RequestInit | undefined, name: string): string | undefined {
   return new Headers(init?.headers).get(name) ?? undefined;
 }
 
 describe('bugfix #1519: Playwright e2e harness authenticates to Tower', () => {
-  it('towerAuthHeaders carries a well-formed local key under the tower-key header', () => {
-    const headers = towerAuthHeaders();
-    const key = headers[TOWER_KEY_HEADER];
-    expect(key).toMatch(HEX_64);
+  it('towerAuthHeaders carries the local key under the tower-key header (B)', () => {
+    // Asserted against ensureLocalKey() rather than a hex shape so a
+    // CODEV_TOWER_KEY override (which auth.ts supports and does not force to
+    // 64 hex) does not false-fail this required-CI check.
+    expect(towerAuthHeaders()[TOWER_KEY_HEADER]).toBe(ensureLocalKey());
   });
 
-  it('global-setup POST /api/launch presents the tower-key header', async () => {
+  it('towerWsProtocols offers the codev-key.<key> subprotocol (C)', () => {
+    const protocols = towerWsProtocols();
+    expect(protocols).toContain(`${WS_KEY_PROTOCOL_PREFIX}${ensureLocalKey()}`);
+  });
+
+  it('global-setup POST /api/launch presents the tower-key header (A)', async () => {
     const seen: Array<RequestInit | undefined> = [];
     const fetchFn = vi.fn(async (_url: string, init?: RequestInit) => {
       seen.push(init);
@@ -47,13 +56,27 @@ describe('bugfix #1519: Playwright e2e harness authenticates to Tower', () => {
     });
 
     expect(seen).toHaveLength(1);
-    expect(headerOf(seen[0], TOWER_KEY_HEADER)).toMatch(HEX_64);
+    expect(headerOf(seen[0], TOWER_KEY_HEADER)).toBe(ensureLocalKey());
     // The pre-existing Content-Type is preserved alongside the injected key.
     expect(headerOf(seen[0], 'Content-Type')).toBe('application/json');
   });
 
-  it('playwright.config injects the tower-key header into every request context', () => {
-    const key = playwrightConfig.use?.extraHTTPHeaders?.[TOWER_KEY_HEADER];
-    expect(key).toMatch(HEX_64);
+  it('global-setup state poll presents the tower-key header (A)', async () => {
+    const seen: Array<RequestInit | undefined> = [];
+    const fetchFn = vi.fn(async (_url: string, init?: RequestInit) => {
+      seen.push(init);
+      return new Response(JSON.stringify({ architect: { terminalId: 'term-1' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const ready = await waitForArchitectReady('http://localhost:4100/workspace/x/api/state', {
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+
+    expect(ready).toBe(true);
+    expect(seen).toHaveLength(1);
+    expect(headerOf(seen[0], TOWER_KEY_HEADER)).toBe(ensureLocalKey());
   });
 });

--- a/packages/codev/src/agent-farm/__tests__/bugfix-1519-e2e-auth.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-1519-e2e-auth.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Regression test for Bugfix #1519: the schedule-only Playwright dashboard-e2e
+ * suite made keyless Tower requests.
+ *
+ * PR #1421 (advisory GHSA-xvjp-7748-v88v) put every non-public Tower route
+ * behind the shared local key (`codev-tower-key` header). Its in-PR fix keyed
+ * only the *vitest* harness (`vitest-e2e-setup.ts`); the *Playwright* harness —
+ * whose workflow is schedule-only and so never ran on the PR — kept sending
+ * keyless requests. `global-setup.ts`'s `POST /api/launch` then 401'd, the
+ * workspace never activated, and the suite went red with `element(s) not
+ * found` the first time its schedule fired after merge.
+ *
+ * These assertions pin the harness to presenting the key the way a real client
+ * does. They fail against the pre-fix harness (no key header) and pass with it.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { TOWER_KEY_HEADER } from '@cluesmith/codev-types';
+import { launchWorkspaceWithRetry, towerAuthHeaders } from './e2e/global-setup.js';
+import playwrightConfig from '../../../playwright.config.js';
+
+const HEX_64 = /^[0-9a-f]{64}$/;
+
+function headerOf(init: RequestInit | undefined, name: string): string | undefined {
+  return new Headers(init?.headers).get(name) ?? undefined;
+}
+
+describe('bugfix #1519: Playwright e2e harness authenticates to Tower', () => {
+  it('towerAuthHeaders carries a well-formed local key under the tower-key header', () => {
+    const headers = towerAuthHeaders();
+    const key = headers[TOWER_KEY_HEADER];
+    expect(key).toMatch(HEX_64);
+  });
+
+  it('global-setup POST /api/launch presents the tower-key header', async () => {
+    const seen: Array<RequestInit | undefined> = [];
+    const fetchFn = vi.fn(async (_url: string, init?: RequestInit) => {
+      seen.push(init);
+      return new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    await launchWorkspaceWithRetry('http://localhost:4100/api/launch', '/tmp/ws', {
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(headerOf(seen[0], TOWER_KEY_HEADER)).toMatch(HEX_64);
+    // The pre-existing Content-Type is preserved alongside the injected key.
+    expect(headerOf(seen[0], 'Content-Type')).toBe('application/json');
+  });
+
+  it('playwright.config injects the tower-key header into every request context', () => {
+    const key = playwrightConfig.use?.extraHTTPHeaders?.[TOWER_KEY_HEADER];
+    expect(key).toMatch(HEX_64);
+  });
+});

--- a/packages/codev/src/agent-farm/__tests__/bugfix-1519-e2e-auth.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-1519-e2e-auth.test.ts
@@ -10,12 +10,21 @@
  * workspace never activated, and the suite went red with `element(s) not
  * found` the first time its schedule fired after merge.
  *
- * These assertions pin the shared auth tokens (`tower-key.ts`) that the harness
- * now presents on every Tower-bound path: HTTP setup calls (A), the direct-API
- * request fixture / `page.request` calls (B), and raw WebSocket opens (C). They
- * fail against the pre-fix harness and pass with it. The tokens are keyed to
- * Tower only — never installed as an all-origins header — so the key is never
- * disclosed to a cross-origin request.
+ * What this required-CI test pins, and what it deliberately leaves to the
+ * Playwright suite itself:
+ *   - The `global-setup.ts` HTTP paths (launch POST + state poll) are pinned
+ *     end-to-end: each is exercised through a mock `fetch` and asserted to carry
+ *     the key. Reverting either regresses this test. These are the paths that
+ *     caused the whole-suite cascade, so they are the ones worth gating here.
+ *   - The shared tokens (`towerAuthHeaders` / `towerWsProtocols`) are asserted
+ *     to carry the local key, keyed to Tower only — never an all-origins header.
+ *     This pins token *correctness*, not that the Playwright `request` fixture or
+ *     the WebSocket opens actually use them: that wiring lives in Playwright
+ *     files vitest doesn't execute, and is proven by the `workflow_dispatch` run
+ *     of `dashboard-e2e.yml` cited in the PR.
+ *
+ * All assertions compare against `ensureLocalKey()`, so they fail against the
+ * pre-fix harness and pass with it.
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -29,14 +38,14 @@ function headerOf(init: RequestInit | undefined, name: string): string | undefin
 }
 
 describe('bugfix #1519: Playwright e2e harness authenticates to Tower', () => {
-  it('towerAuthHeaders carries the local key under the tower-key header (B)', () => {
+  it('towerAuthHeaders carries the local key under the tower-key header (token)', () => {
     // Asserted against ensureLocalKey() rather than a hex shape so a
     // CODEV_TOWER_KEY override (which auth.ts supports and does not force to
     // 64 hex) does not false-fail this required-CI check.
     expect(towerAuthHeaders()[TOWER_KEY_HEADER]).toBe(ensureLocalKey());
   });
 
-  it('towerWsProtocols offers the codev-key.<key> subprotocol (C)', () => {
+  it('towerWsProtocols offers the codev-key.<key> subprotocol (token)', () => {
     const protocols = towerWsProtocols();
     expect(protocols).toContain(`${WS_KEY_PROTOCOL_PREFIX}${ensureLocalKey()}`);
   });

--- a/packages/codev/src/agent-farm/__tests__/e2e/dashboard-bugs.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/dashboard-bugs.test.ts
@@ -12,7 +12,7 @@
  * Run: npx playwright test dashboard-bugs
  */
 
-import { test, expect } from '@playwright/test';
+import { test, expect } from './tower-auth.js';
 import { resolve } from 'node:path';
 
 const TOWER_URL = 'http://localhost:4100';

--- a/packages/codev/src/agent-farm/__tests__/e2e/dashboard-terminals.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/dashboard-terminals.test.ts
@@ -9,10 +9,9 @@
  * Run: npx playwright test
  */
 
-import { test, expect } from '@playwright/test';
 import { resolve } from 'node:path';
-import { ensureLocalKey } from '@cluesmith/codev-core/auth';
-import { terminalWsProtocols } from '@cluesmith/codev-types';
+import { test, expect } from './tower-auth.js';
+import { towerWsProtocols } from './tower-key.js';
 
 const TOWER_URL = 'http://localhost:4100';
 const WORKSPACE_PATH = resolve(import.meta.dirname, '../../../../../../');
@@ -21,7 +20,7 @@ const ENCODED_PATH = Buffer.from(WORKSPACE_PATH).toString('base64url');
 // `Sec-WebSocket-Protocol` offer (advisory GHSA-xvjp-7748-v88v); a keyless
 // upgrade is rejected at the handshake. Mirror the real dashboard client and
 // offer the marker + `codev-key.<key>` subprotocol on raw WebSocket opens.
-const WS_PROTOCOLS = terminalWsProtocols(ensureLocalKey());
+const WS_PROTOCOLS = towerWsProtocols();
 // BASE_URL without trailing slash for API calls
 const BASE_URL = `${TOWER_URL}/workspace/${ENCODED_PATH}`;
 // PAGE_URL with trailing slash for page loads (needed for relative asset resolution)

--- a/packages/codev/src/agent-farm/__tests__/e2e/dashboard-terminals.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/dashboard-terminals.test.ts
@@ -11,10 +11,17 @@
 
 import { test, expect } from '@playwright/test';
 import { resolve } from 'node:path';
+import { ensureLocalKey } from '@cluesmith/codev-core/auth';
+import { terminalWsProtocols } from '@cluesmith/codev-types';
 
 const TOWER_URL = 'http://localhost:4100';
 const WORKSPACE_PATH = resolve(import.meta.dirname, '../../../../../../');
 const ENCODED_PATH = Buffer.from(WORKSPACE_PATH).toString('base64url');
+// Browsers can't set headers on a WebSocket, so Tower's key travels as a
+// `Sec-WebSocket-Protocol` offer (advisory GHSA-xvjp-7748-v88v); a keyless
+// upgrade is rejected at the handshake. Mirror the real dashboard client and
+// offer the marker + `codev-key.<key>` subprotocol on raw WebSocket opens.
+const WS_PROTOCOLS = terminalWsProtocols(ensureLocalKey());
 // BASE_URL without trailing slash for API calls
 const BASE_URL = `${TOWER_URL}/workspace/${ENCODED_PATH}`;
 // PAGE_URL with trailing slash for page loads (needed for relative asset resolution)
@@ -65,9 +72,9 @@ test.describe('Dashboard Terminals E2E', () => {
 
     // Verify WebSocket connects to this terminal through tower proxy
     await page.goto(PAGE_URL);
-    const wsConnected = await page.evaluate(({ tid, encodedPath }: { tid: string; encodedPath: string }) => {
+    const wsConnected = await page.evaluate(({ tid, encodedPath, protocols }: { tid: string; encodedPath: string; protocols: string[] | undefined }) => {
       return new Promise<boolean>((resolve) => {
-        const ws = new WebSocket(`ws://localhost:4100/workspace/${encodedPath}/ws/terminal/${tid}`);
+        const ws = new WebSocket(`ws://localhost:4100/workspace/${encodedPath}/ws/terminal/${tid}`, protocols);
         ws.binaryType = 'arraybuffer';
         ws.onopen = () => {
           ws.close();
@@ -76,7 +83,7 @@ test.describe('Dashboard Terminals E2E', () => {
         ws.onerror = () => resolve(false);
         setTimeout(() => resolve(false), 5000);
       });
-    }, { tid: terminalId, encodedPath: ENCODED_PATH });
+    }, { tid: terminalId, encodedPath: ENCODED_PATH, protocols: WS_PROTOCOLS });
     expect(wsConnected).toBe(true);
 
     // Clean up
@@ -96,9 +103,9 @@ test.describe('Dashboard Terminals E2E', () => {
     expect(terminalId).toBeTruthy();
 
     await page.goto(PAGE_URL);
-    const wsConnected = await page.evaluate(({ tid, encodedPath }: { tid: string; encodedPath: string }) => {
+    const wsConnected = await page.evaluate(({ tid, encodedPath, protocols }: { tid: string; encodedPath: string; protocols: string[] | undefined }) => {
       return new Promise<boolean>((resolve) => {
-        const ws = new WebSocket(`ws://localhost:4100/workspace/${encodedPath}/ws/terminal/${tid}`);
+        const ws = new WebSocket(`ws://localhost:4100/workspace/${encodedPath}/ws/terminal/${tid}`, protocols);
         ws.binaryType = 'arraybuffer';
         ws.onopen = () => {
           ws.close();
@@ -107,7 +114,7 @@ test.describe('Dashboard Terminals E2E', () => {
         ws.onerror = () => resolve(false);
         setTimeout(() => resolve(false), 5000);
       });
-    }, { tid: terminalId!, encodedPath: ENCODED_PATH });
+    }, { tid: terminalId!, encodedPath: ENCODED_PATH, protocols: WS_PROTOCOLS });
     expect(wsConnected).toBe(true);
   });
 

--- a/packages/codev/src/agent-farm/__tests__/e2e/global-setup.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/global-setup.ts
@@ -16,8 +16,7 @@
 
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { ensureLocalKey } from '@cluesmith/codev-core/auth';
-import { TOWER_KEY_HEADER } from '@cluesmith/codev-types';
+import { towerAuthHeaders } from './tower-key.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -27,21 +26,12 @@ const WORKSPACE_PATH = resolve(__dirname, '../../../../../../');
 const ENCODED_PATH = Buffer.from(WORKSPACE_PATH).toString('base64url');
 const STATE_URL = `${TOWER_URL}/workspace/${ENCODED_PATH}/api/state`;
 
-/**
- * The `codev-tower-key` header authenticating this setup's requests to Tower.
- *
- * `/api/launch` and `/workspace/<enc>/api/state` are non-public routes, so
- * Tower (advisory GHSA-xvjp-7748-v88v) rejects a keyless request with 401 —
- * which left the workspace un-activated and cascaded into `element(s) not
- * found` failures across the whole Playwright suite (issue #1519). These calls
- * run outside Playwright's request contexts, so `use.extraHTTPHeaders` in
- * playwright.config.ts cannot reach them; the key is attached here directly.
- *
- * Exported for the regression test.
- */
-export function towerAuthHeaders(): Record<string, string> {
-  return { [TOWER_KEY_HEADER]: ensureLocalKey() };
-}
+// `/api/launch` and `/workspace/<enc>/api/state` are non-public routes, so Tower
+// (advisory GHSA-xvjp-7748-v88v) rejects a keyless request with 401 — which left
+// the workspace un-activated and cascaded into `element(s) not found` failures
+// across the whole Playwright suite (issue #1519). These calls run outside
+// Playwright's request contexts, so they present the key via `towerAuthHeaders()`
+// directly.
 
 /**
  * Tower returns this exact error string while its async `_deps` initialization
@@ -103,6 +93,45 @@ export async function launchWorkspaceWithRetry(
   }
 }
 
+/**
+ * Poll GET /api/state (keyed, like every non-public route) until the architect
+ * terminal is present, or the budget is exhausted. Returns true once
+ * `architect.terminalId` appears. A keyless poll would 401 forever — the very
+ * failure this bugfix (#1519) closes — so the key is presented on every request.
+ *
+ * Exported (with an injectable `fetchFn`) for unit testing — see
+ * bugfix-1519-e2e-auth.test.ts.
+ */
+export async function waitForArchitectReady(
+  stateUrl: string,
+  options: {
+    timeout?: number;
+    interval?: number;
+    fetchFn?: typeof fetch;
+  } = {},
+): Promise<boolean> {
+  const timeout = options.timeout ?? 30_000;
+  const interval = options.interval ?? 500;
+  const fetchFn = options.fetchFn ?? fetch;
+  const start = Date.now();
+
+  while (Date.now() - start < timeout) {
+    try {
+      const stateRes = await fetchFn(stateUrl, { headers: towerAuthHeaders() });
+      if (stateRes.ok) {
+        const state = await stateRes.json();
+        if ((state as { architect?: { terminalId?: string } }).architect?.terminalId) {
+          return true;
+        }
+      }
+    } catch {
+      // Server may not be fully ready yet
+    }
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  return false;
+}
+
 export default async function globalSetup() {
   // Step 1: Activate the workspace via POST /api/launch (with retry).
   const launch = await launchWorkspaceWithRetry(`${TOWER_URL}/api/launch`, WORKSPACE_PATH);
@@ -120,30 +149,18 @@ export default async function globalSetup() {
   }
 
   // Step 2: Poll for architect terminal readiness
-  const timeout = 30_000;
-  const interval = 500;
   const start = Date.now();
+  const ready = await waitForArchitectReady(STATE_URL);
 
-  while (Date.now() - start < timeout) {
-    try {
-      const stateRes = await fetch(STATE_URL, { headers: towerAuthHeaders() });
-      if (stateRes.ok) {
-        const state = await stateRes.json();
-        if ((state as { architect?: { terminalId?: string } }).architect?.terminalId) {
-          console.log(`[global-setup] Architect terminal ready (${Date.now() - start}ms)`);
-          return;
-        }
-      }
-    } catch {
-      // Server may not be fully ready yet
-    }
-    await new Promise((r) => setTimeout(r, interval));
+  if (ready) {
+    console.log(`[global-setup] Architect terminal ready (${Date.now() - start}ms)`);
+    return;
   }
 
   // Don't fail hard — some tests don't need the terminal.
   // Terminal-dependent tests will fail on their own with clear timeout errors.
   console.warn(
-    `[global-setup] Architect terminal not ready after ${timeout}ms. ` +
+    '[global-setup] Architect terminal not ready after 30000ms. ' +
       'Terminal-dependent tests will likely fail. ' +
       'In CI, ensure TOWER_ARCHITECT_CMD=bash is set.',
   );

--- a/packages/codev/src/agent-farm/__tests__/e2e/global-setup.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/global-setup.ts
@@ -16,6 +16,8 @@
 
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { ensureLocalKey } from '@cluesmith/codev-core/auth';
+import { TOWER_KEY_HEADER } from '@cluesmith/codev-types';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -24,6 +26,22 @@ const TOWER_URL = `http://localhost:${TOWER_PORT}`;
 const WORKSPACE_PATH = resolve(__dirname, '../../../../../../');
 const ENCODED_PATH = Buffer.from(WORKSPACE_PATH).toString('base64url');
 const STATE_URL = `${TOWER_URL}/workspace/${ENCODED_PATH}/api/state`;
+
+/**
+ * The `codev-tower-key` header authenticating this setup's requests to Tower.
+ *
+ * `/api/launch` and `/workspace/<enc>/api/state` are non-public routes, so
+ * Tower (advisory GHSA-xvjp-7748-v88v) rejects a keyless request with 401 —
+ * which left the workspace un-activated and cascaded into `element(s) not
+ * found` failures across the whole Playwright suite (issue #1519). These calls
+ * run outside Playwright's request contexts, so `use.extraHTTPHeaders` in
+ * playwright.config.ts cannot reach them; the key is attached here directly.
+ *
+ * Exported for the regression test.
+ */
+export function towerAuthHeaders(): Record<string, string> {
+  return { [TOWER_KEY_HEADER]: ensureLocalKey() };
+}
 
 /**
  * Tower returns this exact error string while its async `_deps` initialization
@@ -68,7 +86,7 @@ export async function launchWorkspaceWithRetry(
     const res = await fetchFn(url, {
       method: 'POST',
       body: JSON.stringify({ workspacePath }),
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...towerAuthHeaders() },
     });
     const body = await res.text();
 
@@ -108,7 +126,7 @@ export default async function globalSetup() {
 
   while (Date.now() - start < timeout) {
     try {
-      const stateRes = await fetch(STATE_URL);
+      const stateRes = await fetch(STATE_URL, { headers: towerAuthHeaders() });
       if (stateRes.ok) {
         const state = await stateRes.json();
         if ((state as { architect?: { terminalId?: string } }).architect?.terminalId) {

--- a/packages/codev/src/agent-farm/__tests__/e2e/global-setup.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/global-setup.ts
@@ -41,6 +41,9 @@ const STATE_URL = `${TOWER_URL}/workspace/${ENCODED_PATH}/api/state`;
  */
 const TOWER_STARTING_MARKER = 'Tower is still starting up';
 
+/** How long globalSetup waits for the architect terminal before giving up. */
+const ARCHITECT_READY_TIMEOUT_MS = 30_000;
+
 export interface LaunchResult {
   ok: boolean;
   status: number;
@@ -110,7 +113,7 @@ export async function waitForArchitectReady(
     fetchFn?: typeof fetch;
   } = {},
 ): Promise<boolean> {
-  const timeout = options.timeout ?? 30_000;
+  const timeout = options.timeout ?? ARCHITECT_READY_TIMEOUT_MS;
   const interval = options.interval ?? 500;
   const fetchFn = options.fetchFn ?? fetch;
   const start = Date.now();
@@ -160,7 +163,7 @@ export default async function globalSetup() {
   // Don't fail hard — some tests don't need the terminal.
   // Terminal-dependent tests will fail on their own with clear timeout errors.
   console.warn(
-    '[global-setup] Architect terminal not ready after 30000ms. ' +
+    `[global-setup] Architect terminal not ready after ${ARCHITECT_READY_TIMEOUT_MS}ms. ` +
       'Terminal-dependent tests will likely fail. ' +
       'In CI, ensure TOWER_ARCHITECT_CMD=bash is set.',
   );

--- a/packages/codev/src/agent-farm/__tests__/e2e/team-tab.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/team-tab.test.ts
@@ -12,7 +12,7 @@
  * Run: npx playwright test team-tab
  */
 
-import { test, expect } from '@playwright/test';
+import { test, expect } from './tower-auth.js';
 import { resolve } from 'node:path';
 
 const TOWER_URL = `http://localhost:${process.env.TOWER_TEST_PORT || '4100'}`;

--- a/packages/codev/src/agent-farm/__tests__/e2e/tower-auth.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/tower-auth.ts
@@ -1,0 +1,28 @@
+/**
+ * Playwright fixtures that authenticate the dashboard-e2e suite to Tower the
+ * way a real client does — same-origin only (advisory GHSA-xvjp-7748-v88v;
+ * issue #1519).
+ *
+ * The `request` fixture is replaced with a Tower-scoped, keyed
+ * `APIRequestContext`: direct-API tests present the `codev-tower-key` header on
+ * their calls, which only ever target Tower, so the key is never attached to a
+ * page navigation or a cross-origin subresource load. Browser page fetches use
+ * the key Tower injects into the shell same-origin, exactly as the shipped
+ * dashboard does; raw WebSocket and `page.request` calls carry the key
+ * explicitly via `tower-key.ts`.
+ */
+
+import { test as base, expect } from '@playwright/test';
+import { towerAuthHeaders } from './tower-key.js';
+
+export const test = base.extend({
+  request: async ({ playwright }, use) => {
+    const context = await playwright.request.newContext({
+      extraHTTPHeaders: towerAuthHeaders(),
+    });
+    await use(context);
+    await context.dispose();
+  },
+});
+
+export { expect };

--- a/packages/codev/src/agent-farm/__tests__/e2e/tower-auth.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/tower-auth.ts
@@ -16,8 +16,11 @@ import { test as base, expect } from '@playwright/test';
 import { towerAuthHeaders } from './tower-key.js';
 
 export const test = base.extend({
-  request: async ({ playwright }, use) => {
+  request: async ({ playwright, baseURL }, use) => {
+    // Preserve the config's `baseURL` (a fresh APIRequestContext would otherwise
+    // drop it) so relative-URL calls keep resolving against Tower.
     const context = await playwright.request.newContext({
+      baseURL,
       extraHTTPHeaders: towerAuthHeaders(),
     });
     await use(context);

--- a/packages/codev/src/agent-farm/__tests__/e2e/tower-integration.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/tower-integration.test.ts
@@ -5,6 +5,7 @@
  */
 import { test, expect } from '@playwright/test';
 import path from 'node:path';
+import { towerAuthHeaders } from './tower-key.js';
 
 const TOWER_URL = 'http://localhost:4100';
 const VIDEO_DIR = path.resolve(import.meta.dirname, '../../../../test-results/videos');
@@ -52,7 +53,7 @@ test.describe('Tower Desktop', () => {
 
   test('tower proxy WebSocket terminal works', async ({ page }) => {
     // Get terminalId through tower proxy
-    const stateRes = await page.request.get(`${TOWER_URL}/workspace/${ENCODED_PATH}/api/state`);
+    const stateRes = await page.request.get(`${TOWER_URL}/workspace/${ENCODED_PATH}/api/state`, { headers: towerAuthHeaders() });
     expect(stateRes.ok()).toBe(true);
     const state = await stateRes.json();
     
@@ -61,7 +62,7 @@ test.describe('Tower Desktop', () => {
     if (!terminalId) {
       for (let i = 0; i < 30; i++) {
         await new Promise(r => setTimeout(r, 500));
-        const res = await page.request.get(`${TOWER_URL}/workspace/${ENCODED_PATH}/api/state`);
+        const res = await page.request.get(`${TOWER_URL}/workspace/${ENCODED_PATH}/api/state`, { headers: towerAuthHeaders() });
         const s = await res.json();
         terminalId = s.architect?.terminalId;
         if (terminalId) break;
@@ -82,6 +83,7 @@ test.describe('Tower Desktop', () => {
     // Create shell tab through tower proxy
     const response = await page.request.post(`${TOWER_URL}/workspace/${ENCODED_PATH}/api/tabs/shell`, {
       data: { name: 'tower-test-shell' },
+      headers: towerAuthHeaders(),
     });
     expect(response.status()).toBe(200); // Tower returns 200 for shell creation
     const body = await response.json();
@@ -89,7 +91,7 @@ test.describe('Tower Desktop', () => {
     expect(body.terminalId).toBeTruthy();
 
     // Clean up
-    await page.request.delete(`${TOWER_URL}/workspace/${ENCODED_PATH}/api/tabs/${body.id}`);
+    await page.request.delete(`${TOWER_URL}/workspace/${ENCODED_PATH}/api/tabs/${body.id}`, { headers: towerAuthHeaders() });
   });
 });
 

--- a/packages/codev/src/agent-farm/__tests__/e2e/tower-key.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/tower-key.ts
@@ -1,0 +1,32 @@
+/**
+ * Tower authentication tokens for the Playwright dashboard-e2e harness.
+ *
+ * Tower requires the shared local key on every non-public route (advisory
+ * GHSA-xvjp-7748-v88v; issue #1519). A real client only ever presents the key
+ * to Tower itself: the browser shell receives it injected same-origin
+ * (`window.__CODEV_TOWER_KEY__`) and never forwards it to another origin. The
+ * harness mirrors that — it keys ONLY Tower-bound requests and never installs
+ * an all-origins header that could disclose the key cross-origin.
+ *
+ * This module is deliberately free of any `@playwright/test` import so it can be
+ * shared by `global-setup.ts` (node-`fetch` calls) and the vitest regression
+ * test without pulling the Playwright runtime into either. The Playwright
+ * `request`-fixture wiring lives in `tower-auth.ts`.
+ */
+
+import { ensureLocalKey } from '@cluesmith/codev-core/auth';
+import { TOWER_KEY_HEADER, terminalWsProtocols } from '@cluesmith/codev-types';
+
+/** The `codev-tower-key` header for a single Tower HTTP request. */
+export function towerAuthHeaders(): Record<string, string> {
+  return { [TOWER_KEY_HEADER]: ensureLocalKey() };
+}
+
+/**
+ * The `Sec-WebSocket-Protocol` offer carrying the key for a raw browser
+ * WebSocket against Tower (browsers can't set headers on a WebSocket, so the
+ * key travels as the `codev-key.<key>` subprotocol).
+ */
+export function towerWsProtocols(): string[] | undefined {
+  return terminalWsProtocols(ensureLocalKey());
+}

--- a/packages/codev/src/agent-farm/__tests__/e2e/work-view-backlog.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/work-view-backlog.test.ts
@@ -11,7 +11,8 @@
  * Run: npx playwright test work-view-backlog
  */
 
-import { test, expect } from '@playwright/test';
+import { test, expect } from './tower-auth.js';
+import { towerAuthHeaders } from './tower-key.js';
 import { resolve } from 'node:path';
 
 const TOWER_URL = `http://localhost:${process.env.TOWER_TEST_PORT || '4100'}`;
@@ -149,7 +150,7 @@ test.describe('Work view: backlog clickability and artifacts', () => {
     await page.locator('.work-section').first().waitFor({ state: 'visible', timeout: 15_000 });
 
     // Check the overview API for recently closed items
-    const res = await page.request.get(`${API_URL}/api/overview`);
+    const res = await page.request.get(`${API_URL}/api/overview`, { headers: towerAuthHeaders() });
     const data = await res.json();
 
     if (data.recentlyClosed && data.recentlyClosed.length > 0) {


### PR DESCRIPTION
## Summary

The schedule-only Playwright dashboard-e2e suite made keyless requests to Tower and went red on `main` the first time it ran after PR #1421's auth enforcement merged. This keys the Playwright harness the way a real client does — **same-origin only** — mirroring what #1421's in-PR fix did for the vitest harness.

Fixes #1519

## Root Cause

PR #1421 (advisory GHSA-xvjp-7748-v88v) put every non-public Tower route behind the shared local key (`codev-tower-key` header). Its in-PR CI fix keyed only the **vitest** e2e harness (`vitest-e2e-setup.ts` + `towerWsProtocols`). The **Playwright** dashboard suite is a separate harness whose workflow is **schedule-only**, so it never ran on the PR and its keyless requests were never caught. On the next scheduled run, setup's `POST /api/launch` 401'd, the workspace never activated, and the whole suite failed with `element(s) not found` / API-contract assertions.

The key-injection product path is healthy: both the Tower front page and the SPA shell are served with `window.__CODEV_TOWER_KEY__` injected (`tower-routes.ts:injectWebKey`), so real-UI `page.goto` tests authenticate correctly once setup succeeds. This is purely a test-harness gap, not a product bug.

## Fix

Authentication is scoped to Tower-bound traffic — the key is **never** attached to a page navigation or a cross-origin request, matching how a real client behaves (same-origin injection).

- **`e2e/tower-key.ts`** (new, no Playwright import) — one source of truth for the tokens: `towerAuthHeaders()` (the `codev-tower-key` header) and `towerWsProtocols()` (the `codev-key.<key>` WebSocket subprotocol). Shared by `global-setup.ts` and the vitest regression test.
- **`e2e/tower-auth.ts`** (new) — a Playwright `test` whose `request` fixture is a Tower-scoped, keyed `APIRequestContext`. Direct-API tests import `{ test, expect }` from here. Browser page fetches use the key Tower injects into the shell same-origin, so no all-origins header is installed.
- **`playwright.config.ts`** — no global `extraHTTPHeaders` (an earlier revision used one; it was removed because it would attach the key to every origin).
- **`e2e/global-setup.ts`** — the launch `POST` and the extracted, unit-testable `waitForArchitectReady()` state poll present the key via `towerAuthHeaders()`; these run outside Playwright's request contexts. Fixes the activation cascade.
- **`page.request` call sites** (`tower-integration.ts`, `work-view-backlog.ts`) — pass `{ headers: towerAuthHeaders() }` explicitly (they bypass the `request` fixture).
- **`e2e/dashboard-terminals.test.ts`** — the two raw `WebSocket` opens offer `towerWsProtocols()`; browsers can't set headers on a WebSocket, so the key travels as a subprotocol.

## Validation

The `Dashboard E2E Tests` workflow is **schedule-only**, so ordinary PR CI cannot turn it green. Validated by:

- **End-to-end `workflow_dispatch` run of `dashboard-e2e.yml` from this branch**: https://github.com/cluesmith/codev/actions/runs/32126675026 (the real Playwright suite against a fresh keyed Tower — exercises the fixture, `page.request`, and WebSocket wiring that vitest cannot).
- New vitest regression test `bugfix-1519-e2e-auth.test.ts` (runs in **required** CI): pins the launch POST, the state poll, the request-header token, and the WS-subprotocol token — each asserted against `ensureLocalKey()`. Reverting either `global-setup.ts` key makes it fail.
- Full `pnpm vitest run` for the package: **4916 passed, 48 skipped, 0 failed**; `pnpm build` passes.

## Test Plan

- [x] Regression test added (fails without the fix, passes with it)
- [x] Build passes
- [x] All tests pass (vitest full suite)
- [x] `workflow_dispatch` run of `dashboard-e2e.yml` dispatched from this branch (link above)
