### PR TITLE
Fix #1630: sync e2e test ports with TOWER_TEST_PORT (completes PR #1632)

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/e2e/dashboard-bugs.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/dashboard-bugs.test.ts
@@ -15,7 +15,7 @@
 import { test, expect } from './tower-auth.js';
 import { resolve } from 'node:path';
 
-const TOWER_URL = 'http://localhost:4100';
+const TOWER_URL = `http://localhost:${process.env.TOWER_TEST_PORT || '4100'}`;
 const WORKSPACE_PATH = resolve(import.meta.dirname, '../../../../../../');
 
 function toBase64URL(str: string): string {

--- a/packages/codev/src/agent-farm/__tests__/e2e/dashboard-terminals.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/dashboard-terminals.test.ts
@@ -13,7 +13,7 @@ import { resolve } from 'node:path';
 import { test, expect } from './tower-auth.js';
 import { towerWsProtocols } from './tower-key.js';
 
-const TOWER_URL = 'http://localhost:4100';
+const TOWER_URL = `http://localhost:${process.env.TOWER_TEST_PORT || '4100'}`;
 const WORKSPACE_PATH = resolve(import.meta.dirname, '../../../../../../');
 const ENCODED_PATH = Buffer.from(WORKSPACE_PATH).toString('base64url');
 // Browsers can't set headers on a WebSocket, so Tower's key travels as a
@@ -73,7 +73,7 @@ test.describe('Dashboard Terminals E2E', () => {
     await page.goto(PAGE_URL);
     const wsConnected = await page.evaluate(({ tid, encodedPath, protocols }: { tid: string; encodedPath: string; protocols: string[] | undefined }) => {
       return new Promise<boolean>((resolve) => {
-        const ws = new WebSocket(`ws://localhost:4100/workspace/${encodedPath}/ws/terminal/${tid}`, protocols);
+        const ws = new WebSocket(`ws://localhost:${process.env.TOWER_TEST_PORT || '4100'}/workspace/${encodedPath}/ws/terminal/${tid}`, protocols);
         ws.binaryType = 'arraybuffer';
         ws.onopen = () => {
           ws.close();
@@ -104,7 +104,7 @@ test.describe('Dashboard Terminals E2E', () => {
     await page.goto(PAGE_URL);
     const wsConnected = await page.evaluate(({ tid, encodedPath, protocols }: { tid: string; encodedPath: string; protocols: string[] | undefined }) => {
       return new Promise<boolean>((resolve) => {
-        const ws = new WebSocket(`ws://localhost:4100/workspace/${encodedPath}/ws/terminal/${tid}`, protocols);
+        const ws = new WebSocket(`ws://localhost:${process.env.TOWER_TEST_PORT || '4100'}/workspace/${encodedPath}/ws/terminal/${tid}`, protocols);
         ws.binaryType = 'arraybuffer';
         ws.onopen = () => {
           ws.close();

--- a/packages/codev/src/agent-farm/__tests__/e2e/terminal-controls.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/terminal-controls.test.ts
@@ -13,7 +13,7 @@
 import { test, expect } from '@playwright/test';
 import { resolve } from 'node:path';
 
-const TOWER_URL = 'http://localhost:4100';
+const TOWER_URL = `http://localhost:${process.env.TOWER_TEST_PORT || '4100'}`;
 const WORKSPACE_PATH = resolve(import.meta.dirname, '../../../../../../');
 const ENCODED_PATH = Buffer.from(WORKSPACE_PATH).toString('base64url');
 const PAGE_URL = `${TOWER_URL}/workspace/${ENCODED_PATH}/`;

--- a/packages/codev/src/agent-farm/__tests__/e2e/tower-cloud-connect.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/tower-cloud-connect.test.ts
@@ -14,7 +14,7 @@
 
 import { test, expect, type Page } from '@playwright/test';
 
-const TOWER_URL = process.env.TOWER_URL || 'http://localhost:4100';
+const TOWER_URL = process.env.TOWER_URL || `http://localhost:${process.env.TOWER_TEST_PORT || '4100'}`;
 
 /** Intercept the tunnel status API to return a mocked response. */
 async function mockTunnelStatus(page: Page, body: Record<string, unknown> | null, status = 200) {

--- a/packages/codev/src/agent-farm/__tests__/e2e/tower-integration.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/tower-integration.test.ts
@@ -7,7 +7,7 @@ import { test, expect } from '@playwright/test';
 import path from 'node:path';
 import { towerAuthHeaders } from './tower-key.js';
 
-const TOWER_URL = 'http://localhost:4100';
+const TOWER_URL = `http://localhost:${process.env.TOWER_TEST_PORT || '4100'}`;
 const VIDEO_DIR = path.resolve(import.meta.dirname, '../../../../test-results/videos');
 
 // Helper to get base64url encoded workspace path


### PR DESCRIPTION
PR #1632 set TOWER_TEST_PORT=14100 in the dashboard workflow, which moved the Playwright webServer off 4100 — and exposed five e2e files hardcoding localhost:4100, now failing with ERR_CONNECTION_REFUSED (dispatch run 34075438347). This makes every e2e test derive its URL from TOWER_TEST_PORT with the existing 4100 local default, matching spec-1313-held-count-indicator and work-view-backlog which already did. tsc clean. With this, the CI suite runs fully on the throwaway port and the #1604 guard's protection applies suite-wide. Refs #1630.