### PR TITLE
Fix #1599: skip the tunnel-status poll when the shell is cloud-served

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/bugfix-1599-shell-tunnel-poll.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-1599-shell-tunnel-poll.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression test for Bugfix #1599: the Tower shell must not poll
+ * /api/tunnel/status when it is being viewed through Codev Cloud.
+ *
+ * Over the tunnel, every /api/tunnel/* endpoint is local-only by design
+ * (blocked at the tunnel edge and again by Tower, #1370), so a cloud-served
+ * shell polling tunnel status can only ever collect 403s — for a widget
+ * renderCloudStatus() suppresses in that case anyway. The fix gates the
+ * fetch and the render on one shared isCloudServed() predicate.
+ *
+ * Source-text assertions on the template, following the
+ * bugfix-430-tower-restart.test.ts pattern.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const towerHtmlPath = path.resolve(import.meta.dirname, '../../../templates/tower.html');
+
+function read(): string {
+  return fs.readFileSync(towerHtmlPath, 'utf-8');
+}
+
+describe('Bugfix #1599: cloud-served shell skips the tunnel-status poll', () => {
+  it('fetchCloudStatus is gated on isCloudServed() before the request', () => {
+    const html = read();
+    const fnMatch = html.match(/async function fetchCloudStatus\(\)[\s\S]*?\n    \}/);
+    expect(fnMatch).not.toBeNull();
+    const fnBody = fnMatch![0];
+
+    const guardIdx = fnBody.indexOf('isCloudServed()');
+    const fetchIdx = fnBody.indexOf('api/tunnel/status');
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(fetchIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(fetchIdx);
+  });
+
+  it('renderCloudStatus uses the same shared predicate (no drift)', () => {
+    const html = read();
+    const fnMatch = html.match(/function renderCloudStatus\(status\)[\s\S]*?\n    \}/);
+    expect(fnMatch).not.toBeNull();
+    expect(fnMatch![0]).toContain('isCloudServed()');
+    // The old inline hostname check must not survive anywhere outside the
+    // single predicate definition — that is the drift this test pins.
+    const inlineChecks = html.match(/hostname\.endsWith\(['"]/g) ?? [];
+    expect(inlineChecks.length).toBeLessThanOrEqual(1);
+  });
+
+  it('the predicate matches codevos.ai exactly or as a subdomain, not as a bare suffix', () => {
+    const html = read();
+    const fnMatch = html.match(/function isCloudServed\(\)[\s\S]*?\n    \}/);
+    expect(fnMatch).not.toBeNull();
+    const fnBody = fnMatch![0];
+    expect(fnBody).toContain("=== 'codevos.ai'");
+    expect(fnBody).toContain(".endsWith('.codevos.ai')");
+  });
+});

--- a/packages/codev/templates/tower.html
+++ b/packages/codev/templates/tower.html
@@ -1667,6 +1667,11 @@
 
     async function fetchCloudStatus() {
       try {
+        // Served through the tunnel, /api/tunnel/* is local-only — blocked at
+        // the tunnel edge and again by Tower (#1370), so this poll can only
+        // ever 403 (#1599). The widget renders nothing cloud-served anyway;
+        // skip the forbidden request instead of paying it every refresh.
+        if (isCloudServed()) return null;
         const res = await authFetch('./api/tunnel/status');
         if (res.status === 404) return null;
         if (!res.ok) return { state: 'error' };
@@ -1674,6 +1679,13 @@
       } catch {
         return null;
       }
+    }
+
+    // Is this page being viewed through Codev Cloud rather than served by the
+    // local Tower directly? One shared predicate for the tunnel-status poll
+    // and the cloud widget render, so the two can never drift (#1599).
+    function isCloudServed() {
+      return window.location.hostname.endsWith('codevos.ai');
     }
 
     function formatUptime(ms) {
@@ -1723,7 +1735,7 @@
       noteCloudStateChange(status && status.state ? status.state : null);
 
       // When accessed through codevos.ai, cloud status is irrelevant
-      if (window.location.hostname.endsWith('codevos.ai')) {
+      if (isCloudServed()) {
         el.innerHTML = '';
         return;
       }

--- a/packages/codev/templates/tower.html
+++ b/packages/codev/templates/tower.html
@@ -1684,8 +1684,11 @@
     // Is this page being viewed through Codev Cloud rather than served by the
     // local Tower directly? One shared predicate for the tunnel-status poll
     // and the cloud widget render, so the two can never drift (#1599).
+    // Exact-or-subdomain match, not a bare suffix — `endsWith('codevos.ai')`
+    // would also match an unrelated `evilcodevos.ai` (CMAP).
     function isCloudServed() {
-      return window.location.hostname.endsWith('codevos.ai');
+      const h = window.location.hostname;
+      return h === 'codevos.ai' || h.endsWith('.codevos.ai');
     }
 
     function formatUptime(ms) {


### PR DESCRIPTION
Fixes #1599.

The Tower shell's `refresh()` polled `./api/tunnel/status` unconditionally, but over the tunnel that endpoint is local-only by design (blocked at the tunnel edge and again by Tower, #1370) — so every remote-viewed refresh produced a guaranteed 403 in the console, for a widget `renderCloudStatus()` suppresses when cloud-served anyway.

`fetchCloudStatus()` now short-circuits on the same condition the renderer uses, factored into one shared `isCloudServed()` predicate so the poll and the render cannot drift. The server-side blocklist is untouched — carving out read-only `status` would leak registration details to anyone reaching the tunnel URL.

Verified: inline script syntax-checked (node --check on the extracted block); behavior locally unchanged (poll still runs when served by the local Tower directly).

Owner direction: lands before the v3.3.3 tag. Cosmetic-class fix (console noise + wasted requests); no security or functional change.