### PR TITLE
cron: add the required message field to team-update.yaml

### DIFF
--- a/.af-cron/team-update.yaml
+++ b/.af-cron/team-update.yaml
@@ -3,3 +3,4 @@ schedule: "0 * * * *"
 enabled: true
 command: "team update"
 timeout: 30
+message: "team update: ${output}"


### PR DESCRIPTION
Tower logged `Skipping team-update.yaml ... missing required fields` every minute because the task had no `message`. One line, no behavior change beyond the task actually running on its hourly schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155b4aDth71uiePbJSb43y4