### PR TITLE
Fix #1586: stamp Host + local key on tunnel-proxied requests

### DIFF
--- a/codev/projects/bugfix-1586-tower-cloud-proxied-requests-a/status.yaml
+++ b/codev/projects/bugfix-1586-tower-cloud-proxied-requests-a/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1586
 title: tower-cloud-proxied-requests-a
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-02T16:15:15.952Z'
-updated_at: '2026-09-02T16:17:12.072Z'
+updated_at: '2026-09-02T16:21:23.618Z'

--- a/codev/projects/bugfix-1586-tower-cloud-proxied-requests-a/status.yaml
+++ b/codev/projects/bugfix-1586-tower-cloud-proxied-requests-a/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1586
+title: tower-cloud-proxied-requests-a
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-09-02T16:15:15.952Z'
+updated_at: '2026-09-02T16:15:15.953Z'

--- a/codev/projects/bugfix-1586-tower-cloud-proxied-requests-a/status.yaml
+++ b/codev/projects/bugfix-1586-tower-cloud-proxied-requests-a/status.yaml
@@ -11,4 +11,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-02T16:15:15.952Z'
-updated_at: '2026-09-02T16:21:23.618Z'
+updated_at: '2026-09-02T16:27:48.391Z'
+pr_history:
+  - phase: pr
+    pr_number: 1588
+    branch: builder/bugfix-1586
+    created_at: '2026-09-02T16:27:48.390Z'

--- a/codev/projects/bugfix-1586-tower-cloud-proxied-requests-a/status.yaml
+++ b/codev/projects/bugfix-1586-tower-cloud-proxied-requests-a/status.yaml
@@ -7,13 +7,15 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-09-02T16:27:50.680Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-02T16:15:15.952Z'
-updated_at: '2026-09-02T16:27:48.391Z'
+updated_at: '2026-09-02T16:27:50.681Z'
 pr_history:
   - phase: pr
     pr_number: 1588
     branch: builder/bugfix-1586
     created_at: '2026-09-02T16:27:48.390Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1586-tower-cloud-proxied-requests-a/status.yaml
+++ b/codev/projects/bugfix-1586-tower-cloud-proxied-requests-a/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1586
 title: tower-cloud-proxied-requests-a
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-02T16:15:15.952Z'
-updated_at: '2026-09-02T16:15:15.953Z'
+updated_at: '2026-09-02T16:17:12.072Z'

--- a/codev/resources/arch.md
+++ b/codev/resources/arch.md
@@ -1996,6 +1996,8 @@ consult -m claude spec 42
 
 **Complementary controls that predate the key** (still in force): `/api/tunnel/*` rejects tunnel-borne requests outright (PR #1374), and `via=tunnel/local` attribution logs every proxied request. The cloud edge (codevos.ai) still owns *remote user* authentication; the local key authenticates *local* actors to their own Tower.
 
+**Tunnel-borne requests are stamped local** (#1586, PR #1588): `TunnelClient` runs inside the Tower process and is itself a local actor, so it strips any inbound `Host`, key, or proxy-marker headers from cloud-proxied requests and stamps `Host: localhost:<port>`, the tunnel marker, and the local key. The key check stays the single choke point (no tunnel exemption, `/api/tunnel/*` refusal unchanged), and the remote browser, once past cloud-edge auth, receives the same injected local key a local browser does; per-session scoping/revocation is tracked in #1589.
+
 > **Superseded ruling** (issue #1375, 2026-08-09): Tower briefly had an explicit no-internal-auth-by-design position — localhost binding as the local boundary, the cloud edge as the remote one. Security advisory GHSA-xvjp-7748-v88v reversed it nine days later: localhost binding proves same-*machine*, not same-actor, and any local process could reach every management route. The key model above is the current authority; the trust boundary honesty to preserve is that browser-path key delivery still relaxes "same user" to "same machine reaching loopback."
 
 ## Integration Points

--- a/codev/state/bugfix-1586_thread.md
+++ b/codev/state/bugfix-1586_thread.md
@@ -1,0 +1,112 @@
+# bugfix-1586 — tower: cloud-proxied requests are 401'd
+
+Issue #1586. Second half of the #1421 regression (Tower API auth, 3.3.1).
+First half was the OAuth callback (#1570, fixed in 3.3.2); this half is every
+request arriving *through* the tunnel.
+
+## INVESTIGATE (2026-09-02)
+
+### Reproduced against the live local Tower (:4100)
+
+| Request | Result |
+|---|---|
+| `GET /` — Host localhost, no key | 200 (public dashboard shell) |
+| `GET /` — `Host: cloud.codevos.ai`, no key | **401** |
+| `GET /api/state` — Host localhost, + key | 404 (route absent in this build; auth passed) |
+| `GET /api/state` — `Host: cloud.codevos.ai`, + key | **401** |
+| `GET /api/projects` — Host localhost, no key | **401** |
+
+Both failure modes from the issue reproduce independently: the Host guard
+rejects `cloud.codevos.ai` even *with* a valid key, and keyed routes reject a
+request that carries no key even *with* an allowed Host. So both must be fixed;
+neither alone unblocks cloud access.
+
+### Root cause (confirmed in code)
+
+`packages/codev/src/agent-farm/lib/tunnel-client.ts`
+
+1. **`proxyHttpRequest` (:809–:830) forwards `Host` verbatim.** The header loop
+   copies every non-pseudo, non-hop-by-hop inbound header into the localhost
+   `http.request`, including `host: cloud.codevos.ai`. `isAllowedHost()`
+   (`utils/server-utils.ts:269`) accepts only loopback hostnames, configured
+   `CODEV_TOWER_ALLOWED_ORIGINS` hostnames, and (bridge mode) IP literals — so
+   it rejects the cloud authority, and `isRequestAllowed()` (:310) runs that
+   guard *before* the public-route allowlist, which is why even `GET /` 401s.
+
+   The comment on `handleWebSocketConnect` (:737–:741) claiming "the HTTP proxy
+   path already lets Node default Host to localhost" is false: Node only
+   defaults `Host` when no `host` header is supplied, and the cloud edge always
+   supplies one.
+
+2. **No local key is stamped.** `stampProxyMarker` (:87) stamps only
+   `x-codev-tunnel-proxy`. Tower gives that marker no auth exemption — it is
+   used solely for `/api/tunnel/*` refusal and log attribution
+   (`servers/tower-tunnel.ts:319`, `describeSource`). So every keyed route 401s
+   even once Host is fixed.
+
+Trust model is unchanged (arch.md §Tower API Authentication): the cloud edge
+authenticates the remote *user*; the local key authenticates *local actors*.
+`TunnelClient` runs inside the Tower process — it is a local actor and
+legitimately holds the key.
+
+### Fix shape (as prescribed in the issue)
+
+In `tunnel-client.ts`, extend the existing stamp helper so Host + marker + key
+cannot drift:
+
+1. Drop any inbound `host`; set `Host: localhost:<localPort>`.
+2. Strip any inbound `codev-tower-key` / legacy `codev-web-key` (anti-forgery,
+   same pattern as `stampProxyMarker`), then stamp `getExpectedKey()` from
+   `utils/server-utils.ts` (shares Tower's cache, honours `CODEV_TOWER_KEY`).
+   No import cycle: server-utils imports only `codev-core/auth` + `codev-types`.
+3. Fix the misleading WS-path comment; pin that the browser's
+   `Sec-WebSocket-Protocol: codev-key.<KEY>` subprotocol survives the
+   H2 CONNECT → localhost upgrade.
+4. Leave the `/api/tunnel/*` refusal untouched — the key stamp must not let a
+   cloud actor reach management routes.
+
+### Scope
+
+Well inside BUGFIX: one helper + two call sites in one file, plus tests. Tests
+go in `__tests__/tunnel-edge-cases.test.ts`, whose echo server already reflects
+request headers back (existing marker tests use it), and `helpers/mock-tunnel-server.ts`
+already supports per-request headers and `sendConnect`.
+
+<signal>PHASE_COMPLETE</signal>
+
+## FIX (2026-09-02)
+
+`stampProxyMarker` → `stampLocalHeaders(headers, localPort)` in
+`lib/tunnel-client.ts`. It now owns four headers outright — strips any inbound
+copy of `host`, `codev-tower-key`, `codev-web-key`, `x-codev-tunnel-proxy`,
+then stamps `Host: localhost:<port>`, the marker, and `getExpectedKey()`. Fails
+closed: no readable key → no key header → Tower rejects, as before.
+
+Both proxy paths call it. The WS path loses its hand-rolled Host handling (the
+shared helper does it) and its false comment about Node defaulting Host.
+
+**Only 46 insertions / 13 deletions in one file.** No Tower-side exemption was
+added — the key check stays the single choke point, and `/api/tunnel/*` refusal
+is untouched (asserted in both root and workspace-scoped forms).
+
+### Regression tests — `__tests__/bugfix-1586-tunnel-auth.test.ts`
+
+Runs the **real `isRequestAllowed`** in the local server rather than an echo
+server, so authorization is pinned end-to-end.
+
+| Test | pre-fix | post-fix |
+|---|---|---|
+| keyed `/api/state` with cloud Host, no key | FAIL 401 | PASS 200 |
+| public `/` with cloud Host | FAIL 401 | PASS 200 |
+| forged key/legacy-key/marker replaced not forwarded | FAIL 401 | PASS 200 |
+| `/api/tunnel/disconnect` + workspace-scoped form still 403 | PASS | PASS |
+| browser `codev-key.<KEY>` subprotocol survives H2 CONNECT | PASS | PASS |
+
+3 of 5 fail without the fix. The last two are invariant pins (per issue items
+3 and 4), expected green both ways.
+
+Gotcha: an H2 CONNECT stream rejects a `host` header (`NGHTTP2_PROTOCOL_ERROR`)
+— authority travels as `:authority` there. Noted in the test.
+
+Worktree had no `node_modules`; `pnpm install --frozen-lockfile` plus building
+`codev-types`/`codev-core` was needed before vitest could resolve imports.

--- a/codev/state/bugfix-1586_thread.md
+++ b/codev/state/bugfix-1586_thread.md
@@ -110,3 +110,19 @@ Gotcha: an H2 CONNECT stream rejects a `host` header (`NGHTTP2_PROTOCOL_ERROR`)
 
 Worktree had no `node_modules`; `pnpm install --frozen-lockfile` plus building
 `codev-types`/`codev-core` was needed before vitest could resolve imports.
+
+## CMAP (2026-09-02) — 3× APPROVE, HIGH confidence
+
+gemini APPROVE · codex APPROVE · claude APPROVE. No blocking issues from any
+lane. Claude raised three non-blocking items, all addressed:
+
+- **Per-session remote credential** — filed as #1589 (the follow-up the issue
+  itself designates as out of scope, cc @amrmelsayed).
+- **Fail-closed branch untested** — added a sixth test: with `ensureLocalKey`
+  throwing, the local server sees the request with *no* `codev-tower-key` and a
+  localhost Host, and rejects it 401. This pins that the forged inbound key is
+  stripped even when we have nothing to stamp in its place — the branch the
+  commit message claims but nothing previously exercised.
+- **Branch behind main** — merged `origin/main` (porch records only, no code).
+
+CI on PR #1588: all 7 checks green.

--- a/packages/codev/src/agent-farm/__tests__/bugfix-1586-tunnel-auth.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-1586-tunnel-auth.test.ts
@@ -23,6 +23,7 @@ vi.mock('@cluesmith/codev-core/auth', () => ({
 }));
 
 import { isRequestAllowed, resetExpectedKeyCache } from '../utils/server-utils.js';
+import { ensureLocalKey } from '@cluesmith/codev-core/auth';
 
 /** The public authority the cloud edge puts on tunnel-borne requests. */
 const CLOUD_HOST = 'cloud.codevos.ai';
@@ -53,8 +54,9 @@ async function stopServer(server: http.Server): Promise<void> {
  * `/api/state` is a keyed route; `/` is on the public allowlist but still
  * subject to the Host guard.
  */
-function createGuardedServer(): http.Server {
+function createGuardedServer(seen?: http.IncomingHttpHeaders[]): http.Server {
   return http.createServer((req, res) => {
+    seen?.push(req.headers);
     if (!isRequestAllowed(req)) {
       res.writeHead(401, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unauthorized', host: req.headers.host }));
@@ -72,6 +74,7 @@ describe('#1586 tunnel-borne request authentication', () => {
 
   beforeEach(() => {
     resetExpectedKeyCache();
+    (ensureLocalKey as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => TEST_KEY);
   });
 
   afterEach(async () => {
@@ -136,6 +139,28 @@ describe('#1586 tunnel-borne request authentication', () => {
     expect(body.headers['codev-tower-key']).toBe(TEST_KEY);
     expect(body.headers['codev-web-key']).toBeUndefined();
     expect(body.headers['x-codev-tunnel-proxy']).toBe('1');
+  });
+
+  it('fails closed when no local key is readable — strips the forged key and stamps none', async () => {
+    (ensureLocalKey as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('~/.agent-farm is unwritable');
+    });
+    const seen: http.IncomingHttpHeaders[] = [];
+
+    await connect(createGuardedServer(seen));
+
+    const response = await mockServer.sendRequest({
+      path: '/api/state',
+      headers: { host: CLOUD_HOST, 'codev-tower-key': 'forged-key' },
+    });
+
+    // The request still reaches the local server, but unkeyed — so Tower rejects
+    // it, exactly as it did before this stamp existed. What must never happen is
+    // the cloud side's forged key surviving into the local request.
+    expect(seen).toHaveLength(1);
+    expect(seen[0]['codev-tower-key']).toBeUndefined();
+    expect(seen[0].host).toMatch(/^localhost:\d+$/);
+    expect(response.status).toBe(401);
   });
 
   it('still refuses tunnel management endpoints, keyed or not', async () => {

--- a/packages/codev/src/agent-farm/__tests__/bugfix-1586-tunnel-auth.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-1586-tunnel-auth.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Regression: #1586 — cloud-proxied requests are 401'd by the local Tower.
+ *
+ * Second half of the #1421 auth regression. A request arriving through the
+ * tunnel carried the cloud edge's `Host: cloud.codevos.ai` verbatim and no
+ * local key, so Tower rejected it twice over: the Host guard runs even ahead
+ * of the public-route allowlist (so `GET /` 401s too), and every keyed route
+ * has no key to check.
+ *
+ * These tests run the REAL `isRequestAllowed` in the local server, so they pin
+ * authorization end-to-end rather than merely asserting header shapes.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import http from 'node:http';
+import { MockTunnelServer } from './helpers/mock-tunnel-server.js';
+import { TunnelClient } from '../lib/tunnel-client.js';
+
+const TEST_KEY = 'b'.repeat(64);
+
+vi.mock('@cluesmith/codev-core/auth', () => ({
+  ensureLocalKey: vi.fn(() => TEST_KEY),
+  readLocalKey: vi.fn(() => TEST_KEY),
+}));
+
+import { isRequestAllowed, resetExpectedKeyCache } from '../utils/server-utils.js';
+
+/** The public authority the cloud edge puts on tunnel-borne requests. */
+const CLOUD_HOST = 'cloud.codevos.ai';
+
+async function waitFor(fn: () => boolean, timeoutMs = 5000): Promise<void> {
+  const start = Date.now();
+  while (!fn()) {
+    if (Date.now() - start > timeoutMs) throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
+async function startServer(server: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (addr && typeof addr !== 'string') resolve(addr.port);
+    });
+  });
+}
+
+async function stopServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+/**
+ * A stand-in for Tower: enforces the real auth guard, then echoes what it saw.
+ * `/api/state` is a keyed route; `/` is on the public allowlist but still
+ * subject to the Host guard.
+ */
+function createGuardedServer(): http.Server {
+  return http.createServer((req, res) => {
+    if (!isRequestAllowed(req)) {
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Unauthorized', host: req.headers.host }));
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ path: req.url, headers: req.headers }));
+  });
+}
+
+describe('#1586 tunnel-borne request authentication', () => {
+  let mockServer: MockTunnelServer;
+  let localServer: http.Server;
+  let client: TunnelClient;
+
+  beforeEach(() => {
+    resetExpectedKeyCache();
+  });
+
+  afterEach(async () => {
+    if (client) client.disconnect();
+    if (mockServer) await mockServer.stop();
+    if (localServer) await stopServer(localServer);
+    vi.restoreAllMocks();
+  });
+
+  async function connect(server: http.Server): Promise<void> {
+    localServer = server;
+    const localPort = await startServer(server);
+    mockServer = new MockTunnelServer();
+    const port = await mockServer.start();
+    client = new TunnelClient({
+      serverUrl: `http://127.0.0.1:${port}`,
+      apiKey: 'ctk_test_key',
+      towerId: '',
+      localPort,
+    });
+    client.connect();
+    await waitFor(() => client.getState() === 'connected');
+  }
+
+  it('authorizes a keyed API route that arrives with the cloud Host and no key', async () => {
+    await connect(createGuardedServer());
+
+    const response = await mockServer.sendRequest({
+      path: '/api/state',
+      headers: { host: CLOUD_HOST },
+    });
+
+    expect(response.status).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.headers.host).toMatch(/^localhost:\d+$/);
+    expect(body.headers['codev-tower-key']).toBe(TEST_KEY);
+  });
+
+  it('authorizes the public dashboard shell, which the Host guard also rejected', async () => {
+    await connect(createGuardedServer());
+
+    const response = await mockServer.sendRequest({ path: '/', headers: { host: CLOUD_HOST } });
+
+    expect(response.status).toBe(200);
+  });
+
+  it('replaces a key forged by the cloud side rather than passing it through', async () => {
+    await connect(createGuardedServer());
+
+    const response = await mockServer.sendRequest({
+      path: '/api/state',
+      headers: {
+        host: CLOUD_HOST,
+        'codev-tower-key': 'forged-key',
+        'codev-web-key': 'forged-legacy-key',
+        'x-codev-tunnel-proxy': 'forged-marker',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.headers['codev-tower-key']).toBe(TEST_KEY);
+    expect(body.headers['codev-web-key']).toBeUndefined();
+    expect(body.headers['x-codev-tunnel-proxy']).toBe('1');
+  });
+
+  it('still refuses tunnel management endpoints, keyed or not', async () => {
+    await connect(createGuardedServer());
+
+    const enc = Buffer.from('/Users/me/proj').toString('base64url');
+    for (const path of ['/api/tunnel/disconnect', `/workspace/${enc}/api/tunnel/disconnect`]) {
+      const response = await mockServer.sendRequest({
+        method: 'POST',
+        path,
+        headers: { host: CLOUD_HOST },
+      });
+      expect(response.status).toBe(403);
+      expect(JSON.parse(response.body).error).toContain('local-only');
+    }
+  });
+
+  it('forwards the browser codev-key subprotocol untouched through the WebSocket upgrade', async () => {
+    let seen: http.IncomingHttpHeaders = {};
+    const sockets: import('node:net').Socket[] = [];
+    const wsServer = http.createServer();
+    wsServer.on('upgrade', (req, socket) => {
+      seen = req.headers;
+      sockets.push(socket);
+      socket.write('HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n');
+      socket.resume();
+      socket.on('error', () => {});
+    });
+
+    try {
+      await connect(wsServer);
+
+      // HTTP/2 CONNECT carries the authority as `:authority`, not a `host`
+      // header — Node rejects the latter on a CONNECT stream.
+      const stream = mockServer.sendConnect('/ws/terminal/test', {
+        'sec-websocket-protocol': `codev-key.${TEST_KEY}`,
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        stream.on('response', (headers) => {
+          expect(headers[':status']).toBe(200);
+          resolve();
+        });
+        stream.on('error', reject);
+        setTimeout(() => reject(new Error('CONNECT timeout')), 5000);
+      });
+
+      // The key travels in the subprotocol offer, which is what `isWebSocketAllowed`
+      // reads — it must survive the H2 CONNECT → localhost upgrade verbatim.
+      expect(seen['sec-websocket-protocol']).toBe(`codev-key.${TEST_KEY}`);
+      expect(seen.host).toMatch(/^localhost:\d+$/);
+      stream.destroy();
+    } finally {
+      for (const s of sockets) if (!s.destroyed) s.destroy();
+    }
+  });
+});

--- a/packages/codev/src/agent-farm/lib/tunnel-client.ts
+++ b/packages/codev/src/agent-farm/lib/tunnel-client.ts
@@ -17,6 +17,8 @@ import https from 'node:https';
 import { Duplex } from 'node:stream';
 import { URL } from 'node:url';
 import WebSocket, { createWebSocketStream } from 'ws';
+import { TOWER_KEY_HEADER, LEGACY_WEB_KEY_HEADER } from '@cluesmith/codev-types';
+import { getExpectedKey } from '../utils/server-utils.js';
 import { backoffDelayMs } from './reconnect-backoff.js';
 
 export interface TunnelClientOptions {
@@ -83,12 +85,46 @@ const BLOCKED_PATH_SEGMENT = /(^|\/)api\/tunnel\//;
  */
 export const TUNNEL_PROXY_HEADER = 'x-codev-tunnel-proxy';
 
-/** Strip any caller-supplied proxy marker, then stamp our own. */
-function stampProxyMarker(headers: Record<string, string | string[]>): void {
+/**
+ * Headers this client owns outright: whatever the cloud side sent under these
+ * names is dropped before ours is stamped, so none of them can be forged or
+ * suppressed from outside (#1586).
+ */
+const CLIENT_OWNED_HEADERS = new Set([
+  TUNNEL_PROXY_HEADER,
+  TOWER_KEY_HEADER,
+  LEGACY_WEB_KEY_HEADER,
+  'host',
+]);
+
+/**
+ * Rewrite the headers of a tunnel-borne request into what a *local* caller
+ * would have sent (#1586).
+ *
+ * Tower authenticates local actors with the shared local key and rejects any
+ * `Host` outside its allowlist (advisory GHSA-xvjp-7748-v88v). A request that
+ * arrives through the tunnel carries the cloud edge's `Host` and no key, so
+ * without this it is rejected twice over — the Host guard runs even ahead of
+ * the public-route allowlist, so every page 401s too, not just the API.
+ *
+ * The cloud edge has already authenticated the remote user; `TunnelClient`
+ * runs inside the Tower process and is itself a local actor, so it
+ * legitimately holds the key. Host, key and proxy marker are stamped together
+ * here so the three can never drift apart.
+ */
+function stampLocalHeaders(
+  headers: Record<string, string | string[]>,
+  localPort: number
+): void {
   for (const key of Object.keys(headers)) {
-    if (key.toLowerCase() === TUNNEL_PROXY_HEADER) delete headers[key];
+    if (CLIENT_OWNED_HEADERS.has(key.toLowerCase())) delete headers[key];
   }
+  headers['Host'] = `localhost:${localPort}`;
   headers[TUNNEL_PROXY_HEADER] = '1';
+  // Fails closed: with no local key readable, the request goes on unkeyed and
+  // Tower rejects it, exactly as it did before this stamp existed.
+  const key = getExpectedKey();
+  if (key) headers[TOWER_KEY_HEADER] = key;
 }
 
 /** Heartbeat ping interval — send a WebSocket ping every 30 seconds */
@@ -734,12 +770,11 @@ export class TunnelClient {
   private handleWebSocketConnect(stream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders): void {
     const path = headers[':path'] as string || '/';
 
-    // WebSocket CONNECT: proxy to local server. The upgrade goes to localhost,
-    // so the Host must be localhost too — Tower's Host guard (advisory
-    // GHSA-xvjp-7748-v88v) rejects the tunnel's public :authority, and the HTTP
-    // proxy path already lets Node default Host to localhost. Matching it here
-    // keeps tunneled terminals working.
-    const localHost = `localhost:${this.options.localPort}`;
+    // WebSocket CONNECT: proxy to local server. `stampLocalHeaders` rewrites
+    // Host to localhost — Tower's Host guard (advisory GHSA-xvjp-7748-v88v)
+    // rejects the tunnel's public authority. The browser's own
+    // `Sec-WebSocket-Protocol: codev-key.<KEY>` offer is forwarded untouched
+    // and is what authenticates the upgrade.
 
     // Forward non-hop-by-hop headers from the H2 CONNECT to the local WS upgrade
     const forwardHeaders: Record<string, string | string[]> = {
@@ -747,17 +782,15 @@ export class TunnelClient {
       'Connection': 'Upgrade',
       'Sec-WebSocket-Version': '13',
       'Sec-WebSocket-Key': randomBytes(16).toString('base64'),
-      'Host': localHost,
     };
     for (const [key, value] of Object.entries(headers)) {
       if (key.startsWith(':')) continue;
       if (HOP_BY_HOP_HEADERS.has(key.toLowerCase())) continue;
-      if (key.toLowerCase() === 'host') continue; // Already set
       if (value !== undefined) {
         forwardHeaders[key] = value as string | string[];
       }
     }
-    stampProxyMarker(forwardHeaders);
+    stampLocalHeaders(forwardHeaders, this.options.localPort);
 
     // Make HTTP/1.1 WebSocket upgrade request to localhost
     const wsReq = http.request({
@@ -821,7 +854,7 @@ export class TunnelClient {
         reqHeaders[key] = value as string | string[];
       }
     }
-    stampProxyMarker(reqHeaders);
+    stampLocalHeaders(reqHeaders, this.options.localPort);
 
     const proxyReq = http.request(
       {


### PR DESCRIPTION
## Summary

Every request reaching a Tower through Codev Cloud was 401'd — the dashboard, its API calls, everything — even with the tunnel connected. This is the second half of the #1421 auth regression (the first half, the OAuth callback, was #1570 in 3.3.2); it stayed hidden because connecting was broken first.

Fixes #1586

## Root Cause

`packages/codev/src/agent-farm/lib/tunnel-client.ts`, two independent failures — either alone is fatal:

1. **`Host` forwarded verbatim.** `proxyHttpRequest` copied every non-pseudo, non-hop-by-hop inbound header into the localhost request, including `Host: cloud.codevos.ai`. `isAllowedHost()` rejects it. And `isRequestAllowed()` runs the Host guard *ahead of* the public-route allowlist, so even `GET /` — the keyless dashboard shell — 401'd, not just the API.

   The comment on `handleWebSocketConnect` claiming "the HTTP proxy path already lets Node default Host to localhost" was false: Node only defaults `Host` when none is supplied, and the cloud edge always supplies one.

2. **No local key stamped.** Tunnel-borne requests carried no `codev-tower-key`, and Tower gives the `x-codev-tunnel-proxy` marker no auth exemption — it exists only for `/api/tunnel/*` refusal and log attribution. So keyed routes had nothing to check.

Reproduced against a live Tower before touching code: `Host: cloud.codevos.ai` + valid key → 401; localhost + no key → 401; localhost + key → through.

## Fix

`stampProxyMarker` becomes `stampLocalHeaders(headers, localPort)`. It strips any inbound `host`, `codev-tower-key`, `codev-web-key` and `x-codev-tunnel-proxy`, then stamps `Host: localhost:<port>`, the proxy marker, and the local key from `getExpectedKey()`. All three are set in one place so they cannot drift, and stripping first means a cloud-side actor can neither forge nor suppress any of them.

Both proxy paths call it; the WebSocket path drops its hand-rolled `Host` handling and the misleading comment.

**Trust model is unchanged.** The cloud edge authenticates the remote user; the local key authenticates local actors to their own Tower. `TunnelClient` runs inside the Tower process and is itself a local actor, so it legitimately holds the key. No Tower-side exemption is added — the key check stays the single choke point — and the `/api/tunnel/*` refusal is untouched, so the stamp cannot open management routes to a cloud actor.

Fails closed: with no readable local key the request goes on unkeyed and Tower rejects it, exactly as before.

46 insertions / 13 deletions in one source file.

Out of scope (per the issue): a per-session remote credential. The remote browser receives the same injected key a local one does — no worse than pre-#1421, when tunnel access was unauthenticated locally.

## Test Plan

New `__tests__/bugfix-1586-tunnel-auth.test.ts` runs the **real `isRequestAllowed`** in the local server rather than a bare echo server, so authorization is pinned end-to-end rather than by header shape.

| Test | without fix | with fix |
|---|---|---|
| keyed `/api/state` with cloud Host, no key | FAIL 401 | PASS 200, Host localhost, valid key |
| public `/` with cloud Host | FAIL 401 | PASS 200 |
| forged key / legacy key / marker replaced, not forwarded | FAIL 401 | PASS 200 |
| `/api/tunnel/disconnect` + workspace-scoped form still 403 | PASS | PASS |
| browser `codev-key.<KEY>` subprotocol survives H2 CONNECT | PASS | PASS |

Three of five fail without the fix. The last two are invariant pins (issue items 3 and 4) — they must be green both ways, and are.

- [x] Regression test added (fails without the fix, passes with it)
- [x] Build passes
- [x] All tests pass — 5382 passed, 48 skipped, 0 failed
- [ ] Field verification (architect, post-release): open Tower via cloud.codevos.ai → dashboard loads, workspace list populates, terminal WebSocket attaches

Rides the 3.3.3 hotfix with #1584 — cloud access is broken on every release since 3.3.1 without it.

cc @amrmelsayed — author of #1421; the stamp lives entirely in the tunnel client, adds no Tower-side exemption, and keeps the key check as the single choke point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rvbkr7kt4N488yY1jwG3zg