### PR TITLE
Fix #1630: set TOWER_TEST_PORT in the scheduled dashboard e2e workflow

### DIFF
--- a/.github/workflows/dashboard-e2e.yml
+++ b/.github/workflows/dashboard-e2e.yml
@@ -46,4 +46,7 @@ jobs:
         env:
           TOWER_ARCHITECT_CMD: bash
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # #1630: the held-popover e2e test (PR #1604) refuses to run without an
+          # explicit port so it can never target a live Tower on 4100.
+          TOWER_TEST_PORT: '14100'
         run: pnpm exec playwright test --retries 3


### PR DESCRIPTION
One env line: the scheduled Dashboard E2E run has been red since PR #1604 landed its live-Tower guard (the test refuses to default to port 4100). CI never had TOWER_TEST_PORT set, so the guard trips. Sets it to 14100, matching the guard's own suggestion. The playwright.config 4100 default remains a flagged follow-up in #1630 (needs per-test default sync). Fixes #1630.