### PR TITLE
[Bugfix #1573] records: post-merge porch bookkeeping + thread closeout

### DIFF
--- a/codev/projects/bugfix-1573-tower-delivery-write-edge-veri/status.yaml
+++ b/codev/projects/bugfix-1573-tower-delivery-write-edge-veri/status.yaml
@@ -13,10 +13,12 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-01T11:38:13.671Z'
-updated_at: '2026-09-01T12:42:44.352Z'
+updated_at: '2026-09-01T12:48:33.697Z'
 pr_history:
   - phase: pr
     pr_number: 1577
     branch: builder/bugfix-1573
     created_at: '2026-09-01T12:09:39.805Z'
+    merged: true
+    merged_at: '2026-09-01T12:48:33.697Z'
 pr_ready_for_human: false

--- a/codev/state/bugfix-1573_thread.md
+++ b/codev/state/bugfix-1573_thread.md
@@ -228,3 +228,20 @@ That is the real lesson from this rebase: my hand-copied `### [ARCHITECT INSTRUC
 would have kept passing while the frame it modelled drifted away from what the delivery path
 writes. Deriving it means the next frame change fails in this suite instead of in the field.
 Added an explicit assertion that the recipient segment reaches the needle.
+
+### 2026-09-01 — merged and closed out
+
+PR #1577 admin-merged as `ff684153b` at 12:48Z (GitHub blocked a formal review because the
+architect account authored the branch; the review is a PR comment instead). Recorded with
+`porch done --merged 1577`; project is at `verified`.
+
+Closeout per the architect:
+- Completion stats posted on #1573.
+- #1564 and #1521 left **OPEN** with comments explaining which change addresses each and what
+  field evidence should close them. Neither is verified by a reproduction of the original
+  failure — only by tests — so closing them now would be claiming more than was demonstrated.
+- One stranded porch commit for the records PR: `5d717a278` (`chore(porch): bugfix-1573 PR
+  #1577 merged`) — the status.yaml transition porch wrote after the merge, so it could not have
+  ridden the PR.
+
+Total: 70 minutes, one iteration, no rollbacks, 2 CMAP rounds.


### PR DESCRIPTION
The status.yaml transition porch wrote after PR #1577 (write-edge delivery verification) merged, plus the builder thread's closeout entry — stranded on the builder branch by construction (#1367 pattern). No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)