### PR TITLE
Fix #1630: pass the test port into page.evaluate (browser has no process)

### DIFF
--- a/packages/codev/src/agent-farm/__tests__/e2e/dashboard-terminals.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/e2e/dashboard-terminals.test.ts
@@ -71,9 +71,9 @@ test.describe('Dashboard Terminals E2E', () => {
 
     // Verify WebSocket connects to this terminal through tower proxy
     await page.goto(PAGE_URL);
-    const wsConnected = await page.evaluate(({ tid, encodedPath, protocols }: { tid: string; encodedPath: string; protocols: string[] | undefined }) => {
+    const wsConnected = await page.evaluate(({ tid, encodedPath, protocols, port }: { tid: string; encodedPath: string; protocols: string[] | undefined; port: string }) => {
       return new Promise<boolean>((resolve) => {
-        const ws = new WebSocket(`ws://localhost:${process.env.TOWER_TEST_PORT || '4100'}/workspace/${encodedPath}/ws/terminal/${tid}`, protocols);
+        const ws = new WebSocket(`ws://localhost:${port}/workspace/${encodedPath}/ws/terminal/${tid}`, protocols);
         ws.binaryType = 'arraybuffer';
         ws.onopen = () => {
           ws.close();
@@ -82,7 +82,7 @@ test.describe('Dashboard Terminals E2E', () => {
         ws.onerror = () => resolve(false);
         setTimeout(() => resolve(false), 5000);
       });
-    }, { tid: terminalId, encodedPath: ENCODED_PATH, protocols: WS_PROTOCOLS });
+    }, { tid: terminalId, encodedPath: ENCODED_PATH, protocols: WS_PROTOCOLS, port: process.env.TOWER_TEST_PORT || '4100' });
     expect(wsConnected).toBe(true);
 
     // Clean up
@@ -102,9 +102,9 @@ test.describe('Dashboard Terminals E2E', () => {
     expect(terminalId).toBeTruthy();
 
     await page.goto(PAGE_URL);
-    const wsConnected = await page.evaluate(({ tid, encodedPath, protocols }: { tid: string; encodedPath: string; protocols: string[] | undefined }) => {
+    const wsConnected = await page.evaluate(({ tid, encodedPath, protocols, port }: { tid: string; encodedPath: string; protocols: string[] | undefined; port: string }) => {
       return new Promise<boolean>((resolve) => {
-        const ws = new WebSocket(`ws://localhost:${process.env.TOWER_TEST_PORT || '4100'}/workspace/${encodedPath}/ws/terminal/${tid}`, protocols);
+        const ws = new WebSocket(`ws://localhost:${port}/workspace/${encodedPath}/ws/terminal/${tid}`, protocols);
         ws.binaryType = 'arraybuffer';
         ws.onopen = () => {
           ws.close();
@@ -113,7 +113,7 @@ test.describe('Dashboard Terminals E2E', () => {
         ws.onerror = () => resolve(false);
         setTimeout(() => resolve(false), 5000);
       });
-    }, { tid: terminalId!, encodedPath: ENCODED_PATH, protocols: WS_PROTOCOLS });
+    }, { tid: terminalId!, encodedPath: ENCODED_PATH, protocols: WS_PROTOCOLS, port: process.env.TOWER_TEST_PORT || '4100' });
     expect(wsConnected).toBe(true);
   });
 


### PR DESCRIPTION
Third and final piece of the #1630 chain. PR #1635 interpolated process.env.TOWER_TEST_PORT inside two page.evaluate callbacks in dashboard-terminals.test.ts — browser context, where process does not exist, so every WebSocket test failed with ReferenceError (dispatch run 34101211083). The port now travels through the evaluate argument object alongside tid/protocols, resolved on the Node side. tsc clean; tsc could not have caught the original (it cannot know an evaluate callback runs in the browser), which is why the proving dispatch exists. Refs #1630.