### PR TITLE
Fix #759: pr-search includes all PR states so merged PRs are found

### DIFF
--- a/packages/codev/scripts/forge/github/pr-search.sh
+++ b/packages/codev/scripts/forge/github/pr-search.sh
@@ -2,4 +2,6 @@
 # Forge concept: pr-search (GitHub via gh CLI)
 # Input: CODEV_SEARCH_QUERY
 # Output: JSON [{number, headRefName, baseRefName}]
-exec gh pr list --search "$CODEV_SEARCH_QUERY" --json number,headRefName,baseRefName
+# --state all is required so the search includes merged/closed PRs; without it
+# `gh pr list` defaults to --state open and post-merge lookups return nothing (#759).
+exec gh pr list --state all --search "$CODEV_SEARCH_QUERY" --json number,headRefName,baseRefName

--- a/packages/codev/scripts/forge/gitlab/pr-search.sh
+++ b/packages/codev/scripts/forge/gitlab/pr-search.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 # Forge concept: pr-search (GitLab via glab CLI)
-exec glab mr list --search "$CODEV_SEARCH_QUERY" --output json
+# --all is required so the search includes merged/closed MRs; without it
+# `glab mr list` defaults to opened only and post-merge lookups return nothing (#759).
+exec glab mr list --all --search "$CODEV_SEARCH_QUERY" --output json

--- a/packages/codev/src/commands/porch/__tests__/bugfix-759-pr-search-state-all.test.ts
+++ b/packages/codev/src/commands/porch/__tests__/bugfix-759-pr-search-state-all.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Regression test for pr-search forge scripts.
+ *
+ * Bugfix #759: pr-search must include all PR states so post-merge lookups
+ * (consult --type pr after a PR merges) still find the PR. Without it,
+ * `gh pr list --search` / `glab mr list --search` default to open-only and
+ * return nothing once the PR has merged.
+ *
+ * These tests validate the forge scripts directly, not protocol.json commands.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const SCRIPTS_ROOT = path.resolve(__dirname, '../../../../scripts/forge');
+
+describe('pr-search forge scripts', () => {
+  describe('github/pr-search.sh', () => {
+    const scriptPath = path.join(SCRIPTS_ROOT, 'github', 'pr-search.sh');
+
+    it('exists and is readable', () => {
+      expect(fs.existsSync(scriptPath)).toBe(true);
+    });
+
+    it('fetches all PR states (--state all) so merged PRs are found (#759)', () => {
+      const content = fs.readFileSync(scriptPath, 'utf-8');
+      expect(content).toContain('--state all');
+    });
+
+    it('still searches with the provided query', () => {
+      const content = fs.readFileSync(scriptPath, 'utf-8');
+      expect(content).toContain('--search "$CODEV_SEARCH_QUERY"');
+    });
+  });
+
+  describe('gitlab/pr-search.sh', () => {
+    const scriptPath = path.join(SCRIPTS_ROOT, 'gitlab', 'pr-search.sh');
+
+    it('exists and is readable', () => {
+      expect(fs.existsSync(scriptPath)).toBe(true);
+    });
+
+    it('fetches all MR states (--all) so merged MRs are found (#759)', () => {
+      const content = fs.readFileSync(scriptPath, 'utf-8');
+      expect(content).toContain('--all');
+    });
+
+    it('still searches with the provided query', () => {
+      const content = fs.readFileSync(scriptPath, 'utf-8');
+      expect(content).toContain('--search "$CODEV_SEARCH_QUERY"');
+    });
+  });
+});


### PR DESCRIPTION
Clean re-cut of #1331, which was accidentally branched from the Spec 1280 builder branch instead of main and therefore carried ~8.5k lines of unrelated churn around a 60-line fix. Same two commits (fix + regression test), cherry-picked onto current main; nothing else.

## Problem
After a PR merges, the post-merge `consult --type pr` lookup fails with `No PR found for branch: …` — the same lookup worked pre-merge. One of the roots of the "consult cannot review merged PRs" blocker (#1531).

## Root cause
The forge `pr-search` scripts call `gh pr list --search …` / `glab mr list --search …` with no state flag; both CLIs default to open-only, so merged PRs vanish from the search.

## Fix
`--state all` (GitHub) and `--all` (GitLab) in the two `pr-search.sh` scripts, each with a comment citing #759.

## Testing
`bugfix-759-pr-search-state-all.test.ts`: both scripts fetch all states; both still pass the search query through. 3 files, +60/−2.

Fixes #759. Supersedes #1331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)