### PR TITLE
[#1381] Sync marketplace collateral to the approved listing text

### DIFF
--- a/apps/streamdeck/marketplace/description.md
+++ b/apps/streamdeck/marketplace/description.md
@@ -1,13 +1,35 @@
 Drive Codev's AI coding agents from your Stream Deck. Approve gates, monitor a live board of your agent fleet, and review their code with the dials, all without leaving VS Code. Companion plugin for Codev, the AI agent orchestration framework.
 
-HOW IT WORKS
-The plugin connects to Codev's Tower server on your machine. Keys are live tiles: each Builder Action key tracks one running agent, showing its issue and phase as work progresses. Press to select that agent and open its current spec, plan, or diff in VS Code. On Stream Deck +, the dials drive code review: step across files and changes, scroll, zoom, and press to forward the current change back to the agent as feedback.
+ABOUT CODEV
+Codev runs AI coding agents ("builders") that implement issues in isolated git worktrees while you review and steer from VS Code. Its local Tower server tracks every workspace, agent, and approval gate. This plugin turns that live state into a physical control surface.
 
-WHAT IS INCLUDED
-- Live tiles: Builder Action and Architect Action keys that self-arrange into a fleet board
-- Command keys: Approve Gate, Send Feedback, Open Builder Terminal, Open Architect Terminal, Run Dev, and a configurable Codev Action
-- Dials: Zoom Navigator, Review: Files / Headings, Review: Changes / Blocks, Scroll & Forward Selection, plus PR Navigator and Spawn from Backlog
-- A ready-made Stream Deck + profile: a review cockpit page and an architects page, installed automatically on first run
+HOW IT WORKS
+The plugin is a stateless controller: it reads Tower's live overview (refreshed over server-sent events) and sends canonical commands back, which the focused VS Code window executes. Nothing is stored on the deck, so every surface (deck, VS Code sidebar, web dashboard) always shows the same state. The board works as one instrument: the top row selects an agent, the second row acts on it, and the dials review its work. Keys commit, dials review.
+
+KEYS
+- Builder Action: a live tile per agent showing its issue and phase; press to select it and open its current spec, plan, or diff, or bind a fixed verb of your choice
+- Architect Action: a live tile per architect agent; press opens its terminal
+- Approve Gate: shows the selected agent's pending approval gate; press to surface that gate's review in VS Code
+- Send Feedback: flushes your queued review feedback to the selected agent; the badge counts what is queued
+- Open Builder Terminal / Open Architect Terminal: jump straight to the right terminal
+- Codev Action: run any Codev command (open terminals, view diff, send, spawn, refresh)
+- Run Dev: start and stop the dev server for the selected agent's worktree
+
+DIALS (Stream Deck +)
+- Zoom Navigator: rotate to browse workspaces and agents, tap to zoom into the diff, press to zoom back out
+- Review: Files / Headings: step across files in a diff or headings in a spec; press forwards the current file to the agent
+- Review: Changes / Blocks: step across changes within a file or blocks in a spec; press forwards the change as feedback
+- Scroll & Forward Selection: rotate to scroll the active editor; press to forward the current selection to the agent
+- PR Navigator: browse open pull requests and open the selected one
+- Spawn from Backlog: browse the issue backlog and spawn an agent for the selected issue
+
+INCLUDED PROFILE
+A ready-made Stream Deck + profile installs automatically on first run: a review cockpit page (agent tiles, gate and terminal keys, all four review dials) and a second page for architect terminals.
+
+GETTING STARTED
+1. Install Codev (free): npm install -g @cluesmith/codev, plus the Codev VS Code extension
+2. Start the Tower server and open your Codev workspace in VS Code
+3. Install this plugin; the bundled profile lands the full layout on a Stream Deck +
 
 REQUIREMENTS
-Codev (free, https://codevos.ai/) running locally with its Tower server and the Codev VS Code extension. Works on macOS and Windows.
+Codev (https://codevos.ai/) with its Tower server running locally and the Codev VS Code extension. Keys work on any Stream Deck; the review dials need a Stream Deck +. macOS 10.15+ or Windows 10+, Stream Deck software 6.9 or later.

--- a/apps/streamdeck/marketplace/release-notes.md
+++ b/apps/streamdeck/marketplace/release-notes.md
@@ -1,27 +1,23 @@
 **Initial release of Codev for Stream Deck.**
 
-Drive Codev's AI agent workflows from your desk. This plugin pairs with Codev (https://codevos.ai/) and its Tower server running locally.
+Drive Codev's AI agent workflows from your desk. Pairs with Codev (https://codevos.ai/) and its Tower server running locally.
 
 **Keys**
 
-- **Builder Action**: a live tile, one builder per key, showing its issue and phase; press selects the builder and opens the artifact for its current phase (spec / plan / diff), or a fixed verb you choose.
-- **Architect Action**: a live tile, one architect per key; press opens that architect's terminal.
-- **Approve Gate**: shows the selected builder's pending gate; press to surface that gate's review in VS Code.
-- **Send Feedback**: flushes the selected builder's queued review feedback; the badge counts what's queued.
-- **Open Builder Terminal** / **Open Architect Terminal**: jump straight to a builder's or an architect's terminal.
+- **Builder Action**: a live tile per builder showing its issue and phase; press selects it and opens its current spec, plan, or diff (or a fixed verb).
+- **Architect Action**: a live tile per architect; press opens its terminal.
+- **Approve Gate**: shows the selected builder's pending gate; press surfaces its review in VS Code.
+- **Send Feedback**: flushes queued review feedback to the selected builder; the badge counts what's queued.
+- **Open Builder / Architect Terminal**: jump straight to the right terminal.
 - **Codev Action**: run Codev commands (open terminals, view diff, send, spawn, refresh).
 - **Run Dev**: start and stop dev for the selected builder's worktree.
 
 **Dials (Stream Deck +)**
 
 - **Zoom Navigator**: browse workspaces and builders, zoom into the diff.
-- **Review: Files / Headings** and **Review: Changes / Blocks**: step through a review — files and changes in a diff, headings and blocks in a spec or plan — and forward what's under the cursor to the builder.
-- **Scroll & Forward Selection**: scroll the active editor; press to forward the current selection.
-- **PR Navigator**: browse open pull requests and open the selected one.
-- **Spawn from Backlog**: browse the issue backlog and spawn a builder.
+- **Review: Files / Headings** and **Review: Changes / Blocks**: step through files/changes in a diff or headings/blocks in a spec; press forwards the current item to the builder.
+- **Scroll & Forward Selection**: scroll the editor; press forwards the selection.
+- **PR Navigator**: browse open pull requests; press opens the selected one.
+- **Spawn from Backlog**: browse the backlog and spawn a builder.
 
-**Included profile**
-
-A ready-made Stream Deck + profile — a review cockpit page and an architects page — installs automatically on first run.
-
-Requires a local Codev installation with Tower running.
+**Included profile**: a ready-made Stream Deck + layout (review cockpit + architects pages) installs automatically.


### PR DESCRIPTION
The Marketplace listing was approved and published on 2026-08-19. This syncs the checked-in collateral in `apps/streamdeck/marketplace/` to the exact text the listing carries, so the repo copy is the source of truth for future edits:

- `description.md`: the expanded listing description accepted in re-review (3,084 chars; first 250 unformatted per Elgato's SEO guidance) — adds ABOUT CODEV, a fuller HOW IT WORKS, itemized keys and dials, the bundled profile, GETTING STARTED, and device requirements.
- `release-notes.md`: the trimmed wording actually pasted into the console, whose release-notes field caps at 1,500 characters (this text is 1,488).

Collateral only — no plugin code or packaged artifact changes.
