### PR TITLE
[Bugfix #1515] Post-merge completion records: gate-approved + merge + protocol complete

### DIFF
--- a/codev/projects/bugfix-1515-test-spawned-towers-inherit-re/status.yaml
+++ b/codev/projects/bugfix-1515-test-spawned-towers-inherit-re/status.yaml
@@ -13,10 +13,12 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T06:21:58.071Z'
-updated_at: '2026-08-18T15:36:15.705Z'
+updated_at: '2026-08-18T15:36:21.101Z'
 pr_history:
   - phase: pr
     pr_number: 1516
     branch: builder/bugfix-1515
     created_at: '2026-08-18T07:05:34.514Z'
+    merged: true
+    merged_at: '2026-08-18T15:36:21.100Z'
 pr_ready_for_human: false

--- a/codev/projects/bugfix-1515-test-spawned-towers-inherit-re/status.yaml
+++ b/codev/projects/bugfix-1515-test-spawned-towers-inherit-re/status.yaml
@@ -6,16 +6,17 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-08-18T07:05:40.277Z'
+    approved_at: '2026-08-18T15:36:15.704Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T06:21:58.071Z'
-updated_at: '2026-08-18T07:05:40.277Z'
+updated_at: '2026-08-18T15:36:15.705Z'
 pr_history:
   - phase: pr
     pr_number: 1516
     branch: builder/bugfix-1515
     created_at: '2026-08-18T07:05:34.514Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1515-test-spawned-towers-inherit-re/status.yaml
+++ b/codev/projects/bugfix-1515-test-spawned-towers-inherit-re/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1515
 title: test-spawned-towers-inherit-re
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,7 +13,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-18T06:21:58.071Z'
-updated_at: '2026-08-18T15:36:21.101Z'
+updated_at: '2026-08-18T15:36:26.193Z'
 pr_history:
   - phase: pr
     pr_number: 1516


### PR DESCRIPTION
Ships the three porch completion-record commits stranded on `builder/bugfix-1515` after PR #1516 (the test-suite Tower-deregistration fix) merged — same records-PR pattern as the PRs that closed out the 1489 rename and Spec 1280. Records-only: status.yaml gate/merge/completion entries, no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)