### PR TITLE
[Bugfix #1570] records: post-merge porch bookkeeping (gate-approved, merged, protocol complete)

### DIFF
--- a/codev/projects/bugfix-1570-tower-cloud-oauth-callback-get/status.yaml
+++ b/codev/projects/bugfix-1570-tower-cloud-oauth-callback-get/status.yaml
@@ -6,16 +6,17 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-09-01T04:20:03.195Z'
+    approved_at: '2026-09-01T05:10:03.995Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-01T04:08:22.670Z'
-updated_at: '2026-09-01T04:20:03.195Z'
+updated_at: '2026-09-01T05:10:03.996Z'
 pr_history:
   - phase: pr
     pr_number: 1571
     branch: builder/bugfix-1570
     created_at: '2026-09-01T04:19:57.398Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1570-tower-cloud-oauth-callback-get/status.yaml
+++ b/codev/projects/bugfix-1570-tower-cloud-oauth-callback-get/status.yaml
@@ -13,10 +13,12 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-01T04:08:22.670Z'
-updated_at: '2026-09-01T05:10:03.996Z'
+updated_at: '2026-09-01T05:10:09.980Z'
 pr_history:
   - phase: pr
     pr_number: 1571
     branch: builder/bugfix-1570
     created_at: '2026-09-01T04:19:57.398Z'
+    merged: true
+    merged_at: '2026-09-01T05:10:09.979Z'
 pr_ready_for_human: false

--- a/codev/projects/bugfix-1570-tower-cloud-oauth-callback-get/status.yaml
+++ b/codev/projects/bugfix-1570-tower-cloud-oauth-callback-get/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1570
 title: tower-cloud-oauth-callback-get
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,7 +13,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-01T04:08:22.670Z'
-updated_at: '2026-09-01T05:10:09.980Z'
+updated_at: '2026-09-01T05:10:14.281Z'
 pr_history:
   - phase: pr
     pr_number: 1571


### PR DESCRIPTION
The three status.yaml bookkeeping commits porch wrote after PR #1571 (OAuth callback carve-out for issue #1570) merged — stranded on the builder branch by construction (the known #1367 pattern). Cherry-picked onto main; status.yaml only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)