### PR TITLE
[Bugfix #1586] records: post-merge porch bookkeeping + thread closeout

### DIFF
--- a/codev/projects/bugfix-1586-tower-cloud-proxied-requests-a/status.yaml
+++ b/codev/projects/bugfix-1586-tower-cloud-proxied-requests-a/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1586
 title: tower-cloud-proxied-requests-a
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,7 +13,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-02T16:15:15.952Z'
-updated_at: '2026-09-03T15:29:57.116Z'
+updated_at: '2026-09-03T15:30:03.067Z'
 pr_history:
   - phase: pr
     pr_number: 1588

--- a/codev/projects/bugfix-1586-tower-cloud-proxied-requests-a/status.yaml
+++ b/codev/projects/bugfix-1586-tower-cloud-proxied-requests-a/status.yaml
@@ -6,16 +6,17 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-09-02T16:27:50.680Z'
+    approved_at: '2026-09-03T15:29:33.198Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-02T16:15:15.952Z'
-updated_at: '2026-09-02T16:27:50.681Z'
+updated_at: '2026-09-03T15:29:33.199Z'
 pr_history:
   - phase: pr
     pr_number: 1588
     branch: builder/bugfix-1586
     created_at: '2026-09-02T16:27:48.390Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1586-tower-cloud-proxied-requests-a/status.yaml
+++ b/codev/projects/bugfix-1586-tower-cloud-proxied-requests-a/status.yaml
@@ -13,10 +13,12 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-02T16:15:15.952Z'
-updated_at: '2026-09-03T15:29:33.199Z'
+updated_at: '2026-09-03T15:29:57.116Z'
 pr_history:
   - phase: pr
     pr_number: 1588
     branch: builder/bugfix-1586
     created_at: '2026-09-02T16:27:48.390Z'
+    merged: true
+    merged_at: '2026-09-03T15:29:57.115Z'
 pr_ready_for_human: false

--- a/codev/state/bugfix-1586_thread.md
+++ b/codev/state/bugfix-1586_thread.md
@@ -126,3 +126,27 @@ lane. Claude raised three non-blocking items, all addressed:
 - **Branch behind main** — merged `origin/main` (porch records only, no code).
 
 CI on PR #1588: all 7 checks green.
+
+## MERGED (2026-09-03)
+
+PR #1588 merged 11:21 UTC by @amrmelsayed (owner-approved lane) as
+`3591ad1d3`. Issue #1586 auto-closed by the `Fixes` line; completion stats
+posted as a comment.
+
+Amr also pushed `db08a16bc` onto the branch before merging — an arch.md
+Decision 8 entry recording the Host + local-key stamping. Merged into the
+branch here so nothing was lost.
+
+`porch approve ... pr` failed its first run: it commits state then pushes, and
+the push was rejected non-fast-forward because of that unseen commit. The gate
+approval *was* already committed locally, so the fix was to merge origin and
+push — not to re-run approve. Worth knowing: a partial `porch approve` failure
+is a push failure, not a state failure; check `git log` before assuming the
+approval didn't take.
+
+Porch commits after the merge are stranded on the branch and need a records PR:
+`d6ed709b2` (pr gate-approved), `623fd2577` (PR #1588 merged),
+`b760f1205` (protocol complete), plus this thread update.
+
+Field verification through the real cloud edge remains open and is
+architect-driven post-release — I cannot exercise cloud.codevos.ai from here.


### PR DESCRIPTION
The status.yaml bookkeeping commits porch wrote after PR #1588 (cloud-proxied request auth fix) merged, plus the builder thread's closeout entry — stranded on the builder branch by construction (#1367 pattern). No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbysMBdkFuycRE3vun3AE6