### PR TITLE
[Bugfix #1584] records: post-merge porch bookkeeping

### DIFF
--- a/codev/projects/bugfix-1584-tower-hotfix-echo-verify-re-wr/status.yaml
+++ b/codev/projects/bugfix-1584-tower-hotfix-echo-verify-re-wr/status.yaml
@@ -13,10 +13,12 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-02T14:02:15.761Z'
-updated_at: '2026-09-02T16:14:25.530Z'
+updated_at: '2026-09-02T16:14:27.827Z'
 pr_ready_for_human: false
 pr_history:
   - phase: verified
     pr_number: 1585
     branch: builder/bugfix-1584
     created_at: '2026-09-02T16:14:25.529Z'
+    merged: true
+    merged_at: '2026-09-02T16:14:27.826Z'

--- a/codev/projects/bugfix-1584-tower-hotfix-echo-verify-re-wr/status.yaml
+++ b/codev/projects/bugfix-1584-tower-hotfix-echo-verify-re-wr/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1584
 title: tower-hotfix-echo-verify-re-wr
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,5 +13,5 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-02T14:02:15.761Z'
-updated_at: '2026-09-02T16:14:11.495Z'
+updated_at: '2026-09-02T16:14:16.873Z'
 pr_ready_for_human: false

--- a/codev/projects/bugfix-1584-tower-hotfix-echo-verify-re-wr/status.yaml
+++ b/codev/projects/bugfix-1584-tower-hotfix-echo-verify-re-wr/status.yaml
@@ -6,11 +6,12 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-09-02T14:33:45.499Z'
+    approved_at: '2026-09-02T16:14:11.494Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-02T14:02:15.761Z'
-updated_at: '2026-09-02T14:33:45.500Z'
-pr_ready_for_human: true
+updated_at: '2026-09-02T16:14:11.495Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1584-tower-hotfix-echo-verify-re-wr/status.yaml
+++ b/codev/projects/bugfix-1584-tower-hotfix-echo-verify-re-wr/status.yaml
@@ -13,5 +13,10 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-02T14:02:15.761Z'
-updated_at: '2026-09-02T16:14:16.873Z'
+updated_at: '2026-09-02T16:14:25.530Z'
 pr_ready_for_human: false
+pr_history:
+  - phase: verified
+    pr_number: 1585
+    branch: builder/bugfix-1584
+    created_at: '2026-09-02T16:14:25.529Z'


### PR DESCRIPTION
The status.yaml bookkeeping commits porch wrote after PR #1585 (re-injection loop hotfix) merged — stranded on the builder branch by construction (#1367 pattern). No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbysMBdkFuycRE3vun3AE6