### PR TITLE
Test coverage: mailbox owner-resolution wiring (escalateHeldToOwner) and cleanupBuilder() held-row dismissal (#1477)

### DIFF
--- a/codev/projects/1477-test-coverage-mailbox-owner-re/status.yaml
+++ b/codev/projects/1477-test-coverage-mailbox-owner-re/status.yaml
@@ -6,16 +6,17 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
     requested_at: '2026-09-05T20:43:55.305Z'
+    approved_at: '2026-09-05T21:16:23.438Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-05T15:45:20.744Z'
-updated_at: '2026-09-05T20:43:55.305Z'
+updated_at: '2026-09-05T21:16:23.438Z'
 pr_history:
   - phase: implement
     pr_number: 1625
     branch: builder/air-1477
     created_at: '2026-09-05T16:02:03.166Z'
-pr_ready_for_human: true
+pr_ready_for_human: false

--- a/codev/projects/1477-test-coverage-mailbox-owner-re/status.yaml
+++ b/codev/projects/1477-test-coverage-mailbox-owner-re/status.yaml
@@ -1,7 +1,7 @@
 id: '1477'
 title: test-coverage-mailbox-owner-re
 protocol: air
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -13,7 +13,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-05T15:45:20.744Z'
-updated_at: '2026-09-05T21:16:23.438Z'
+updated_at: '2026-09-05T21:16:27.278Z'
 pr_history:
   - phase: implement
     pr_number: 1625

--- a/codev/projects/1477-test-coverage-mailbox-owner-re/status.yaml
+++ b/codev/projects/1477-test-coverage-mailbox-owner-re/status.yaml
@@ -1,0 +1,14 @@
+id: '1477'
+title: test-coverage-mailbox-owner-re
+protocol: air
+phase: implement
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-09-05T15:45:20.744Z'
+updated_at: '2026-09-05T15:45:20.745Z'

--- a/codev/projects/1477-test-coverage-mailbox-owner-re/status.yaml
+++ b/codev/projects/1477-test-coverage-mailbox-owner-re/status.yaml
@@ -1,7 +1,7 @@
 id: '1477'
 title: test-coverage-mailbox-owner-re
 protocol: air
-phase: implement
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,7 +11,7 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-05T15:45:20.744Z'
-updated_at: '2026-09-05T16:02:03.166Z'
+updated_at: '2026-09-05T20:38:49.691Z'
 pr_history:
   - phase: implement
     pr_number: 1625

--- a/codev/projects/1477-test-coverage-mailbox-owner-re/status.yaml
+++ b/codev/projects/1477-test-coverage-mailbox-owner-re/status.yaml
@@ -7,13 +7,15 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-09-05T20:43:55.305Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-05T15:45:20.744Z'
-updated_at: '2026-09-05T20:38:49.691Z'
+updated_at: '2026-09-05T20:43:55.305Z'
 pr_history:
   - phase: implement
     pr_number: 1625
     branch: builder/air-1477
     created_at: '2026-09-05T16:02:03.166Z'
+pr_ready_for_human: true

--- a/codev/projects/1477-test-coverage-mailbox-owner-re/status.yaml
+++ b/codev/projects/1477-test-coverage-mailbox-owner-re/status.yaml
@@ -11,4 +11,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-05T15:45:20.744Z'
-updated_at: '2026-09-05T15:45:20.745Z'
+updated_at: '2026-09-05T16:02:03.166Z'
+pr_history:
+  - phase: implement
+    pr_number: 1625
+    branch: builder/air-1477
+    created_at: '2026-09-05T16:02:03.166Z'

--- a/codev/state/air-1477_thread.md
+++ b/codev/state/air-1477_thread.md
@@ -1,0 +1,85 @@
+# air-1477 — AIR builder thread
+
+## Issue
+#1477 — Test coverage: mailbox owner-resolution wiring (`escalateHeldToOwner`) and
+`cleanupBuilder()` held-row dismissal. Pure test-coverage work, no production change.
+
+## Contributor constraint (architect, 2026-09-05)
+We are NOT cluesmith/codev maintainers. Open the PR, get it reviewed, then PARK: do not merge,
+do not close the issue, do not clean up the worktree.
+
+## Orientation
+
+Architect pre-verified both premises against main; my own reading agrees:
+
+- `escalateHeldToOwner` lives at `packages/codev/src/agent-farm/servers/mailbox-wiring.ts:405` and
+  is reachable only through the exported `makeDeliveryPorts` (`:292`), which is documented as safe
+  to call before Tower is up. `send-delivery.test.ts` only ever stubs the port, so the live
+  resolution path (architect-skip, affinity → `main` → first-registered, supersede-keyed enqueue)
+  had no test.
+- `cleanupBuilder`'s dismissal call site is `commands/cleanup.ts:389`. The existing
+  `spec-1313-cleanup-dismiss.test.ts` says in its own header that it re-implements the seam and
+  that "the full `cleanupBuilder` ... is out of scope here" — so the invocation was uncovered.
+
+Both new tests are NEW files (pir-1473 is concurrently touching mailbox-delivery.ts /
+session-submit.ts / tower-routes.ts and shared test files — no overlap by construction).
+
+## Approach
+
+Substitute only the DB singleton. `vi.mock('../db/index.js')` returning an in-memory
+`GLOBAL_SCHEMA` database makes `getDb()`/`getGlobalDb()` the same handle, which is exactly the
+Issue #1118 production shape — so `state.ts` (registry), `tower-messages.ts`
+(`resolveAgentInRegistry`) and `db/mailbox.ts` all run for REAL against seeded rows. Precedent:
+`spec-755-lookup-builder.test.ts`.
+
+For the cleanup test, only the side-effecting collaborators are stubbed (git via `utils/shell`,
+Tower client, forge, `ps` via `node:child_process`, state writes). `db/mailbox.ts` and
+`utils/workspace-path.ts` stay real, so the assertions are about rows the production path actually
+transitioned — including the normalized-workspace round-trip, which a raw `config.workspaceRoot`
+would fail.
+
+## Log
+
+- 2026-09-05: `pnpm install` needed in the worktree (no node_modules at spawn).
+- 2026-09-05: Implementation done. Two new test files, 11 tests, all passing; `tsc --noEmit` clean.
+- 2026-09-05: **Mutation-verified** the tests actually bind the wiring (sources restored after):
+  - deleting `dismissHeldForAgent(...)` from `cleanup.ts:389` → 3 failures
+  - dropping the `sender` arg from `resolveAgentInRegistry('architect', ws, info.toAgent)` → 1 failure
+  - deleting the `getArchitectByName` architect-skip guard → 1 failure
+  The skip-guard mutation initially did NOT fail, because the downstream self-notify guard
+  (`owner.agent === info.toAgent`) absorbed it in a single-architect workspace. Sharpened the test
+  to register `main` AND `zeta` and starve `zeta`, so the two guards are distinguishable. Worth
+  keeping in mind: a passing test is not evidence of coverage until you break the thing.
+- 2026-09-05: Full unit suite: 12 suites failed on the first run, ALL environmental (fresh worktree
+  had no `packages/codev/skeleton/` and no `dist/`). After `pnpm bundle-assets` + `npx tsc` all 12
+  pass. Nothing related to this change.
+- 2026-09-05: 3-way review. Gemini APPROVE; applied both of its suggestions — close the
+  better-sqlite3 handle in `afterAll`, and make the "no `main`" fallback test discriminating about
+  `getArchitects`' `ORDER BY id` tie-break (it previously registered a single architect and so
+  passed vacuously). Codex + Claude reviews pending.
+- 2026-09-05: Codex + Claude reviews landed and converged. Applied every actionable finding:
+  - **`scheduleDrain` glue was uncovered** (both reviewers, independently). The drainer is never
+    started in a unit test, so `scheduleDrain` no-ops and deleting the call left all tests green.
+    Added a spy on the exported `getMailboxDrainer()` singleton asserting the drain targets the
+    resolved OWNER, not the starving agent. Mutation-verified.
+  - **Self-notify guard claim was false.** `owner.agent === info.toAgent` is unreachable under the
+    real resolver (resolving to an architect requires it registered, which the architect-skip
+    already caught). Corrected the comment rather than mocking a path to a dead branch.
+  - **`TowerClient` stub was backwards**: implemented `killTerminal` (never called — test builders
+    have no terminalId) and omitted `refreshOverview` (called at cleanup.ts:422), so every test
+    silently ran the Tower-unreachable branch. Added `refreshOverview`.
+  - **`findStarvingAgents(db, 9999)`** — the second arg is `now`, not an age threshold; 9999 read
+    like one and pinned nothing. Dropped it.
+  - Added: cross-workspace scoping for the cleanup dismissal (#1118 invariant), cross-workspace
+    owner resolution, and `clearHeldOwnerNotice` key specificity.
+  - Renamed the non-fatal test to describe what it actually simulates (a global.db failure, not a
+    targeted mailbox failure).
+- 2026-09-05: **Production observation for the maintainer — flagged, not fixed** (test-only AIR).
+  `resolveRegistryArchitect` takes `architects[0]` from `getArchitects`, which is `ORDER BY id`,
+  i.e. ALPHABETICAL by architect name. The doc comments there and in `mailbox-wiring.ts` say
+  "first-registered", and `loadState` (`ORDER BY (id != 'main'), started_at`) and the live resolver
+  (registry insertion order) both implement it that way. So an offline hold can name a different
+  architect than a live send would. Deterministic, low-impact, but a genuine divergence. The test
+  pins current behaviour and says so explicitly, so the discrepancy is visible rather than silent.
+- 2026-09-05: Final: 13 tests, 5 mutation points verified (workspace scope, sender affinity,
+  architect-skip, scheduleDrain target, clear-notice key).

--- a/codev/state/air-1477_thread.md
+++ b/codev/state/air-1477_thread.md
@@ -181,3 +181,13 @@ NOT acted on, deliberately:
   "dies with this review thread". The concern is right, but the architect explicitly holds that one
   for the human and told me not to file it. Raised it with them instead of acting. A reviewer being
   correct does not override an explicit instruction about whose call it is.
+
+### Gate reached
+
+`porch check 1477` (pr phase): pr_exists ✓, e2e_tests ✓. `porch done 1477` → **GATE REQUIRED: pr**.
+
+Stopped here. The pr gate is a HUMAN approval gate — I do not run `porch approve 1477 pr` until the
+architect relays an explicit human decision. Architect notified; parked.
+
+Protocol trace so far: implement (build ✓ / tests ✓) → pr (pr_exists ✓ / e2e_tests ✓) → pr gate
+[WAITING]. Nothing left for me to do on #1477 until the gate is approved.

--- a/codev/state/air-1477_thread.md
+++ b/codev/state/air-1477_thread.md
@@ -191,3 +191,34 @@ architect relays an explicit human decision. Architect notified; parked.
 
 Protocol trace so far: implement (build ✓ / tests ✓) → pr (pr_exists ✓ / e2e_tests ✓) → pr gate
 [WAITING]. Nothing left for me to do on #1477 until the gate is approved.
+
+## Protocol complete (round 4)
+
+Human approved the pr gate; architect relayed it. Ran
+`porch approve 1477 pr --a-human-explicitly-approved-this` → checks re-ran green → `porch done 1477`
+→ **PROTOCOL COMPLETE**, phase `verified`.
+
+**Filed Issue #1633** (the human's call was that I file it, reversing the earlier hold):
+"Offline architect resolver picks alphabetically, live resolver picks first-registered
+(getArchitects ORDER BY id)". Labelled `area/tower`, deliberately NOT under #1483 — that tracks the
+post-1313 mailbox program, this is a Spec 755 defect the mailbox work merely walked into.
+
+Verified every claim against source before writing it, and found one thing worth more than the
+report itself: **this exact bug was already fixed once, in the singular.** `getArchitect`
+(state.ts:487) carries the comment "not the lexicographically-first name" and uses
+`ORDER BY started_at`, and `spec-755-migration.test.ts:279` pins it as a Codex-flagged regression.
+`getArchitects` (plural) — which is what the offline resolver actually reads — never got the same
+treatment. So the original fix landed on one of the two functions and nobody noticed the other.
+That reframes it from "an inconsistency" to "a known bug, half-fixed".
+
+Cross-linked both directions so neither dies alone: the test comment names #1633 and says that
+fixing it SHOULD break the assertion (flip to `zeta`, don't delete); the issue names the test and
+explains why it pins current behaviour.
+
+**Size figure corrected again** — and this is the second time it was wrong. 511 was the round-1
+count left stale by round 2; 544 was right when I wrote it but went stale when the `rmSync` lines
+landed in 3bb65d0f2. Now 554 insertions (252 + 296 + 6). The PR body quotes the command rather than
+a remembered number, because a number I retype by hand is a number that goes stale silently. Small
+lesson, same shape as the big one: state the thing that regenerates, not the snapshot.
+
+Parked: no merge, no issue close, no worktree cleanup.

--- a/codev/state/air-1477_thread.md
+++ b/codev/state/air-1477_thread.md
@@ -141,3 +141,43 @@ it. My test keeps pinning current behaviour with the divergence comment unchange
 Mutation sweep now 7 points, all caught: strip normalize / drop workspace scope / delete dismissal
 call / drop sender affinity / delete architect-skip / retarget scheduleDrain / getArchitects
 registration order.
+
+## Protocol completion (round 3)
+
+Architect verified the round-2 fixes independently and requested no further changes; all three of
+my declines were accepted with their stated reasons. But the AIR protocol itself was still
+incomplete — `porch status 1477` showed PHASE: implement with build/tests "not yet run". A PR being
+open is not the same as the protocol being done, and #1477's checkbox in the #1483 tracking issue
+can't be ticked until it is.
+
+- `porch check 1477` → build ✓ (13.4s), tests ✓ (28.7s).
+- `porch done 1477` → advanced implement → **pr**.
+- PR phase criteria: `pr_exists`, `e2e_tests`.
+- Running the PR-stage 3-way CMAP (`--type pr`) as instructed. This is a DIFFERENT review from the
+  architect's integration CMAP on the PR — different stage, different prompt — so it is not skipped
+  on the grounds that the PR was already reviewed.
+
+### PR-stage CMAP verdicts
+
+**gemini APPROVE (HIGH)** — no issues. **codex COMMENT (HIGH)** — one real doc inaccuracy.
+**claude APPROVE (HIGH)** — none blocking, three minor items.
+
+Claude re-ran three mutations itself against real source (restoring after) and reproduced my
+claimed counts exactly. It also checked CI is ubuntu+macos only, so the symlink fixture has no
+Windows exposure — a platform risk I had not thought to check when I chose symlinks.
+
+Acted on:
+- **Stale size disclosure** (codex): PR body said 511 lines; actual is 544 (248 + 296), or 550
+  added lines counting the cross-reference. That was my round-1 number left unrevised after round 2
+  grew the files — the same class of error as the false normalization claim, just cosmetic this
+  time. Corrected, with a note saying it was corrected.
+- **Stale-symlink EEXIST hazard** (claude): the module-scope `symlinkSync` uses a PID-derived name,
+  so a hard-killed run strands the link and a later run drawing the same PID dies at COLLECTION —
+  losing the whole file with an opaque error, not one test. Added `rmSync(..., { force: true })`
+  before it. Verified the primitive both ways: EEXIST without, idempotent with.
+
+NOT acted on, deliberately:
+- Claude flagged that the `resolveRegistryArchitect` ORDER BY id divergence has no filed issue and
+  "dies with this review thread". The concern is right, but the architect explicitly holds that one
+  for the human and told me not to file it. Raised it with them instead of acting. A reviewer being
+  correct does not override an explicit instruction about whose call it is.

--- a/codev/state/air-1477_thread.md
+++ b/codev/state/air-1477_thread.md
@@ -83,3 +83,61 @@ would fail.
   pins current behaviour and says so explicitly, so the discrepancy is visible rather than silent.
 - 2026-09-05: Final: 13 tests, 5 mutation points verified (workspace scope, sender affinity,
   architect-skip, scheduleDrain target, clear-notice key).
+
+## Review round 2 (PR #1625, architect 3-way CMAP)
+
+Verdicts: gemini APPROVE-HIGH, codex COMMENT-MEDIUM, claude REQUEST_CHANGES-HIGH. One blocker.
+
+**The blocker was real, and it was mine.** `air-1477-cleanup-dismiss-invocation.test.ts`'s
+"normalizes the configured workspaceRoot" test was VACUOUS. I reproduced it before fixing:
+stripping `normalizeWorkspacePath` from `cleanup.ts:389` left all 4 tests green.
+
+Two independent mistakes stacked:
+1. `workspaceRoot` was already `realpathSync`'d at creation, so `normalizeWorkspacePath` on it was
+   the identity.
+2. The "non-canonical" override `join(workspaceRoot, 'nested', '..')` collapses LEXICALLY inside
+   `path.join` — no filesystem access — so it was byte-identical to `workspaceRoot` before
+   normalization was ever reached.
+
+So `config.workspaceRoot === WS` in every test, and the assertion I described as "only reachable
+because the call site normalizes" was reachable no matter what. My inline comment and the matching
+PR-description line were both false as written.
+
+Fix: the fixture now creates a real dir as `WS` and a SYMLINK to it as `workspaceRoot`, and the
+symlink is what `getConfig()` returns — so every test in the file now traverses the normalization,
+not just one. A symlink cannot be resolved lexically; only `realpathSync` gets from one to the
+other. Added a guard (`expect(workspaceRoot).not.toBe(WS)`) so the fixture cannot silently
+degenerate again. Confirmed by mutation: the fixed test now FAILS (3 tests) without
+`normalizeWorkspacePath`.
+
+Lesson worth keeping: I "verified" this test by mutation in round 1 — but only mutated the *call*,
+never the *argument*. Deleting `dismissHeldForAgent` failed the test, which felt like proof, so I
+never asked whether the normalization specifically was pinned. A mutation sweep is only as good as
+the set of mutations you think to try, and the ones you skip are exactly the ones you were already
+confident about.
+
+Also fixed (both confirmed by reading the source):
+- `scheduleDrain.mockRestore()` was the last statement of its `it` body, so a failed assertion
+  above it would leak the spy into later tests. Moved to an `afterEach` (`vi.restoreAllMocks()`).
+- The architect fixture used `new Date().toISOString()` for both architects, which can tie. Now
+  takes an explicit `startedAt`, and the id-order test registers `zeta` with the EARLIER timestamp
+  so id order and registration order genuinely disagree. Confirmed by mutation: switching
+  `getArchitects` to `ORDER BY started_at` now fails that test (it would not have before).
+
+Non-blocking, done: cross-referenced `spec-1313-cleanup-dismiss.test.ts`'s header to the invocation
+test so the seam-vs-wiring split is discoverable from either side.
+
+Non-blocking, NOT done, with reasons:
+- `scheduleDrain`'s workspace argument is genuinely unpinnable from outside:
+  `resolveRegistryArchitect` returns the workspace it was asked about, so `owner.workspacePath` and
+  `info.workspacePath` are equal by construction. Documented in a comment rather than faked.
+- `loadConfig(homedir())` hermeticity is inherited from production (`ensureDrainer`) and
+  try/catch-guarded; fixing it would need a production change.
+- The `spec-755-lookup-builder.test.ts` `GLOBAL_SCHEMA` follow-up is explicitly for MAINTAIN.
+
+Architect is holding the `resolveRegistryArchitect` id-order issue for the human — I am NOT filing
+it. My test keeps pinning current behaviour with the divergence comment unchanged, as instructed.
+
+Mutation sweep now 7 points, all caught: strip normalize / drop workspace scope / delete dismissal
+call / drop sender affinity / delete architect-skip / retarget scheduleDrain / getArchitects
+registration order.

--- a/packages/codev/src/agent-farm/__tests__/air-1477-cleanup-dismiss-invocation.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/air-1477-cleanup-dismiss-invocation.test.ts
@@ -16,7 +16,7 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import Database from 'better-sqlite3';
 import { execFile } from 'node:child_process';
-import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { mkdtempSync, realpathSync, rmSync, symlinkSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { GLOBAL_SCHEMA } from '../db/schema.js';
@@ -97,15 +97,29 @@ const { getGlobalDb } = await import('../db/index.js');
 const mailbox = await import('../db/mailbox.js');
 const { normalizeWorkspacePath } = await import('../utils/workspace-path.js');
 
-/** A real directory so `normalizeWorkspacePath`'s realpathSync resolves on both sides. */
-const workspaceRoot = realpathSync(mkdtempSync(join(tmpdir(), 'air-1477-cleanup-')));
-/** Exactly what the mailbox keys rows under. */
-const WS = normalizeWorkspacePath(workspaceRoot);
+/**
+ * TWO names for one directory, and the difference is the whole point.
+ *
+ * `WS` is the canonical path — what the mailbox keys its rows under. `workspaceRoot` is a SYMLINK
+ * to it, and is what `getConfig()` hands `cleanupBuilder`, exactly as a config pointing at a
+ * symlinked checkout would. So `config.workspaceRoot !== WS` as raw strings, and only
+ * `normalizeWorkspacePath` collapses one onto the other.
+ *
+ * An earlier version of this fixture used `join(realRoot, 'nested', '..')` and was VACUOUS: that
+ * collapses lexically inside `path.join` before normalization is ever reached, so the raw and
+ * normalized strings were already identical and the suite stayed green with
+ * `normalizeWorkspacePath` deleted from `cleanup.ts`. A symlink cannot be resolved lexically —
+ * only a real `realpathSync` gets from one to the other.
+ */
+const WS = realpathSync(mkdtempSync(join(tmpdir(), 'air-1477-cleanup-')));
+const workspaceRoot = join(realpathSync(tmpdir()), `air-1477-cleanup-link-${process.pid}`);
+symlinkSync(WS, workspaceRoot);
 
 afterAll(() => {
   db?.close();
   db = null;
-  rmSync(workspaceRoot, { recursive: true, force: true });
+  unlinkSync(workspaceRoot); // remove the symlink itself, never its target's contents
+  rmSync(WS, { recursive: true, force: true });
 });
 
 function config(overrides: Partial<Config> = {}): Config {
@@ -188,15 +202,18 @@ describe('Issue #1477 — cleanup() dismisses the removed builder\'s held mail',
   });
 
   it('normalizes the configured workspaceRoot to the path the mailbox keyed rows under', async () => {
-    // A non-canonical but equivalent workspaceRoot — the round-trip only matches because the
-    // call site normalizes. A raw `config.workspaceRoot` would key a different string and dismiss
-    // nothing.
-    mockGetConfig.mockReturnValue(config({ workspaceRoot: join(workspaceRoot, 'nested', '..') }));
+    // Guard the fixture itself: if these two ever became the same string, this test would go
+    // quietly vacuous again rather than failing.
+    expect(workspaceRoot).not.toBe(WS);
+    expect(normalizeWorkspacePath(workspaceRoot)).toBe(WS);
+
     const held = hold('air-1477', 1000);
     mockLoadState.mockReturnValue({ builders: [builder('air-1477')], architects: [], utils: [], annotations: [] });
 
     await cleanup({ project: 'air-1477' });
 
+    // Only reachable because `cleanup.ts:389` normalizes: keying on the raw symlinked
+    // `config.workspaceRoot` matches no row, and this stays `held`.
     expect(mailbox.getById(getGlobalDb(), held.id)?.status).toBe('dismissed');
   });
 

--- a/packages/codev/src/agent-farm/__tests__/air-1477-cleanup-dismiss-invocation.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/air-1477-cleanup-dismiss-invocation.test.ts
@@ -1,0 +1,231 @@
+/**
+ * `cleanupBuilder()` actually INVOKES the held-mail dismissal (Issue #1477, refs Spec 1313 round 3).
+ *
+ * `spec-1313-cleanup-dismiss.test.ts` covers the seam by re-implementing it — it calls
+ * `mailbox.dismissHeldForAgent` directly and says outright that "the full `cleanupBuilder` ... is
+ * out of scope here". That leaves the call site itself untested: nothing proved that `afx cleanup`
+ * reaches the dismissal at all, nor that it passes the NORMALIZED workspace path and the canonical
+ * `builder.id` the mailbox actually keyed the rows under.
+ *
+ * So these tests drive the real exported `cleanup()` end to end with only its side-effecting
+ * collaborators stubbed (git, Tower, forge, ps, state writes). `db/mailbox.js` and
+ * `utils/workspace-path.js` stay REAL against an in-memory GLOBAL_SCHEMA database, so the
+ * assertions are about rows the production code path actually transitioned.
+ */
+
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { execFile } from 'node:child_process';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { GLOBAL_SCHEMA } from '../db/schema.js';
+import type { Builder, Config } from '../types.js';
+
+let db: Database.Database | null = null;
+/** Flips on to simulate a mailbox/DB hiccup at the dismissal step (must stay non-fatal). */
+let dbUnavailable = false;
+
+vi.mock('../db/index.js', () => {
+  const ensure = () => {
+    if (dbUnavailable) throw new Error('global.db unavailable');
+    if (!db) {
+      db = new Database(':memory:');
+      db.exec(GLOBAL_SCHEMA);
+    }
+    return db;
+  };
+  return { getDb: ensure, getGlobalDb: ensure, closeDb: () => {}, closeGlobalDb: () => {} };
+});
+
+// `ps` must never run for real here — killShellperProcesses would otherwise signal processes.
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return { ...actual, execFile: vi.fn() };
+});
+
+const mockLoadState = vi.fn();
+const mockRemoveBuilder = vi.fn();
+vi.mock('../state.js', () => ({
+  loadState: (ws: string) => mockLoadState(ws),
+  removeBuilder: (id: string, ws?: string) => mockRemoveBuilder(id, ws),
+}));
+
+const mockGetConfig = vi.fn<() => Config>();
+vi.mock('../utils/index.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../utils/index.js')>()),
+  getConfig: () => mockGetConfig(),
+}));
+
+// Silence the console logger but keep `info` observable — the dismissal's operator-facing line
+// is part of what this test asserts. Derived from the real logger's own keys so a new method
+// added upstream cannot make this suite fail for an unrelated reason.
+const loggerInfo = vi.fn();
+vi.mock('../utils/logger.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/logger.js')>();
+  const silent = Object.fromEntries(Object.keys(actual.logger).map((k) => [k, vi.fn()]));
+  return {
+    ...actual,
+    logger: { ...silent, info: loggerInfo },
+    fatal: (msg: string) => {
+      throw new Error(msg);
+    },
+  };
+});
+
+const mockRun = vi.fn(async () => ({ stdout: '', stderr: '' }));
+vi.mock('../utils/shell.js', () => ({ run: (...args: unknown[]) => mockRun(...(args as [])) }));
+
+vi.mock('../lib/tower-client.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/tower-client.js')>()),
+  TowerClient: class {
+    async killTerminal() {
+      return false;
+    }
+    // cleanupBuilder's last step (invalidate Tower's overview cache). Stubbed rather than omitted:
+    // a missing method would throw a TypeError into the surrounding catch, silently exercising the
+    // Tower-is-down recovery branch instead of the normal path.
+    async refreshOverview() {}
+  },
+}));
+
+vi.mock('../utils/file-tabs.js', () => ({ deleteFileTabsByPathPrefix: () => 0 }));
+vi.mock('../../lib/forge.js', () => ({ executeForgeCommand: vi.fn(async () => []) }));
+
+const { cleanup } = await import('../commands/cleanup.js');
+const { getGlobalDb } = await import('../db/index.js');
+const mailbox = await import('../db/mailbox.js');
+const { normalizeWorkspacePath } = await import('../utils/workspace-path.js');
+
+/** A real directory so `normalizeWorkspacePath`'s realpathSync resolves on both sides. */
+const workspaceRoot = realpathSync(mkdtempSync(join(tmpdir(), 'air-1477-cleanup-')));
+/** Exactly what the mailbox keys rows under. */
+const WS = normalizeWorkspacePath(workspaceRoot);
+
+afterAll(() => {
+  db?.close();
+  db = null;
+  rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+function config(overrides: Partial<Config> = {}): Config {
+  return {
+    workspaceRoot,
+    codevDir: join(workspaceRoot, 'codev'), // absent on disk → cleanupPorchState is a no-op
+    buildersDir: join(workspaceRoot, '.builders'),
+    stateDir: join(workspaceRoot, '.codev'),
+    templatesDir: join(workspaceRoot, 'templates'),
+    serversDir: join(workspaceRoot, 'servers'),
+    bundledRolesDir: join(workspaceRoot, 'roles'),
+    terminalBackend: 'node-pty',
+    ...overrides,
+  };
+}
+
+function builder(id: string, overrides: Partial<Builder> = {}): Builder {
+  return {
+    id,
+    name: id,
+    status: 'complete',
+    phase: 'done',
+    // Never created on disk: existsSync() is false, so no worktree/git side effects are reached.
+    worktree: join(workspaceRoot, '.builders', id),
+    branch: `builder/${id}`,
+    type: 'spec',
+    ...overrides,
+  };
+}
+
+const hold = (toAgent: string, now: number) =>
+  mailbox.enqueue(getGlobalDb(), { workspacePath: WS, toAgent, body: 'hi', formattedMessage: 'M', reason: 'busy' }, now);
+
+describe('Issue #1477 — cleanup() dismisses the removed builder\'s held mail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbUnavailable = false;
+    if (db) db.close();
+    db = null;
+    getGlobalDb();
+    mockGetConfig.mockReturnValue(config());
+    mockRun.mockResolvedValue({ stdout: '', stderr: '' });
+    vi.mocked(execFile).mockImplementation(((_cmd: string, _args: string[], cb: (e: Error | null, out: string) => void) => {
+      cb(null, '');
+      return {} as ReturnType<typeof execFile>;
+    }) as unknown as typeof execFile);
+  });
+
+  it('transitions the removed builder\'s held rows to dismissed, leaving a sibling\'s mail alone', async () => {
+    const gone1 = hold('air-1477', 1000);
+    const gone2 = hold('air-1477', 1100);
+    const stays = hold('spir-1313', 1200);
+    // Issue #1118: one global.db holds every workspace's rows, and the SAME builder id can exist
+    // in two of them. Cleaning up here must not reach into another workspace's mailbox.
+    const otherWorkspace = mailbox.enqueue(
+      getGlobalDb(),
+      { workspacePath: '/somewhere/else', toAgent: 'air-1477', body: 'hi', formattedMessage: 'M', reason: 'busy' },
+      1300,
+    );
+    mockLoadState.mockReturnValue({ builders: [builder('air-1477')], architects: [], utils: [], annotations: [] });
+
+    await cleanup({ project: 'air-1477' });
+
+    // Soft, audit-preserving transition — not a delete.
+    expect(mailbox.getById(getGlobalDb(), gone1.id)?.status).toBe('dismissed');
+    expect(mailbox.getById(getGlobalDb(), gone2.id)?.status).toBe('dismissed');
+    expect(mailbox.getById(getGlobalDb(), stays.id)?.status).toBe('held');
+    expect(mailbox.getById(getGlobalDb(), otherWorkspace.id)?.status).toBe('held');
+
+    // The removed builder no longer pins the workspace held count or the starvation alarm.
+    expect(mailbox.heldSummaryForWorkspace(getGlobalDb(), WS).byAgent.map((a) => a.toAgent)).toEqual(['spir-1313']);
+    // findStarvingAgents is Tower-GLOBAL, so scope to this workspace — the surviving
+    // `/somewhere/else` row for the same id is exactly what must NOT have been dismissed.
+    const starving = mailbox.findStarvingAgents(getGlobalDb());
+    expect(starving.filter((s) => s.workspacePath === WS).map((s) => s.toAgent)).toEqual(['spir-1313']);
+    expect(starving.some((s) => s.workspacePath === '/somewhere/else' && s.toAgent === 'air-1477')).toBe(true);
+
+    expect(loggerInfo).toHaveBeenCalledWith('Dismissed 2 held mailbox message(s) for air-1477');
+    expect(mockRemoveBuilder).toHaveBeenCalledWith('air-1477', workspaceRoot);
+  });
+
+  it('normalizes the configured workspaceRoot to the path the mailbox keyed rows under', async () => {
+    // A non-canonical but equivalent workspaceRoot — the round-trip only matches because the
+    // call site normalizes. A raw `config.workspaceRoot` would key a different string and dismiss
+    // nothing.
+    mockGetConfig.mockReturnValue(config({ workspaceRoot: join(workspaceRoot, 'nested', '..') }));
+    const held = hold('air-1477', 1000);
+    mockLoadState.mockReturnValue({ builders: [builder('air-1477')], architects: [], utils: [], annotations: [] });
+
+    await cleanup({ project: 'air-1477' });
+
+    expect(mailbox.getById(getGlobalDb(), held.id)?.status).toBe('dismissed');
+  });
+
+  it('dismisses held mail for an ephemeral (bugfix) builder too — the step is type-agnostic', async () => {
+    const held = hold('bugfix-42', 1000);
+    mockLoadState.mockReturnValue({
+      builders: [builder('bugfix-42', { type: 'bugfix', issueNumber: 42 })],
+      architects: [],
+      utils: [],
+      annotations: [],
+    });
+
+    await cleanup({ issue: 42, force: true });
+
+    expect(mailbox.getById(getGlobalDb(), held.id)?.status).toBe('dismissed');
+    expect(mockRemoveBuilder).toHaveBeenCalledWith('bugfix-42', workspaceRoot);
+  });
+
+  it('is non-fatal: a global.db failure at the dismissal step does not block state cleanup', async () => {
+    hold('air-1477', 1000);
+    mockLoadState.mockReturnValue({ builders: [builder('air-1477')], architects: [], utils: [], annotations: [] });
+    // Blunt on purpose: every `getGlobalDb()` throws, which the earlier file-tab step also
+    // absorbs. The dismissal's own `try` is still what this pins — remove it from cleanup.ts and
+    // the throw escapes `cleanup()`, failing the assertion below.
+    dbUnavailable = true;
+
+    await expect(cleanup({ project: 'air-1477' })).resolves.toBeUndefined();
+
+    dbUnavailable = false;
+    expect(mockRemoveBuilder).toHaveBeenCalledWith('air-1477', workspaceRoot);
+  });
+});

--- a/packages/codev/src/agent-farm/__tests__/air-1477-cleanup-dismiss-invocation.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/air-1477-cleanup-dismiss-invocation.test.ts
@@ -113,6 +113,10 @@ const { normalizeWorkspacePath } = await import('../utils/workspace-path.js');
  */
 const WS = realpathSync(mkdtempSync(join(tmpdir(), 'air-1477-cleanup-')));
 const workspaceRoot = join(realpathSync(tmpdir()), `air-1477-cleanup-link-${process.pid}`);
+// A hard-killed run (SIGKILL/OOM) skips afterAll and strands this link; a later run that draws the
+// same pid would then die on EEXIST at module load — taking the whole FILE, not one test, and with
+// an opaque error. Clearing first makes the fixture idempotent.
+rmSync(workspaceRoot, { force: true });
 symlinkSync(WS, workspaceRoot);
 
 afterAll(() => {

--- a/packages/codev/src/agent-farm/__tests__/air-1477-owner-escalation-wiring.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/air-1477-owner-escalation-wiring.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Owner-resolution WIRING for the starvation alarm (Issue #1477, refs Spec 1313 round 3).
+ *
+ * `escalateHeldToOwner` is the glue between the drainer's `noticeOverdue` pass and the live
+ * registry: it decides WHO hears that a builder's mail is stuck, and enqueues the notice. The
+ * resolver underneath (`resolveAgentInRegistry`) and the drainer→port contract are both covered
+ * elsewhere; the invocation layer between them was not — `send-delivery.test.ts` only ever stubs
+ * `ports.escalateHeldToOwner`, so nothing exercised the real binding.
+ *
+ * These tests drive it through its production seam — the exported `makeDeliveryPorts`, which is
+ * deliberately safe to call before Tower is up — against a seeded global.db registry and the real
+ * `state.js` / `tower-messages.js` / `db/mailbox.js` code. Only the DB singleton is substituted
+ * (an in-memory GLOBAL_SCHEMA database), so the architect-skip guard, the spawning-architect →
+ * `main` → first-registered fallback chain, and the supersede-keyed coalescing are all exercised
+ * as they run in production.
+ */
+
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { mkdtempSync, mkdirSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { GLOBAL_SCHEMA } from '../db/schema.js';
+import type { ArchitectState, Builder } from '../types.js';
+
+let db: Database.Database | null = null;
+
+// The single shared global.db (Issue #1118): getDb() and getGlobalDb() both return it, so
+// state.ts (registry reads/writes) and mailbox-wiring.ts (notice enqueue) see the same rows.
+vi.mock('../db/index.js', () => {
+  const ensure = () => {
+    if (!db) {
+      db = new Database(':memory:');
+      db.exec(GLOBAL_SCHEMA);
+    }
+    return db;
+  };
+  return { getDb: ensure, getGlobalDb: ensure, closeDb: () => {}, closeGlobalDb: () => {} };
+});
+
+const { getGlobalDb } = await import('../db/index.js');
+const { setArchitectByName, upsertBuilder } = await import('../state.js');
+const { makeDeliveryPorts, formatOwnerNoticeBody } = await import('../servers/mailbox-wiring.js');
+const { getMailboxDrainer } = await import('../servers/mailbox-wiring.js');
+const { listHeld, getById, NOTICE_SUPERSEDE_PREFIX } = await import('../db/mailbox.js');
+const mailbox = await import('../db/mailbox.js');
+import type { HeldOwnerNoticeInfo } from '../servers/mailbox-delivery.js';
+
+/** A real directory, so `normalizeWorkspacePath`'s realpathSync resolves on both sides. */
+const root = realpathSync(mkdtempSync(join(tmpdir(), 'air-1477-escalate-')));
+const WS = root;
+
+afterAll(() => {
+  db?.close();
+  db = null;
+  rmSync(root, { recursive: true, force: true });
+});
+
+function architect(name: string): ArchitectState {
+  return { name, cmd: 'claude', startedAt: new Date().toISOString() };
+}
+
+/** Register a builder whose worktree places it in WS (upsertBuilder derives the workspace). */
+function registerBuilder(id: string, spawnedByArchitect?: string): Builder {
+  const worktree = join(WS, '.builders', id);
+  mkdirSync(worktree, { recursive: true });
+  const builder: Builder = {
+    id,
+    name: id,
+    status: 'implementing',
+    phase: 'implement',
+    worktree,
+    branch: `builder/${id}`,
+    type: 'spec',
+    spawnedByArchitect,
+  };
+  upsertBuilder(builder);
+  return builder;
+}
+
+const logs: Array<{ level: string; message: string }> = [];
+const ports = () => makeDeliveryPorts((level, message) => logs.push({ level, message }));
+
+function info(overrides: Partial<HeldOwnerNoticeInfo> = {}): HeldOwnerNoticeInfo {
+  return {
+    workspacePath: WS,
+    toAgent: 'air-1477',
+    reason: 'busy',
+    detail: 'no-region-end',
+    ageMs: 7 * 60_000,
+    heldCount: 3,
+    streak: 41,
+    ...overrides,
+  };
+}
+
+/** The still-held notice rows about `toAgent` (what the owner would actually receive). */
+function notices(toAgent: string) {
+  return listHeld(getGlobalDb(), WS).filter((r) => r.supersede_key === `${NOTICE_SUPERSEDE_PREFIX}${toAgent}`);
+}
+
+describe('Issue #1477 — escalateHeldToOwner owner-resolution wiring', () => {
+  beforeEach(() => {
+    if (db) db.close();
+    db = null;
+    getGlobalDb(); // recreate a clean schema for this test
+    logs.length = 0;
+  });
+
+  it('never raises a notice about a starving ARCHITECT — not even to a different architect', () => {
+    setArchitectByName(WS, 'main', architect('main'));
+    setArchitectByName(WS, 'zeta', architect('zeta'));
+
+    // The starving agent IS an architect. Without the skip, `zeta` would resolve an owner
+    // (`main`, a DIFFERENT agent, so the self-notify guard would not catch it) and the alarm
+    // would become mail about mail. `afx status` covers the starving-architect case instead.
+    expect(ports().escalateHeldToOwner!(info({ toAgent: 'zeta' }))).toBe(false);
+    // The degenerate single-architect case is silent too. (NB: it is stopped by this same
+    // architect-skip guard, not by the later `owner.agent === info.toAgent` one — under the real
+    // resolver that second guard is unreachable, since resolving to an architect requires it to be
+    // registered, which the skip already caught. No test here claims to cover it.)
+    expect(ports().escalateHeldToOwner!(info({ toAgent: 'main' }))).toBe(false);
+    expect(listHeld(getGlobalDb(), WS)).toHaveLength(0);
+  });
+
+  it('routes the notice to the starving builder\'s SPAWNING architect (affinity beats main)', () => {
+    setArchitectByName(WS, 'main', architect('main'));
+    setArchitectByName(WS, 'alpha', architect('alpha'));
+    registerBuilder('air-1477', 'alpha');
+
+    const payload = info();
+    expect(ports().escalateHeldToOwner!(payload)).toBe(true);
+
+    const [notice] = notices('air-1477');
+    expect(notice).toBeDefined();
+    expect(notice.to_agent).toBe('alpha');
+    expect(notice.from_agent).toBe('af-mailbox');
+    expect(notice.status).toBe('held'); // gate-delivered like any other mail, never forced
+    // The row carries the tested operator-facing body, and the PTY bytes wrap it.
+    expect(notice.body).toBe(formatOwnerNoticeBody(payload));
+    expect(notice.formatted_message).toContain(notice.body);
+    expect(logs.some((l) => l.level === 'WARN' && l.message.includes('STARVATION notice → alpha'))).toBe(true);
+  });
+
+  it('falls back to `main` when the spawning architect is no longer registered', () => {
+    setArchitectByName(WS, 'main', architect('main'));
+    setArchitectByName(WS, 'zeta', architect('zeta'));
+    registerBuilder('air-1477', 'ghost'); // spawner has since been removed
+
+    expect(ports().escalateHeldToOwner!(info())).toBe(true);
+    expect(notices('air-1477')[0].to_agent).toBe('main');
+  });
+
+  it('falls back to the workspace\'s first architect (getArchitects\' id order) when there is no `main`', () => {
+    // Registered zeta-then-alpha on purpose: `resolveRegistryArchitect` takes `architects[0]`
+    // from `getArchitects`, which is `ORDER BY id` — LEXICOGRAPHIC, not insertion order.
+    //
+    // This asserts what ships, and what ships is not quite what the surrounding prose promises:
+    // the doc comments say "first registered", and both `loadState`
+    // (`ORDER BY (id != 'main'), started_at`) and the LIVE resolver (`entry.architects.values()`,
+    // registration order) implement it that way. Only this REGISTRY fallback sorts by id, so an
+    // offline hold can name a different architect than a live send would. That divergence is a
+    // production question, not something a test-only change should quietly fix — the test pins
+    // current behaviour so the discrepancy is visible rather than silent.
+    setArchitectByName(WS, 'zeta', architect('zeta'));
+    setArchitectByName(WS, 'alpha', architect('alpha'));
+    registerBuilder('air-1477'); // legacy row: no spawning architect recorded
+
+    expect(ports().escalateHeldToOwner!(info())).toBe(true);
+    expect(notices('air-1477')[0].to_agent).toBe('alpha');
+  });
+
+  it('no-ops (and logs why) when no architect is registered, leaving the alarm to retry', () => {
+    registerBuilder('air-1477', 'alpha');
+
+    // Returning false is load-bearing: the drainer arms its once-per-episode guard only on
+    // `true`, so a no-op here retries next tick rather than silencing the episode.
+    expect(ports().escalateHeldToOwner!(info())).toBe(false);
+    expect(listHeld(getGlobalDb(), WS)).toHaveLength(0);
+    expect(logs.some((l) => l.message.includes('no architect to notify'))).toBe(true);
+  });
+
+  it('coalesces repeat escalations onto ONE pending notice via the supersede key', () => {
+    setArchitectByName(WS, 'main', architect('main'));
+    registerBuilder('air-1477', 'main');
+    registerBuilder('air-1500', 'main');
+
+    expect(ports().escalateHeldToOwner!(info({ heldCount: 3 }))).toBe(true);
+    const stale = notices('air-1477')[0].id;
+    expect(ports().escalateHeldToOwner!(info({ heldCount: 9 }))).toBe(true);
+    // A different starving agent gets its OWN key, so it is not collapsed into the first.
+    expect(ports().escalateHeldToOwner!(info({ toAgent: 'air-1500' }))).toBe(true);
+
+    const pending = notices('air-1477');
+    expect(pending).toHaveLength(1);
+    expect(pending[0].id).not.toBe(stale);
+    expect(pending[0].body).toContain('9 messages held'); // the freshest metadata wins
+    expect(notices('air-1500')).toHaveLength(1);
+
+    // Audit-preserving: the replaced notice is `superseded`, not deleted, and the architect's
+    // pending set stays at exactly one notice per starving agent.
+    expect(getById(getGlobalDb(), stale)?.status).toBe('superseded');
+    expect(listHeld(getGlobalDb(), WS)).toHaveLength(2);
+  });
+
+  it('schedules a prompt gated drain for the RESOLVED owner, so the notice is not left to the backstop', () => {
+    setArchitectByName(WS, 'main', architect('main'));
+    setArchitectByName(WS, 'alpha', architect('alpha'));
+    registerBuilder('air-1477', 'alpha');
+    // Spy on the module's drainer singleton — the same instance `escalateHeldToOwner` reaches via
+    // `ensureDrainer()`. Without this the glue is invisible: the drainer is never started in a unit
+    // test, so `scheduleDrain` no-ops and deleting the call would leave every other test green.
+    const scheduleDrain = vi.spyOn(getMailboxDrainer(), 'scheduleDrain').mockResolvedValue();
+
+    expect(ports().escalateHeldToOwner!(info())).toBe(true);
+
+    // The drain targets the OWNER (who must read the notice), never the starving agent.
+    expect(scheduleDrain).toHaveBeenCalledWith(WS, 'alpha');
+    scheduleDrain.mockRestore();
+  });
+
+  it('clearHeldOwnerNotice dismisses the pending notice once the starvation is over', () => {
+    setArchitectByName(WS, 'main', architect('main'));
+    registerBuilder('air-1477', 'main');
+    const port = ports();
+
+    port.escalateHeldToOwner!(info());
+    const noticeId = notices('air-1477')[0].id;
+
+    // A notice about a DIFFERENT starving agent must survive: the clear is keyed to one agent.
+    registerBuilder('air-1500', 'main');
+    port.escalateHeldToOwner!(info({ toAgent: 'air-1500' }));
+    const otherNoticeId = notices('air-1500')[0].id;
+
+    // Ordinary mail to the same architect must survive too.
+    const ordinary = mailbox.enqueue(getGlobalDb(), {
+      workspacePath: WS,
+      toAgent: 'main',
+      body: 'unrelated',
+      formattedMessage: 'unrelated',
+    });
+
+    port.clearHeldOwnerNotice!(WS, 'air-1477');
+    expect(getById(getGlobalDb(), noticeId)?.status).toBe('dismissed');
+    expect(getById(getGlobalDb(), otherNoticeId)?.status).toBe('held');
+    expect(getById(getGlobalDb(), ordinary.id)?.status).toBe('held');
+  });
+
+  it('resolves the owner within the STARVING agent\'s workspace, not some other one', () => {
+    // Issue #1118: one global.db serves every workspace, and the same builder id can live in two.
+    // A notice must be raised against `info.workspacePath`'s registry and enqueued there.
+    const other = realpathSync(mkdtempSync(join(tmpdir(), 'air-1477-escalate-other-')));
+    try {
+      setArchitectByName(WS, 'alpha', architect('alpha'));
+      setArchitectByName(other, 'beta', architect('beta'));
+      registerBuilder('air-1477', 'alpha');
+      // A same-id builder in the OTHER workspace, spawned by that workspace's architect.
+      mkdirSync(join(other, '.builders', 'air-1477'), { recursive: true });
+      upsertBuilder({
+        id: 'air-1477',
+        name: 'air-1477',
+        status: 'implementing',
+        phase: 'implement',
+        worktree: join(other, '.builders', 'air-1477'),
+        branch: 'builder/air-1477',
+        type: 'spec',
+        spawnedByArchitect: 'beta',
+      });
+
+      expect(ports().escalateHeldToOwner!(info())).toBe(true);
+
+      const [notice] = notices('air-1477');
+      expect(notice.to_agent).toBe('alpha'); // WS's architect, never `other`'s beta
+      expect(notice.workspace_path).toBe(WS);
+      expect(listHeld(getGlobalDb(), other)).toHaveLength(0);
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/codev/src/agent-farm/__tests__/air-1477-owner-escalation-wiring.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/air-1477-owner-escalation-wiring.test.ts
@@ -15,7 +15,7 @@
  * as they run in production.
  */
 
-import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
 import Database from 'better-sqlite3';
 import { mkdtempSync, mkdirSync, rmSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -56,8 +56,12 @@ afterAll(() => {
   rmSync(root, { recursive: true, force: true });
 });
 
-function architect(name: string): ArchitectState {
-  return { name, cmd: 'claude', startedAt: new Date().toISOString() };
+/**
+ * `startedAt` is explicit, never `new Date()`: two architects created in the same millisecond tie,
+ * and a tie would make any registration-order assertion arbitrary rather than discriminating.
+ */
+function architect(name: string, startedAt = '2026-01-01T00:00:00.000Z'): ArchitectState {
+  return { name, cmd: 'claude', startedAt };
 }
 
 /** Register a builder whose worktree places it in WS (upsertBuilder derives the workspace). */
@@ -107,6 +111,12 @@ describe('Issue #1477 — escalateHeldToOwner owner-resolution wiring', () => {
     logs.length = 0;
   });
 
+  // The drainer is a module singleton shared by every test in this file, so a spy on it must be
+  // torn down unconditionally — an in-body restore is skipped when an assertion above it fails.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('never raises a notice about a starving ARCHITECT — not even to a different architect', () => {
     setArchitectByName(WS, 'main', architect('main'));
     setArchitectByName(WS, 'zeta', architect('zeta'));
@@ -152,8 +162,10 @@ describe('Issue #1477 — escalateHeldToOwner owner-resolution wiring', () => {
   });
 
   it('falls back to the workspace\'s first architect (getArchitects\' id order) when there is no `main`', () => {
-    // Registered zeta-then-alpha on purpose: `resolveRegistryArchitect` takes `architects[0]`
-    // from `getArchitects`, which is `ORDER BY id` — LEXICOGRAPHIC, not insertion order.
+    // Registered zeta first and, crucially, with the EARLIER `started_at`. So id order and
+    // registration order disagree, and only one of them can produce `alpha`:
+    // `resolveRegistryArchitect` takes `architects[0]` from `getArchitects`, which is
+    // `ORDER BY id` — LEXICOGRAPHIC, not registration order.
     //
     // This asserts what ships, and what ships is not quite what the surrounding prose promises:
     // the doc comments say "first registered", and both `loadState`
@@ -162,8 +174,8 @@ describe('Issue #1477 — escalateHeldToOwner owner-resolution wiring', () => {
     // offline hold can name a different architect than a live send would. That divergence is a
     // production question, not something a test-only change should quietly fix — the test pins
     // current behaviour so the discrepancy is visible rather than silent.
-    setArchitectByName(WS, 'zeta', architect('zeta'));
-    setArchitectByName(WS, 'alpha', architect('alpha'));
+    setArchitectByName(WS, 'zeta', architect('zeta', '2026-01-01T00:00:00.000Z'));
+    setArchitectByName(WS, 'alpha', architect('alpha', '2026-06-01T00:00:00.000Z'));
     registerBuilder('air-1477'); // legacy row: no spawning architect recorded
 
     expect(ports().escalateHeldToOwner!(info())).toBe(true);
@@ -210,13 +222,17 @@ describe('Issue #1477 — escalateHeldToOwner owner-resolution wiring', () => {
     // Spy on the module's drainer singleton — the same instance `escalateHeldToOwner` reaches via
     // `ensureDrainer()`. Without this the glue is invisible: the drainer is never started in a unit
     // test, so `scheduleDrain` no-ops and deleting the call would leave every other test green.
+    // Restored by the suite's afterEach, NOT here: a failed assertion below would skip an
+    // in-body restore and leak the spy into every later test in the file.
     const scheduleDrain = vi.spyOn(getMailboxDrainer(), 'scheduleDrain').mockResolvedValue();
 
     expect(ports().escalateHeldToOwner!(info())).toBe(true);
 
     // The drain targets the OWNER (who must read the notice), never the starving agent.
+    // NB the workspace argument is NOT pinned here: production passes `owner.workspacePath`, and
+    // `resolveRegistryArchitect` returns the very workspace it was asked about, so owner and
+    // starving workspace are equal by construction and swapping them is undetectable from outside.
     expect(scheduleDrain).toHaveBeenCalledWith(WS, 'alpha');
-    scheduleDrain.mockRestore();
   });
 
   it('clearHeldOwnerNotice dismisses the pending notice once the starvation is over', () => {

--- a/packages/codev/src/agent-farm/__tests__/air-1477-owner-escalation-wiring.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/air-1477-owner-escalation-wiring.test.ts
@@ -167,13 +167,15 @@ describe('Issue #1477 — escalateHeldToOwner owner-resolution wiring', () => {
     // `resolveRegistryArchitect` takes `architects[0]` from `getArchitects`, which is
     // `ORDER BY id` — LEXICOGRAPHIC, not registration order.
     //
-    // This asserts what ships, and what ships is not quite what the surrounding prose promises:
+    // Tracked as Issue #1633 — read that before "fixing" this assertion. It is pinned, not blessed:
+    // this asserts what ships, and what ships is not quite what the surrounding prose promises:
     // the doc comments say "first registered", and both `loadState`
     // (`ORDER BY (id != 'main'), started_at`) and the LIVE resolver (`entry.architects.values()`,
     // registration order) implement it that way. Only this REGISTRY fallback sorts by id, so an
     // offline hold can name a different architect than a live send would. That divergence is a
     // production question, not something a test-only change should quietly fix — the test pins
-    // current behaviour so the discrepancy is visible rather than silent.
+    // current behaviour so the discrepancy is visible rather than silent. When #1633 is fixed this
+    // test SHOULD fail; flip it to `zeta` and update the comment rather than deleting it.
     setArchitectByName(WS, 'zeta', architect('zeta', '2026-01-01T00:00:00.000Z'));
     setArchitectByName(WS, 'alpha', architect('alpha', '2026-06-01T00:00:00.000Z'));
     registerBuilder('air-1477'); // legacy row: no spawning architect recorded

--- a/packages/codev/src/agent-farm/__tests__/spec-1313-cleanup-dismiss.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/spec-1313-cleanup-dismiss.test.ts
@@ -12,6 +12,12 @@
  * and that the workspace-path round-trip (store side ↔ cleanup side) matches. The full
  * `cleanupBuilder` (git worktree + forge + state removal) is out of scope here by the same
  * re-implementation convention `cleanup-preserve-status.test.ts` uses.
+ *
+ * Issue #1477: the INVOCATION half — that `afx cleanup` actually reaches this seam, with the
+ * normalized workspace path and the canonical builder id — is covered by
+ * `air-1477-cleanup-dismiss-invocation.test.ts`, which drives the real exported `cleanup()`.
+ * Keep the split in mind before extending either file: this one owns the seam's semantics, that
+ * one owns the wiring that calls it.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';


### PR DESCRIPTION
Closes #1477.

Test-only. **No production file is modified** — `git diff` against `main` touches nothing under
`src/`, and all three reviewers verified that independently.

Issue #1477 named two Spec 1313 round-3 glue points that were verified by inspection only. Both
are now covered directly.

## What was actually uncovered

| Glue point | Why the existing tests missed it |
|---|---|
| `escalateHeldToOwner` (`servers/mailbox-wiring.ts:405`) | `send-delivery.test.ts` only ever **stubs** `ports.escalateHeldToOwner` (`:150`, `:1189`, `:1196`), so it tests the drainer's *decision to escalate*, never the binding that resolves the owner. |
| `cleanupBuilder`'s held-row dismissal (`commands/cleanup.ts:389`) | `spec-1313-cleanup-dismiss.test.ts` says in its own header that it **re-implements** the seam (`mailbox.dismissHeldForAgent` called directly) and that "the full `cleanupBuilder` … is out of scope here". |

The resolvers underneath (`resolveAgentInRegistry`) and `formatOwnerNoticeBody` are already tested
in isolation. These two files are the missing third leg: the binding between them.

## Approach — substitute the DB singleton, nothing else

`vi.mock('../db/index.js')` returns one in-memory `GLOBAL_SCHEMA` database from both `getDb()` and
`getGlobalDb()` — which *is* the Issue #1118 production shape. That leaves `state.ts`,
`servers/tower-messages.ts`, `db/mailbox.ts` and `utils/workspace-path.ts` all running for real, so
the tests observe rows the production code path actually transitioned.

Precedent: `spec-755-lookup-builder.test.ts`, improved on by importing the real `GLOBAL_SCHEMA`
rather than hand-copying a `CREATE TABLE`.

The cleanup test drives the real exported `cleanup()` end to end, stubbing only side-effecting
collaborators (git, Tower, forge, `ps`, state writes).

## Coverage

**`air-1477-owner-escalation-wiring.test.ts`** (9 tests) — architect-skip; spawning-architect
affinity; `main` fallback when the spawner is deregistered; the no-`main` tie-break; the no-op that
returns `false` so the drainer's once-per-episode guard stays unarmed and retries; supersede-keyed
coalescing; drain scheduled for the resolved owner; cross-workspace owner resolution;
`clearHeldOwnerNotice` key specificity.

**`air-1477-cleanup-dismiss-invocation.test.ts`** (4 tests) — dismissal reached from `cleanup()`,
siblings untouched; the normalized-workspace round-trip; cross-workspace isolation of the same
builder id (#1118); ephemeral builders; non-fatal on a DB failure.

The fixture hands `getConfig()` a **symlink** to the workspace directory while the mailbox keys
rows under the canonical path, so every test in that file traverses `normalizeWorkspacePath` rather
than just one, and a guard assertion fails loudly if the two paths ever collapse to the same
string.

## Verification

Every assertion was mutation-checked against the real source, then the source restored:

| Mutation | Result |
|---|---|
| Delete `dismissHeldForAgent(...)` from `cleanup.ts:389` | 3 failures |
| Strip `normalizeWorkspacePath` from that call | 3 failures |
| Drop the workspace scope from that call | 3 failures |
| Drop the `sender` arg from `resolveAgentInRegistry('architect', ws, info.toAgent)` | 2 failures |
| Delete the `getArchitectByName` architect-skip guard | 1 failure |
| Point `scheduleDrain` at the starving agent instead of the owner | 1 failure |
| Make `clearHeldOwnerNotice` ignore the agent key | 1 failure |
| Switch `getArchitects` to `ORDER BY started_at` | 1 failure |

13 tests pass; `tsc --noEmit` clean; the full `agent-farm` suite is green (163 files, 3442 tests).

On size, against AIR's "<300 LOC" framing:

```
$ git diff --stat main...HEAD -- packages/codev/src
 air-1477-cleanup-dismiss-invocation.test.ts | 252 +
 air-1477-owner-escalation-wiring.test.ts    | 298 +
 spec-1313-cleanup-dismiss.test.ts           |   6 +
 3 files changed, 556 insertions(+)
```

This number has been wrong three times now — 511 went stale when the round-2 fixes grew the files,
544 when the `rmSync` lines landed, 554 when the #1633 cross-link did. Each time I retyped a
snapshot instead of re-running the command. Pasting the output so the next reader can see what it
counts, and re-checked against the final commit. Comment density is high, but flagging the number rather than letting you
discover it. Happy to trim; the cross-workspace cases are the ones I'd cut last.

Note for anyone running the suite in a fresh worktree: 12 unrelated suites fail until
`pnpm bundle-assets` and `tsc` have run (they need `packages/codev/skeleton/` and `dist/`). All 12
pass afterwards.

## Correction to an earlier revision of this description

The first push of this PR claimed the normalization test proved "a raw `config.workspaceRoot` would
key a different string and dismiss nothing." **That was false**, and the review caught it. The
fixture pre-`realpathSync`'d its root (making `normalizeWorkspacePath` the identity) and its
"non-canonical" override `join(root, 'nested', '..')` collapsed *lexically* inside `path.join`
before normalization was ever reached — so the two strings were already equal and the suite stayed
green with `normalizeWorkspacePath` deleted from `cleanup.ts`. I reproduced that before fixing it.

Round 1 said the tests were "mutation-checked", and they were — but I mutated the *call* and never
its *argument*, so the one thing that test existed to pin was the one thing I never tried to break.
The symlink fixture fixes it, and stripping `normalizeWorkspacePath` now fails 3 tests.

## Reviewed 3 ways

Gemini APPROVE. Codex and Claude each found real defects in the first draft, all fixed here — most
importantly that **`scheduleDrain` was uncovered**: the drainer is never started in a unit test, so
the call no-ops and deleting it left every test green. It now has a spy asserting the drain targets
the resolved owner.

Two other corrections worth naming, because both were cases of the tests *claiming* more than they
did:

- The suite implied it covered the `owner.agent === info.toAgent` self-notify guard. It does not —
  that branch is unreachable under the real resolver, since resolving to an architect requires that
  architect to be registered, which the architect-skip already caught. Comment corrected rather than
  mocking a path to dead code.
- The `TowerClient` stub was backwards: it implemented `killTerminal` (never called) and omitted
  `refreshOverview` (called at `cleanup.ts:422`), so every test silently ran the Tower-unreachable
  branch.

Round 2 (on this PR) fixed the vacuous test above, plus a `scheduleDrain` spy whose `mockRestore`
sat at the end of the `it` body (a failed assertion above it would leak the spy into later tests),
and an architect fixture where both records shared `new Date()` and could tie — `startedAt` is now
explicit, with `zeta` registered *earlier*, so id order and registration order genuinely disagree.

Two review items are deliberately not addressed, rather than silently skipped: `scheduleDrain`'s
workspace argument cannot be pinned from outside (`resolveRegistryArchitect` returns the workspace
it was asked about, so owner and starving workspace are equal by construction — noted in a comment
instead of faked), and the `loadConfig(homedir())` hermeticity smell is inherited from production
and would need a production change.

## One production observation — now filed as #1633

`resolveRegistryArchitect` takes `architects[0]` from `getArchitects`, which is `ORDER BY id` —
**alphabetical by architect name**. The doc comments there and in `mailbox-wiring.ts` say
"first-registered", and both `loadState` (`ORDER BY (id != 'main'), started_at`) and the live
resolver (registry insertion order) implement it that way. So an offline hold can name a different
architect than a live send to the same workspace would.

Deterministic and low-impact, and changing it is a production decision outside a test-only AIR — so
the test pins current behaviour and says plainly in a comment that it diverges from the documented
contract, rather than either blessing the wording or quietly asserting the aspiration.

Filed as **#1633**. Worth noting there: `getArchitect` (singular) was already fixed for exactly this
bug — `spec-755-migration.test.ts:279` pins it as "started_at order, not lexicographic" — but
`getArchitects` (plural), which the offline resolver reads, never got the same treatment. The fix
landed on one of the two functions.

## PR-stage CMAP (AIR `pr` phase)

Distinct from the architect's integration review above — different stage, different prompt.

**gemini APPROVE (HIGH)** · **codex COMMENT (HIGH)** · **claude APPROVE (HIGH)**. No blockers.

Claude independently re-ran three mutations against real source (restoring afterwards) and
reproduced the claimed counts exactly: stripping `normalizeWorkspacePath` → 3 failures, retargeting
`scheduleDrain` → 1, dropping the `sender` arg → 2. It also confirmed CI runs ubuntu + macos only,
so the `symlinkSync` fixture has no Windows exposure.

Two review items acted on:

- **Codex** — the size disclosure was stale (511 vs the actual 544). Corrected above; it was my
  round-1 number left unrevised after round 2 grew the files.
- **Claude** — the module-scope `symlinkSync` used a PID-derived name, so a hard-killed run
  (SIGKILL/OOM) could strand the link and make a later run drawing the same PID fail with `EEXIST`
  at *collection*, losing the whole file rather than one test. Now `rmSync(…, { force: true })`
  first, which I verified reproduces `EEXIST` without it and succeeds with it.

Claude also noted the `ORDER BY id` divergence had no filed issue and could die with this thread.
The human's call was that I file it: **#1633**. The test that pins the current behaviour now names
that issue in its comment, and the issue names the test — including the fact that fixing #1633
*should* break that assertion, and that flipping it to `zeta` is the intended response rather than
deleting it.

Refs #1313 (PR #1330), maintainer optional-2 in the Follow-up section of
`codev/reviews/1313-afx-send-mailbox-first-delivery.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
