### PR TITLE
Fix #1584: never re-write a mailbox row whose write completed

### DIFF
--- a/codev/projects/bugfix-1584-tower-hotfix-echo-verify-re-wr/status.yaml
+++ b/codev/projects/bugfix-1584-tower-hotfix-echo-verify-re-wr/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1584
+title: tower-hotfix-echo-verify-re-wr
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-09-02T14:02:15.761Z'
+updated_at: '2026-09-02T14:02:15.762Z'

--- a/codev/projects/bugfix-1584-tower-hotfix-echo-verify-re-wr/status.yaml
+++ b/codev/projects/bugfix-1584-tower-hotfix-echo-verify-re-wr/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-09-02T14:33:45.499Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-02T14:02:15.761Z'
-updated_at: '2026-09-02T14:16:20.185Z'
+updated_at: '2026-09-02T14:33:45.500Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1584-tower-hotfix-echo-verify-re-wr/status.yaml
+++ b/codev/projects/bugfix-1584-tower-hotfix-echo-verify-re-wr/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1584
 title: tower-hotfix-echo-verify-re-wr
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-02T14:02:15.761Z'
-updated_at: '2026-09-02T14:02:15.762Z'
+updated_at: '2026-09-02T14:05:43.590Z'

--- a/codev/projects/bugfix-1584-tower-hotfix-echo-verify-re-wr/status.yaml
+++ b/codev/projects/bugfix-1584-tower-hotfix-echo-verify-re-wr/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1584
 title: tower-hotfix-echo-verify-re-wr
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-02T14:02:15.761Z'
-updated_at: '2026-09-02T14:05:43.590Z'
+updated_at: '2026-09-02T14:16:20.185Z'

--- a/codev/state/bugfix-1584_thread.md
+++ b/codev/state/bugfix-1584_thread.md
@@ -84,3 +84,22 @@ in and re-running); the 7th is the pre-write-hold guard, which should pass on bo
 
 Updated (not deleted) the two #1573 tests that pinned hold-and-redeliver, plus route
 (`tower-routes.test.ts`) and CLI (`send.test.ts`) coverage for `verified`.
+
+## 2026-09-02 — PR
+
+PR #1585 opened (`Fixes #1584`). Three commits: the fix, the tests + this thread, and a
+follow-up tightening (report `verified` only for the row *this* request's pass delivered — a
+pass picks the agent's OLDEST held row, so without an id check a concurrent drainer delivery
+of our row could be reported with another message's verification result).
+
+**Environment note for whoever picks this up:** the worktree arrived with no `node_modules`
+and no `packages/codev/skeleton/`. 12 test files (adopt, update, hot/cold-tier, protocol-drift,
+consult, consolidate, spawn-retirement, session-manager, …) fail until `pnpm install` +
+`pnpm --filter "@cluesmith/codev^..." build` + `pnpm build` in `packages/codev`. I confirmed
+the identical per-file failure counts at HEAD before building, so none were mine. After the
+build: **5372 passed, 0 failed, 48 skipped** across 273 files.
+
+`consult` did NOT auto-detect the project from builder context — it listed every project and
+exited 0 without reviewing. `--project-id bugfix-1584` fixes it. Worth an issue if it recurs.
+
+CMAP verdicts: gemini=APPROVE (no issues, 12.8s). codex + claude pending.

--- a/codev/state/bugfix-1584_thread.md
+++ b/codev/state/bugfix-1584_thread.md
@@ -103,3 +103,40 @@ build: **5372 passed, 0 failed, 48 skipped** across 273 files.
 exited 0 without reviewing. `--project-id bugfix-1584` fixes it. Worth an issue if it recurs.
 
 CMAP verdicts: gemini=APPROVE (no issues, 12.8s). codex + claude pending.
+
+### CMAP round 1 — gemini=APPROVE, codex=REQUEST_CHANGES, claude=COMMENT
+
+Both non-approvals were correct. Fixed rather than rebutted.
+
+**codex #1 (critical, and I had missed it):** the point of no return was not DURABLE. The row
+stayed `held` in the database through up to ~1.2 s of verification, so a Tower crash/restart in
+that window — or an `echo.verify()` that *rejects* rather than answering — left it held and
+re-writable by the next tick. My item-3 audit had looked only for `hold(...)` calls and missed
+the throw path. Fix: `markDelivered` now runs **immediately** after `status === 'written'`,
+before any further await (better-sqlite3 is synchronous, so there is no window at all);
+verification is now pure reporting downstream of a committed delivery, and a rejection is caught
+and treated as unconfirmed.
+
+**codex #2:** the `escalated` flag reaches nobody. A *delivered* row is excluded from
+`heldSummaryForWorkspace`, `afx inbox` and the held-count indicator, so for a cron/backstop
+delivery the only trace was a log line. My earlier judgment call (don't fire `onEscalation`
+because its title says "held past escalation age") was right about the wording and wrong to stop
+there. Fix: a new optional `DeliveryPorts.onUnverifiedDelivery` port, bound to the same generic
+`notification` SSE channel `surfaceLiveness` uses, with truthful wording — "delivered but not
+confirmed on screen … will NOT be sent again".
+
+Required a delivered-only `markEscalatedDelivered` in `db/mailbox.ts`: the ordering fix means
+the verdict is known only after the row has left `held`, where the existing held-only
+`markEscalated` would silently no-op. Added as a separate function rather than relaxing
+`markEscalated`'s guard, which is what makes the drainer's escalation pass safe to call blindly.
+
+**claude (COMMENT), all real:** three doc blocks left behind now asserted the *inverted* safety
+property — `watchEcho` and `EchoWatch.verify` in `mailbox-delivery.ts` still said the caller
+holds for redelivery ("a duplicate delivery instead of a silent loss"), and `watchEchoOnScreen`
+in `mailbox-wiring.ts` still called its residuals "safe (a redelivery, never a dropped
+message)". Those residuals ARE the #1583 trigger. All three rewritten. Its fourth point — issue
+item 4 was only covered indirectly — is now a direct test: 12 unverified deliveries in a row
+produce 12 writes and zero `onLiveness` calls (LIVENESS_STREAK_THRESHOLD is 10).
+
+Five new tests, three of which fail against the pre-CMAP commit (verified by swapping the module
+back in): commits-before-verifying, verify-throws, and the notice.

--- a/codev/state/bugfix-1584_thread.md
+++ b/codev/state/bugfix-1584_thread.md
@@ -140,3 +140,25 @@ produce 12 writes and zero `onLiveness` calls (LIVENESS_STREAK_THRESHOLD is 10).
 
 Five new tests, three of which fail against the pre-CMAP commit (verified by swapping the module
 back in): commits-before-verifying, verify-throws, and the notice.
+
+### CMAP round 2 — gemini=APPROVE, codex=COMMENT, claude=APPROVE
+
+Re-ran all three after the round-1 fixes (the changes were substantial: a reordering, a new db
+function, a new port + binding).
+
+- **gemini=APPROVE**, no issues.
+- **claude=APPROVE.** Three non-blocking minors, all of which it recommends folding into #1578
+  rather than this hotfix: (a) unverified-delivery notices are un-deduplicated and would be
+  noisy on a harness that NEVER echoes; (b) the double `verify()` is equivalent to doubling the
+  timeout for the real binding — a timeout parameter would express it more honestly than "a
+  second look"; (c) `dropped`/`preempted` still hold after bytes may have hit the wire
+  (pre-existing, documented at the point-of-no-return comment, worth recording as a residual).
+- **codex=COMMENT** (up from REQUEST_CHANGES — it confirmed both round-1 findings resolved).
+  Two staleness findings, both mine and both fixed: the PR body still described the *pre*-
+  reorder design (verification while held, `markEscalated`, no notification, "seven tests"), and
+  two comments — the `watchEcho` port doc and its wiring binding — still said the echo is
+  consulted BEFORE `markDelivered`. PR body rewritten; both comments corrected.
+
+Nothing was rebutted across either round. Every finding from both non-approving lanes was real.
+
+Residuals to record on #1578 at the gate: claude's (a), (b) and (c) above.

--- a/codev/state/bugfix-1584_thread.md
+++ b/codev/state/bugfix-1584_thread.md
@@ -1,0 +1,86 @@
+# bugfix-1584 — tower: echo-verify re-write loop re-injects a delivered message unboundedly
+
+Builder thread. Issue #1584 (hotfix for the 3.3.2 regression from #1573 / PR #1577;
+field report #1583).
+
+## 2026-09-02 — INVESTIGATE
+
+**Root cause confirmed at current main** (no guessing — traced the whole path):
+
+1. `packages/codev/src/agent-farm/servers/mailbox-delivery.ts:694` — inside
+   `deliverAgentMail`, AFTER `ports.writeMessage(...)` has returned
+   `{ status: 'written' }` (every byte + Enter accepted by the PTY), a failed
+   `echo.verify()` does `return hold('busy')`. The row stays `held`.
+2. `MailboxDrainer.tick()` (1.5 s backstop) and `scheduleDrain` re-run
+   `deliverAgentMail` for that agent on every later clean-prompt pass, which does a
+   **full re-write** of `current.formatted_message`. There is no attempt counter
+   anywhere — `grep attempt` over `mailbox-delivery.ts` and `db/mailbox.ts` returns
+   only prose; the `mailbox` table has no attempts column.
+3. `isClassifierStuck()` (line ~305) deliberately excludes `busy`, so the loop never
+   reaches liveness telemetry — it is silent to the owner.
+4. Field trigger (per #1583): the recipient starts responding immediately, so its
+   output either scrolls the header out of the 1000-line `SessionScreen` mirror or
+   evicts the pre-write copy. `countEchoOnScreen` then does not see `count > before`
+   (`mailbox-wiring.ts:237` `watchEchoOnScreen`), verification fails, the message is
+   re-injected, the recipient responds again → self-sustaining. `afx interrupt` makes
+   it worse: each interrupt produces a fresh clean prompt = another pass.
+
+**Existing proof in-tree:** `bugfix-1573-delivery-verification.test.ts` →
+"a row held by a failed verification is redelivered by the next pass" asserts
+`h.writes).toEqual([FORMATTED, FORMATTED])` — i.e. the current suite pins the
+re-write as intended behaviour. That test is one of the two #1573 tests the issue
+says to update to the new contract.
+
+**Scope:** small. Verify site in `mailbox-delivery.ts`, a `verified` field threaded
+through `DeliveryOutcome` → `tower-routes.ts handleSend` → `sdk/tower-client.ts` →
+`commands/send.ts`, plus tests. Well under 300 LOC. Fits BUGFIX.
+
+**Design (prescribed by the issue, owner-approved — not relitigated):** a row whose
+write completed is at-least-once delivered and must NEVER be written again. One extra
+bounded verify window, then mark `delivered` + `escalated`, WARN log, `verified:false`
+to the sender.
+
+**Note:** the worktree had no `node_modules` — ran `pnpm install` before testing.
+
+## 2026-09-02 — FIX
+
+Change (6 source files + 3 test files, ~155 LOC of source diff):
+
+- `mailbox-delivery.ts` — the fix. After `writeMessage` returns `written` there is now an
+  explicit POINT OF NO RETURN: no `hold(...)` may follow it. The echo check still runs but
+  decides what we *report*, not whether we write again. On failure: one extra bounded
+  `verify()` window (a second LOOK, zero bytes written; ~1.2 s total since
+  `ECHO_VERIFY_TIMEOUT_MS` is 600), then `markEscalated` (while the row is still `held`, since
+  `markEscalated` is held-only) + a `WARN` log + `verified: false` on the outcome.
+- `DeliveryOutcome.verified?: boolean` — absent when verification was skipped (no needle) or
+  nothing was delivered.
+- `DeliveryPorts.log(message, level?)` — needed a `WARN` level; the wiring binding was
+  hardcoding `INFO`. Existing 1-arg fakes stay assignable.
+- `tower-routes.ts handleSend` — keeps the delivery outcome and spreads `verified` onto the
+  delivered response (additive; omitted when undefined).
+- `sdk/tower-client.ts` — `verified?: boolean` on the send response type + passthrough.
+- `commands/send.ts` — `[ok] Message delivered to X (N bytes) (unverified — header not seen
+  on the terminal)` when `verified === false`; unchanged otherwise.
+
+**Audit of item 3 (holds reachable after a completed write):** the only one was the verify
+site. `dropped` = bytes lost mid-pace; `preempted` = an unserialized operator write may have
+truncated the composer; `contended`/`aborted` = nothing written. None is `written`, so none is
+the at-least-once case. Documented at the point-of-no-return comment. `cron-delivery.ts` shares
+`deliverAgentMailSerialized`, so it has no second verify site. Item 4 needed no code change —
+pinned by test instead.
+
+**Judgment call (worth an architect glance):** I set the `escalated` DB column but did NOT fire
+`ports.onEscalation`. That SSE event's binding hardcodes the title "Message held past
+escalation age", which would be false for a delivered row. The sender-facing `verified:false`
+(item 2) is the surface that actually reaches a human.
+
+**Tests.** New `bugfix-1584-no-rewrite-after-write.test.ts` (7 tests): control test (written
+exactly once, ends `delivered` + `escalated`, two real `MailboxDrainer.tick()`s write nothing),
+WARN log content, at-most-two verify windows, broadcast still fires, verified path unchanged,
+pre-write hold still holds, and the immediate-responder simulation against a REAL
+`SessionScreen` (header echoed then buried under 2000 lines of response). **6 of its 7 tests
+fail against the unmodified `mailbox-delivery.ts` at HEAD** (verified by swapping the file back
+in and re-running); the 7th is the pre-write-hold guard, which should pass on both.
+
+Updated (not deleted) the two #1573 tests that pinned hold-and-redeliver, plus route
+(`tower-routes.test.ts`) and CLI (`send.test.ts`) coverage for `verified`.

--- a/packages/codev/src/agent-farm/__tests__/bugfix-1573-delivery-verification.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-1573-delivery-verification.test.ts
@@ -238,27 +238,32 @@ describe('#1573 echo verification before markDelivered', () => {
   }
 
   /**
-   * THE CONTROL TEST for this issue. Every upstream signal says success — the gate was clean,
-   * the paced write completed, every `session.write` returned true — and the terminal never
-   * showed the message. Before this change that combination produced `delivered` plus a
-   * broadcast, which is precisely the false receipt #1564 and #1521 were reported as.
+   * THE CONTROL TEST for this issue, REWRITTEN for #1584 rather than deleted — the scenario is
+   * unchanged, the contract is not. Every upstream signal says success (clean gate, completed
+   * paced write, every `session.write` true) and the terminal never showed the message.
+   *
+   * #1573 answered that with a hold, so the drainer re-wrote the whole message on the next clean
+   * pass, with no attempt cap — and #1583 saw one `afx send --file` re-injected dozens of times.
+   * A completed write is at-least-once delivered, so the answer is now: record it, flag it, tell
+   * the sender it could not be confirmed, and never write it again.
    */
-  it('a completed write whose header never reaches the screen is HELD, not delivered', async () => {
+  it('a completed write whose header never reaches the screen is delivered-unverified, not held', async () => {
     const h = harness();
     h.echoVerified = false;
     const row = enqueue();
 
     const out = await deliverAgentMail(h.ports, db, '/ws/a', 'spir-1');
 
-    expect(out).toEqual({ delivered: [], reason: 'busy' });
-    // The bytes DID go out — this is a hold for redelivery, not a claim that nothing happened.
+    expect(out).toEqual({ delivered: [row.id], reason: null, verified: false });
+    // Written exactly once — the property the whole hotfix exists for.
     expect(h.writes).toEqual([FORMATTED]);
     const stored = mailbox.getById(db, row.id);
-    expect(stored?.status).toBe('held');
-    expect(stored?.reason).toBe('busy');
-    // No delivery broadcast: the dashboard must not show a message the agent never saw.
-    expect(h.broadcasts).toEqual([]);
-    expect(h.logs.join('\n')).toContain('never appeared on the terminal');
+    expect(stored?.status).toBe('delivered');
+    // Flagged, so an unconfirmed delivery is discoverable rather than silent.
+    expect(stored?.escalated).toBe(1);
+    // The bytes went out, so the delivery IS broadcast — the agent may well have seen it.
+    expect(h.broadcasts).toHaveLength(1);
+    expect(h.logs.join('\n')).toContain('delivered-unverified');
   });
 
   it('a confirmed header marks the row delivered and broadcasts it', async () => {
@@ -278,22 +283,54 @@ describe('#1573 echo verification before markDelivered', () => {
     expect(h.order).toEqual(['watch', 'write', 'verify']);
   });
 
-  it('a row held by a failed verification is redelivered by the next pass', async () => {
-    // The hold is the whole safety argument: the direction of error becomes a duplicate
-    // delivery the agent can see, never a silent loss the sender was told was a success.
+  it('a row whose verification failed is never written a second time (#1584)', async () => {
+    // The inverse of the assertion this test carried under #1573, and the exact loop #1583
+    // reported: the row left `held`, so every later clean-prompt pass re-wrote the whole
+    // message. Nothing re-holds a completed write now, so the second pass has nothing to send.
     const h = harness();
     h.echoVerified = false;
     const row = enqueue();
 
     await deliverAgentMail(h.ports, db, '/ws/a', 'spir-1');
-    expect(mailbox.getById(db, row.id)?.status).toBe('held');
+    expect(mailbox.getById(db, row.id)?.status).toBe('delivered');
 
-    h.echoVerified = true;
+    const second = await deliverAgentMail(h.ports, db, '/ws/a', 'spir-1');
+
+    expect(second).toEqual({ delivered: [], reason: null });
+    expect(h.writes).toEqual([FORMATTED]);
+  });
+
+  it('reports verified:true on the confirmed path and does not flag the row', async () => {
+    const h = harness();
+    const row = enqueue();
+
     const out = await deliverAgentMail(h.ports, db, '/ws/a', 'spir-1');
 
-    expect(out.delivered).toEqual([row.id]);
-    expect(h.writes).toEqual([FORMATTED, FORMATTED]);
-    expect(mailbox.getById(db, row.id)?.status).toBe('delivered');
+    expect(out).toEqual({ delivered: [row.id], reason: null, verified: true });
+    expect(mailbox.getById(db, row.id)?.escalated).toBe(0);
+  });
+
+  it('gives a slow renderer a second verify window before recording it unverified', async () => {
+    // No bytes are written between the two windows — this is a second LOOK, not a retry. A
+    // terminal that paints the header late is confirmed rather than flagged.
+    const h = harness();
+    let attempt = 0;
+    h.ports.watchEcho = () =>
+      Promise.resolve({
+        verify: () => {
+          attempt++;
+          h.order.push('verify');
+          return Promise.resolve(attempt > 1);
+        },
+      });
+    const row = enqueue();
+
+    const out = await deliverAgentMail(h.ports, db, '/ws/a', 'spir-1');
+
+    expect(out).toEqual({ delivered: [row.id], reason: null, verified: true });
+    expect(attempt).toBe(2);
+    expect(h.writes).toEqual([FORMATTED]);
+    expect(mailbox.getById(db, row.id)?.escalated).toBe(0);
   });
 
   it('skips verification for a message too short to have a distinctive header', async () => {
@@ -309,8 +346,10 @@ describe('#1573 echo verification before markDelivered', () => {
 
     const out = await deliverAgentMail(h.ports, db, '/ws/a', 'spir-1');
 
-    expect(out.delivered).toEqual([row.id]);
+    expect(out).toEqual({ delivered: [row.id], reason: null });
     expect(h.needles).toEqual([]);
+    // No needle → no evidence either way, so `verified` is absent rather than a guess.
+    expect('verified' in out).toBe(false);
   });
 });
 

--- a/packages/codev/src/agent-farm/__tests__/bugfix-1584-no-rewrite-after-write.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-1584-no-rewrite-after-write.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Issue #1584 — a completed write is NEVER written again.
+ *
+ * The 3.3.2 field failure (#1583): one `afx send --file` message was re-injected into a
+ * builder's prompt dozens of times, byte-identical. #1573 had made a failed echo-verification
+ * return `hold('busy')` AFTER the paced write completed, so the row went back into the
+ * drainer's held set and every later clean-prompt pass re-wrote the whole message. No attempt
+ * cap existed anywhere in the module, and `busy` holds are excluded from `isClassifierStuck`,
+ * so the loop was silent. It was self-sustaining in the common case: a recipient that starts
+ * responding immediately scrolls the header out of the sampled mirror, verification fails, the
+ * message is re-injected, the recipient responds again.
+ *
+ * The contract this file pins: once `writeMessage` returns `written`, the row is at-least-once
+ * delivered. It is marked `delivered` whatever the echo says — flagged `escalated` and reported
+ * `verified: false` when the echo could not confirm — and no later pass may write it again.
+ *
+ * `bugfix-1573-delivery-verification.test.ts` keeps the settle-before-write and needle
+ * properties, which this change does not touch.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { GLOBAL_SCHEMA } from '../db/schema.js';
+import * as mailbox from '../db/mailbox.js';
+import {
+  MailboxDrainer,
+  deliverAgentMail,
+  echoNeedle,
+  type DeliveryPorts,
+  type DeliverySession,
+  type DeliveredBroadcast,
+  type WriteAbort,
+  type WriteResult,
+} from '../servers/mailbox-delivery.js';
+import { watchEchoOnScreen } from '../servers/mailbox-wiring.js';
+import { SessionScreen } from '../../terminal/session-screen.js';
+import type { GateProfile, GateVerdict } from '../servers/render-gate.js';
+import { formatArchitectToBuilderMessage } from '../utils/message-format.js';
+
+const PROFILE: GateProfile = { app: 'claude', markerPattern: /^❯/, regionEndPatterns: [] };
+const CLEAN: GateVerdict = { clean: true, detail: 'empty' };
+
+/** A long-ish body, as in the field report: a `--file` send is what looped. */
+const FORMATTED = formatArchitectToBuilderMessage(
+  'spir-1',
+  Array.from({ length: 60 }, (_, i) => `plan line ${i}`).join('\n'),
+);
+const HEADER = FORMATTED.split('\n', 1)[0];
+
+const NOW = 2_000_000;
+
+interface Harness {
+  ports: DeliveryPorts;
+  session: DeliverySession;
+  broadcasts: DeliveredBroadcast[];
+  logs: { message: string; level?: string }[];
+  /** Formatted messages the write port accepted — one entry per completed paced write. */
+  writes: string[];
+  /** What every echo watch answers. */
+  echoVerified: boolean;
+  /** How many times a watch's `verify()` was consulted, across all watches. */
+  verifyCalls: number;
+}
+
+function harness(): Harness {
+  const h: Harness = {
+    session: {
+      id: 'term-1584',
+      bytesWritten: 7,
+      lastDataAt: NOW - 10_000,
+      info: { cols: 110, rows: 32 },
+      command: 'claude',
+      launchArgs: [],
+      cwd: '/ws/a',
+      writable: true,
+      write: () => true,
+    },
+    broadcasts: [],
+    logs: [],
+    writes: [],
+    echoVerified: false,
+    verifyCalls: 0,
+    ports: {
+      getSessionForAgent: () => h.session,
+      resolveProfile: () => PROFILE,
+      classify: () => Promise.resolve(CLEAN),
+      writeMessage: (_s, formattedMessage, _noEnter, precheck): WriteResult => {
+        const abort: WriteAbort | null = precheck();
+        if (abort) return { status: 'aborted', abort };
+        h.writes.push(formattedMessage);
+        return { status: 'written' };
+      },
+      watchEcho: () =>
+        Promise.resolve({
+          verify: () => {
+            h.verifyCalls++;
+            return Promise.resolve(h.echoVerified);
+          },
+        }),
+      broadcast: (f) => h.broadcasts.push(f),
+      onHeldStateChange: () => {},
+      onEscalation: () => {},
+      onLiveness: () => {},
+      log: (message, level) => h.logs.push({ message, level }),
+      now: () => NOW,
+    },
+  };
+  return h;
+}
+
+describe('#1584 a completed write is never re-written', () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec(GLOBAL_SCHEMA);
+  });
+  afterEach(() => db.close());
+
+  function enqueue() {
+    return mailbox.enqueue(
+      db,
+      { workspacePath: '/ws/a', toAgent: 'spir-1', body: 'the plan', formattedMessage: FORMATTED },
+      NOW,
+    );
+  }
+
+  /**
+   * THE CONTROL TEST for this issue: it fails on 3.3.2, where the first pass returned
+   * `hold('busy')` and the drainer tick wrote a second byte-identical copy.
+   */
+  it('writes exactly once when the terminal never shows the header, and the drainer adds nothing', async () => {
+    const h = harness(); // echoVerified: false — the mirror never shows the header
+    const row = enqueue();
+
+    const out = await deliverAgentMail(h.ports, db, '/ws/a', 'spir-1');
+
+    expect(out).toEqual({ delivered: [row.id], reason: null, verified: false });
+    expect(h.writes).toEqual([FORMATTED]);
+    const stored = mailbox.getById(db, row.id);
+    expect(stored?.status).toBe('delivered');
+    expect(stored?.status).not.toBe('held');
+    expect(stored?.escalated).toBe(1);
+
+    // A real backstop tick, the thing that actually re-injected in the field.
+    const drainer = new MailboxDrainer({ intervalMs: 999_999 });
+    drainer.start(h.ports, db);
+    await drainer.tick();
+    await drainer.tick();
+    drainer.stop();
+
+    expect(h.writes).toEqual([FORMATTED]);
+  });
+
+  it('logs the unconfirmed delivery at WARN so an operator can find it after the fact', async () => {
+    const h = harness();
+    const row = enqueue();
+
+    await deliverAgentMail(h.ports, db, '/ws/a', 'spir-1');
+
+    const warn = h.logs.find((l) => l.level === 'WARN');
+    expect(warn).toBeDefined();
+    expect(warn?.message).toContain('delivered-unverified');
+    expect(warn?.message).toContain(row.id.slice(0, 8));
+    expect(warn?.message).toContain('spir-1');
+    expect(warn?.message).toContain(h.session.id);
+    // The needle length, so a too-short/mangled needle is diagnosable from the log alone.
+    expect(warn?.message).toContain(`${echoNeedle(FORMATTED).length} chars`);
+  });
+
+  it('spends at most two verify windows and writes no bytes between them', async () => {
+    // The extra window is the concession to a slow renderer. It must stay a LOOK, never a retry:
+    // an unbounded number of windows would just move the latency, and a re-write would restore
+    // the loop.
+    const h = harness();
+    enqueue();
+
+    await deliverAgentMail(h.ports, db, '/ws/a', 'spir-1');
+
+    expect(h.verifyCalls).toBe(2);
+    expect(h.writes).toHaveLength(1);
+  });
+
+  it('still broadcasts the delivery — the bytes did reach the PTY', async () => {
+    const h = harness();
+    enqueue();
+
+    await deliverAgentMail(h.ports, db, '/ws/a', 'spir-1');
+
+    expect(h.broadcasts).toHaveLength(1);
+    expect(h.broadcasts[0].to).toEqual({ project: 'a', agent: 'spir-1' });
+  });
+
+  it('leaves the verified path exactly as it was: delivered, verified, not flagged', async () => {
+    const h = harness();
+    h.echoVerified = true;
+    const row = enqueue();
+
+    const out = await deliverAgentMail(h.ports, db, '/ws/a', 'spir-1');
+
+    expect(out).toEqual({ delivered: [row.id], reason: null, verified: true });
+    expect(h.verifyCalls).toBe(1); // no second window when the first one confirms
+    expect(mailbox.getById(db, row.id)?.escalated).toBe(0);
+  });
+
+  it('a PRE-write hold still holds — this change touches nothing before the write', async () => {
+    const h = harness();
+    h.ports.classify = () => Promise.resolve({ clean: false, reason: 'busy', detail: 'user-text' });
+    const row = enqueue();
+
+    const out = await deliverAgentMail(h.ports, db, '/ws/a', 'spir-1');
+
+    expect(out.delivered).toEqual([]);
+    expect(h.writes).toEqual([]);
+    expect(mailbox.getById(db, row.id)?.status).toBe('held');
+  });
+
+  /**
+   * The field trigger, against the REAL screen mirror rather than a boolean: the recipient
+   * starts responding at once, and its output pushes the header out of the retained buffer, so
+   * the post-write count is not greater than the pre-write one. On 3.3.2 this is the input that
+   * produced the loop; here it must produce one write and a flagged delivery.
+   */
+  it('an immediate responder that scrolls the header away is delivered once, not re-injected', async () => {
+    const screen = new SessionScreen(110, 32);
+    const needle = echoNeedle(FORMATTED);
+    const h = harness();
+    h.ports.watchEcho = (_s, n) => watchEchoOnScreen({ gateScreen: screen } as unknown as DeliverySession, n);
+    h.ports.writeMessage = (_s, formattedMessage, _noEnter, precheck): WriteResult => {
+      const abort: WriteAbort | null = precheck();
+      if (abort) return { status: 'aborted', abort };
+      h.writes.push(formattedMessage);
+      // The header is echoed, then the recipient's own response buries it past the mirror's
+      // retention before verification ever samples.
+      screen.feed(`❯ ${HEADER}\r\n`);
+      screen.feed(Array.from({ length: 2000 }, (_, i) => `assistant response line ${i}`).join('\r\n') + '\r\n');
+      return { status: 'written' };
+    };
+    const row = enqueue();
+
+    const out = await deliverAgentMail(h.ports, db, '/ws/a', 'spir-1');
+
+    expect(needle).not.toBe('');
+    expect(h.writes).toEqual([FORMATTED]);
+    expect(out.delivered).toEqual([row.id]);
+    expect(mailbox.getById(db, row.id)?.status).toBe('delivered');
+
+    const drainer = new MailboxDrainer({ intervalMs: 999_999 });
+    drainer.start(h.ports, db);
+    await drainer.tick();
+    drainer.stop();
+
+    expect(h.writes).toEqual([FORMATTED]);
+    screen.dispose();
+  });
+});

--- a/packages/codev/src/agent-farm/__tests__/bugfix-1584-no-rewrite-after-write.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-1584-no-rewrite-after-write.test.ts
@@ -29,6 +29,8 @@ import {
   type DeliveryPorts,
   type DeliverySession,
   type DeliveredBroadcast,
+  type LivenessInfo,
+  type UnverifiedDeliveryInfo,
   type WriteAbort,
   type WriteResult,
 } from '../servers/mailbox-delivery.js';
@@ -60,6 +62,12 @@ interface Harness {
   echoVerified: boolean;
   /** How many times a watch's `verify()` was consulted, across all watches. */
   verifyCalls: number;
+  /** Unverified-delivery notices raised through the port. */
+  notices: UnverifiedDeliveryInfo[];
+  /** Liveness escalations raised through the port (must stay empty — issue item 4). */
+  liveness: LivenessInfo[];
+  /** The row's DB status at the moment `verify()` was first consulted. */
+  statusAtVerify: string | undefined;
 }
 
 function harness(): Harness {
@@ -80,6 +88,9 @@ function harness(): Harness {
     writes: [],
     echoVerified: false,
     verifyCalls: 0,
+    notices: [],
+    liveness: [],
+    statusAtVerify: undefined,
     ports: {
       getSessionForAgent: () => h.session,
       resolveProfile: () => PROFILE,
@@ -100,7 +111,8 @@ function harness(): Harness {
       broadcast: (f) => h.broadcasts.push(f),
       onHeldStateChange: () => {},
       onEscalation: () => {},
-      onLiveness: () => {},
+      onLiveness: (info) => h.liveness.push(info),
+      onUnverifiedDelivery: (info) => h.notices.push(info),
       log: (message, level) => h.logs.push({ message, level }),
       now: () => NOW,
     },
@@ -212,6 +224,107 @@ describe('#1584 a completed write is never re-written', () => {
     expect(out.delivered).toEqual([]);
     expect(h.writes).toEqual([]);
     expect(mailbox.getById(db, row.id)?.status).toBe('held');
+  });
+
+  /**
+   * DURABILITY of the point of no return (CMAP round 1 — Codex). Committing the row only AFTER
+   * verification would leave it `held` for up to ~1.2 s: a Tower crash or restart inside that
+   * window, and the next drainer tick re-writes the message. The commit must therefore precede
+   * every await that follows the write, which this pins by reading the row's status from the
+   * database at the instant `verify()` is first consulted.
+   */
+  it('commits the row to delivered BEFORE it starts verifying', async () => {
+    const h = harness();
+    const row = enqueue();
+    h.ports.watchEcho = () =>
+      Promise.resolve({
+        verify: () => {
+          h.verifyCalls++;
+          h.statusAtVerify ??= mailbox.getById(db, row.id)?.status;
+          return Promise.resolve(false);
+        },
+      });
+
+    await deliverAgentMail(h.ports, db, '/ws/a', 'spir-1');
+
+    expect(h.statusAtVerify).toBe('delivered');
+  });
+
+  it('treats a verification that THROWS as unconfirmed, not as a delivery failure', async () => {
+    // A rejection used to propagate out of the delivery pass, leaving the row `held` — the same
+    // re-writable state the hold did. The bytes are already out, so the only honest answer is
+    // "could not confirm".
+    const h = harness();
+    h.ports.watchEcho = () =>
+      Promise.resolve({ verify: () => Promise.reject(new Error('screen read failed')) });
+    const row = enqueue();
+
+    const out = await deliverAgentMail(h.ports, db, '/ws/a', 'spir-1');
+
+    expect(out).toEqual({ delivered: [row.id], reason: null, verified: false });
+    const stored = mailbox.getById(db, row.id);
+    expect(stored?.status).toBe('delivered');
+    expect(stored?.escalated).toBe(1);
+    expect(h.logs.some((l) => l.level === 'WARN' && l.message.includes('screen read failed'))).toBe(true);
+
+    const drainer = new MailboxDrainer({ intervalMs: 999_999 });
+    drainer.start(h.ports, db);
+    await drainer.tick();
+    drainer.stop();
+
+    expect(h.writes).toEqual([FORMATTED]);
+  });
+
+  it('raises a human-visible notice, since a delivered row is invisible to every held surface', async () => {
+    // `afx inbox`, the held-count indicator and heldSummaryForWorkspace all filter on `held`, so
+    // the escalated flag alone reaches nobody. An interactive send learns this from
+    // `verified: false`; a cron or backstop delivery has no sender waiting (CMAP round 1 — Codex).
+    const h = harness();
+    const row = enqueue();
+
+    await deliverAgentMail(h.ports, db, '/ws/a', 'spir-1');
+
+    expect(h.notices).toEqual([
+      { workspacePath: '/ws/a', toAgent: 'spir-1', mailboxId: row.id, terminalId: 'term-1584' },
+    ]);
+    expect(mailbox.heldSummaryForWorkspace(db, '/ws/a', NOW).total).toBe(0);
+  });
+
+  it('raises no notice when verification confirms', async () => {
+    const h = harness();
+    h.echoVerified = true;
+    enqueue();
+
+    await deliverAgentMail(h.ports, db, '/ws/a', 'spir-1');
+
+    expect(h.notices).toEqual([]);
+  });
+
+  /**
+   * Issue item 4, confirmed rather than assumed. `isClassifierStuck` excludes `busy`, which is
+   * what kept the old loop silent. There is no longer a busy-hold after a completed write, so a
+   * repeated unverified delivery must never accumulate a streak or raise liveness telemetry —
+   * the reason is `null` on every pass, because every pass is a delivery.
+   */
+  it('never accumulates a not-clean streak for unverified deliveries', async () => {
+    const h = harness();
+    const drainer = new MailboxDrainer({ intervalMs: 999_999 });
+    drainer.start(h.ports, db);
+
+    for (let i = 0; i < 12; i++) {
+      mailbox.enqueue(
+        db,
+        { workspacePath: '/ws/a', toAgent: 'spir-1', body: `m${i}`, formattedMessage: FORMATTED },
+        NOW,
+      );
+      await drainer.tick();
+    }
+    drainer.stop();
+
+    // Twelve messages, twelve writes — one each, never a repeat.
+    expect(h.writes).toHaveLength(12);
+    // LIVENESS_STREAK_THRESHOLD is 10; a busy-hold streak would have crossed it by now.
+    expect(h.liveness).toEqual([]);
   });
 
   /**

--- a/packages/codev/src/agent-farm/__tests__/send.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/send.test.ts
@@ -253,6 +253,34 @@ describe('send command', () => {
       expect(successMessages.some((m) => m.includes('(1234 bytes)'))).toBe(true);
     });
 
+    it('says so when Tower could not confirm the message reached the terminal (Issue #1584)', async () => {
+      // Tower now records an unconfirmed delivery instead of re-writing it — re-writing is what
+      // re-injected one message dozens of times in #1583 — so this line is the ONLY place the
+      // sender learns the echo never came back.
+      mockSendMessage.mockResolvedValue({
+        ok: true, resolvedTo: 'builder-spir-109', bodyLength: 1234, verified: false,
+      });
+
+      await send({ builder: 'builder-spir-109', message: 'hi' });
+
+      const successMessages = vi.mocked(logger.success).mock.calls.map((c) => String(c[0]));
+      expect(successMessages.some((m) => m.includes('unverified — header not seen on the terminal'))).toBe(true);
+    });
+
+    it('prints the plain delivered line when verification confirmed or does not apply (Issue #1584)', async () => {
+      // `verified: true` and an absent field (older Tower, or a body with no header worth
+      // matching) must read exactly as they always did — the field is additive.
+      for (const extra of [{ verified: true }, {}]) {
+        vi.mocked(logger.success).mockClear();
+        mockSendMessage.mockResolvedValue({ ok: true, resolvedTo: 'builder-spir-109', bodyLength: 7, ...extra });
+
+        await send({ builder: 'builder-spir-109', message: 'hi' });
+
+        const successMessages = vi.mocked(logger.success).mock.calls.map((c) => String(c[0]));
+        expect(successMessages.some((m) => m === 'Message delivered to builder-spir-109 (7 bytes)')).toBe(true);
+      }
+    });
+
     it('throws on file not found', async () => {
       await expect(
         send({ builder: 'builder-spir-109', message: 'Test', file: '/tmp/missing.txt' }),

--- a/packages/codev/src/agent-farm/__tests__/tower-routes.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tower-routes.test.ts
@@ -1782,9 +1782,41 @@ describe('tower-routes', () => {
       expect(parsed.ok).toBe(true);
       expect(parsed.delivered).toBe(true);
       expect(parsed.deferred).toBe(false);
+      // Issue #1584: the terminal double echoes what is written to it, so the delivery is
+      // CONFIRMED and the sender is told so.
+      expect(parsed.verified).toBe(true);
       // Message SHOULD be written — user is idle (Bugfix #492)
       expect(mockWrite).toHaveBeenCalled();
     });
+
+    it('reports verified:false for a terminal that swallows the write (Issue #1584)', async () => {
+      // The #1583 loop: the write completes, the terminal never shows the header. Tower used to
+      // re-hold the row, and every later clean-prompt pass re-wrote the whole message. It is now
+      // recorded as delivered and the sender is told it could not be confirmed.
+      mockParseJsonBody.mockResolvedValue({ to: 'architect', message: 'hello', workspace: '/tmp/ws' });
+      mockResolveTarget.mockReturnValue({
+        terminalId: 'term-swallow', workspacePath: '/tmp/ws', agent: 'architect',
+      });
+      const mockWrite = vi.fn();
+      // Same double, minus the echo: every byte is accepted, nothing reaches the mirror.
+      const swallowing = {
+        ...gateSession(mockWrite, '❯ ', true, 'term-swallow'),
+        write: (data: string): boolean => { mockWrite(data); return true; },
+      };
+      mockGetTerminalManager.mockReturnValue({ getSession: () => swallowing, listSessions: () => [] });
+      const req = makeReq('POST', '/api/send');
+      const ctx = makeCtx();
+      const { res, statusCode, body } = makeRes();
+
+      await handleRequest(req, res, ctx);
+
+      expect(statusCode()).toBe(200);
+      const parsed = JSON.parse(body());
+      expect(parsed.delivered).toBe(true);
+      expect(parsed.held).toBe(false);
+      expect(parsed.verified).toBe(false);
+      expect(mockWrite).toHaveBeenCalled();
+    }, 10_000);
 
     it('a body-bearing interrupt that crosses the wait ceiling reports degraded (Issue #1365)', async () => {
       // codex review of PR #1492: the interrupt claims its mailbox row `delivered` BEFORE the

--- a/packages/codev/src/agent-farm/commands/send.ts
+++ b/packages/codev/src/agent-farm/commands/send.ts
@@ -399,7 +399,13 @@ export async function send(options: SendOptions): Promise<void> {
         // echo exists for (#1564: a ~1,900-char message arriving as its final ~30) all read as
         // an unqualified success at the sender.
         const size = result.bodyLength !== undefined ? ` (${result.bodyLength} bytes)` : '';
-        logger.success(`Message delivered to ${result.resolvedTo ?? target}${size}`);
+        // Issue #1584: say so when the bytes were accepted but the terminal never showed them.
+        // Tower records that row as delivered and does NOT re-write it — re-writing is what
+        // re-injected one message dozens of times in #1583 — so this line is the only place the
+        // sender learns the delivery was unconfirmed. `verified` absent (older Tower, or a body
+        // with no header worth matching) keeps today's wording.
+        const unverified = result.verified === false ? ' (unverified — header not seen on the terminal)' : '';
+        logger.success(`Message delivered to ${result.resolvedTo ?? target}${size}${unverified}`);
         // Issue #1365: an interrupt/escape that gave up waiting for the terminal's submission
         // lock wrote unserialized, so its bytes may have interleaved with the delivery it
         // skipped. The row is claimed `delivered` before the write (un-claiming would risk a

--- a/packages/codev/src/agent-farm/db/mailbox.ts
+++ b/packages/codev/src/agent-farm/db/mailbox.ts
@@ -282,6 +282,26 @@ export function markEscalated(db: Database.Database, id: string, now: number = D
 }
 
 /**
+ * Flag an already-DELIVERED row as escalated (Issue #1584) — visibility only, and the
+ * counterpart to {@link markEscalated} for the one case that flags a row *after* it has left
+ * the held set: a delivery whose write completed but whose echo never confirmed.
+ *
+ * A separate function rather than a relaxed guard on {@link markEscalated}, because that one's
+ * held-only contract is what makes the drainer's escalation pass safe to call blindly. Here the
+ * ordering is the point: the row is marked `delivered` FIRST (that commit is what makes the
+ * write un-repeatable even across a crash), so by the time the verdict is known the held-only
+ * guard would silently no-op and the flag would be lost.
+ *
+ * Delivered-only and idempotent (the `escalated = 0` guard). Returns true if it flipped.
+ */
+export function markEscalatedDelivered(db: Database.Database, id: string, now: number = Date.now()): boolean {
+  const info = db
+    .prepare("UPDATE mailbox SET escalated = 1, updated_at = ? WHERE id = ? AND status = 'delivered' AND escalated = 0")
+    .run(now, id);
+  return info.changes > 0;
+}
+
+/**
  * Supersede-key prefix for architect starvation notices (Spec 1313 round 3, change 3). A
  * notice row carries `${NOTICE_SUPERSEDE_PREFIX}<starving-agent>` so (a) one pending notice
  * per starving agent coalesces via {@link supersede}, and (b) notice rows are recognizable by

--- a/packages/codev/src/agent-farm/servers/mailbox-delivery.ts
+++ b/packages/codev/src/agent-farm/servers/mailbox-delivery.ts
@@ -44,6 +44,7 @@ import {
   pruneTerminal,
   findEscalatable,
   markEscalated,
+  markEscalatedDelivered,
   findStarvingAgents,
 } from '../db/mailbox.js';
 import type { DbMailbox, MailboxReason } from '../db/types.js';
@@ -232,11 +233,30 @@ export interface DeliveryPorts {
    *
    * DELIBERATELY NARROW: presence of the header line, nothing else. No screen diffing, no
    * repair, no per-harness branches. A negative therefore means "could not confirm", not
-   * "definitely lost" — so the caller HOLDS the row for the existing redelivery machinery
-   * rather than dropping it, making the direction of error a duplicate delivery instead of
-   * a silent loss.
+   * "definitely lost".
+   *
+   * What the caller does with a negative CHANGED in Issue #1584: it no longer holds the row for
+   * redelivery. The bytes are already out, so a redelivery is a re-injection — and because the
+   * residuals below recur for the same message every time, holding produced an unbounded loop
+   * (#1583). The row is committed as delivered, flagged `escalated`, and reported to the sender
+   * as `verified: false`. This watch is evidence for a REPORT, never a retry decision.
    */
   watchEcho(session: DeliverySession, needle: string): Promise<EchoWatch>;
+  /**
+   * Raise a human-visible notice for a delivery whose write completed but whose echo never
+   * confirmed (Issue #1584). The row is marked `delivered` + `escalated`, and a DELIVERED row
+   * is invisible to every held-scoped surface — `afx inbox`, the held-count indicator,
+   * `heldSummaryForWorkspace` — so without this the only trace of an unconfirmed delivery is a
+   * log line. That is fine for an interactive `afx send` (the sender gets `verified: false`)
+   * and not fine for a cron or backstop delivery, which has no sender waiting.
+   *
+   * Deliberately NOT `onEscalation`: that event means "held past the escalation age" and its
+   * binding says so in its title, which would be a false statement about a delivered row.
+   *
+   * Metadata only (no message body), per the spec's redaction rule. OPTIONAL, so unit fakes
+   * that do not exercise it may omit it.
+   */
+  onUnverifiedDelivery?(info: UnverifiedDeliveryInfo): void;
   /**
    * Tower log line. `level` defaults to `INFO`; the delivery path passes `WARN` for the one
    * case an operator must be able to find after the fact — a delivery whose echo never
@@ -275,6 +295,19 @@ export interface LivenessInfo {
   toAgent: string;
   /** Consecutive not-clean (`no-profile`) checks at the moment the streak crossed the threshold. */
   streak: number;
+}
+
+/**
+ * Metadata for a delivery that completed its write but could not be confirmed on the receiving
+ * terminal (Issue #1584). Ids and addresses only — no message body, per the spec's redaction
+ * rule — since this rides the SSE bus to the dashboard's notification surface.
+ */
+export interface UnverifiedDeliveryInfo {
+  workspacePath: string;
+  toAgent: string;
+  mailboxId: string;
+  /** The terminal the bytes were written to, for correlating against its transcript. */
+  terminalId: string;
 }
 
 /**
@@ -363,7 +396,10 @@ export interface EchoWatch {
   /**
    * Did the message's header appear on the terminal as a result of the write this watch was
    * opened for? Bounded — it waits a short interval and then answers false, which the caller
-   * treats as "could not confirm" and holds.
+   * treats as "could not confirm" and REPORTS (Issue #1584): the row is delivered and flagged,
+   * never re-written. Callable more than once; each call opens a fresh window against the same
+   * pre-write sample, and the delivery path uses a second one to give a slow renderer more time
+   * without putting a byte on the line.
    */
   verify(): Promise<boolean>;
 }
@@ -714,36 +750,16 @@ export async function deliverAgentMail(
   // composer under them). Only `written` reaches this line, and only `written` is the
   // at-least-once guarantee that forbids a re-write.
   //
-  // Echo verification (Issue #1573) still runs — it is the only end-to-end evidence the bytes
-  // reached the terminal — but its answer now decides what we TELL people, not whether we
-  // write again. `false` means "could not confirm", never "definitely lost": the honest
-  // response is to record the delivery, flag it, and say so to the sender.
-  let verified: boolean | undefined;
-  if (echo) {
-    // One bounded RE-verify window before giving up. `verify()` polls to its own deadline and
-    // then answers false; a second call opens a fresh window against the SAME pre-write sample,
-    // so it still requires evidence THIS write produced. It accommodates a slow renderer
-    // without writing a single byte, and the total stays inside the sender's patience (~1.5 s)
-    // because the request path awaits this.
-    verified = (await echo.verify()) || (await echo.verify());
-    if (!verified) {
-      // Not a hold — a flagged delivery. The `escalated` column is set while the row is still
-      // `held` (markEscalated is held-only) so it survives onto the delivered row, and the
-      // sender is told via `verified: false` in the send response.
-      markEscalated(db, row.id, ports.now());
-      ports.log(
-        `[mailbox] delivered-unverified ${row.id.slice(0, 8)}… → ${toAgent} @ ` +
-          `${path.basename(workspacePath)} (terminal ${session.id}, needle ${needle.length} chars): ` +
-          `the write completed but its header never appeared on the terminal. Recorded as ` +
-          `delivered and flagged — NOT re-written (Issue #1584).`,
-        'WARN',
-      );
-    }
-  }
-
-  // markDelivered is guarded (held→delivered only). If it did NOT transition, the row
-  // was dismissed/superseded during the paced write — accept that terminal state and
-  // do not broadcast a delivery for it.
+  // COMMIT THE DELIVERY FIRST, before any further await or fallible call (CMAP round 1 — Codex).
+  // The point of no return is only real if it is DURABLE: while the row still reads `held` in
+  // the database it is re-writable by the next drainer tick, so leaving it held across ~1.2 s of
+  // verification would reopen the loop for any interruption of that window — a Tower crash or
+  // restart, or a `verify()` that rejects instead of answering. `markDelivered` is synchronous
+  // (better-sqlite3), so ordering it here leaves no window at all.
+  //
+  // markDelivered is guarded (held→delivered only). If it did NOT transition, the row was
+  // dismissed/superseded during the paced write — accept that terminal state and do not
+  // broadcast a delivery for it.
   if (!markDelivered(db, row.id, ports.now())) {
     ports.onHeldStateChange();
     return { delivered: [], reason: null };
@@ -751,6 +767,51 @@ export async function deliverAgentMail(
   ports.broadcast(broadcastForRow(current, ports.now()));
   ports.onHeldStateChange(); // a held row left the set → refresh the indicator count
   ports.log(`[mailbox] delivered ${row.id} → ${toAgent} @ ${path.basename(workspacePath)}`);
+
+  // Echo verification (Issue #1573) still runs — it is the only end-to-end evidence the bytes
+  // reached the terminal — but it is now pure REPORTING, downstream of a delivery that is
+  // already committed. `false` means "could not confirm", never "definitely lost".
+  let verified: boolean | undefined;
+  if (echo) {
+    // One bounded RE-verify window before giving up. `verify()` polls to its own deadline and
+    // then answers false; a second call opens a fresh window against the SAME pre-write sample,
+    // so it still requires evidence THIS write produced. It accommodates a slow renderer
+    // without writing a single byte, and the total stays inside the sender's patience (~1.5 s)
+    // because the request path awaits this.
+    //
+    // A REJECTION is unconfirmed, not an error to propagate: the bytes are out and the row is
+    // committed, so throwing here would only deny the sender the `verified` answer and log a
+    // spurious delivery failure.
+    try {
+      verified = (await echo.verify()) || (await echo.verify());
+    } catch (err) {
+      verified = false;
+      ports.log(`[mailbox] echo verification errored for ${row.id.slice(0, 8)}…: ${String(err)}`, 'WARN');
+    }
+    if (!verified) {
+      // The row is already `delivered`, so this is the delivered-only counterpart of the
+      // drainer's held-only `markEscalated`.
+      markEscalatedDelivered(db, row.id, ports.now());
+      ports.log(
+        `[mailbox] delivered-unverified ${row.id.slice(0, 8)}… → ${toAgent} @ ` +
+          `${path.basename(workspacePath)} (terminal ${session.id}, needle ${needle.length} chars): ` +
+          `the write completed but its header never appeared on the terminal. Recorded as ` +
+          `delivered and flagged — NOT re-written (Issue #1584).`,
+        'WARN',
+      );
+      // Raise it where a human will see it. The sender's `verified: false` covers an
+      // interactive `afx send`, but a cron or backstop delivery has no sender waiting on a
+      // response, and a DELIVERED row is invisible to every held-scoped surface (`afx inbox`,
+      // the held-count indicator) — without this its only trace is a log line (CMAP round 1 —
+      // Codex).
+      ports.onUnverifiedDelivery?.({
+        workspacePath,
+        toAgent,
+        mailboxId: row.id,
+        terminalId: session.id,
+      });
+    }
+  }
   return { delivered: [row.id], reason: null, ...(verified === undefined ? {} : { verified }) };
 }
 

--- a/packages/codev/src/agent-farm/servers/mailbox-delivery.ts
+++ b/packages/codev/src/agent-farm/servers/mailbox-delivery.ts
@@ -216,8 +216,9 @@ export interface DeliveryPorts {
   /**
    * Begin watching for evidence that a message actually LANDS on the receiving terminal
    * (Issue #1573). Called with the normalized needle from {@link echoNeedle} immediately
-   * BEFORE the write; the returned {@link EchoWatch} is consulted after it and before
-   * `markDelivered`.
+   * BEFORE the write; the returned {@link EchoWatch} is consulted AFTER `markDelivered`
+   * (Issue #1584 — the delivery is committed first, so verification cannot leave the row in a
+   * re-writable state), and its answer becomes the `verified` report, not a retry decision.
    *
    * This is the only end-to-end evidence the delivery path has. Everything upstream of it
    * proves the bytes were QUEUED, never that the terminal absorbed them: `session.write`

--- a/packages/codev/src/agent-farm/servers/mailbox-delivery.ts
+++ b/packages/codev/src/agent-farm/servers/mailbox-delivery.ts
@@ -237,7 +237,12 @@ export interface DeliveryPorts {
    * a silent loss.
    */
   watchEcho(session: DeliverySession, needle: string): Promise<EchoWatch>;
-  log(message: string): void;
+  /**
+   * Tower log line. `level` defaults to `INFO`; the delivery path passes `WARN` for the one
+   * case an operator must be able to find after the fact — a delivery whose echo never
+   * confirmed (Issue #1584), which is recorded as delivered rather than re-written.
+   */
+  log(message: string, level?: 'INFO' | 'WARN'): void;
   now(): number;
 }
 
@@ -292,6 +297,19 @@ export interface DeliveryOutcome {
   delivered: string[];
   /** When nothing was delivered, why the agent's mail stays held; null if delivered or the mailbox was empty. */
   reason: MailboxReason | null;
+  /**
+   * Issue #1584: whether the delivered message's header was actually SEEN on the receiving
+   * terminal. Present only when a delivery happened AND the message had a needle worth
+   * matching ({@link echoNeedle}) — `true` when the echo confirmed, `false` when it did not.
+   * Absent means verification was skipped (a body with no distinctive first line) or nothing
+   * was delivered, and reads exactly as it did before this field existed.
+   *
+   * A `false` is "could not confirm", never "definitely lost". The row is delivered and
+   * flagged `escalated` either way, because a completed write must never be re-written — the
+   * #1573 hold-and-redeliver it replaces is what re-injected one message dozens of times
+   * (#1583). This field is how the sender is told, instead.
+   */
+  verified?: boolean;
   /**
    * The gate's internal detail when a `busy` hold came from the render-gate (Spec 1313
    * render-gate hardening) — telemetry only. Distinguishes a legitimately-occupied line
@@ -681,23 +699,46 @@ export async function deliverAgentMail(
     return hold(result.abort.reason);
   }
 
-  // The write completed — every byte, Enter included, was accepted by the session. That is
-  // still only proof the bytes were QUEUED (Issue #1573): `session.write` reports true whenever
-  // the socket object is connected, so a composer that ate the leading bytes (#1564) lands here
-  // looking identical to a clean delivery. Ask the screen before claiming success.
+  // THE POINT OF NO RETURN (Issue #1584). Past this line the write COMPLETED — every byte,
+  // Enter included, was accepted by the session — so the row is at-least-once delivered and
+  // must NEVER be written again. Nothing below may `hold(...)`: a hold puts the row back in
+  // the drainer's held set, and the next clean-prompt pass re-writes the WHOLE message with
+  // no attempt cap anywhere in this module. That is exactly what #1583 saw in the field —
+  // one `afx send --file` re-injected dozens of times, byte-identical, silently (a `busy`
+  // hold is excluded from {@link isClassifierStuck}, so no streak ever escalates it).
   //
-  // A `false` here is "could not confirm", so the row is HELD, not dropped: the existing
-  // redelivery machinery retries it on a later clean gate, and the escalation path already makes
-  // a row that never confirms visible. That inverts the failure this issue exists to remove —
-  // the worst case becomes a duplicate delivery the agent can see, instead of a silent loss the
-  // sender was told was a success.
-  if (echo && !(await echo.verify())) {
-    ports.log(
-      `[mailbox] write to ${toAgent} @ ${path.basename(workspacePath)} completed but its header ` +
-        `never appeared on the terminal — holding ${row.id.slice(0, 8)}… for redelivery rather ` +
-        `than reporting it delivered`,
-    );
-    return hold('busy');
+  // Only PRE-write prechecks may hold, and every hold above this point is one: the branches
+  // between the write and here wrote NOTHING (`contended`, `aborted`) or produced a write that
+  // cannot be trusted to have landed (`dropped` — bytes lost mid-pace to a dead socket;
+  // `preempted` — an unserialized operator submission may have cleared or truncated the
+  // composer under them). Only `written` reaches this line, and only `written` is the
+  // at-least-once guarantee that forbids a re-write.
+  //
+  // Echo verification (Issue #1573) still runs — it is the only end-to-end evidence the bytes
+  // reached the terminal — but its answer now decides what we TELL people, not whether we
+  // write again. `false` means "could not confirm", never "definitely lost": the honest
+  // response is to record the delivery, flag it, and say so to the sender.
+  let verified: boolean | undefined;
+  if (echo) {
+    // One bounded RE-verify window before giving up. `verify()` polls to its own deadline and
+    // then answers false; a second call opens a fresh window against the SAME pre-write sample,
+    // so it still requires evidence THIS write produced. It accommodates a slow renderer
+    // without writing a single byte, and the total stays inside the sender's patience (~1.5 s)
+    // because the request path awaits this.
+    verified = (await echo.verify()) || (await echo.verify());
+    if (!verified) {
+      // Not a hold — a flagged delivery. The `escalated` column is set while the row is still
+      // `held` (markEscalated is held-only) so it survives onto the delivered row, and the
+      // sender is told via `verified: false` in the send response.
+      markEscalated(db, row.id, ports.now());
+      ports.log(
+        `[mailbox] delivered-unverified ${row.id.slice(0, 8)}… → ${toAgent} @ ` +
+          `${path.basename(workspacePath)} (terminal ${session.id}, needle ${needle.length} chars): ` +
+          `the write completed but its header never appeared on the terminal. Recorded as ` +
+          `delivered and flagged — NOT re-written (Issue #1584).`,
+        'WARN',
+      );
+    }
   }
 
   // markDelivered is guarded (held→delivered only). If it did NOT transition, the row
@@ -710,7 +751,7 @@ export async function deliverAgentMail(
   ports.broadcast(broadcastForRow(current, ports.now()));
   ports.onHeldStateChange(); // a held row left the set → refresh the indicator count
   ports.log(`[mailbox] delivered ${row.id} → ${toAgent} @ ${path.basename(workspacePath)}`);
-  return { delivered: [row.id], reason: null };
+  return { delivered: [row.id], reason: null, ...(verified === undefined ? {} : { verified }) };
 }
 
 /**

--- a/packages/codev/src/agent-farm/servers/mailbox-wiring.ts
+++ b/packages/codev/src/agent-farm/servers/mailbox-wiring.ts
@@ -290,7 +290,8 @@ export function makeDeliveryPorts(log: LogFn): DeliveryPorts {
     // module's, re-run inside that lock.
     writeMessage: (session, msg, noEnter, precheck) => submitMessagePaced(session, msg, noEnter, precheck),
     // Issue #1573: the only end-to-end evidence that the bytes reached the terminal — opened
-    // before the write, consulted before the row is marked delivered.
+    // before the write. Issue #1584: consulted AFTER the row is marked delivered, because the
+    // commit is what makes a completed write un-repeatable; this only decides what we report.
     watchEcho: (session, needle) => watchEchoOnScreen(session, needle),
     broadcast: (frame) => broadcastDelivered(frame),
     onHeldStateChange: () => broadcastHeldStateChange(),

--- a/packages/codev/src/agent-farm/servers/mailbox-wiring.ts
+++ b/packages/codev/src/agent-farm/servers/mailbox-wiring.ts
@@ -189,6 +189,11 @@ export async function classifyAgentScreen(session: DeliverySession, profile: Gat
  * therefore slack for a loaded machine, not the expected cost — the common case returns on the
  * first read with no added latency. It is bounded because the `afx send` request path awaits
  * this before answering the sender.
+ *
+ * Issue #1584: the delivery path calls `verify()` at most TWICE (a second window for a slow
+ * renderer, no bytes written), so this constant is half the worst-case wait a sender sees —
+ * ~1.2 s. Raising it raises that, and the answer is no longer a retry decision: an unconfirmed
+ * delivery is recorded as delivered-unverified, never re-written.
  */
 const ECHO_VERIFY_TIMEOUT_MS = 600;
 const ECHO_VERIFY_POLL_MS = 50;
@@ -287,7 +292,7 @@ export function makeDeliveryPorts(log: LogFn): DeliveryPorts {
     onLiveness: (info) => surfaceLiveness(info, log),
     escalateHeldToOwner: (info) => escalateHeldToOwner(info, log),
     clearHeldOwnerNotice: (ws, agent) => clearHeldOwnerNotice(ws, agent),
-    log: (m) => log('INFO', m),
+    log: (m, level) => log(level ?? 'INFO', m),
     now: () => Date.now(),
   };
 }

--- a/packages/codev/src/agent-farm/servers/mailbox-wiring.ts
+++ b/packages/codev/src/agent-farm/servers/mailbox-wiring.ts
@@ -35,6 +35,7 @@ import {
   MailboxDrainer,
   normalizeForEcho,
   type EchoWatch,
+  type UnverifiedDeliveryInfo,
   type DeliveryPorts,
   type DeliverySession,
   type DeliveredBroadcast,
@@ -228,16 +229,21 @@ async function countEchoOnScreen(screen: SessionScreen, needle: string): Promise
  * A session with no mirror has produced no output and therefore cannot echo anything, so its
  * watch verifies `false` rather than passing.
  *
- * Known residuals, all of which fail in the SAFE direction (a redelivery, never a dropped
- * message), and none of which are designed around here:
+ * Known residuals — these are why a negative is "could not confirm", not "not delivered". Issue
+ * #1584: they are also why a negative must NOT trigger a redelivery. Each recurs for the same
+ * message on every attempt, so holding-and-rewriting on one of them is a loop that cannot
+ * converge — #1583 saw a message re-injected dozens of times on exactly the second one. The
+ * caller now commits the delivery and reports it unverified instead. None is designed around
+ * here; #1578 tracks smarter verification:
  *   - a harness on the ALTERNATE screen buffer has no scrollback, so a message longer than one
  *     viewport can scroll its header out of reach and never confirm. The agy profile boots into
  *     the alternate buffer and was not measurable here (unauthenticated).
  *   - a very long write can evict the pre-write copy from the 1000-line mirror, so the count
  *     comes back equal rather than greater and a genuine delivery reads as unconfirmed.
  *   - an unconfirmed delivery re-reads and re-normalizes the retained buffer once per poll
- *     while the `afx send` request waits. Bounded by the timeout, and off the happy path
- *     entirely — the measured case confirms on the first read.
+ *     while the `afx send` request waits. Bounded by the timeout (and by the delivery path's
+ *     two windows, ~1.2 s total), and off the happy path entirely — the measured case confirms
+ *     on the first read.
  */
 export async function watchEchoOnScreen(session: DeliverySession, needle: string): Promise<EchoWatch> {
   const screen = (session as PtySession).gateScreen;
@@ -290,6 +296,9 @@ export function makeDeliveryPorts(log: LogFn): DeliveryPorts {
     onHeldStateChange: () => broadcastHeldStateChange(),
     onEscalation: (info) => broadcastEscalation(info),
     onLiveness: (info) => surfaceLiveness(info, log),
+    // Issue #1584: an unconfirmed delivery is committed, not retried, so this notice is the
+    // only human-facing trace for a cron/backstop send with no sender waiting on a response.
+    onUnverifiedDelivery: (info) => surfaceUnverifiedDelivery(info),
     escalateHeldToOwner: (info) => escalateHeldToOwner(info, log),
     clearHeldOwnerNotice: (ws, agent) => clearHeldOwnerNotice(ws, agent),
     log: (m, level) => log(level ?? 'INFO', m),
@@ -432,6 +441,28 @@ function surfaceLiveness(info: LivenessInfo, log: LogFn): void {
     type: 'notification',
     title: 'Mailbox: delivery blocked (unrecognized app)',
     body: `${where} — its screen never classifies as a ready prompt, so held messages will not deliver. A classifier profile may need updating.`,
+    workspace: info.workspacePath,
+  });
+}
+
+/**
+ * Surface an unconfirmed delivery (Issue #1584) on the generic `notification` SSE channel that
+ * {@link surfaceLiveness} already uses — human title/body, no message body.
+ *
+ * Deliberately NOT the `mailbox-escalation` event: that one means "held past the escalation
+ * age", and saying that about a row we just delivered would be false. The wording here states
+ * exactly what is and is not known — the bytes went out, the screen never showed them, and it
+ * will not be sent again.
+ */
+function surfaceUnverifiedDelivery(info: UnverifiedDeliveryInfo): void {
+  const where = `${info.toAgent} @ ${path.basename(info.workspacePath)}`;
+  mailboxBroadcaster?.({
+    type: 'notification',
+    title: 'Mailbox: delivered but not confirmed on screen',
+    body:
+      `${where} — the message was written to terminal ${info.terminalId.slice(0, 8)}… and every byte was ` +
+      `accepted, but its header never appeared on that screen. It is recorded as delivered and will NOT ` +
+      `be sent again (mailbox id ${info.mailboxId.slice(0, 8)}…). Check the agent's transcript.`,
     workspace: info.workspacePath,
   });
 }

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -2223,11 +2223,15 @@ async function handleSend(
       mailboxId: row.id,
       reason: null,
       bodyLength,
-      // Additive (Issue #1584). Present only when this request's own delivery pass ran the echo
-      // check: `false` means the bytes were written and accepted but the header never appeared
-      // on the terminal — delivered, flagged, and NOT re-written. Absent (verification skipped,
-      // or another pass delivered the row) reads as it always did.
-      ...(outcome?.verified === undefined ? {} : { verified: outcome.verified }),
+      // Additive (Issue #1584). `false` means the bytes were written and accepted but the header
+      // never appeared on the terminal — delivered, flagged, and NOT re-written. Reported only
+      // when THIS row is the one our own pass delivered: a pass picks the agent's OLDEST held
+      // row, so without the id check a concurrent drainer delivery of this row could be
+      // reported with another message's verification. Absent (verification skipped, or someone
+      // else's pass delivered it) reads exactly as it did before this field existed.
+      ...(outcome?.delivered.includes(row.id) && outcome.verified !== undefined
+        ? { verified: outcome.verified }
+        : {}),
     });
     return;
   }

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -60,7 +60,7 @@ import {
 import type { PtySession } from '../../terminal/pty-session.js';
 import { writeMessageToSession, writeEscapeToSession } from './message-write.js';
 import { makeDeliveryPorts, getMailboxDrainer } from './mailbox-wiring.js';
-import { deliverAgentMailSerialized, type DeliveryPorts } from './mailbox-delivery.js';
+import { deliverAgentMailSerialized, type DeliveryOutcome, type DeliveryPorts } from './mailbox-delivery.js';
 import { deliverCronMail, CRON_SENDER, type CronDeliveryResult } from './cron-delivery.js';
 import {
   enqueue as enqueueMailbox,
@@ -2199,8 +2199,12 @@ async function handleSend(
     getSessionForAgent: (ws, agent) =>
       ws === result.workspacePath && agent === toAgent ? session : basePorts.getSessionForAgent(ws, agent),
   };
+  // Issue #1584: keep the outcome — it carries whether the delivered message's header was
+  // actually seen on the receiving terminal, which is the only thing the sender can act on now
+  // that an unconfirmed delivery is recorded rather than re-written.
+  let outcome: DeliveryOutcome | null = null;
   try {
-    await deliverAgentMailSerialized(ports, db, result.workspacePath, toAgent);
+    outcome = await deliverAgentMailSerialized(ports, db, result.workspacePath, toAgent);
   } catch (err) {
     // A gate/write error leaves the row HELD (markDelivered only runs on a
     // completed write); the backstop drainer will retry. Report held, not a 500.
@@ -2219,6 +2223,11 @@ async function handleSend(
       mailboxId: row.id,
       reason: null,
       bodyLength,
+      // Additive (Issue #1584). Present only when this request's own delivery pass ran the echo
+      // check: `false` means the bytes were written and accepted but the header never appeared
+      // on the terminal — delivered, flagged, and NOT re-written. Absent (verification skipped,
+      // or another pass delivered the row) reads as it always did.
+      ...(outcome?.verified === undefined ? {} : { verified: outcome.verified }),
     });
     return;
   }

--- a/packages/sdk/src/tower-client.ts
+++ b/packages/sdk/src/tower-client.ts
@@ -845,6 +845,15 @@ export class TowerClient {
      * Tower binaries.
      */
     bodyLength?: number;
+    /**
+     * Issue #1584: whether the delivered message's header was actually SEEN on the receiving
+     * terminal. `false` = the bytes were written and accepted, but the terminal never showed
+     * them — the message is recorded as delivered and flagged, and is deliberately NOT
+     * re-written (re-writing is what re-injected one message dozens of times in #1583).
+     * Absent = verification was skipped or does not apply; older Tower binaries omit it, and
+     * absent reads exactly as `true` always did.
+     */
+    verified?: boolean;
   }> {
     const result = await this.request<{
       ok: boolean;
@@ -859,6 +868,7 @@ export class TowerClient {
       degradedReason?: string;
       notBefore?: number;
       bodyLength?: number;
+      verified?: boolean;
     }>(
       '/api/send',
       {
@@ -897,6 +907,7 @@ export class TowerClient {
       degradedReason: result.data!.degradedReason,
       notBefore: result.data!.notBefore,
       bodyLength: result.data!.bodyLength,
+      verified: result.data!.verified,
     };
   }
 


### PR DESCRIPTION
## Summary

Hotfix for a 3.3.2 regression from #1573 (PR #1577). A failed echo-verification *after* a completed PTY write returned `hold('busy')`, so the drainer re-wrote the whole message on every later clean-prompt pass — with no attempt cap. #1583 saw one `afx send --file` re-injected into a builder's prompt dozens of times, byte-identical, silently.

A row whose write completed is at-least-once delivered and is now **never written again**.

Fixes #1584

## Root Cause

`mailbox-delivery.ts:694` (pre-fix). After `ports.writeMessage(...)` returned `{ status: 'written' }` — every byte and the trailing Enter accepted by the session — a `false` from `echo.verify()` re-held the row:

1. The row stayed `held`, so `MailboxDrainer.tick()` (1.5s backstop) and `scheduleDrain` re-ran `deliverAgentMail` for that agent, which performed a **full re-write** of `formatted_message`. No attempt counter exists anywhere in the module and the `mailbox` table has no attempts column.
2. `isClassifierStuck()` deliberately excludes `busy`, so the loop never reached liveness telemetry — it was invisible to the owner.
3. The field trigger is the *common* case, not the agy corner #1578 predicted: a recipient that starts responding immediately scrolls the header out of the 1000-line `SessionScreen` mirror (or a long write evicts the pre-write copy), so `countEchoOnScreen` never sees `count > before`. Verification fails → the message is re-injected → the recipient responds again. Self-sustaining. `afx interrupt` makes it worse: each interrupt is a fresh clean prompt, i.e. another pass.

The in-tree proof: the #1573 suite's "a row held by a failed verification is redelivered by the next pass" asserted `writes == [FORMATTED, FORMATTED]` — the loop was pinned as intended behaviour.

## Fix

Per the owner-approved design in the issue (zero re-writes). Verify-then-rewrite was the dangerous half of #1573; the honest half — settle-before-write, the 48KB cap, telling the sender when we could not verify — stays.

**The delivery is committed before it is verified.** `markDelivered` now runs immediately after `status === 'written'`, before any further `await` or fallible call. That ordering is the fix: while the row still reads `held` it is re-writable by the next drainer tick, so verifying first would leave a ~1.2s window in which a Tower crash/restart — or a `verify()` that *rejects* rather than answering — reopens the loop. `better-sqlite3` is synchronous, so committing here leaves no window at all.

Echo verification still runs — it remains the only end-to-end evidence the bytes reached the terminal — but it is now pure **reporting**, downstream of a committed delivery:

- one extra bounded `verify()` window (a second *look*, zero bytes written; ~1.2s total since `ECHO_VERIFY_TIMEOUT_MS` is 600) to accommodate a slow renderer;
- a rejection is caught and treated as unconfirmed, never propagated;
- still unconfirmed → `markEscalatedDelivered`, a `WARN` log tagged `delivered-unverified` carrying row id / to_agent / terminal id / needle length, and `verified: false` on the outcome;
- **plus a human-visible notice** via a new optional `DeliveryPorts.onUnverifiedDelivery` port. A *delivered* row is invisible to every held-scoped surface (`afx inbox`, `heldSummaryForWorkspace`, the held-count indicator), so the `escalated` flag alone reaches nobody — fine for an interactive `afx send`, which gets `verified: false`, and not fine for a cron or backstop delivery with no sender waiting. Its live binding rides the same generic `notification` SSE channel `surfaceLiveness` uses, with truthful wording; it is deliberately **not** `onEscalation`, whose title says "held past escalation age" and would be a false statement about a delivered row.

`db/mailbox.ts` gains a delivered-only `markEscalatedDelivered`: the commit-first ordering means the verdict is known only after the row has left `held`, where the existing held-only `markEscalated` would silently no-op. A separate function rather than a relaxed guard — held-only is what makes the drainer's escalation pass safe to call blindly.

`verified` is threaded additively onto the immediate-delivery response through `tower-routes.ts handleSend` → `sdk/tower-client.ts` → `commands/send.ts`, which prints `Message delivered to X (N bytes) (unverified — header not seen on the terminal)`. `verified: true` or absent prints today's line, so older clients are unaffected. It is reported only when *this request's own pass* delivered *this* row (a pass picks the agent's oldest held row).

**Audit of every `hold(...)` reachable after `submitMessagePaced` (issue item 3):** the verify site was the only one. `dropped` lost bytes mid-pace to a dead socket; `preempted` may have been cleared or truncated by an unserialized operator write; `contended`/`aborted` wrote nothing. None is a completed write, so all four may still hold — documented at the point-of-no-return comment. `cron-delivery.ts` shares `deliverAgentMailSerialized`, so there is no second verify site.

## Test Plan

- [x] Regression test added — `bugfix-1584-no-rewrite-after-write.test.ts`, **12 tests**.
  - **Control test**: a terminal that never shows the header → written **exactly once**, row ends `delivered` + `escalated` (never `held`), and two real `MailboxDrainer.tick()`s write nothing.
  - **Durability**: the row's DB status read at the instant `verify()` is first consulted is already `delivered`; and a `verify()` that **throws** yields `verified: false` with no second write.
  - **Immediate-responder simulation** against a REAL `SessionScreen`: the header is echoed, then buried under 2000 lines of the recipient's own response → written once, delivered, not re-injected.
  - **Issue item 4, confirmed rather than assumed**: twelve unverified deliveries in a row produce twelve writes and **zero** `onLiveness` calls (`LIVENESS_STREAK_THRESHOLD` is 10).
  - Plus the notice's contents, no-notice-when-confirmed, the WARN log, at-most-two verify windows, the delivery broadcast, the unchanged verified path, and a pre-write hold that must still hold.
  - Six of the original seven fail against the unmodified module at HEAD; three of the five added after review fail against the pre-review commit. Both verified by swapping the module back in and re-running.
- [x] The two #1573 tests that pinned hold-and-redeliver are **rewritten to the new contract, not deleted** — the scenario is unchanged, only the answer differs.
- [x] Route (`tower-routes.test.ts`) and CLI (`send.test.ts`) coverage for `verified`: `false` surfaces the unverified wording; `true` and absent print today's line.
- [x] Build passes (`pnpm build` in `packages/codev`, tsc clean).
- [x] All tests pass — **5377 passed, 0 failed, 48 skipped** across 273 files. (Note for reviewers: a fresh worktree fails 12 files until `pnpm install` + `pnpm build` materializes `packages/codev/skeleton/`; I confirmed those failures are identical at HEAD before building.)
- [x] CI green — 7/7 checks.
- [ ] Field verification before close (architect-driven, post-release): a long `--file` send to a builder that responds immediately → exactly one copy in its transcript.

## Review

Two CMAP rounds. Round 1: gemini=APPROVE, codex=REQUEST_CHANGES, claude=COMMENT — every finding was real and fixed rather than rebutted. Codex caught that the point of no return was not *durable* (the row stayed held across verification; my item-3 audit had looked for `hold(...)` calls and missed the throw path) and that the `escalated` flag reached no human surface. Claude caught three doc blocks that still asserted the **inverted** safety property — `watchEcho`, `EchoWatch.verify` and `watchEchoOnScreen` all still said a negative means "hold for redelivery, a duplicate rather than a silent loss", when those very residuals are the #1583 trigger.

Round 2 after the fixes: gemini=APPROVE, codex=COMMENT (stale PR body + two stale comments — this body is the rewrite, and both comments are fixed), claude pending at time of writing.

## Release

Per the issue: hotfix release **3.3.3 to `@latest`** immediately on merge. This **supersedes the residual recorded in #1578**, which stays open as the "smarter verification" follow-up (scrolled-header tolerance, agy measurement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VS5Pk5bRniMHMJreVZYvsN