### PR TITLE
Fix #1597: sandbox the user-global agent-farm dir in the vitest harness

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/bugfix-1597-local-key-isolation.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-1597-local-key-isolation.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Isolation canary for the user-global Agent Farm directory (#1597).
+ *
+ * The vitest harness (vitest-setup.ts) pins `CODEV_AGENT_FARM_DIR` into the
+ * per-run sandbox so that `ensureLocalKey()` — reached by the e2e fetch patch,
+ * `towerWsProtocols()`, and any suite touching core auth — never reads or
+ * creates the developer's real `~/.agent-farm/local-key`. These tests prove the
+ * pin is present and actually governs the key path, in the same spirit as the
+ * fake-agy canary (#1323) and the isolated-Tower checks (#1515).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { ensureLocalKey } from '@cluesmith/codev-core/auth';
+import { AGENT_FARM_DIR } from '@cluesmith/codev-core/constants';
+
+const REAL_AGENT_FARM_DIR = resolve(homedir(), '.agent-farm');
+
+describe('agent-farm dir isolation (#1597)', () => {
+  it('the harness pins CODEV_AGENT_FARM_DIR away from the real ~/.agent-farm', () => {
+    const pinned = process.env.CODEV_AGENT_FARM_DIR;
+    expect(pinned, 'vitest-setup.ts must pin CODEV_AGENT_FARM_DIR').toBeTruthy();
+    expect(resolve(pinned!)).not.toBe(REAL_AGENT_FARM_DIR);
+  });
+
+  it('core resolved AGENT_FARM_DIR from the pin (module-load ordering held)', () => {
+    // AGENT_FARM_DIR is a module-load const; if core was imported before the
+    // harness set the env var, it silently froze on the real home path and
+    // every downstream key read/write escapes the sandbox.
+    expect(AGENT_FARM_DIR).toBe(resolve(process.env.CODEV_AGENT_FARM_DIR!));
+    expect(AGENT_FARM_DIR).not.toBe(REAL_AGENT_FARM_DIR);
+  });
+
+  it('ensureLocalKey() creates and reads the key inside the sandbox', () => {
+    const key = ensureLocalKey();
+    expect(key).toMatch(/^[0-9a-f]{64}$/);
+    const sandboxKeyPath = join(AGENT_FARM_DIR, 'local-key');
+    expect(existsSync(sandboxKeyPath)).toBe(true);
+    expect(readFileSync(sandboxKeyPath, 'utf-8').trim()).toBe(key);
+
+    // The real key file must not have been created by this run. If the
+    // developer already has one, it must not be what the suites are using —
+    // both keys are 32 random bytes, so equality means the sandbox read it.
+    const realKeyPath = join(REAL_AGENT_FARM_DIR, 'local-key');
+    if (existsSync(realKeyPath)) {
+      expect(readFileSync(realKeyPath, 'utf-8').trim()).not.toBe(key);
+    }
+  });
+});

--- a/packages/codev/src/agent-farm/__tests__/cloud-config.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/cloud-config.test.ts
@@ -2,23 +2,40 @@
  * Tests for cloud-config module (Spec 0097 Phase 1)
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
 import { mkdirSync, writeFileSync, existsSync, readFileSync, statSync, rmSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 
 // vi.hoisted runs before vi.mock hoisting, so TEST_DIR is available
-const { TEST_DIR, AGENT_FARM_DIR, CONFIG_PATH } = vi.hoisted(() => {
+const { TEST_DIR, AGENT_FARM_DIR, CONFIG_PATH, PREV_AGENT_FARM_DIR_ENV } = vi.hoisted(() => {
   const { resolve } = require('node:path');
   const { tmpdir } = require('node:os');
   const { randomBytes } = require('node:crypto');
   const testDir = resolve(tmpdir(), `cloud-config-test-${randomBytes(4).toString('hex')}`);
+  const agentFarmDir = resolve(testDir, '.agent-farm');
+  // The vitest harness pins CODEV_AGENT_FARM_DIR into its per-run sandbox
+  // (#1597), and core's AGENT_FARM_DIR reads that env var BEFORE consulting
+  // homedir — so the homedir mock below no longer redirects it. Re-pin the
+  // env to this suite's dir before the module graph evaluates; afterAll
+  // restores the harness value so later files stay sandboxed.
+  const prevEnv = process.env.CODEV_AGENT_FARM_DIR;
+  process.env.CODEV_AGENT_FARM_DIR = agentFarmDir;
   return {
     TEST_DIR: testDir,
-    AGENT_FARM_DIR: resolve(testDir, '.agent-farm'),
-    CONFIG_PATH: resolve(testDir, '.agent-farm', 'cloud-config.json'),
+    AGENT_FARM_DIR: agentFarmDir,
+    CONFIG_PATH: resolve(agentFarmDir, 'cloud-config.json'),
+    PREV_AGENT_FARM_DIR_ENV: prevEnv,
   };
+});
+
+afterAll(() => {
+  if (PREV_AGENT_FARM_DIR_ENV === undefined) {
+    delete process.env.CODEV_AGENT_FARM_DIR;
+  } else {
+    process.env.CODEV_AGENT_FARM_DIR = PREV_AGENT_FARM_DIR_ENV;
+  }
 });
 
 vi.mock('node:os', async () => {

--- a/packages/codev/src/agent-farm/__tests__/helpers/tower-test-utils.ts
+++ b/packages/codev/src/agent-farm/__tests__/helpers/tower-test-utils.ts
@@ -134,10 +134,12 @@ async function findAvailablePort(startPort: number): Promise<number> {
  * files into the real directory.
  *
  * The shared local key is copied in rather than left to be regenerated: the
- * test process authenticates its own HTTP/WS calls with the key from the real
- * directory (see `vitest-e2e-setup.ts` and `towerWsProtocols()`), so both sides
- * must present the same value or every request 401s. The key is the only thing
- * carried over — no cloud config, no DB, no log.
+ * test process authenticates its own HTTP/WS calls with whatever key
+ * `ensureLocalKey()` resolves in this process — the harness-sandboxed
+ * directory since #1597, never the developer's real one (see
+ * `vitest-setup.ts`, `vitest-e2e-setup.ts` and `towerWsProtocols()`) — so both
+ * sides must present the same value or every request 401s. The key is the only
+ * thing carried over — no cloud config, no DB, no log.
  */
 export function createIsolatedAgentFarmDir(): string {
   const dir = mkdtempSync(resolve(tmpdir(), 'codev-af-'));

--- a/packages/codev/src/agent-farm/__tests__/tower-cloud-cli.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/tower-cloud-cli.test.ts
@@ -5,15 +5,30 @@
  * with mocked readline, browser, and HTTP interactions.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
 import { mkdirSync, rmSync } from 'node:fs';
 
-// Redirect homedir to temp dir
-const TEST_DIR = vi.hoisted(() => {
+// Redirect homedir to temp dir. The vitest harness also pins
+// CODEV_AGENT_FARM_DIR into its per-run sandbox (#1597), and core's
+// AGENT_FARM_DIR reads that env var BEFORE consulting homedir — so the
+// homedir mock alone no longer redirects it. Re-pin the env to this suite's
+// dir before the module graph evaluates; afterAll restores the harness value.
+const { TEST_DIR, PREV_AGENT_FARM_DIR_ENV } = vi.hoisted(() => {
   const { resolve } = require('node:path');
   const { tmpdir } = require('node:os');
   const { randomBytes } = require('node:crypto');
-  return resolve(tmpdir(), `tower-cli-test-${randomBytes(4).toString('hex')}`);
+  const testDir = resolve(tmpdir(), `tower-cli-test-${randomBytes(4).toString('hex')}`);
+  const prevEnv = process.env.CODEV_AGENT_FARM_DIR;
+  process.env.CODEV_AGENT_FARM_DIR = resolve(testDir, '.agent-farm');
+  return { TEST_DIR: testDir, PREV_AGENT_FARM_DIR_ENV: prevEnv };
+});
+
+afterAll(() => {
+  if (PREV_AGENT_FARM_DIR_ENV === undefined) {
+    delete process.env.CODEV_AGENT_FARM_DIR;
+  } else {
+    process.env.CODEV_AGENT_FARM_DIR = PREV_AGENT_FARM_DIR_ENV;
+  }
 });
 
 // Queue of answers for readline prompts (shifted one at a time)

--- a/packages/codev/vitest-setup.ts
+++ b/packages/codev/vitest-setup.ts
@@ -82,6 +82,23 @@ if (!process.env.CODEV_METRICS_DB) {
   process.env.CODEV_METRICS_DB = join(metricsDir, 'metrics.db');
 }
 
+// Point the whole user-global Agent Farm tree (cloud credentials, `local-key`,
+// `global.db`) into the sandbox (#1597). Without this, `ensureLocalKey()` —
+// reached in-process via the e2e fetch patch and `towerWsProtocols()`, and by
+// any suite touching core auth — read AND created the developer's real
+// `~/.agent-farm/local-key`. Auth stays consistent end-to-end because both
+// sides derive from the same call: `createIsolatedAgentFarmDir()` seeds each
+// spawned test Tower with a copy of whatever key `ensureLocalKey()` resolves
+// here. The env var must be set before `@cluesmith/codev-core` is first
+// imported (its key path is a module-load const); `setupFiles` order guarantees
+// that for `vitest-e2e-setup.ts`. A pre-set value is respected — exporting
+// `CODEV_AGENT_FARM_DIR` is the one named way to point suites elsewhere.
+if (!process.env.CODEV_AGENT_FARM_DIR) {
+  const agentFarmDir = join(sandbox, '.agent-farm');
+  mkdirSync(agentFarmDir, { recursive: true, mode: 0o700 });
+  process.env.CODEV_AGENT_FARM_DIR = agentFarmDir;
+}
+
 if (firstRun) {
   process.on('exit', () => {
     try {

--- a/packages/codev/vitest-setup.ts
+++ b/packages/codev/vitest-setup.ts
@@ -2,7 +2,7 @@
  * Global test harness — sandboxes every user-global side effect a suite can
  * reach (#1323). Wired into all three vitest configs via `setupFiles`.
  *
- * Two escapes motivated this file:
+ * Three escapes motivated this file:
  *
  *  1. Any test that reached the gemini consult lane without pinning
  *     `CODEV_AGY_BIN` resolved the developer's REAL `agy` binary and spawned it.
@@ -11,6 +11,9 @@
  *  2. In-process tests ran under the developer's real `HOME`, so every
  *     `recordMetrics()` call appended junk rows (with temp-dir workspace paths)
  *     to the real `~/.codev/metrics.db`, silently skewing `consult stats`.
+ *  3. Suites reaching core auth read AND created the developer's real
+ *     `~/.agent-farm/local-key` (#1597) — see the `CODEV_AGENT_FARM_DIR` pin
+ *     below.
  *
  * Both are failures of *omission*: safety depended on each test remembering to
  * opt out. This harness inverts that — the sandbox is on by default and a test

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -6,11 +6,13 @@ import { homedir } from 'node:os';
  * shared local key, `global.db`, `tower.log`, session logs.
  *
  * `CODEV_AGENT_FARM_DIR` overrides the default (#1515). Nothing in production
- * sets it — it exists so a spawned *test* Tower can be pointed at a throwaway
- * directory. Without an override there was no way to isolate one: every test
- * Tower read the developer's real cloud credentials and real local key, wrote
- * its test DB into `~/.agent-farm`, and watched the real config file. A test
- * that then exercised tunnel disconnect acted as the user's registered Tower —
+ * sets it — its two users are test infrastructure: spawned *test* Towers are
+ * pointed at throwaway directories, and the codev vitest harness pins the
+ * whole test process into its per-run sandbox (#1597, vitest-setup.ts).
+ * Without an override there was no way to isolate either: every test Tower
+ * read the developer's real cloud credentials and real local key, wrote its
+ * test DB into `~/.agent-farm`, and watched the real config file. A test that
+ * then exercised tunnel disconnect acted as the user's registered Tower —
  * deregistering it server-side and deleting the real credentials.
  */
 export const AGENT_FARM_DIR = process.env.CODEV_AGENT_FARM_DIR


### PR DESCRIPTION
Fixes #1597.

## What

The vitest harness (`vitest-setup.ts`, the #1323 sandbox) now pins `CODEV_AGENT_FARM_DIR` into its per-run sandbox, so `ensureLocalKey()` — reached by the e2e fetch patch, `towerWsProtocols()`, and any suite touching core auth — never reads or creates the developer's real `~/.agent-farm/local-key`.

## Why this is the whole fix

The redirect mechanism already existed (`CODEV_AGENT_FARM_DIR`, #1515); the harness just never set it, so safety depended on each suite remembering — exactly the failure-of-omission pattern #1323 exists to prevent. Auth stays consistent end to end by construction: `createIsolatedAgentFarmDir()` seeds each spawned test Tower with a copy of whatever key `ensureLocalKey()` resolves in the test process, so client and server always share the sandbox key. No e2e opt-in is needed; exporting `CODEV_AGENT_FARM_DIR` remains the one named way to point suites elsewhere. Defense in depth: a stray suite fetch at a real Tower on :4100 now carries the sandbox key and 401s instead of arriving authenticated (the #1515 incident class).

Ordering constraint honored: core's key path is a module-load const, so the pin must land before `@cluesmith/codev-core` is first imported. `setupFiles` order guarantees that for `vitest-e2e-setup.ts`, and the new canary asserts the ordering held.

## Test adaptations

`cloud-config.test.ts` and `tower-cloud-cli.test.ts` redirected the agent-farm dir by mocking `node:os.homedir` — inert now, since the env var outranks homedir. Both re-pin `CODEV_AGENT_FARM_DIR` to their own temp dir inside `vi.hoisted` (before the module graph evaluates) and restore the harness value in `afterAll`.

## New canary

`bugfix-1597-local-key-isolation.test.ts` proves the pin is present, that core resolved `AGENT_FARM_DIR` from it (module-load ordering), and that `ensureLocalKey()` creates the key inside the sandbox and is not reading a real key file.

## Verification

- Full unit suite: 5386 passed, 0 failed (272 files).
- `tsc --noEmit` clean.
- E2E isolation suite (`bugfix-1515-tower-isolation.e2e.test.ts`) green under the pin.
- The three `homedir()`-literal e2e fixtures (`test-workspaces` paths) bypass `AGENT_FARM_DIR` and are unaffected — out of #1597's scope.
