### PR TITLE
docs: correct Tower-restart rationale in irreversible-acts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ a human decision.
 - Never hand-edit `status.yaml` — only porch commands modify project state.
 - Run `afx` commands only from the main workspace root, never from inside a builder worktree — spawning from a worktree nests builders and breaks the workspace.
 - Never kill a shellper process without verifying it is an orphan (match each PID to its workspace via Tower) — an 'extra' shellper may be a live architect session.
-- Never restart or stop Tower without explicit human permission — it kills every running builder session.
+- Never restart or stop Tower without explicit human permission. Builder sessions survive a restart (detached shellpers), but Tower-mediated messaging, dashboards, and gate delivery drop until it is back.
 
 ## Gates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ a human decision.
 - Never hand-edit `status.yaml` — only porch commands modify project state.
 - Run `afx` commands only from the main workspace root, never from inside a builder worktree — spawning from a worktree nests builders and breaks the workspace.
 - Never kill a shellper process without verifying it is an orphan (match each PID to its workspace via Tower) — an 'extra' shellper may be a live architect session.
-- Never restart or stop Tower without explicit human permission — it kills every running builder session.
+- Never restart or stop Tower without explicit human permission. Builder sessions survive a restart (detached shellpers), but Tower-mediated messaging, dashboards, and gate delivery drop until it is back.
 
 ## Gates
 

--- a/codev/resources/scar-rules.yaml
+++ b/codev/resources/scar-rules.yaml
@@ -76,7 +76,7 @@ scar_rules:
       - CLAUDE.md
 
   - id: tower-restart-permission
-    canonical: "Never restart or stop Tower without explicit human permission — it kills every running builder session."
+    canonical: "Never restart or stop Tower without explicit human permission. Builder sessions survive a restart (detached shellpers), but Tower-mediated messaging, dashboards, and gate delivery drop until it is back."
     must_appear_on:
       - AGENTS.md
       - CLAUDE.md


### PR DESCRIPTION
## What

One-line correction in the irreversible-acts section of `CLAUDE.md` and its byte-identical twin `AGENTS.md`: the Tower-restart guardrail claimed a restart "kills every running builder session." It does not. The line now keeps the ask-first rule but states the real cost:

> Never restart or stop Tower without explicit human permission. Builder sessions survive a restart (detached shellpers), but Tower-mediated messaging, dashboards, and gate delivery drop until it is back.

## Why

Verified against source, owner-confirmed: `towerStop` (`packages/codev/src/agent-farm/commands/tower.ts`) SIGTERMs the Tower daemon only, and the code comments state shellpers are spawned detached and intentionally survive Tower restarts; only the explicit force-kill path touches them. The stale rationale actively misleads agents into overstating deployment risk (it did exactly that when planning the 3.3.3 pickup).

## Scope check

Instance files only. The skeleton shipped to adopters was swept and carries no equivalent wrong claim (its only related statements are accurate: held mailbox rows survive a Tower restart; `afx dev` child processes do die with Tower). CLAUDE.md and AGENTS.md verified byte-identical after the edit.
