### PR TITLE
[Bugfix #1574] records: post-merge porch bookkeeping

### DIFF
--- a/codev/projects/bugfix-1574-tower-self-attesting-message-f/status.yaml
+++ b/codev/projects/bugfix-1574-tower-self-attesting-message-f/status.yaml
@@ -6,16 +6,17 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-09-01T12:09:44.350Z'
+    approved_at: '2026-09-01T12:39:07.725Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-01T11:50:08.201Z'
-updated_at: '2026-09-01T12:09:44.351Z'
+updated_at: '2026-09-01T12:39:07.726Z'
 pr_history:
   - phase: pr
     pr_number: 1575
     branch: builder/bugfix-1574
     created_at: '2026-09-01T12:09:38.368Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1574-tower-self-attesting-message-f/status.yaml
+++ b/codev/projects/bugfix-1574-tower-self-attesting-message-f/status.yaml
@@ -13,10 +13,12 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-01T11:50:08.201Z'
-updated_at: '2026-09-01T12:39:07.726Z'
+updated_at: '2026-09-01T12:39:15.947Z'
 pr_history:
   - phase: pr
     pr_number: 1575
     branch: builder/bugfix-1574
     created_at: '2026-09-01T12:09:38.368Z'
+    merged: true
+    merged_at: '2026-09-01T12:39:15.946Z'
 pr_ready_for_human: false

--- a/codev/projects/bugfix-1574-tower-self-attesting-message-f/status.yaml
+++ b/codev/projects/bugfix-1574-tower-self-attesting-message-f/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1574
 title: tower-self-attesting-message-f
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,7 +13,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-01T11:50:08.201Z'
-updated_at: '2026-09-01T12:39:15.947Z'
+updated_at: '2026-09-01T12:39:38.654Z'
 pr_history:
   - phase: pr
     pr_number: 1575


### PR DESCRIPTION
The three status.yaml bookkeeping commits porch wrote after PR #1575 (self-attesting message frames) merged — stranded on the builder branch by construction (#1367 pattern). Cherry-picked onto main; status.yaml only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)