### PR TITLE
[Spec 1470] Post-merge porch records and verify-phase documentation

### DIFF
--- a/codev/projects/1470-automatic-builder-context-refr/status.yaml
+++ b/codev/projects/1470-automatic-builder-context-refr/status.yaml
@@ -42,7 +42,7 @@ gates:
   verify-approval:
     status: pending
 iteration: 1
-build_complete: false
+build_complete: true
 history:
   - iteration: 1
     plan_phase: phase_1_boundary_declaration
@@ -225,7 +225,7 @@ history:
         file: >-
           /Users/mwk/Development/cluesmith/codev/.builders/spir-1470/codev/projects/1470-automatic-builder-context-refr/1470-phase_8_end_to_end-iter2-claude.txt
 started_at: '2026-08-18T00:15:05.131Z'
-updated_at: '2026-08-19T18:35:25.617Z'
+updated_at: '2026-08-19T18:36:31.947Z'
 force_advanced:
   phase: phase_4_selfrefresh_command
   iteration: 3

--- a/codev/projects/1470-automatic-builder-context-refr/status.yaml
+++ b/codev/projects/1470-automatic-builder-context-refr/status.yaml
@@ -225,7 +225,7 @@ history:
         file: >-
           /Users/mwk/Development/cluesmith/codev/.builders/spir-1470/codev/projects/1470-automatic-builder-context-refr/1470-phase_8_end_to_end-iter2-claude.txt
 started_at: '2026-08-18T00:15:05.131Z'
-updated_at: '2026-08-19T15:38:47.472Z'
+updated_at: '2026-08-19T18:35:25.617Z'
 force_advanced:
   phase: phase_4_selfrefresh_command
   iteration: 3
@@ -237,3 +237,5 @@ pr_history:
     pr_number: 1528
     branch: builder/spir-1470
     created_at: '2026-08-19T15:38:47.471Z'
+    merged: true
+    merged_at: '2026-08-19T18:35:25.617Z'

--- a/codev/reviews/1470-automatic-builder-context-refr.md
+++ b/codev/reviews/1470-automatic-builder-context-refr.md
@@ -3,6 +3,24 @@
 **Spec**: `codev/specs/1470-automatic-builder-context-refr.md` · **Plan**:
 `codev/plans/1470-automatic-builder-context-refr.md` · **Issue**: #1470 · **Protocol**: SPIR (strict)
 
+> ## ⚠ Porch state reads `review / iteration 1` — this project is COMPLETE, not abandoned
+>
+> PR #1528 is **merged** (true merge, 2026-08-19). The feature is on `main`, issues #1470 and #1503
+> are closed, and every plan phase passed its review.
+>
+> Porch is **parked**, deliberately and honestly. SPIR's review phase requires a `pr`-type
+> consultation; `consult` cannot resolve a **merged** PR by branch or by `--issue`, and porch has no
+> command that records an unrunnable consultation — so the phase can neither complete nor escape.
+> Both halves are **issue #1531**.
+>
+> The architect ruled the consultation satisfied by this project's 24 completed review rounds. That
+> ruling lives here, in the artifact. It was deliberately **not** written into `status.yaml`, which
+> records only what mechanically happened — no hand-written verdict files, no faked pass. A parked
+> state at a visible, explained boundary is a truer record than one force-marched to `verified`
+> through a lever built for a different phase.
+>
+> See *Protocol deviation: the review-phase consultation could not run*.
+
 ## Summary
 
 Porch now emits a context-refresh step at boundaries a protocol declares, so a builder gets the

--- a/codev/reviews/1470-automatic-builder-context-refr.md
+++ b/codev/reviews/1470-automatic-builder-context-refr.md
@@ -430,6 +430,20 @@ wrong locally: it became a public issue with a fix direction attached, and someo
 would have hunted a bug that did not exist. The correction had to be as loud as the original claim,
 and had to go out before the issue aged into received knowledge.
 
+**A formatting habit reached a state-destroying command.** Composing a message to the architect, I
+wrote command names in backticks for readability and passed the body as a **double-quoted** bash
+string. The shell performed command substitution: `porch rollback` and `porch verify …` actually
+executed. Both died on argument errors and nothing changed — verified immediately, phase, iteration,
+timestamp and tree all unmoved — but that was luck. Had I quoted `porch rollback 1470 implement`,
+which is exactly the kind of concrete example worth putting in a message, it would have silently
+rewound this project.
+
+Filed as **issue #1532**. The rule: build message bodies with a quoted heredoc and pass the variable
+— parameter expansion does not re-run substitution — never a double-quoted string containing
+backticks. It belongs with `git add .` and `git reset --hard` in the same category: an ordinary
+convenience with an unguarded path to something irreversible. The difference is that this one hides
+inside *writing prose about* dangerous commands, which is precisely when they get typed.
+
 ### What would be done differently
 
 Survey before editing. Three of the five instance/class misses would have been caught by one grep

--- a/codev/reviews/1470-automatic-builder-context-refr.md
+++ b/codev/reviews/1470-automatic-builder-context-refr.md
@@ -303,6 +303,37 @@ in `status.yaml` and the rebuttal file is on disk — and refreshing right after
 REQUEST_CHANGES spiral is arguably the most valuable moment to refresh. But it is a surprise, and
 surprises get rediscovered expensively.
 
+## Protocol deviation: the review-phase consultation could not run
+
+Recorded because a `status.yaml` that says "reviewed" should be traceable to what actually happened.
+
+SPIR's review phase emits a `pr`-type consultation. By the time that phase ran, PR #1528 was merged
+— and **consult cannot resolve a merged PR by either route**:
+
+```
+consult --type pr                 → No PR found for branch: builder/spir-1470   (exit 1)
+consult --type pr --issue 1528    → No PR found for issue #1528                 (exit 1)
+```
+
+Verified across four runs, both models. `gh pr list --head builder/spir-1470 --state all` finds
+#1528 immediately, so consult's own query is open-PR-only. Filed as **issue #1531**, with the fix
+direction recorded there (teach consult `--state all`, and have porch pass the `pr_history` number
+rather than re-deriving from the branch).
+
+This is a protocol-level chicken-and-egg rather than a quirk of this project: **any** SPIR project
+that merges before its review phase completes has no findable PR left for the consult that phase
+requires.
+
+**Architect ruling: the consultation is satisfied by the project's 24 completed review rounds.** The
+reasoning, recorded rather than summarised: the diff this consult would examine was already
+consulted pre-merge across the PR phase and all of phase 8, so a post-merge re-review adds no
+information — and blocking a finished project on a lookup bug is disproportionate. The phase's four
+checks (`pr_exists`, `review_has_arch_updates`, `review_has_lessons_updates`, `e2e_tests`) all
+passed on their own merits.
+
+What was *not* done: no verdict files were hand-written and no pass was recorded as if the consult
+had run. A false entry in `status.yaml` would outlive every memory of why it was convenient.
+
 ## Lessons Learned
 
 ### What went well
@@ -367,6 +398,19 @@ loudly was correct. I put it on porch's normal task-emission path for a purely i
 record, where a transient push failure would have stopped a builder getting work because a
 *visibility* row could not be filed. The reuse question is not "is this the right helper" but "is
 failing the way this helper fails right here".
+
+**I misdiagnosed a tool by misreading my own harness.** I reported to the architect that consult
+"exited 0 and wrote empty verdict files", and they filed an issue on it — including a prescribed fix
+for an exit code that was already correct. The truth was that consult exits 1 and writes nothing; I
+had piped `sed` over filenames that did not exist, seen no output, and read absence-of-file as
+empty-file.
+
+Two things worth keeping from it. First, **the harness is part of the experiment** — I spent this
+whole project insisting that a test proves nothing until you check it can fail, and then trusted an
+ad-hoc display pipeline that had never been checked at all. Second, a wrong report does not stay
+wrong locally: it became a public issue with a fix direction attached, and someone acting on it
+would have hunted a bug that did not exist. The correction had to be as loud as the original claim,
+and had to go out before the issue aged into received knowledge.
 
 ### What would be done differently
 
@@ -467,7 +511,11 @@ Confirmed out of scope for this project; none block the PR.
    Observed on a task-lane builder, not a protocol builder; unrelated to this spec's changes and
    explicitly **not fixed here** per architect direction. Worth its own issue: a lost reply looks
    identical to no reply, which is the same failure shape this feature exists to make visible.
-11. **Happy-path step log is a superset of spec test 30's literal sequence** —
+11. **`consult` cannot resolve a merged PR** (**issue #1531**) — the `pr`-type review's lookup is
+   open-PR-only, by branch and by `--issue` alike, so SPIR's review phase cannot run its
+   consultation on any project that merges first. Hit by this project; see *Protocol deviation*
+   above.
+12. **Happy-path step log is a superset of spec test 30's literal sequence** —
    `challenge-read`, `worktree-checked`, `challenge-marked`, `clear-attempted` and
    `challenge-consumed` are extra. The required subsequence and its ordering *are* asserted; the
    extras are gates the handshake needs. Recorded so it is not scored as a miss.

--- a/codev/state/spir-1470_thread.md
+++ b/codev/state/spir-1470_thread.md
@@ -1792,6 +1792,16 @@ not consume the re-entry (15.9s and 15.8s, two independent measurements), and a 
 leaves the context intact. Four fail-safes fired live — receipt rejection, stale challenge, dirty
 worktree, and the echo-the-request bypass — three of them unplanned.
 
+## One near-miss, worth carrying
+
+Composing a message to the architect, I put command names in backticks inside a **double-quoted**
+bash string. The shell substituted them and actually ran `porch rollback` and `porch verify` — both
+died on argument errors, nothing changed, verified immediately. Luck, not design: quoting a *valid*
+`porch rollback 1470 implement` would have rewound this project silently. **Issue #1532.** Build
+message bodies with a quoted heredoc and pass the variable. Same category as `git add .` — an
+ordinary convenience with an unguarded path to something irreversible, and it hides inside writing
+*about* dangerous commands, which is exactly when they get typed.
+
 ## Open, deliberately
 
 - **#1529** false acknowledgment — unmitigated, and it weakens a signal shipping in this PR.

--- a/codev/state/spir-1470_thread.md
+++ b/codev/state/spir-1470_thread.md
@@ -1740,3 +1740,26 @@ rather than an issue pointing at a doc that merged three weeks ago.
 
 **Not merging.** The merge word is Waleed's; the architect is presenting #1528 to him now. When it
 lands: `porch done 1470 --merged 1528`, then the verify phase.
+
+## Verify phase — merge clean, review consult blocked, architect ruled (b)
+
+Merge verified against origin/main (not my worktree): true merge with 2 parents, commits preserved,
+`context_refresh` in both trees, 18/18 `$schema` correct, #1470 + #1503 closed by the PR, #1529/#1530
+open. Review-phase checks all green including e2e.
+
+**The review-phase `pr` consult cannot run**: consult's PR lookup is open-PR-only, so a merged PR is
+invisible by branch AND by `--issue` (four runs, both models, all exit 1, no files). Issue #1531.
+Architect ruled the consultation satisfied by the 24 completed rounds — recorded in the review as a
+ruling with its reasoning, not as if the consult had run. No verdict files hand-written.
+
+**My worst mistake of the project, and it was in the reporting, not the code (item 27).** I told the
+architect consult "exited 0 and wrote empty verdict files" and speculated porch might score files by
+presence. Both false — it exits 1 and writes nothing. I had `sed`-piped filenames that did not exist,
+seen no output, and read absence-of-file as empty-file. The architect had already filed #1531 with my
+error in the title and a prescribed fix for an exit code that was already correct.
+
+The lesson has two halves and I have put both in the review. **The harness is part of the
+experiment** — I spent eight phases insisting a test proves nothing until you check it can fail, then
+trusted an ad-hoc display pipeline never checked at all. And **a wrong report does not stay local**:
+it became a public issue with a fix direction attached. The correction had to be louder than the
+original claim and had to land before the issue aged into received knowledge.

--- a/codev/state/spir-1470_thread.md
+++ b/codev/state/spir-1470_thread.md
@@ -1763,3 +1763,54 @@ experiment** — I spent eight phases insisting a test proves nothing until you 
 trusted an ad-hoc display pipeline never checked at all. And **a wrong report does not stay local**:
 it became a public issue with a fix direction attached. The correction had to be louder than the
 original claim and had to land before the issue aged into received knowledge.
+
+---
+
+# FINAL — Spec 1470 complete (2026-08-19)
+
+**PR #1528 merged.** True merge, 2 parents, individual commits preserved. Feature verified on
+`origin/main`: `context_refresh` declared in both trees, 18/18 `$schema` paths correct including the
+generator fix that stops adopters inheriting the bug. Issues #1470 and #1503 closed by the PR.
+
+## ⚠ Porch reads `review / iteration 1`. That is PARKED, not abandoned.
+
+SPIR's review phase requires a `pr`-type consultation. `consult` cannot resolve a **merged** PR —
+by branch or by `--issue`, four runs, both models, all exit 1, no files written. And porch has no
+command that records an unrunnable consultation: `verify --skip` is scoped to the verify phase and
+refuses in review, while the force-advance ceiling counts iterations that only advance on completed
+verdict rounds. So the phase can neither finish nor escape. **Issue #1531**, both halves.
+
+Architect ruled the consultation satisfied by the project's 24 completed rounds. That ruling is in
+the review **artifact**; `status.yaml` records only what mechanically happened. No verdict files were
+hand-written, no pass faked, no `rollback` used to manufacture a tidier history.
+
+## What shipped
+
+8 plan phases, 24 consultation rounds, ~370 tests across 17 files, suite 5289 green. Three
+architect-driven live passes proved the one property no unit test can reach: the queued `/clear` does
+not consume the re-entry (15.9s and 15.8s, two independent measurements), and a failed receipt gate
+leaves the context intact. Four fail-safes fired live — receipt rejection, stale challenge, dirty
+worktree, and the echo-the-request bypass — three of them unplanned.
+
+## Open, deliberately
+
+- **#1529** false acknowledgment — unmitigated, and it weakens a signal shipping in this PR.
+- **#1530** task-lane reply loss.
+- **#1531** consult cannot resolve a merged PR; porch cannot record an unrunnable consultation.
+- Save staleness — mitigated by instruction only; belongs with #1529, same root.
+- Adopter projects keep their broken `$schema`; the generator is fixed going forward.
+
+## The through-line, for whoever reads this next
+
+Every serious defect on this project was **green and wrong**. Nine vacuous tests. A guard correct at
+three layers and never invoked in production. A test proving only that `enqueue` stores its argument.
+A simulation that never drove the thing it was named for. A live pass satisfying two of four clauses.
+A diagnostic that lied in the reassuring direction. And, at the very end, me misreading my own `sed`
+pipeline and reporting a tool bug that did not exist — into a public issue, with a fix direction
+attached.
+
+The cure that worked was never vigilance. It was **making things singular** (one invocation builder,
+one fs port, one fixture, one set of fakes) and **mutation checking** — inject the defect, watch the
+test fail. What that discipline cannot reach is the class the reviewers caught: asking *what does the
+caller actually pass?* and *does this evidence answer the clause that was asked?*
+


### PR DESCRIPTION
Post-merge records for Spec 1470. **Documentation and porch state only — no code.**

PR #1528 merged the feature; these five commits were written *after* that merge, so they could only
ever land on the builder branch. Shipping them separately is the standard remedy for stranded porch
records.

## What is here

| Commit | Why it was stranded |
|---|---|
| `chore(porch): 1470 PR #1528 merged` | `porch done --merged 1528` writes `status.yaml` *after* the merge, by definition |
| `chore(porch): 1470 review build-complete` | the review phase's checks ran post-merge |
| review-consult deviation + architect ruling | written during the verify phase |
| parked-state banner + thread FINAL | written during the verify phase |
| backtick near-miss (#1532) | written during the verify phase |

## Please read the banner at the top of the review artifact

`status.yaml` says **`phase: review, iteration: 1`**. That is **parked, not abandoned**, and it is
deliberate.

SPIR's review phase requires a `pr`-type consultation. `consult` cannot resolve a **merged** PR — by
branch or by `--issue`, four runs across both models, all exit 1 — and porch has no command that
records an *unrunnable* consultation (`verify --skip` is scoped to the verify phase and refuses in
review; the force-advance ceiling counts iterations that only advance on completed verdict rounds).
So the phase can neither complete nor escape. Both halves are **#1531**.

The architect ruled the consultation satisfied by the project's 24 completed review rounds. **That
ruling is recorded in the review artifact, not in `status.yaml`** — which continues to record only
what mechanically happened. No verdict files were hand-written, no pass faked, and no `rollback` used
to manufacture a tidier history.

## Also recorded here

- **#1532** — a backtick inside a double-quoted `afx send` body was substituted by the shell and
  actually executed `porch` commands. Nothing changed (verified), but a valid
  `porch rollback 1470 implement` would have rewound the project.
- Cross-references to **#1529** (false acknowledgment — unmitigated) and **#1530** (task-lane reply
  loss).

Merge with `--merge`, not squash.
