### PR TITLE
Fix #1645: cache forge failures and suspend on rate limit

### DIFF
--- a/codev/projects/bugfix-1645-tower-overview-cache-burns-the/status.yaml
+++ b/codev/projects/bugfix-1645-tower-overview-cache-burns-the/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1645
+title: tower-overview-cache-burns-the
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-09-08T05:46:08.226Z'
+updated_at: '2026-09-08T05:46:08.227Z'

--- a/codev/projects/bugfix-1645-tower-overview-cache-burns-the/status.yaml
+++ b/codev/projects/bugfix-1645-tower-overview-cache-burns-the/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1645
 title: tower-overview-cache-burns-the
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-08T05:46:08.226Z'
-updated_at: '2026-09-08T05:46:08.227Z'
+updated_at: '2026-09-08T05:54:04.689Z'

--- a/codev/projects/bugfix-1645-tower-overview-cache-burns-the/status.yaml
+++ b/codev/projects/bugfix-1645-tower-overview-cache-burns-the/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1645
 title: tower-overview-cache-burns-the
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-08T05:46:08.226Z'
-updated_at: '2026-09-08T05:54:04.689Z'
+updated_at: '2026-09-08T06:07:00.487Z'

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -118,3 +118,27 @@ rate-limit error never reached any caller for the most frequently spawned of the
 Also reverted an over-reach: `rate-limit` is no longer disabled in the gitlab/gitea/linear
 presets. It falls through to the gh default like every other non-issue concept, which is
 what the spec-719 hybrid-model guard requires.
+
+### Verification (real forge path, no Tower started)
+
+Real `OverviewCache` driven for 40 polls against a fake `gh` on `PATH` that always
+returns the GraphQL rate-limit error:
+
+| | `gh` invocations for 40 polls |
+|---|---|
+| pre-fix (negative caching reverted in the built JS) | **200** — 5 every poll |
+| with the fix | **5** — one batch, then zero until reset |
+
+Payload: `forgeStatus=rate-limited`, `forgeResetAt` populated.
+
+Full suite: 5,768 passed / 48 skipped, 0 failed.
+
+## 2026-09-07 — PR
+
+PR #1646. Follow-up for prescribed item 4 filed as issue #1647.
+
+Architect set the positive TTL to **180 s** (msg 06:06Z), not 120 s: at 120 s the
+`pr-list` + `issue-list` pair alone costs 60 calls/h per watched workspace, which is
+already the whole acceptance budget, so no search-TTL value could get under it. 180 s
+gives 40 + 12 = 52/h, and ~2,028 GraphQL points/h at 13 watched workspaces — 41 % of the
+5,000/h limit.

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -337,3 +337,45 @@ fixed with `# forge-executable:` declarations plus a test asserting no built-in 
 resolves to a shell builtin. Flagged to the architect as scope-adjacent.
 
 Full suite 5,785 green.
+
+## 2026-09-07 — CMAP round 5: gemini APPROVE, codex + claude REQUEST_CHANGES
+
+Five more real bugs, two of them introduced by round 4's own fixes.
+
+- **A stale flight could unregister the live one.** My `inflight.clear()` in `invalidate()`
+  created it: an older flight's `.finally` deleted the *newer* join-table entry, so the
+  next caller started a duplicate batch — the exact fan-out single-flight exists to
+  prevent. Both lanes found it independently; claude measured 3 `pr-list` spawns where 2
+  are correct. Fixed by deleting only when the registered promise is still this one.
+- **The REST identity call was resetting the escalating backoff.** `user-identity` is
+  `gh api user` — separate budget, same `gh` backend key. Once its own 1h TTL expired
+  alongside a suspension window, its success cleared the state and reset
+  `consecutiveHits`, so the 60 s→15 min escalation would frequently never escalate. Fixed
+  with a `countsAsRecovery` flag; only the four list concepts count as evidence.
+- **Linear keyed `curl` healthy vs `linear` on fallback** — the fragmentation the alias map
+  was meant to remove. Generic transports (`curl`, `wget`, `sh`, …) now key by provider,
+  which also removes a latent collision with any future curl-based provider.
+- **An extensionless script override** (`/opt/forge/issue-list`) keyed by its own filename,
+  re-fragmenting one account across concepts.
+- **`api.ts` still told SDK consumers** that `POST /api/overview/refresh` clears the
+  suspension — false since the previous commit.
+
+### Both tests I added in round 4 were vacuous
+
+They passed with the fix **and** with the fix reverted. The escalation test never re-ran
+the identity call (1h TTL kept it cached), and the coalescing test had every caller join
+before the stale cleanup fired. Rewritten to genuinely exercise the guards, and verified
+failing without them: `expected 60000 to be greater than 60000`, and
+`called 2 times, but got 3`.
+
+Second time in this PR that green tests meant nothing. The habit that caught it — revert
+the fix, confirm the new test goes red, restore — is the only reason either was found.
+Worth doing for **every** regression test, not just the ones that look risky.
+
+### Deliberately not done
+
+Removing the suspension-clear from `invalidate()` leaves the round-1 gap — no way to end a
+wait early — unaddressed. The dashboard's own refresh button is distinguishable from
+porch/VSCode/cleanup and could carry an explicit opt-in, but that is an API parameter, an
+SDK argument and a web change on a PR already five rounds deep, and the wait is bounded at
+15 min (or the forge's true reset). Raised with the architect; documented in `api.ts`.

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -190,3 +190,38 @@ synchronously at dispatch, so `user-identity` is never dispatched once a sibling
 recorded the limit. Verified by removing the guard: the *unit* test in
 forge-rate-limit.test.ts fails, the overview one does not. The integration test now says
 which mechanism it pins and points at the unit test for the other.
+
+## 2026-09-07 — CMAP round 2 (final tree)
+
+| lane | verdict |
+|---|---|
+| gemini | APPROVE (HIGH), no key issues |
+| claude | APPROVE (HIGH), none blocking, 6 observations |
+| codex | REQUEST_CHANGES (HIGH), 2 issues |
+
+Codex's first issue — the PR should not auto-close #1645 "unless the issue's scope and
+acceptance criteria are formally revised" — is satisfied: the architect chose option (a)
+and the amended acceptance is now a comment on #1645 (zero spawns until reset; ≤50 % of
+the GraphQL budget at 13 watched workspaces; single-flight — with the ≤60/h-across-13
+number moving to #1647). Codex reviewed before that comment existed.
+
+Codex's second issue and claude's (a) are **the same finding from two lanes**, so I fixed
+it rather than deferring: the suspension was process-global and provider-blind, so a
+GitHub rate limit blanked a GitLab / Gitea / Linear workspace's Work view for the whole
+backoff window. `ForgeFailure` now carries the resolved `provider`, suspension state is
+keyed per provider, and `OverviewCache` memoizes each workspace's provider (cleared by
+`invalidate()`). The reset probe is GitHub-only — the `rate-limit` concept has no script
+outside the github preset, so on any other provider it would have fallen through to the
+github default and shelled out to `gh` for a forge that does not use it (claude's (d)).
+
+Also fixed from claude's list: entries are now stamped at fetch **completion**, not
+dispatch — a command sitting for its full 30 s timeout was burning half the 60 s negative
+window before the entry was even written (c); and `api.ts` claimed rate-limited lists were
+"stale on purpose" when the suspension branch returns empty (b).
+
+### An API footgun caught by its own test
+
+Making `provider` optional-and-last meant `isForgeSuspended(now)` type-checked while
+reading a timestamp as a provider name, and silently answered about the wrong forge — a
+test caught it, but production code could have hit it just as easily. `provider` is now a
+**required first argument** on all five functions, so a stale call site is a type error.

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -521,3 +521,50 @@ And three honesty fixes to the doctor check, all fair:
   reads `≥N calls/h`.
 - The budget line rendered a green `✓` from a reading **this PR's own code documents as
   unreliable** on an exhausted account. Now labelled `(reported)`.
+
+## 2026-09-08 — CMAP round 8: gemini APPROVE, codex + claude REQUEST_CHANGES
+
+Gemini's third consecutive clean round. The other two found five more real things.
+
+**Codex: `invalidate()` bypasses the TTLs entirely.** A refresh means "fetch now" by design,
+but `POST /api/overview/refresh` is fired automatically after every mutating porch command,
+every VSCode review-queue mutation and every cleanup. So in a busy workspace **the
+invalidation rate governed spend, not the TTLs** — every TTL figure in the PR body is an
+idle-state floor. Shipped a 60 s debounce (architect chose (a)); scoping invalidations to
+forge-visible events is the end state and is filed as **#1650**, with "just stop clearing
+forge caches" recorded there as the rejected alternative and why.
+
+Codex also called my burst test too easy — it only covered the synchronous case that
+queue-collapsing already handles. The new test drives *sustained* invalidation.
+
+**Claude: a test I added last round was vacuous AND its fix was dead code.** The
+`failures` re-read could never differ — a stale-generation flight returns before writing, and
+single-flight means no competing writer — and the test built no queued flight at all. Verified
+it passes with the fix reverted, then **removed both**. Adding code in response to a review
+and then a test that cannot fail is the worst combination available; the revert-check is the
+only reason it did not ship.
+
+That is the **fifth** vacuous or artifact-asserting test in this PR. The tendency is
+consistent: a test written to satisfy a finding gets written to pass. The habit that catches
+it — revert the fix, confirm red, restore — has to be unconditional, not reserved for tests
+that look risky.
+
+**Claude: the REST identity call was blocked by a GraphQL suspension.** `user-identity` is
+`gh api user`, a different budget, resolving to the same `gh` key. Blocking it saved no
+points and dropped `currentUser` from the overview for the whole window. It is now neither
+governed by that budget nor evidence for it — one flag, both directions.
+
+**Claude: other forges swallow their exit status the same way `github/pr-list.sh` did.** A
+concept that pipes its CLI into `jq` reports jq's status, so those forges get negative caching
+but can never trigger a suspension. Fixed the overview-path ones (`gitlab/pr-list`,
+`gitea/issue-list`, `gitea/recently-closed`); `gitea/pr-list`, `recently-merged` and
+`user-identity` already did it right, with a comment naming the pipefail issue — the trap was
+known and github's was simply missed. The rest are **#1651**.
+
+I broke the two Linear scripts twice attempting a mechanical rewrite: their `curl` nests
+`$(jq -n …)` inside `-d "…"`, so wrapping it in `"$( … )"` needs care with quoting. Reverted
+rather than ship a shell script I cannot execute here, and said so in #1651.
+
+Nits also fixed: `stateFor` allocated on read (a query grew the map), `probing` was keyed by
+an un-normalized provider, `doctor` could render `Infinity%` on a zero limit, and
+`forgeStatus` was blind to the two search concepts failing.

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -287,3 +287,53 @@ bleed (r4). The negative-caching core has been stable since r1; everything that 
 fixing was code added *in response to a review*. Each layer of hardening introduced its own
 smaller bug. Treat "the reviewers found nothing this time" as the signal to stop, not
 "I've addressed the last round".
+
+## 2026-09-07 — CMAP round 4: all three lanes REQUEST_CHANGES, all three right
+
+### The serious one, and it was mine
+
+I had `invalidate()` clear the rate-limit suspension, on the strength of a code comment I
+wrote asserting *"invalidate() is only reached from POST /api/overview/refresh, never from
+the 2.5s poll, so this cannot reintroduce the hammering."* **I never verified that.** It is
+false. `refreshOverview()` is called automatically by:
+
+- `commands/porch/index.ts:1300` — after every mutating porch command
+- `apps/vscode/src/review-queue/overview-nudge.ts:27` — every review-queue mutation
+- `agent-farm/commands/cleanup.ts:422`
+
+With a dozen builders running porch that fires constantly, so the suspension would be
+lifted and the escalating backoff reset to 60 s over and over — in exactly the busy
+workspace this fix exists for. It would have largely defeated the fix in production with
+every test green.
+
+It was introduced *in response to* claude's round-1 note that a suspension had no manual
+escape. Fixing a minor UX gap created a major correctness bug. The suspension is
+time-bounded anyway (≤15 min, or the probe's true reset), so it is simply not cleared
+there now, and the test asserts the suspension **survives** a refresh.
+
+The lesson is the one already in lessons-critical.md — *verify reviewer/plan claims against
+the actual file* — turned around: verify **your own** claims before writing them into a
+comment that future readers will trust. A one-line grep would have caught it.
+
+### Also fixed
+
+- Absolute executable paths key by basename, so `/usr/local/bin/gh` and `gh` share a
+  suspension (codex).
+- `clearForgeBackendCache()` on invalidate — resolution reads scripts off disk, so an
+  edited script previously needed a process restart (codex).
+- In-flight fetches are dropped from the join table on invalidate, so a post-refresh
+  caller is not handed a result fetched under the old config (codex).
+- Provider→executable alias map, so the unreadable-script fallback (`github`) and a healthy
+  resolve (`gh`) stop being two suspension states for one account (claude).
+- `_backendCache` keyed without the provider (gemini) — fixed in the previous commit.
+
+### A pre-existing gap this surfaced
+
+7 Linear concepts resolved their executable to `echo` (from the API-key guard) and gitlab's
+`issue-search` to `case`. `codev doctor` has therefore been telling Linear users to install
+`echo`, and a missing `curl` would go unreported — the #1455 silent success, still live in
+8 shipped scripts. Not introduced here, but it now also affects rate-limit keying, so it is
+fixed with `# forge-executable:` declarations plus a test asserting no built-in provider
+resolves to a shell builtin. Flagged to the architect as scope-adjacent.
+
+Full suite 5,785 green.

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -494,3 +494,30 @@ limited account's suspension, because the key is the tool (`gh`) rather than the
 Errs toward under-suspension in mixed-host setups, which is worse than the over-suspension
 already documented. Left as a documented limitation; the correct key needs per-host
 credential introspection.
+
+### Round 7, claude's lane: two more real behavioural bugs
+
+The read-only instruction held — `git status` was clean after the lane finished, which is
+the first round that was true. Of its ten items, three described the tree it reviewed
+(already fixed in `fe48a32d3`); two were real behavioural bugs:
+
+- **`invalidate()` wiped the negative cache**, resetting the non-rate-limit backoff on every
+  refresh. porch fires one after every mutating command, so a plainly broken forge (`gh`
+  missing, not authenticated) would have been re-spawned as fast as invalidations arrived —
+  the original bug wearing a different hat, and untouched by all the rate-limit work because
+  it never involves a rate limit. `invalidate()` now drops only successful entries.
+- **The failure counter could not escalate on a chained flight.** `failures` was read at
+  dispatch and written minutes later, so consecutive failures kept re-writing 1 and the
+  backoff never doubled. Re-read at write time.
+
+And three honesty fixes to the doctor check, all fair:
+
+- `countKnownWorkspaces()` counted the **never-pruned** `known_workspaces` table, so anyone
+  with ≥17 lifetime workspaces got a permanent, unclearable warning. Now counts workspaces
+  launched in the last 7 days. A warning that cannot be cleared is a warning that gets
+  ignored.
+- `projectHourlyForgeCalls` is a **floor, not a worst case** — it counts TTL-driven refreshes
+  only, and `/api/overview/refresh` bypasses the TTLs. Documented as such; the label now
+  reads `≥N calls/h`.
+- The budget line rendered a green `✓` from a reading **this PR's own code documents as
+  unreliable** on an exhausted account. Now labelled `(reported)`.

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -225,3 +225,50 @@ Making `provider` optional-and-last meant `isForgeSuspended(now)` type-checked w
 reading a timestamp as a provider name, and silently answered about the wrong forge — a
 test caught it, but production code could have hit it just as easily. `provider` is now a
 **required first argument** on all five functions, so a stale call site is a type error.
+
+## 2026-09-07 — CMAP round 3 (diff-based, on the final commit)
+
+`--type pr` could not run: `consult` resolves the PR through a GraphQL-backed forge
+concept and the quota was exhausted again (reset ~06:42Z). That is #1641 happening live,
+and a reminder that the production Tower still runs the unfixed code and re-burns the
+budget within seconds of each reset. Substituted a diff-based review of the final commit
+from all three models, which needs no GitHub call.
+
+| lane | verdict |
+|---|---|
+| gemini | APPROVE (HIGH), no key issues (skipped on the first attempt — `agy` produced no output; clean on retry) |
+| claude | APPROVE (HIGH), 5 observations |
+| codex | REQUEST_CHANGES (HIGH), 2 issues |
+
+**Both non-gemini lanes independently flagged the same thing again**: suspension was keyed
+on the *configured* provider, not the backend the command actually resolves to. Providers
+are hybrid — a Linear workspace has no `pr-list` script, so that concept falls through to
+`gh` and spends GitHub's budget (spec 719). Fixed: `ForgeFailure` carries `backend` (the
+resolved executable, lowercased), `resolveConceptBackend()` is the shared resolver, and
+`OverviewCache` memoizes per `<workspace>:<concept>` — because one workspace's concepts
+can answer to different budgets. `forgeStatus` now reports limited if *any* of the four
+list concepts' backends is suspended, with the latest reset among them.
+
+Also fixed: in-flight fetches could write results after `invalidate()`, filing a result
+(or a rate limit) against a backend the workspace no longer uses — a generation counter
+now drops those writes (codex); `DEFAULT_PROVIDER` was duplicated as a bare `'github'`
+literal in two modules with nothing pinning them equal — it now lives in `forge.ts` and
+is re-exported (claude); backend keys are lowercased so a config spelling `GitHub` cannot
+split state (claude); the module header still described the suspension as process-global
+(claude); and `unavailable()` said "GitHub" on every provider (claude).
+
+### A regression of my own, found by chasing a test failure
+
+Keying by resolved executable made the overview tests fail in a way that turned out not to
+be about the tests. My earlier `pr-list.sh` rewrite — capturing `gh` into a variable so its
+exit status propagates — made the script's first substantive line an assignment, and the
+executable heuristic therefore reported **`printf`**. That would have filed pr-list's rate
+limits under a backend of its own *and* pointed `codev doctor` at the wrong CLI, which is
+exactly the silent-success bug #1455 exists to prevent. Fixed with the
+`# forge-executable: gh` declaration that mechanism provides, plus a test asserting all
+four overview concepts resolve to the same backend.
+
+Note for anyone reading later: `extractExecutable` returns the command verbatim when it
+cannot read the script, so a missing concept script would give every concept a different
+backend and fragment the suspension. `resolveConceptBackend` now falls back to the
+configured provider when the extracted value looks like a path.

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -379,3 +379,49 @@ wait early — unaddressed. The dashboard's own refresh button is distinguishabl
 porch/VSCode/cleanup and could carry an explicit opt-in, but that is an API parameter, an
 SDK argument and a web change on a PR already five rounds deep, and the wait is bounded at
 15 min (or the forge's true reset). Raised with the architect; documented in `api.ts`.
+
+## 2026-09-08 — CMAP round 6: gemini APPROVE, codex REQUEST_CHANGES
+
+Codex's headline finding was real and significant: **repeated automated invalidations could
+start an unbounded number of concurrent commands** per concept per workspace. `invalidate()`
+cleared the join table, so every invalidation licensed another parallel flight — and porch
+fires invalidate after *every* mutating command across a dozen builders. A live fan-out path
+that bypassed single-flight entirely. Measured by the new test: **6 concurrent `gh` commands
+where 1 is correct.**
+
+Fixed by tagging join-table entries with the cache generation. A stale-generation flight is
+no longer discarded (which raced) nor joined (which served stale data): the new caller
+**chains** behind it. At most one command runs and at most one waits, however many
+invalidations arrive.
+
+Also fixed:
+- `startedAt < suspendedSinceMs` had to be `<=`. The overview dispatches its commands in one
+  tick, so they share a millisecond — a limit recorded in that same millisecond would let a
+  sibling's success clear it. The exact race the guard exists for, slipping through on
+  clock granularity.
+- `/opt/forge/issue-list --json …` still keyed by its own filename (the bare-path rule only
+  covered argument-less commands), fragmenting one account across concepts. A basename
+  equal to the concept name is now treated as a per-concept script, not a tool.
+
+### A test of mine was asserting an artifact
+
+`keeps the suspension when the REST identity call still succeeds` asserted that
+`user-identity` goes **undispatched** — which only held because `fetchCached` re-checked the
+suspension synchronously before a sibling's mocked fetcher had returned. Mocks resolve in
+the same tick; real subprocesses never do. Adding `await predecessor` exposed it. The
+assertion is gone; the test now pins the real guard (`countsAsRecovery`).
+
+Third time green tests have been misleading in this PR: two vacuous, one asserting an
+artifact of the mock harness.
+
+### Unexplained working-tree modification
+
+Mid-round I found both guards in `overview.ts` reverted in the working tree, with
+`// REVERTED FOR VACUITY CHECK` comments **I did not write**. HEAD (`b0c32427c`) was correct
+and pushed; only the working tree was affected. I verified integrity against HEAD, restored
+the two lines, and re-confirmed `git diff` was clean before continuing. I cannot account for
+the origin — the worktree write-guard hook is read-only, and none of my scripts emit that
+comment. Recording it rather than guessing. **If you see it again, treat the working tree as
+untrusted and diff against HEAD before building on it.**
+
+Full suite 5,790 green; e2e still 5 gh calls for 40 polls.

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -568,3 +568,37 @@ rather than ship a shell script I cannot execute here, and said so in #1651.
 Nits also fixed: `stateFor` allocated on read (a query grew the map), `probing` was keyed by
 an un-normalized provider, `doctor` could render `Infinity%` on a zero limit, and
 `forgeStatus` was blind to the two search concepts failing.
+
+## 2026-09-08 — CMAP round 9: gemini APPROVE (4th clean), codex REQUEST_CHANGES
+
+Codex found four; three fixed, one folded into #1650.
+
+- **The queued-flight join branch was unreachable.** The 60 s debounce is longer than a forge
+  command's own 30 s timeout, so a flight can never still be queued when the next honoured
+  invalidation lands. Dead code — added in round 7 to solve a problem the round-8 debounce
+  then solved upstream — and its test went green with it removed. **Removed both.** Second
+  time in two rounds that a fix of mine was superseded and left behind as dead code; the
+  reviewers caught it both times.
+- **The REST exemption was applied unconditionally**, but it is a fact about GitHub: `gh api
+  user` is REST, while Linear's `user-identity` is a GraphQL call on Linear's own budget.
+  Exempting it there would let it hammer a forge already refusing us. Now conditional on the
+  resolved backend being `gh`.
+- **`rate-limit` fell through to the github default for every provider**, so `codev doctor`
+  told GitLab/Gitea/Linear projects to install `gh`. Disabled in those presets; the spec-719
+  hybrid guard updated with the reason.
+- **Global invalidation fans out across workspaces** — `invalidate()` clears every workspace's
+  entries, so one workspace's refresh costs 4 commands in each *watched* workspace
+  (13 × 4 × 60/h = 3,120 calls/h at the debounce ceiling). The debounce bounds the rate, not
+  the fan-out. Added to #1650 as a second scoping dimension rather than adding plumbing here
+  that no caller would use.
+
+### I deleted a real test while removing a fake one
+
+Removing the vacuous `escalates the backoff…` test in round 8, I sliced the file between two
+anchors — and `caps forge spend under sustained invalidation` sat between them. It went with
+it, and commit `54258a3d9`'s message claims that test exists. It did not, from that commit
+until now.
+
+Restored from `ae79c220d` and verified meaningful (`expected 10 to be less than or equal to 1`
+without the debounce). **Anchor-to-anchor slicing deletes whatever is in between** — use an
+exact-block match, and diff the test count before and after any test-file surgery.

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -425,3 +425,27 @@ comment. Recording it rather than guessing. **If you see it again, treat the wor
 untrusted and diff against HEAD before building on it.**
 
 Full suite 5,790 green; e2e still 5 gh calls for 40 polls.
+
+### Provenance of the "VACUITY CHECK" edits — solved
+
+The architect traced it from transcripts: **the consult CLAUDE reviewer lane edited this
+worktree directly.** Its Agent SDK session (started 07:55:18Z) used the Edit tool 5 times
+between 07:00:01 and 07:00:49 to revert my fixes and check whether the tests were vacuous —
+its `allowedTools` list defeated by `permissionMode: bypassPermissions`. Filed as a bug.
+
+So a reviewer was mutating the code under test while I was building on it. Not malicious,
+and its instinct was the right one (it was checking the same vacuity I was), but it means
+**a CMAP lane can silently change your working tree**.
+
+Protocol from round 7 on, per the architect:
+
+1. **Commit everything BEFORE running consult.**
+2. After each lane finishes, run `git status` and `git diff`.
+3. Restore only reviewer-touched files with `git checkout -- <path>` — never a bare
+   `git checkout -- .`, which would take unrelated work with it.
+4. Note the practice in the PR body's verification section.
+
+Retrospective check on this PR: every "verified failing with the fix reverted" result was
+produced by my own scripted revert→test→restore, each confirmed by a subsequent clean
+`git diff` against HEAD, so none of those results is contaminated. The one anomaly I could
+not explain at the time is now fully accounted for.

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -1,0 +1,120 @@
+# bugfix-1645 — Tower overview cache burns the GitHub GraphQL quota
+
+Issue #1645. Strict-mode BUGFIX builder.
+
+## 2026-09-07 — INVESTIGATE
+
+### Reproduced (live, on this machine)
+
+The bug is not hypothetical — it is happening right now:
+
+```
+$ gh api graphql -f query='query { viewer { login } }' -i | grep -i ratelimit
+X-Ratelimit-Limit: 5000
+X-Ratelimit-Remaining: 0
+X-Ratelimit-Used: 5000
+X-Ratelimit-Resource: graphql
+
+$ gh api rate_limit --jq .resources.graphql
+{"limit":5000,"remaining":5000,"reset":...,"used":0}      <-- misleading, as the issue says
+```
+
+`gh issue list …` → `GraphQL: API rate limit already exceeded for user ID …`.
+
+### Measured spawn rate (production Tower, READ-ONLY — never started a Tower)
+
+Sampled `pgrep -P <tower-pid>` at 2 Hz:
+- 60 s window: **180 distinct `gh` processes** → ≈10,800 gh spawns/hour.
+- Confirms the issue's ≈4,600/h estimate is, if anything, low.
+
+### Root cause (three parts)
+
+1. **Failures are never cached.** `servers/overview.ts:1090-1170` — all four cache helpers
+   (`fetchPRsCached`, `fetchIssuesCached`, `fetchRecentlyClosedCached`,
+   `fetchMergedPRsCached`) end with `if (data !== null) cache.set(...)`. `null` = failure,
+   so a failing workspace re-spawns all four forge commands on *every* request. The
+   `TTL = 30_000` at `overview.ts:851` throttles only successes.
+
+2. **The poll is 2.5 s, not 30 s.** `apps/web/src/hooks/useOverview.ts:6` —
+   `POLL_INTERVAL_MS = 2500`. So while GitHub is failing the steady state is
+   `4 gh × 1440 polls/hour = 5,760 gh spawns per hour per open dashboard`, multiplied by
+   every workspace/client. That is the amplifier that turns a transient 429 into a
+   permanent one.
+
+3. **No rate-limit awareness anywhere.** `lib/forge.ts:336-353` — `executeForgeCommand`
+   catches everything, logs to debug, and returns `null`, discarding stderr and exit code.
+   Nothing can distinguish "gh not installed" from "rate limited", so Tower keeps hammering
+   until the hourly window rolls over, then immediately re-exhausts it.
+
+Cost per call is also high: `issue-list.sh` uses `--limit 200`, `recently-closed.sh` and
+`recently-merged.sh` use `--limit 1000` — each is a multi-page, multi-hundred-node GraphQL
+query, so a "call" is worth well more than one point.
+
+There is **no** Tower-side background overview poller — every fetch is demand-driven from
+`/api/overview` (`tower-routes.ts:1169`). So issue item 3's "only refresh watched
+workspaces" is already true; what is missing is the TTL and the negative cache.
+
+### Scope assessment
+
+Items 1, 2, 3, 5 of the prescribed fix + the `forgeStatus` payload field fit BUGFIX
+(~300 LOC incl. tests). **Item 4 (collapse the three calls into one `gh api graphql`
+query) does not** — it needs a new forge concept, provider scripts, contracts and
+fallbacks across every provider preset, and it changes the forge abstraction shipped to
+adopters. Raised with the architect; proceeding with 1/2/3/5 plus differentiated TTLs
+(the two 24 h `--search` concepts change slowly and get a longer TTL), which gets the
+steady state to roughly one refresh set per workspace per 2 min instead of per 2.5 s.
+
+Also noting for the record: the issue's suggestion to move the searches to REST
+`gh api search/issues` for "a separate 5,000 budget" is wrong — the search resource is
+**30 requests/minute**, not 5,000/hour.
+
+### 10-minute baseline (production Tower, read-only)
+
+`pgrep -P <tower-pid>` at 2 Hz for 600 s → **1,515 distinct `gh` processes**
+(≈9,090/hour), plus 495 `sh` wrappers. This is the pre-fix number the acceptance
+criterion is measured against.
+
+Also observed live: the GraphQL budget was re-exhausted *immediately* after its hourly
+reset — `X-Ratelimit-Reset` stayed pinned in the past with `Used: 5000`. That is
+amplifier #2 from the issue, confirmed.
+
+## 2026-09-07 — FIX
+
+Architect decisions (msg 05:54Z): item 4 (one-GraphQL-collapse) is **out** of this PR and
+becomes a follow-up AIR; the substitute TTL scheme is accepted; the 30/min search-budget
+correction goes in the PR body and the issue.
+
+Implemented:
+
+| File | Change |
+|---|---|
+| `lib/forge-rate-limit.ts` (new) | Rate-limit detection, process-global suspension with a 60 s→15 min doubling backoff, opt-in reset probe, budget parsing |
+| `lib/forge.ts` | `onForgeFailure` hook — publishes stderr/exit code that `executeForgeCommand` used to discard; new `rate-limit` concept |
+| `scripts/forge/github/rate-limit.sh` (new) | `gh api rate_limit --jq .resources.graphql` |
+| `scripts/forge/github/pr-list.sh` | Run `gh` into a variable, not straight into the `jq` pipe — the pipe handed the caller **jq's** exit status, so a rate-limited `gh` looked like a successful empty result and its stderr was thrown away |
+| `servers/overview.ts` | One shared `fetchCached` with negative caching; positive TTL 30 s→120 s; 600 s TTL for the two 24 h search windows; `projectHourlyForgeCalls` |
+| `types/api.ts` | `forgeStatus` + `forgeResetAt` on `OverviewData` |
+| `commands/doctor.ts` | GraphQL budget + projected hourly spend, warning above 50 % |
+
+The `pr-list.sh` pipe was not in the issue and was found while implementing: it is why the
+rate-limit error never reached any caller for the most frequently spawned of the four.
+
+### Two things found while making the tests pass
+
+1. **`projectHourlyForgeCalls` cannot live in `overview.ts`.** `doctor.ts` importing it
+   pulled the whole Tower graph, and `team-github.ts`'s module-level
+   `promisify(execFile)` blew up against doctor's partial `node:child_process` mock — 23
+   doctor tests down. Extracted the TTL constants and the projection into
+   `servers/overview-budget.ts`, which has no imports at all.
+
+2. **The old `does not cache failed fetch results` test was leaking a mock into the next
+   test.** It queued two `mockResolvedValueOnce` values and, with negative caching, only
+   consumed the first — `vi.clearAllMocks()` does not drain a `once` queue, so the
+   leftover surfaced in `filters backlog issues that are linked to PRs` and made it fail
+   for an unrelated-looking reason. Rewritten as
+   `recovers from a failed fetch once its negative window expires`, which keeps the
+   original intent (transient failures self-heal) and consumes both values.
+
+Also reverted an over-reach: `rate-limit` is no longer disabled in the gitlab/gitea/linear
+presets. It falls through to the gh default like every other non-issue concept, which is
+what the spec-719 hybrid-model guard requires.

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -272,3 +272,18 @@ Note for anyone reading later: `extractExecutable` returns the command verbatim 
 cannot read the script, so a missing concept script would give every concept a different
 backend and fragment the suspension. `resolveConceptBackend` now falls back to the
 configured provider when the extracted value looks like a path.
+
+## 2026-09-07 — CMAP round 4
+
+Gemini: **REQUEST_CHANGES (HIGH)** — and correct. `_backendCache` keyed on
+`concept + command`, but the path-like fallback answers with the *configured provider*, so
+two workspaces resolving the same default script under different providers shared the
+first one's answer. Provider is now part of the key; the regression test reproduces the
+bleed exactly (`expected 'gitlab' not to be 'gitlab'`) when the fix is reverted.
+
+Worth recording as a pattern: this is the **third consecutive round** in which a lane found
+something real — the REST-success race (r2), provider-vs-backend keying (r3), this cache
+bleed (r4). The negative-caching core has been stable since r1; everything that has needed
+fixing was code added *in response to a review*. Each layer of hardening introduced its own
+smaller bug. Treat "the reviewers found nothing this time" as the signal to stop, not
+"I've addressed the last round".

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -602,3 +602,37 @@ until now.
 Restored from `ae79c220d` and verified meaningful (`expected 10 to be less than or equal to 1`
 without the debounce). **Anchor-to-anchor slicing deletes whatever is in between** — use an
 exact-block match, and diff the test count before and after any test-file surgery.
+
+### Round 9, claude's lane: the debounce was collapsing the long TTLs
+
+The serious one, and it invalidated a number I had been reporting. Every honoured
+invalidation dropped **all five** caches, including the 600 s search windows and the 3600 s
+identity cache — so a refresh forced the two 24 h retrospective queries **ten times** more
+often than their own TTL, and the user's login **sixty times**, for events that cannot have
+changed either. Claude measured **305 calls/h/workspace against the 52 my doctor check was
+projecting**, with the doctor showing green.
+
+Two fixes:
+
+- `invalidate()` drops **only the two open lists** — which is what a refresh means. The
+  long-TTL caches keep their TTLs.
+- `codev doctor` reports a **range and warns on the ceiling**, not the idle floor. Reporting
+  only the floor meant the check would have missed exactly the situation it exists for. That
+  is the second diagnostic in this PR that was itself misleading (the first divided calls by
+  a points budget).
+
+Also replaced the `keeps the suspension when the REST identity call still succeeds` test:
+claude showed it passes with *either* underlying fix reverted **and** its comment
+misattributed which mechanism fires (`noteForgeSuccess` is never called for `user-identity`
+now). Replaced with one that pins the TTL behaviour, verified red (`expected 1, got 2`).
+
+### I lost an uncommitted fix to `git checkout --` again
+
+Second time. The vacuity check reverts the fix, runs the test, then restores with
+`git checkout -- <path>` — which restores to **HEAD**, so any part of the fix that was not yet
+committed is destroyed. The full suite then failed with a symptom that looked like
+cross-test pollution and I started debugging it as one.
+
+The rule I wrote after the first occurrence was "commit before running consult". That was too
+narrow. The rule is: **`git checkout --` is a restore only for committed work — never run a
+revert-based check against a dirty tree.** Commit, then check.

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -449,3 +449,48 @@ Retrospective check on this PR: every "verified failing with the fix reverted" r
 produced by my own scripted revert→test→restore, each confirmed by a subsequent clean
 `git diff` against HEAD, so none of those results is contaminated. The one anomaly I could
 not explain at the time is now fully accounted for.
+
+## 2026-09-08 — CMAP round 7: gemini + codex REQUEST_CHANGES (same finding)
+
+Both lanes independently found that **round 6's chaining fix did not do what I claimed**.
+It bounded *concurrency* but not *total spend*: six invalidations still ran six commands,
+serially. And my own test hid it by asserting only `maxConcurrent`, so it passed —
+the fourth misleading test in this PR.
+
+Redesigned: a burst of invalidations of any size now costs **at most two commands** — one
+running, one queued behind it, and every later caller joins the queued one (`entry.queued`).
+Verified: `expected 2, got 6` when the join is disabled.
+
+Also from gemini, both real:
+- A queued fetch never re-checked `isForgeSuspended` after its wait. It can wait 30 s behind
+  the command ahead of it, and the forge may start refusing us in that window — spawning
+  anyway would be exactly the command the suspension exists to prevent.
+- `await predecessor` had no cap, so one hung `gh` would wedge every later request for that
+  concept. Now raced against 35 s, just past `executeForgeCommand`'s own timeout.
+
+### My first attempt at this fix was worse than the bug
+
+I initially made a superseded flight **skip its fetch** and return cached data. Instrumenting
+showed it skipped the *original, still-needed* fetch — so any overview request racing an
+invalidate would return empty lists, and porch invalidates constantly. That would have
+flickered the dashboard empty in normal use. Reasoning about the interleaving got me the
+wrong answer twice; a `console.error` in the early-return path got it right immediately.
+
+### I destroyed my own fix with the restore step
+
+Running the vacuity check, I reverted the fix, ran the test, then restored with
+`git checkout -- <path>` — but the fix was **uncommitted**, so checkout restored to HEAD and
+threw it away. The suite then failed with the exact pre-fix numbers and I nearly re-diagnosed
+it as a code bug.
+
+The architect's protocol says commit before running consult. It applies just as much to any
+revert-based check of your own: **`git checkout --` is a restore only if the work is
+committed.** Commit first, always.
+
+### Deferred, documented
+
+Codex's second point — a success from a *different* GitHub host or account can clear the
+limited account's suspension, because the key is the tool (`gh`) rather than the account.
+Errs toward under-suspension in mixed-host setups, which is worse than the over-suspension
+already documented. Left as a documented limitation; the correct key needs per-host
+credential introspection.

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -142,3 +142,51 @@ Architect set the positive TTL to **180 s** (msg 06:06Z), not 120 s: at 120 s th
 already the whole acceptance budget, so no search-TTL value could get under it. 180 s
 gives 40 + 12 = 52/h, and ~2,028 GraphQL points/h at 13 watched workspaces — 41 % of the
 5,000/h limit.
+
+## 2026-09-07 — CMAP round 1
+
+| lane | verdict |
+|---|---|
+| gemini | APPROVE (HIGH), no key issues |
+| claude | APPROVE (HIGH), 5 key issues |
+| codex | **REQUEST_CHANGES** (HIGH), 4 key issues |
+
+All findings verified against the actual files before acting. Six were real; two of
+codex's overlapped with claude's.
+
+1. **A concurrent REST success cleared a genuine GraphQL suspension** (both lanes). The
+   five fetches are dispatched together and `user-identity` is REST (`gh api user`) on a
+   *different* budget, so it succeeded while its GraphQL siblings were refused — and its
+   `noteForgeSuccess()` wiped the suspension they had just set. My e2e missed this
+   because the fake `gh` failed for *every* subcommand, `api user` included. Fixed with a
+   dispatch-time guard: a success only clears the suspension if the command was
+   dispatched *after* the suspension began. The fake `gh` is now production-shaped
+   (`api user` and `api rate_limit` succeed).
+2. **No in-flight coalescing** (codex). A cache entry was only written once its fetch
+   resolved, so a `gh` call slower than the 2.5 s poll — and they hang for tens of
+   seconds during an incident, which is exactly when it matters — let every poll and
+   every extra client start another duplicate batch. Added a per-concept-per-workspace
+   single-flight map.
+3. **Doctor compared calls against a points budget** (both lanes) — 676 calls read as
+   14 % of 5,000 when the real figure is 41 %, which would suppress the warning. Now
+   reports points via an explicit `GRAPHQL_POINTS_PER_CALL = 3`.
+4. **Backoff escalated once per failed command, not once per window** (claude). Four
+   parallel failures jumped 60 s straight to ~8 min. Now escalates once per suspension.
+5. **No manual escape from a suspension** (claude) — `invalidate()` didn't touch it, so
+   Refresh was a no-op for up to 15 min after GitHub recovered. `invalidate()` (only
+   reached from `POST /api/overview/refresh`, never the poll) now clears it.
+6. **Overstated docstrings** (claude) — the suspension is honoured only by
+   `OverviewCache.fetchCached`, and the probe guard was in-flight-only. Both corrected;
+   the probe now has a real per-suspension guard.
+
+Codex also argues the PR should not carry `Fixes #1645`, because the issue's acceptance
+says ≤60 `gh`/hour across 13 workspaces and this ships 52/h *per watched workspace*
+(676 total). That is a genuine reading of the original text and is the architect's call —
+raised with them; #1647 is what would actually close it.
+
+Note on test honesty: the overview-level REST test cannot demonstrate the dispatch-time
+guard, because the single-flight refactor made `fetchCached` re-check the suspension
+synchronously at dispatch, so `user-identity` is never dispatched once a sibling has
+recorded the limit. Verified by removing the guard: the *unit* test in
+forge-rate-limit.test.ts fails, the overview one does not. The integration test now says
+which mechanism it pins and points at the unit test for the other.

--- a/packages/codev/scripts/forge/gitea/issue-list.sh
+++ b/packages/codev/scripts/forge/gitea/issue-list.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# forge-executable: tea
 # Forge concept: issue-list (Gitea via tea CLI)
 #
 # tea's default JSON output uses fields that don't match the GitHub-compatible
@@ -9,10 +10,16 @@
 #   author (string) -> author.login
 #   labels    (CSV) -> labels[].name
 #   assignees (CSV) -> assignees[].login
-exec tea issues list --limit 200 \
+#
+# The CLI runs into a variable rather than straight into the `jq` pipe (#1645):
+# POSIX sh has no pipefail, so a pipeline reports jq's exit status (0) even when
+# the CLI failed — a rate-limited or unauthenticated call then looks like a
+# successful empty result, and its stderr, the only place the reason is named,
+# is discarded. Tower's rate-limit suspension depends on that exit status.
+ISSUES="$(tea issues list --limit 200 \
   --fields index,title,state,author,url,created,labels,assignees \
-  --output json \
-  | jq '[.[] | {
+  --output json)" || exit $?
+printf '%s' "$ISSUES" | jq '[.[] | {
       number: (.index | tonumber),
       title,
       state,

--- a/packages/codev/scripts/forge/gitea/recently-closed.sh
+++ b/packages/codev/scripts/forge/gitea/recently-closed.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# forge-executable: tea
 # Forge concept: recently-closed (Gitea via tea CLI)
 #
 # Normalize to GitHub-compatible shape (see IssueListItem in forge-contracts.ts).
@@ -6,10 +7,16 @@
 # `updated` -> `closedAt`. For issues closed without subsequent edits this is
 # exactly the close time; for issues edited after close it overestimates, which
 # is acceptable for the "recently closed" overview filter.
-exec tea issues list --state closed --limit 1000 \
+#
+# The CLI runs into a variable rather than straight into the `jq` pipe (#1645):
+# POSIX sh has no pipefail, so a pipeline reports jq's exit status (0) even when
+# the CLI failed — a rate-limited or unauthenticated call then looks like a
+# successful empty result, and its stderr, the only place the reason is named,
+# is discarded. Tower's rate-limit suspension depends on that exit status.
+ISSUES="$(tea issues list --state closed --limit 1000 \
   --fields index,title,state,author,url,created,updated,labels \
-  --output json \
-  | jq '[.[] | {
+  --output json)" || exit $?
+printf '%s' "$ISSUES" | jq '[.[] | {
       number: (.index | tonumber),
       title,
       state,

--- a/packages/codev/scripts/forge/github/pr-list.sh
+++ b/packages/codev/scripts/forge/github/pr-list.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# forge-executable: gh
 # Forge concept: pr-list (GitHub via gh CLI)
 # Output: JSON [{number, title, url, reviewDecision, body, createdAt, author,
 #                reviewRequests, isDraft}]
@@ -12,5 +13,11 @@
 # would hand the caller jq's exit status, so a rate-limited `gh` looked like a
 # successful empty result and its stderr — the only place the rate limit is
 # named — was thrown away.
+#
+# That rewrite is also why this script needs the explicit `forge-executable`
+# declaration above: the heuristic that infers a concept's CLI reads the first
+# substantive line, which is now an assignment, and it would otherwise report
+# `printf` — leaving `codev doctor` checking for the wrong tool (#1455) and
+# filing this concept's rate limits under a backend of its own (#1645).
 out=$(gh pr list --json number,title,url,reviewDecision,body,createdAt,author,reviewRequests,isDraft) || exit $?
 printf '%s' "$out" | jq '[.[] | .reviewRequests = [.reviewRequests[].login // empty]]'

--- a/packages/codev/scripts/forge/github/pr-list.sh
+++ b/packages/codev/scripts/forge/github/pr-list.sh
@@ -7,5 +7,10 @@
 # as objects (users carry `login`; teams carry `slug`/`name` and no `login`), so
 # `.login // empty` keeps user reviewers and drops team reviewers — matching the
 # `reviewRequests: string[]` contract in PrListItem (forge-contracts.ts).
-exec gh pr list --json number,title,url,reviewDecision,body,createdAt,author,reviewRequests,isDraft \
-  | jq '[.[] | .reviewRequests = [.reviewRequests[].login // empty]]'
+#
+# gh runs into a variable rather than straight into the pipe (#1645): piping
+# would hand the caller jq's exit status, so a rate-limited `gh` looked like a
+# successful empty result and its stderr — the only place the rate limit is
+# named — was thrown away.
+out=$(gh pr list --json number,title,url,reviewDecision,body,createdAt,author,reviewRequests,isDraft) || exit $?
+printf '%s' "$out" | jq '[.[] | .reviewRequests = [.reviewRequests[].login // empty]]'

--- a/packages/codev/scripts/forge/github/rate-limit.sh
+++ b/packages/codev/scripts/forge/github/rate-limit.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Forge concept: rate-limit (GitHub via gh CLI)
+# Output: JSON {limit, remaining, used, reset} for the GraphQL budget.
+# REST endpoint — costs nothing against the GraphQL budget it reports on.
+exec gh api rate_limit --jq .resources.graphql

--- a/packages/codev/scripts/forge/gitlab/issue-search.sh
+++ b/packages/codev/scripts/forge/gitlab/issue-search.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# forge-executable: glab
 # Forge concept: issue-search (GitLab via glab CLI)
 #
 # ⚠️ UNVERIFIED — mirrors gitlab/issue-list.sh (raw `glab ... --output json`,

--- a/packages/codev/scripts/forge/gitlab/pr-list.sh
+++ b/packages/codev/scripts/forge/gitlab/pr-list.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# forge-executable: glab
 # Forge concept: pr-list (GitLab via glab CLI — merge requests)
 #
 # Populate the two fields this concept must emit (PrListItem in
@@ -9,5 +10,11 @@
 # `iid`/`web_url`/`created_at`/`author.username` rather than the GitHub-style
 # `number`/`url`/`createdAt`/`author.login`; normalizing that is a pre-existing
 # concern outside this concept's two-field responsibility.)
-exec glab mr list --output json \
-  | jq '[.[] | . + {reviewRequests: [.reviewers[]?.username], isDraft: (.draft // false)}]'
+#
+# The CLI runs into a variable rather than straight into the `jq` pipe (#1645):
+# POSIX sh has no pipefail, so a pipeline reports jq's exit status (0) even when
+# the CLI failed — a rate-limited or unauthenticated call then looks like a
+# successful empty result, and its stderr, the only place the reason is named,
+# is discarded. Tower's rate-limit suspension depends on that exit status.
+MRS="$(glab mr list --output json)" || exit $?
+printf '%s' "$MRS" | jq '[.[] | . + {reviewRequests: [.reviewers[]?.username], isDraft: (.draft // false)}]'

--- a/packages/codev/scripts/forge/linear/auth-status.sh
+++ b/packages/codev/scripts/forge/linear/auth-status.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# forge-executable: curl
 # Forge concept: auth-status (Linear via GraphQL API)
 # Output: exit code (0 = authenticated)
 set -e

--- a/packages/codev/scripts/forge/linear/issue-comment.sh
+++ b/packages/codev/scripts/forge/linear/issue-comment.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# forge-executable: curl
 # Forge concept: issue-comment (Linear via GraphQL API)
 # Input: CODEV_ISSUE_ID, CODEV_COMMENT_BODY
 # Output: exit code only

--- a/packages/codev/scripts/forge/linear/issue-list.sh
+++ b/packages/codev/scripts/forge/linear/issue-list.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# forge-executable: curl
 # Forge concept: issue-list (Linear via GraphQL API)
 # Input: CODEV_LINEAR_TEAM (team key, e.g. "ENG")
 # Output: JSON [{number, title, url, labels, createdAt, author, assignees}]

--- a/packages/codev/scripts/forge/linear/issue-search.sh
+++ b/packages/codev/scripts/forge/linear/issue-search.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# forge-executable: curl
 # Forge concept: issue-search (Linear via GraphQL API)
 #
 # ⚠️ UNVERIFIED — mirrors linear/issue-list.sh with `description` added to the

--- a/packages/codev/scripts/forge/linear/issue-view.sh
+++ b/packages/codev/scripts/forge/linear/issue-view.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# forge-executable: curl
 # Forge concept: issue-view (Linear via GraphQL API)
 # Input: CODEV_ISSUE_ID (e.g. "ENG-123")
 # Output: JSON {title, body, state, url, author, createdAt, assignees, labels, milestone, comments[]}

--- a/packages/codev/scripts/forge/linear/recently-closed.sh
+++ b/packages/codev/scripts/forge/linear/recently-closed.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# forge-executable: curl
 # Forge concept: recently-closed (Linear via GraphQL API)
 # Input: CODEV_LINEAR_TEAM, CODEV_SINCE_DATE (optional, ISO date)
 # Output: JSON [{number, title, url, labels, createdAt, closedAt}]

--- a/packages/codev/scripts/forge/linear/user-identity.sh
+++ b/packages/codev/scripts/forge/linear/user-identity.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# forge-executable: curl
 # Forge concept: user-identity (Linear via GraphQL API)
 # Output: plain text display name
 set -e

--- a/packages/codev/src/__tests__/doctor.test.ts
+++ b/packages/codev/src/__tests__/doctor.test.ts
@@ -19,13 +19,13 @@ const executeForgeCommandSyncMock = vi.hoisted(() => vi.fn((concept: string) => 
 const loadForgeConfigMock = vi.hoisted(() => vi.fn(() => null));
 const validateForgeConfigMock = vi.hoisted(() => vi.fn(() => []));
 const resolveAllConceptsMock = vi.hoisted(() => vi.fn(() => {
-  // All 18 concepts (KNOWN_CONCEPTS in lib/forge.ts) as default/gh-based, so the
+  // All concepts (KNOWN_CONCEPTS in lib/forge.ts) as default/gh-based, so the
   // doctor report's rendering is exercised for every row it actually prints.
   const concepts = [
     'issue-view', 'pr-list', 'issue-list', 'issue-search', 'issue-comment', 'pr-exists',
     'recently-closed', 'recently-merged', 'user-identity', 'team-activity',
     'on-it-timestamps', 'pr-create', 'pr-merge', 'pr-search', 'pr-view', 'pr-diff',
-    'auth-status', 'repo-archive',
+    'auth-status', 'repo-archive', 'rate-limit',
   ];
   return concepts.map(c => ({ concept: c, command: `gh ${c}`, source: 'default', executable: 'gh' }));
 }));

--- a/packages/codev/src/__tests__/forge-rate-limit.test.ts
+++ b/packages/codev/src/__tests__/forge-rate-limit.test.ts
@@ -14,6 +14,7 @@ import { join } from 'node:path';
 import {
   executeForgeCommand,
   onForgeFailure,
+  resolveAllConcepts,
   resolveConceptBackend,
   type ForgeFailure,
 } from '../lib/forge.js';
@@ -211,6 +212,36 @@ describe('every overview concept resolves to the same backend (#1645)', () => {
       .not.toBe(resolveConceptBackend('issue-list', { ...unresolvable, provider: 'linear' }));
     // Sanity: a concept both presets disable resolves to each one's own name.
     expect(viaGitlab).not.toBe(viaLinear);
+  });
+
+  it('keys an absolute executable path the same as the bare command', () => {
+    // An override spelling the tool in full must not fragment the suspension
+    // away from a concept that spells it bare — same account, same budget.
+    expect(resolveConceptBackend('issue-list', { 'issue-list': '/usr/local/bin/gh issue list' }))
+      .toBe('gh');
+    expect(resolveConceptBackend('issue-list', { 'issue-list': 'gh issue list' }))
+      .toBe('gh');
+  });
+
+  it('keys the unreadable-script fallback in the same namespace as a healthy resolve', () => {
+    // Healthy resolution yields the executable (`gh`); the fallback yields the
+    // provider. Without the alias map those are two suspension states for one
+    // account.
+    expect(resolveConceptBackend('issue-list', { 'issue-list': '/nonexistent/missing.sh' }))
+      .toBe(resolveConceptBackend('issue-list', null));
+  });
+
+  it('leaves no built-in provider resolving to a shell builtin', () => {
+    // The #1455 heuristic picks the first substantive line, which is `echo` for
+    // Linear's API-key guard and `case` for gitlab's issue-search — so `codev
+    // doctor` told those users to install `echo`, and #1645 would file their
+    // rate limits under it. The `# forge-executable:` declarations fix both.
+    for (const provider of ['github', 'gitlab', 'gitea', 'linear']) {
+      for (const r of resolveAllConcepts({ provider })) {
+        if (r.source === 'disabled' || r.executable === null) continue;
+        expect(['gh', 'glab', 'tea', 'curl']).toContain(r.executable);
+      }
+    }
   });
 
   it('resolves pr-list, issue-list and both searches to gh', () => {

--- a/packages/codev/src/__tests__/forge-rate-limit.test.ts
+++ b/packages/codev/src/__tests__/forge-rate-limit.test.ts
@@ -170,7 +170,7 @@ describe('forge rate-limit awareness (#1645)', () => {
       expect(isForgeSuspended(DEFAULT_PROVIDER, dispatchedAt + 20)).toBe(true);
     });
 
-    it('clears outright on an explicit refresh', () => {
+    it('clears outright when asked (no product caller — see the docstring)', () => {
       noteRateLimited(DEFAULT_PROVIDER, Date.now() + 60_000);
       expect(isForgeSuspended(DEFAULT_PROVIDER)).toBe(true);
       clearForgeSuspension();
@@ -221,6 +221,23 @@ describe('every overview concept resolves to the same backend (#1645)', () => {
       .toBe('gh');
     expect(resolveConceptBackend('issue-list', { 'issue-list': 'gh issue list' }))
       .toBe('gh');
+  });
+
+  it('keys a generic transport by provider, not by the transport', () => {
+    // Linear's concepts run `curl`, which names a protocol rather than an
+    // account — and would collide with any future curl-based provider. Its
+    // healthy resolve and its fallback must both key `linear`.
+    expect(resolveConceptBackend('issue-list', { provider: 'linear' })).toBe('linear');
+    expect(resolveConceptBackend('issue-list', { provider: 'linear', 'issue-list': '/nope/missing.sh' }))
+      .toBe('linear');
+  });
+
+  it('does not key an extensionless script override by its own filename', () => {
+    // `/opt/forge/issue-list` is a script we cannot introspect, not a tool
+    // called `issue-list`. Keying on its filename would give every concept a
+    // backend of its own and fragment one account across all of them.
+    expect(resolveConceptBackend('issue-list', { 'issue-list': '/opt/forge/issue-list' }))
+      .toBe(resolveConceptBackend('issue-list', null));
   });
 
   it('keys the unreadable-script fallback in the same namespace as a healthy resolve', () => {

--- a/packages/codev/src/__tests__/forge-rate-limit.test.ts
+++ b/packages/codev/src/__tests__/forge-rate-limit.test.ts
@@ -17,6 +17,7 @@ import {
   noteRateLimited,
   noteForgeSuccess,
   clearForgeSuspension,
+  DEFAULT_PROVIDER,
   resetForgeRateLimit,
   isForgeSuspended,
   getForgeRateLimit,
@@ -53,52 +54,75 @@ describe('forge rate-limit awareness (#1645)', () => {
 
   describe('suspension', () => {
     it('is not suspended by default', () => {
-      expect(isForgeSuspended()).toBe(false);
-      expect(getForgeRateLimit()).toEqual({ limited: false, resetAt: null });
+      expect(isForgeSuspended(DEFAULT_PROVIDER)).toBe(false);
+      expect(getForgeRateLimit(DEFAULT_PROVIDER)).toEqual({ limited: false, resetAt: null });
+    });
+
+    it('suspends only the provider that was refused', () => {
+      // A GitHub limit says nothing about a GitLab workspace's forge, and
+      // blanking its Work view for the backoff window would be a regression
+      // for a workspace that is not even involved.
+      const now = 1_000_000;
+      noteRateLimited('github', null, now);
+
+      expect(isForgeSuspended('github', now)).toBe(true);
+      expect(isForgeSuspended('gitlab', now)).toBe(false);
+      expect(isForgeSuspended('linear', now)).toBe(false);
+      expect(getForgeRateLimit('gitlab', now)).toEqual({ limited: false, resetAt: null });
+    });
+
+    it('backs each provider off independently', () => {
+      const now = 1_000_000;
+      noteRateLimited('github', null, now);
+      noteRateLimited('gitlab', null, now);
+      noteForgeSuccess('github', now + 1);
+
+      expect(isForgeSuspended('github', now)).toBe(false);
+      expect(isForgeSuspended('gitlab', now)).toBe(true);
     });
 
     it('suspends until a reported reset instant', () => {
       const now = Date.now();
       const reset = now + 5 * 60_000;
-      noteRateLimited(reset, now);
+      noteRateLimited(DEFAULT_PROVIDER, reset, now);
 
-      expect(isForgeSuspended(now)).toBe(true);
-      expect(getForgeRateLimit(now).resetAt).toBe(new Date(reset).toISOString());
-      expect(isForgeSuspended(reset + 1)).toBe(false);
+      expect(isForgeSuspended(DEFAULT_PROVIDER, now)).toBe(true);
+      expect(getForgeRateLimit(DEFAULT_PROVIDER, now).resetAt).toBe(new Date(reset).toISOString());
+      expect(isForgeSuspended(DEFAULT_PROVIDER, reset + 1)).toBe(false);
     });
 
     it('falls back to a doubling backoff when the reset instant is unknown', () => {
       const now = 1_000_000;
-      noteRateLimited(null, now);
-      expect(getForgeRateLimit(now).resetAt).toBe(new Date(now + BACKOFF_BASE_MS).toISOString());
+      noteRateLimited(DEFAULT_PROVIDER, null, now);
+      expect(getForgeRateLimit(DEFAULT_PROVIDER, now).resetAt).toBe(new Date(now + BACKOFF_BASE_MS).toISOString());
 
       // Second hit lands past the first window, so the backoff doubles.
       const later = now + BACKOFF_BASE_MS + 1;
-      noteRateLimited(null, later);
-      expect(getForgeRateLimit(later).resetAt).toBe(new Date(later + BACKOFF_BASE_MS * 2).toISOString());
+      noteRateLimited(DEFAULT_PROVIDER, null, later);
+      expect(getForgeRateLimit(DEFAULT_PROVIDER, later).resetAt).toBe(new Date(later + BACKOFF_BASE_MS * 2).toISOString());
     });
 
     it('caps the backoff at 15 minutes', () => {
       let t = 1_000_000;
       for (let i = 0; i < 12; i++) {
-        noteRateLimited(null, t);
+        noteRateLimited(DEFAULT_PROVIDER, null, t);
         t += BACKOFF_MAX_MS + 1;
       }
-      noteRateLimited(null, t);
-      expect(getForgeRateLimit(t).resetAt).toBe(new Date(t + BACKOFF_MAX_MS).toISOString());
+      noteRateLimited(DEFAULT_PROVIDER, null, t);
+      expect(getForgeRateLimit(DEFAULT_PROVIDER, t).resetAt).toBe(new Date(t + BACKOFF_MAX_MS).toISOString());
     });
 
     it('refuses to trust a reset instant more than an hour out', () => {
       const now = 1_000_000;
-      noteRateLimited(now + 5 * SUSPEND_CAP_MS, now);
-      expect(getForgeRateLimit(now).resetAt).toBe(new Date(now + SUSPEND_CAP_MS).toISOString());
+      noteRateLimited(DEFAULT_PROVIDER, now + 5 * SUSPEND_CAP_MS, now);
+      expect(getForgeRateLimit(DEFAULT_PROVIDER, now).resetAt).toBe(new Date(now + SUSPEND_CAP_MS).toISOString());
     });
 
     it('never shortens a suspension already in force', () => {
       const now = 1_000_000;
-      noteRateLimited(now + 10 * 60_000, now);
-      noteRateLimited(now + 60_000, now);
-      expect(getForgeRateLimit(now).resetAt).toBe(new Date(now + 10 * 60_000).toISOString());
+      noteRateLimited(DEFAULT_PROVIDER, now + 10 * 60_000, now);
+      noteRateLimited(DEFAULT_PROVIDER, now + 60_000, now);
+      expect(getForgeRateLimit(DEFAULT_PROVIDER, now).resetAt).toBe(new Date(now + 10 * 60_000).toISOString());
     });
 
     it('escalates once per window, not once per failed command', () => {
@@ -106,19 +130,19 @@ describe('forge rate-limit awareness (#1645)', () => {
       // fail together. Counting each would jump from 60s straight to 8 minutes
       // on the very first refresh.
       const now = 1_000_000;
-      noteRateLimited(null, now);
-      noteRateLimited(null, now);
-      noteRateLimited(null, now);
-      noteRateLimited(null, now);
-      expect(getForgeRateLimit(now).resetAt).toBe(new Date(now + BACKOFF_BASE_MS).toISOString());
+      noteRateLimited(DEFAULT_PROVIDER, null, now);
+      noteRateLimited(DEFAULT_PROVIDER, null, now);
+      noteRateLimited(DEFAULT_PROVIDER, null, now);
+      noteRateLimited(DEFAULT_PROVIDER, null, now);
+      expect(getForgeRateLimit(DEFAULT_PROVIDER, now).resetAt).toBe(new Date(now + BACKOFF_BASE_MS).toISOString());
     });
 
     it('clears on a forge command dispatched after the suspension began', () => {
       const now = 1_000_000;
-      noteRateLimited(null, now);
-      expect(isForgeSuspended(now)).toBe(true);
-      noteForgeSuccess(now + 1);
-      expect(isForgeSuspended(now)).toBe(false);
+      noteRateLimited(DEFAULT_PROVIDER, null, now);
+      expect(isForgeSuspended(DEFAULT_PROVIDER, now)).toBe(true);
+      noteForgeSuccess(DEFAULT_PROVIDER, now + 1);
+      expect(isForgeSuspended(DEFAULT_PROVIDER, now)).toBe(false);
     });
 
     it('ignores a success from a command dispatched BEFORE the suspension', () => {
@@ -126,16 +150,16 @@ describe('forge rate-limit awareness (#1645)', () => {
       // ones and is charged to a different budget, so it succeeds while they
       // are refused. It must not wipe the suspension they just set.
       const dispatchedAt = 1_000_000;
-      noteRateLimited(null, dispatchedAt + 10);
-      noteForgeSuccess(dispatchedAt);
-      expect(isForgeSuspended(dispatchedAt + 20)).toBe(true);
+      noteRateLimited(DEFAULT_PROVIDER, null, dispatchedAt + 10);
+      noteForgeSuccess(DEFAULT_PROVIDER, dispatchedAt);
+      expect(isForgeSuspended(DEFAULT_PROVIDER, dispatchedAt + 20)).toBe(true);
     });
 
     it('clears outright on an explicit refresh', () => {
-      noteRateLimited(Date.now() + 60_000);
-      expect(isForgeSuspended()).toBe(true);
+      noteRateLimited(DEFAULT_PROVIDER, Date.now() + 60_000);
+      expect(isForgeSuspended(DEFAULT_PROVIDER)).toBe(true);
       clearForgeSuspension();
-      expect(isForgeSuspended()).toBe(false);
+      expect(isForgeSuspended(DEFAULT_PROVIDER)).toBe(false);
     });
   });
 
@@ -193,10 +217,10 @@ describe('forge failure detail reaches its observers (#1645)', () => {
     installForgeRateLimitWatch();
     const command = script('echo "GraphQL: API rate limit already exceeded for user ID 1." >&2; exit 1');
 
-    expect(isForgeSuspended()).toBe(false);
+    expect(isForgeSuspended(DEFAULT_PROVIDER)).toBe(false);
     await executeForgeCommand('issue-list', {}, { forgeConfig: { 'issue-list': command } });
 
-    expect(isForgeSuspended()).toBe(true);
+    expect(isForgeSuspended(DEFAULT_PROVIDER)).toBe(true);
   });
 
   it('leaves the forge alone for a non-rate-limit failure', async () => {
@@ -205,7 +229,7 @@ describe('forge failure detail reaches its observers (#1645)', () => {
 
     await executeForgeCommand('issue-list', {}, { forgeConfig: { 'issue-list': command } });
 
-    expect(isForgeSuspended()).toBe(false);
+    expect(isForgeSuspended(DEFAULT_PROVIDER)).toBe(false);
   });
 
   it('does not fire for a command that succeeds', async () => {

--- a/packages/codev/src/__tests__/forge-rate-limit.test.ts
+++ b/packages/codev/src/__tests__/forge-rate-limit.test.ts
@@ -11,7 +11,12 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { executeForgeCommand, onForgeFailure, type ForgeFailure } from '../lib/forge.js';
+import {
+  executeForgeCommand,
+  onForgeFailure,
+  resolveConceptBackend,
+  type ForgeFailure,
+} from '../lib/forge.js';
 import {
   isRateLimitError,
   noteRateLimited,
@@ -58,27 +63,36 @@ describe('forge rate-limit awareness (#1645)', () => {
       expect(getForgeRateLimit(DEFAULT_PROVIDER)).toEqual({ limited: false, resetAt: null });
     });
 
-    it('suspends only the provider that was refused', () => {
-      // A GitHub limit says nothing about a GitLab workspace's forge, and
-      // blanking its Work view for the backoff window would be a regression
-      // for a workspace that is not even involved.
+    it('suspends only the backend that was refused', () => {
+      // A `gh` limit says nothing about a workspace whose concepts run `glab`,
+      // and blanking its Work view for the backoff window would be a
+      // regression for a workspace that is not even involved.
       const now = 1_000_000;
-      noteRateLimited('github', null, now);
+      noteRateLimited('gh', null, now);
 
-      expect(isForgeSuspended('github', now)).toBe(true);
-      expect(isForgeSuspended('gitlab', now)).toBe(false);
-      expect(isForgeSuspended('linear', now)).toBe(false);
-      expect(getForgeRateLimit('gitlab', now)).toEqual({ limited: false, resetAt: null });
+      expect(isForgeSuspended('gh', now)).toBe(true);
+      expect(isForgeSuspended('glab', now)).toBe(false);
+      expect(isForgeSuspended('tea', now)).toBe(false);
+      expect(getForgeRateLimit('glab', now)).toEqual({ limited: false, resetAt: null });
     });
 
-    it('backs each provider off independently', () => {
+    it('backs each backend off independently', () => {
       const now = 1_000_000;
-      noteRateLimited('github', null, now);
-      noteRateLimited('gitlab', null, now);
-      noteForgeSuccess('github', now + 1);
+      noteRateLimited('gh', null, now);
+      noteRateLimited('glab', null, now);
+      noteForgeSuccess('gh', now + 1);
 
-      expect(isForgeSuspended('github', now)).toBe(false);
-      expect(isForgeSuspended('gitlab', now)).toBe(true);
+      expect(isForgeSuspended('gh', now)).toBe(false);
+      expect(isForgeSuspended('glab', now)).toBe(true);
+    });
+
+    it('treats backend keys case-insensitively', () => {
+      // A config spelling its provider `GitHub` must not get state separate
+      // from one spelling it `github`.
+      const now = 1_000_000;
+      noteRateLimited('GitHub', null, now);
+      expect(isForgeSuspended('github', now)).toBe(true);
+      expect(isForgeSuspended('  GITHUB ', now)).toBe(true);
     });
 
     it('suspends until a reported reset instant', () => {
@@ -178,6 +192,21 @@ describe('forge rate-limit awareness (#1645)', () => {
   });
 });
 
+describe('every overview concept resolves to the same backend (#1645)', () => {
+  // Rate-limit suspension is keyed by resolved backend, so the four concepts
+  // backing the overview must agree — they all spend one `gh` account. They
+  // stopped agreeing once pr-list.sh was rewritten to capture gh's exit status
+  // (#1645): its first substantive line became an assignment, so the executable
+  // heuristic reported `printf`, which would have filed that concept's limits
+  // under a backend of its own and pointed `codev doctor` at the wrong CLI
+  // (#1455). The `# forge-executable: gh` declaration is what holds this.
+  it('resolves pr-list, issue-list and both searches to gh', () => {
+    for (const concept of ['pr-list', 'issue-list', 'recently-closed', 'recently-merged']) {
+      expect(resolveConceptBackend(concept, null)).toBe('gh');
+    }
+  });
+});
+
 describe('forge failure detail reaches its observers (#1645)', () => {
   let dir: string;
   let unsubscribe: () => void;
@@ -210,26 +239,33 @@ describe('forge failure detail reaches its observers (#1645)', () => {
     expect(failures).toHaveLength(1);
     expect(failures[0].concept).toBe('issue-list');
     expect(failures[0].exitCode).toBe(1);
+    expect(failures[0].backend).toBeTruthy();
     expect(failures[0].message).toContain('rate limit already exceeded');
   });
 
-  it('suspends the forge when the watch sees a rate-limit failure', async () => {
+  it('suspends the failing command\'s own backend when the watch sees a rate limit', async () => {
     installForgeRateLimitWatch();
     const command = script('echo "GraphQL: API rate limit already exceeded for user ID 1." >&2; exit 1');
+    const forgeConfig = { 'issue-list': command };
+    // Suspension is keyed by the backend the concept actually resolves to,
+    // not by the workspace's configured provider (#1645).
+    const backend = resolveConceptBackend('issue-list', forgeConfig);
 
-    expect(isForgeSuspended(DEFAULT_PROVIDER)).toBe(false);
-    await executeForgeCommand('issue-list', {}, { forgeConfig: { 'issue-list': command } });
+    expect(isForgeSuspended(backend)).toBe(false);
+    await executeForgeCommand('issue-list', {}, { forgeConfig });
 
-    expect(isForgeSuspended(DEFAULT_PROVIDER)).toBe(true);
+    expect(isForgeSuspended(backend)).toBe(true);
+    expect(isForgeSuspended('some-other-backend')).toBe(false);
   });
 
   it('leaves the forge alone for a non-rate-limit failure', async () => {
     installForgeRateLimitWatch();
     const command = script('echo "gh: not authenticated" >&2; exit 1');
+    const forgeConfig = { 'issue-list': command };
 
-    await executeForgeCommand('issue-list', {}, { forgeConfig: { 'issue-list': command } });
+    await executeForgeCommand('issue-list', {}, { forgeConfig });
 
-    expect(isForgeSuspended(DEFAULT_PROVIDER)).toBe(false);
+    expect(isForgeSuspended(resolveConceptBackend('issue-list', forgeConfig))).toBe(false);
   });
 
   it('does not fire for a command that succeeds', async () => {

--- a/packages/codev/src/__tests__/forge-rate-limit.test.ts
+++ b/packages/codev/src/__tests__/forge-rate-limit.test.ts
@@ -200,6 +200,19 @@ describe('every overview concept resolves to the same backend (#1645)', () => {
   // heuristic reported `printf`, which would have filed that concept's limits
   // under a backend of its own and pointed `codev doctor` at the wrong CLI
   // (#1455). The `# forge-executable: gh` declaration is what holds this.
+  it('does not let one workspace\'s provider bleed into another\'s backend', () => {
+    // The path-like fallback answers with the *configured provider*, so two
+    // workspaces resolving the same default script while naming different
+    // providers must not share a memoized answer.
+    const viaGitlab = resolveConceptBackend('team-activity', { provider: 'gitlab' });
+    const viaLinear = resolveConceptBackend('team-activity', { provider: 'linear' });
+    const unresolvable = { 'issue-list': '' };
+    expect(resolveConceptBackend('issue-list', { ...unresolvable, provider: 'gitlab' }))
+      .not.toBe(resolveConceptBackend('issue-list', { ...unresolvable, provider: 'linear' }));
+    // Sanity: a concept both presets disable resolves to each one's own name.
+    expect(viaGitlab).not.toBe(viaLinear);
+  });
+
   it('resolves pr-list, issue-list and both searches to gh', () => {
     for (const concept of ['pr-list', 'issue-list', 'recently-closed', 'recently-merged']) {
       expect(resolveConceptBackend(concept, null)).toBe('gh');

--- a/packages/codev/src/__tests__/forge-rate-limit.test.ts
+++ b/packages/codev/src/__tests__/forge-rate-limit.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Issue #1645 — forge rate-limit awareness.
+ *
+ * Pins the three pieces that stop Tower from burning the account's whole
+ * GitHub GraphQL budget: recognising the error, suspending on it with a
+ * doubling backoff, and getting the error's detail out of `executeForgeCommand`
+ * (which otherwise collapses every failure to `null`).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { executeForgeCommand, onForgeFailure, type ForgeFailure } from '../lib/forge.js';
+import {
+  isRateLimitError,
+  noteRateLimited,
+  noteForgeSuccess,
+  resetForgeRateLimit,
+  isForgeSuspended,
+  getForgeRateLimit,
+  parseBudget,
+  installForgeRateLimitWatch,
+  BACKOFF_BASE_MS,
+  BACKOFF_MAX_MS,
+  SUSPEND_CAP_MS,
+} from '../lib/forge-rate-limit.js';
+
+describe('forge rate-limit awareness (#1645)', () => {
+  beforeEach(() => {
+    resetForgeRateLimit();
+  });
+
+  describe('isRateLimitError', () => {
+    it('recognises the exact message gh prints on an exhausted GraphQL budget', () => {
+      // Captured verbatim from `gh issue list` on a real exhausted account.
+      expect(isRateLimitError('GraphQL: API rate limit already exceeded for user ID 2716496.')).toBe(true);
+    });
+
+    it('recognises the REST wording and the GraphQL error type', () => {
+      expect(isRateLimitError('API rate limit exceeded for user ID 1.')).toBe(true);
+      expect(isRateLimitError('{"type":"RATE_LIMITED","message":"..."}')).toBe(true);
+      expect(isRateLimitError('You have exceeded a secondary rate limit')).toBe(true);
+    });
+
+    it('does not fire on unrelated failures', () => {
+      expect(isRateLimitError('gh: command not found')).toBe(false);
+      expect(isRateLimitError('gh auth login required')).toBe(false);
+      expect(isRateLimitError('')).toBe(false);
+    });
+  });
+
+  describe('suspension', () => {
+    it('is not suspended by default', () => {
+      expect(isForgeSuspended()).toBe(false);
+      expect(getForgeRateLimit()).toEqual({ limited: false, resetAt: null });
+    });
+
+    it('suspends until a reported reset instant', () => {
+      const now = Date.now();
+      const reset = now + 5 * 60_000;
+      noteRateLimited(reset, now);
+
+      expect(isForgeSuspended(now)).toBe(true);
+      expect(getForgeRateLimit(now).resetAt).toBe(new Date(reset).toISOString());
+      expect(isForgeSuspended(reset + 1)).toBe(false);
+    });
+
+    it('falls back to a doubling backoff when the reset instant is unknown', () => {
+      const now = 1_000_000;
+      noteRateLimited(null, now);
+      expect(getForgeRateLimit(now).resetAt).toBe(new Date(now + BACKOFF_BASE_MS).toISOString());
+
+      // Second hit lands past the first window, so the backoff doubles.
+      const later = now + BACKOFF_BASE_MS + 1;
+      noteRateLimited(null, later);
+      expect(getForgeRateLimit(later).resetAt).toBe(new Date(later + BACKOFF_BASE_MS * 2).toISOString());
+    });
+
+    it('caps the backoff at 15 minutes', () => {
+      let t = 1_000_000;
+      for (let i = 0; i < 12; i++) {
+        noteRateLimited(null, t);
+        t += BACKOFF_MAX_MS + 1;
+      }
+      noteRateLimited(null, t);
+      expect(getForgeRateLimit(t).resetAt).toBe(new Date(t + BACKOFF_MAX_MS).toISOString());
+    });
+
+    it('refuses to trust a reset instant more than an hour out', () => {
+      const now = 1_000_000;
+      noteRateLimited(now + 5 * SUSPEND_CAP_MS, now);
+      expect(getForgeRateLimit(now).resetAt).toBe(new Date(now + SUSPEND_CAP_MS).toISOString());
+    });
+
+    it('never shortens a suspension already in force', () => {
+      const now = 1_000_000;
+      noteRateLimited(now + 10 * 60_000, now);
+      noteRateLimited(now + 60_000, now);
+      expect(getForgeRateLimit(now).resetAt).toBe(new Date(now + 10 * 60_000).toISOString());
+    });
+
+    it('clears on a successful forge command', () => {
+      noteRateLimited(Date.now() + 60_000);
+      expect(isForgeSuspended()).toBe(true);
+      noteForgeSuccess();
+      expect(isForgeSuspended()).toBe(false);
+    });
+  });
+
+  describe('parseBudget', () => {
+    it('parses the rate-limit concept output', () => {
+      expect(parseBudget({ limit: 5000, remaining: 0, used: 5000, reset: 1788847344 }))
+        .toEqual({ limit: 5000, remaining: 0, used: 5000, reset: 1788847344 });
+    });
+
+    it('rejects anything else', () => {
+      expect(parseBudget(null)).toBeNull();
+      expect(parseBudget('nope')).toBeNull();
+      expect(parseBudget({ limit: 5000 })).toBeNull();
+      expect(parseBudget({ limit: '5000', remaining: 0, used: 0, reset: 0 })).toBeNull();
+    });
+  });
+});
+
+describe('forge failure detail reaches its observers (#1645)', () => {
+  let dir: string;
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    resetForgeRateLimit();
+    dir = mkdtempSync(join(tmpdir(), 'forge-fail-'));
+  });
+
+  afterEach(() => {
+    unsubscribe?.();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function script(body: string): string {
+    const p = join(dir, 'concept.sh');
+    writeFileSync(p, `#!/bin/sh\n${body}\n`);
+    chmodSync(p, 0o755);
+    return p;
+  }
+
+  it('publishes stderr and exit code that executeForgeCommand would have discarded', async () => {
+    const command = script('echo "GraphQL: API rate limit already exceeded for user ID 1." >&2; exit 1');
+    const failures: ForgeFailure[] = [];
+    unsubscribe = onForgeFailure(f => failures.push(f));
+
+    const result = await executeForgeCommand('issue-list', {}, { forgeConfig: { 'issue-list': command } });
+
+    expect(result).toBeNull(); // unchanged contract for existing callers
+    expect(failures).toHaveLength(1);
+    expect(failures[0].concept).toBe('issue-list');
+    expect(failures[0].exitCode).toBe(1);
+    expect(failures[0].message).toContain('rate limit already exceeded');
+  });
+
+  it('suspends the forge when the watch sees a rate-limit failure', async () => {
+    installForgeRateLimitWatch();
+    const command = script('echo "GraphQL: API rate limit already exceeded for user ID 1." >&2; exit 1');
+
+    expect(isForgeSuspended()).toBe(false);
+    await executeForgeCommand('issue-list', {}, { forgeConfig: { 'issue-list': command } });
+
+    expect(isForgeSuspended()).toBe(true);
+  });
+
+  it('leaves the forge alone for a non-rate-limit failure', async () => {
+    installForgeRateLimitWatch();
+    const command = script('echo "gh: not authenticated" >&2; exit 1');
+
+    await executeForgeCommand('issue-list', {}, { forgeConfig: { 'issue-list': command } });
+
+    expect(isForgeSuspended()).toBe(false);
+  });
+
+  it('does not fire for a command that succeeds', async () => {
+    const command = script('echo "[]"');
+    const failures: ForgeFailure[] = [];
+    unsubscribe = onForgeFailure(f => failures.push(f));
+
+    await executeForgeCommand('issue-list', {}, { forgeConfig: { 'issue-list': command } });
+
+    expect(failures).toHaveLength(0);
+  });
+});

--- a/packages/codev/src/__tests__/forge-rate-limit.test.ts
+++ b/packages/codev/src/__tests__/forge-rate-limit.test.ts
@@ -16,6 +16,7 @@ import {
   isRateLimitError,
   noteRateLimited,
   noteForgeSuccess,
+  clearForgeSuspension,
   resetForgeRateLimit,
   isForgeSuspended,
   getForgeRateLimit,
@@ -100,10 +101,40 @@ describe('forge rate-limit awareness (#1645)', () => {
       expect(getForgeRateLimit(now).resetAt).toBe(new Date(now + 10 * 60_000).toISOString());
     });
 
-    it('clears on a successful forge command', () => {
+    it('escalates once per window, not once per failed command', () => {
+      // An overview refresh fires four forge commands in parallel and all four
+      // fail together. Counting each would jump from 60s straight to 8 minutes
+      // on the very first refresh.
+      const now = 1_000_000;
+      noteRateLimited(null, now);
+      noteRateLimited(null, now);
+      noteRateLimited(null, now);
+      noteRateLimited(null, now);
+      expect(getForgeRateLimit(now).resetAt).toBe(new Date(now + BACKOFF_BASE_MS).toISOString());
+    });
+
+    it('clears on a forge command dispatched after the suspension began', () => {
+      const now = 1_000_000;
+      noteRateLimited(null, now);
+      expect(isForgeSuspended(now)).toBe(true);
+      noteForgeSuccess(now + 1);
+      expect(isForgeSuspended(now)).toBe(false);
+    });
+
+    it('ignores a success from a command dispatched BEFORE the suspension', () => {
+      // The REST `user-identity` call runs in the same batch as the GraphQL
+      // ones and is charged to a different budget, so it succeeds while they
+      // are refused. It must not wipe the suspension they just set.
+      const dispatchedAt = 1_000_000;
+      noteRateLimited(null, dispatchedAt + 10);
+      noteForgeSuccess(dispatchedAt);
+      expect(isForgeSuspended(dispatchedAt + 20)).toBe(true);
+    });
+
+    it('clears outright on an explicit refresh', () => {
       noteRateLimited(Date.now() + 60_000);
       expect(isForgeSuspended()).toBe(true);
-      noteForgeSuccess();
+      clearForgeSuspension();
       expect(isForgeSuspended()).toBe(false);
     });
   });

--- a/packages/codev/src/__tests__/forge.test.ts
+++ b/packages/codev/src/__tests__/forge.test.ts
@@ -320,9 +320,10 @@ describe('executeForgeCommandSync', () => {
 // =============================================================================
 
 describe('getKnownConcepts', () => {
-  it('returns all 18 known concept names', () => {
+  it('returns all 19 known concept names', () => {
     const concepts = getKnownConcepts();
     expect(concepts).toContain('issue-view');
+    expect(concepts).toContain('rate-limit');
     expect(concepts).toContain('pr-list');
     expect(concepts).toContain('issue-list');
     expect(concepts).toContain('issue-search');
@@ -340,7 +341,7 @@ describe('getKnownConcepts', () => {
     expect(concepts).toContain('pr-diff');
     expect(concepts).toContain('auth-status');
     expect(concepts).toContain('repo-archive');
-    expect(concepts.length).toBe(18);
+    expect(concepts.length).toBe(19);
   });
 });
 
@@ -593,9 +594,9 @@ describe('graceful degradation when command not found', () => {
 // =============================================================================
 
 describe('resolveAllConcepts', () => {
-  it('returns all 18 concepts with default source when no config', () => {
+  it('returns all 19 concepts with default source when no config', () => {
     const resolutions = resolveAllConcepts();
-    expect(resolutions).toHaveLength(18);
+    expect(resolutions).toHaveLength(19);
     expect(resolutions.every(r => r.source === 'default')).toBe(true);
     expect(resolutions.every(r => r.executable !== null)).toBe(true);
   });

--- a/packages/codev/src/__tests__/forge.test.ts
+++ b/packages/codev/src/__tests__/forge.test.ts
@@ -541,9 +541,12 @@ describe('provider presets', () => {
     // every other concept falls through to gh. Only the two concepts linear
     // genuinely cannot serve are disabled. This fails loudly if anyone disables
     // a PR concept again, rather than only catching pr-create by name.
+    // `rate-limit` joins the disabled list (#1645): it probes GitHub's GraphQL
+    // budget, so leaving it to fall through to the github default made `codev
+    // doctor` tell Linear projects to install `gh`.
     const resolutions = resolveAllConcepts({ provider: 'linear' });
     const disabled = resolutions.filter(r => r.source === 'disabled').map(r => r.concept);
-    expect(disabled.sort()).toEqual(['on-it-timestamps', 'team-activity']);
+    expect(disabled.sort()).toEqual(['on-it-timestamps', 'rate-limit', 'team-activity']);
     expect(resolutions.every(r => r.command !== null)).toBe(false); // the two above
     expect(resolutions.filter(r => r.source !== 'disabled').every(r => r.executable !== null)).toBe(true);
   });

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -2130,6 +2130,30 @@ describe('overview', () => {
       expect(mockFetchPRList).toHaveBeenCalledTimes(2);
     });
 
+    it('caps forge spend under sustained invalidation, not just a burst (#1645)', async () => {
+      // The burst test above is synchronous — every invalidation lands while
+      // one flight is queued, so collapsing handles it. Sustained invalidation
+      // is the real shape: porch fires one after every mutating command, spread
+      // over time, each arriving after the previous fetch has already started.
+      // Without a debounce the TTLs stop governing spend entirely and the
+      // invalidation rate governs it instead.
+      mockFetchPRList.mockResolvedValue([]);
+      mockFetchIssueList.mockResolvedValue([]);
+
+      const cache = new OverviewCache();
+      await cache.getOverview(tmpDir);
+      const afterFirst = mockFetchPRList.mock.calls.length;
+
+      // Ten invalidations, each with its fetch fully settling in between.
+      for (let i = 0; i < 10; i++) {
+        cache.invalidate();
+        await cache.getOverview(tmpDir);
+      }
+
+      // At most one of them forced a refresh; the rest were debounced.
+      expect(mockFetchPRList.mock.calls.length - afterFirst).toBeLessThanOrEqual(1);
+    });
+
     it('re-checks the suspension after waiting on a queued fetch (#1645)', async () => {
       // The suspension is checked when a fetch is dispatched. A queued fetch
       // can wait 30s behind the one ahead of it, and the forge may start
@@ -2238,10 +2262,11 @@ describe('overview', () => {
     it('projects spend in GraphQL points, not calls (#1645)', () => {
       // Points, not calls: reporting 676 calls against a 5,000-*point* budget
       // reads as 14% when the real figure is 41%, which would suppress the
-      // warning the doctor check exists to raise.
-      expect(projectHourlyGraphqlPoints(13)).toBe(676 * GRAPHQL_POINTS_PER_CALL);
+      // warning the doctor check exists to raise. Asserting the arithmetic
+      // (676 x 3) would only restate the implementation, so assert the two
+      // properties that actually constrain it.
       expect(projectHourlyGraphqlPoints(13)).toBeGreaterThan(projectHourlyForgeCalls(13));
-      // And the shipped TTLs must keep 13 watched workspaces under half the budget.
+      // The shipped TTLs must keep 13 watched workspaces under half the budget.
       expect(projectHourlyGraphqlPoints(13)).toBeLessThan(0.5 * 5000);
     });
 

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -31,6 +31,7 @@ import {
   noteRateLimited,
   resetForgeRateLimit,
   isForgeSuspended,
+  getForgeRateLimit,
 } from '../../lib/forge-rate-limit.js';
 import { resolveConceptBackend } from '../../lib/forge.js';
 
@@ -2000,6 +2001,69 @@ describe('overview', () => {
       await all;
 
       expect(mockFetchPRList).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not let the REST identity call reset the escalating backoff (#1645)', async () => {
+      // `user-identity` is `gh api user` — REST, a budget separate from the
+      // GraphQL one the lists spend, but resolving to the same `gh` backend
+      // key. Its success must not clear the suspension, or every window that
+      // expires after its 1h TTL also expires would reset the doubling backoff
+      // to its first step and it would never escalate.
+      mockFetchPRList.mockResolvedValue(null);
+      mockFetchIssueList.mockResolvedValue(null);
+      mockFetchRecentlyClosed.mockResolvedValue(null);
+      mockFetchMergedPRs.mockResolvedValue(null);
+      mockFetchCurrentUser.mockResolvedValue('octocat');
+
+      const cache = new OverviewCache();
+      await cache.getOverview(tmpDir);           // identity fetched, nothing suspended yet
+      noteRateLimited(OVERVIEW_BACKEND, null);   // first hit -> 60s window
+
+      vi.useFakeTimers();
+      // Past both the suspension window and the identity call's 1h TTL, so the
+      // identity call actually re-runs and succeeds.
+      vi.advanceTimersByTime(61 * 60_000);
+      await cache.getOverview(tmpDir);
+      expect(mockFetchCurrentUser).toHaveBeenCalledTimes(2); // it really did re-run
+
+      noteRateLimited(OVERVIEW_BACKEND, null);   // second hit
+      const windowMs = new Date(getForgeRateLimit(OVERVIEW_BACKEND).resetAt!).getTime() - Date.now();
+      vi.useRealTimers();
+
+      // Escalated to the second step. Without the guard the identity success
+      // would have reset the counter and this would still be the first.
+      expect(windowMs).toBeGreaterThan(60_000);
+    });
+
+    it('keeps coalescing after an invalidate (#1645)', async () => {
+      // invalidate() clears the join table, so a newer flight is registered
+      // while an older one is still settling. The older one's cleanup must not
+      // delete the newer entry — a caller arriving after that would start yet
+      // another fetch, the fan-out single-flight exists to prevent.
+      let releaseA: (v: unknown) => void = () => {};
+      let releaseB: (v: unknown) => void = () => {};
+      const gateA = new Promise(r => { releaseA = r; });
+      const gateB = new Promise(r => { releaseB = r; });
+      mockFetchPRList
+        .mockImplementationOnce(async () => { await gateA; return []; })
+        .mockImplementation(async () => { await gateB; return []; });
+      mockFetchIssueList.mockResolvedValue([]);
+
+      const cache = new OverviewCache();
+      const first = cache.getOverview(tmpDir);   // flight A
+      cache.invalidate();                        // clears the join table
+      const second = cache.getOverview(tmpDir);  // flight B registers
+
+      // Let A settle and its cleanup run, while B is still in flight.
+      releaseA(null);
+      await first;
+      await new Promise(r => setTimeout(r, 0));
+
+      const third = cache.getOverview(tmpDir);   // must JOIN B, not start C
+      releaseB(null);
+      await Promise.all([second, third]);
+
+      expect(mockFetchPRList).toHaveBeenCalledTimes(2);
     });
 
     it('does not hand a post-refresh caller a result fetched before it (#1645)', async () => {

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -26,6 +26,12 @@ import {
   countQueuedFeedback,
   readFeedbackMode,
 } from '../servers/overview.js';
+import { negativeTtlMs, projectHourlyForgeCalls } from '../servers/overview-budget.js';
+import {
+  noteRateLimited,
+  resetForgeRateLimit,
+  isForgeSuspended,
+} from '../../lib/forge-rate-limit.js';
 
 // ============================================================================
 // Mocks
@@ -163,6 +169,8 @@ function createStateDb(
 describe('overview', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // #1645: the forge rate-limit suspension is module-level process state.
+    resetForgeRateLimit();
     tmpDir = makeTmpDir();
     // Issue #1118: per-test global.db path (file created lazily by createStateDb).
     dbState.globalDbPath = path.join(tmpDir, '.agent-farm', 'global.db');
@@ -1705,6 +1713,20 @@ describe('overview', () => {
       expect(data.backlog).toEqual([]);
     });
 
+    it('doubles the negative-cache window per failure, capped at 15 minutes (#1645)', () => {
+      expect(negativeTtlMs(1)).toBe(60_000);
+      expect(negativeTtlMs(2)).toBe(120_000);
+      expect(negativeTtlMs(3)).toBe(240_000);
+      expect(negativeTtlMs(10)).toBe(900_000);
+    });
+
+    it('projects the hourly forge spend from the TTLs (#1645)', () => {
+      // 2 list calls per 120s window (60/h) + 2 search calls per 600s window (12/h).
+      expect(projectHourlyForgeCalls(1)).toBe(72);
+      expect(projectHourlyForgeCalls(13)).toBe(936);
+      expect(projectHourlyForgeCalls(0)).toBe(0);
+    });
+
     it('caches currentUser across getOverview calls', async () => {
       mockFetchCurrentUser.mockResolvedValue('octocat');
 
@@ -1728,7 +1750,7 @@ describe('overview', () => {
       expect(mockFetchPRList).toHaveBeenCalledTimes(2);
     });
 
-    it('re-fetches after 30s TTL expires (Bugfix #388)', async () => {
+    it('re-fetches after the positive TTL expires (Bugfix #388)', async () => {
       mockFetchPRList.mockResolvedValue([]);
       mockFetchIssueList.mockResolvedValue([]);
       mockFetchRecentlyClosed.mockResolvedValue([]);
@@ -1737,14 +1759,190 @@ describe('overview', () => {
       await cache.getOverview(tmpDir);
       expect(mockFetchPRList).toHaveBeenCalledTimes(1);
 
-      // Advance time past the 30s TTL
+      // Advance time past the 120s positive TTL (raised from 30s in #1645)
       vi.useFakeTimers();
-      vi.advanceTimersByTime(31_000);
+      vi.advanceTimersByTime(121_000);
 
       await cache.getOverview(tmpDir);
       expect(mockFetchPRList).toHaveBeenCalledTimes(2);
 
       vi.useRealTimers();
+    });
+
+    it('holds the positive TTL for 120s, not 30s (#1645)', async () => {
+      mockFetchPRList.mockResolvedValue([]);
+      mockFetchIssueList.mockResolvedValue([]);
+
+      const cache = new OverviewCache();
+      await cache.getOverview(tmpDir);
+
+      vi.useFakeTimers();
+      vi.advanceTimersByTime(90_000);
+      await cache.getOverview(tmpDir);
+      vi.useRealTimers();
+
+      expect(mockFetchPRList).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the 24h search windows cached for 10 minutes (#1645)', async () => {
+      mockFetchPRList.mockResolvedValue([]);
+      mockFetchIssueList.mockResolvedValue([]);
+      mockFetchRecentlyClosed.mockResolvedValue([]);
+      mockFetchMergedPRs.mockResolvedValue([]);
+
+      const cache = new OverviewCache();
+      await cache.getOverview(tmpDir);
+
+      vi.useFakeTimers();
+      // Past the 120s list TTL, well inside the 600s search TTL.
+      vi.advanceTimersByTime(300_000);
+      await cache.getOverview(tmpDir);
+      vi.useRealTimers();
+
+      expect(mockFetchPRList).toHaveBeenCalledTimes(2);
+      expect(mockFetchRecentlyClosed).toHaveBeenCalledTimes(1);
+      expect(mockFetchMergedPRs).toHaveBeenCalledTimes(1);
+    });
+
+    // ======================================================================
+    // Issue #1645 — negative caching, backoff, and rate-limit suspension
+    // ======================================================================
+
+    it('caches a FAILED fetch instead of re-spawning it on the next request (#1645)', async () => {
+      // The bug: `if (data !== null) cache.set(...)` never stored a failure, so
+      // every 2.5s dashboard poll re-spawned all four gh commands. Measured at
+      // 180 gh processes in 60s once GitHub started refusing them.
+      mockFetchPRList.mockResolvedValue(null);
+      mockFetchIssueList.mockResolvedValue(null);
+      mockFetchRecentlyClosed.mockResolvedValue(null);
+      mockFetchMergedPRs.mockResolvedValue(null);
+
+      const cache = new OverviewCache();
+      await cache.getOverview(tmpDir);
+      await cache.getOverview(tmpDir);
+      await cache.getOverview(tmpDir);
+
+      expect(mockFetchPRList).toHaveBeenCalledTimes(1);
+      expect(mockFetchIssueList).toHaveBeenCalledTimes(1);
+      expect(mockFetchRecentlyClosed).toHaveBeenCalledTimes(1);
+      expect(mockFetchMergedPRs).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries a failed fetch once the negative window expires (#1645)', async () => {
+      mockFetchPRList.mockResolvedValue(null);
+      mockFetchIssueList.mockResolvedValue([]);
+
+      const cache = new OverviewCache();
+      await cache.getOverview(tmpDir);
+      expect(mockFetchPRList).toHaveBeenCalledTimes(1);
+
+      vi.useFakeTimers();
+      vi.advanceTimersByTime(61_000); // past the 60s first negative window
+      await cache.getOverview(tmpDir);
+      vi.useRealTimers();
+
+      expect(mockFetchPRList).toHaveBeenCalledTimes(2);
+    });
+
+    it('backs off further on each consecutive failure (#1645)', async () => {
+      mockFetchPRList.mockResolvedValue(null);
+      mockFetchIssueList.mockResolvedValue([]);
+
+      const cache = new OverviewCache();
+      await cache.getOverview(tmpDir);
+
+      vi.useFakeTimers();
+      vi.advanceTimersByTime(61_000);
+      await cache.getOverview(tmpDir); // 2nd failure -> window doubles to 120s
+      expect(mockFetchPRList).toHaveBeenCalledTimes(2);
+
+      vi.advanceTimersByTime(61_000); // inside the doubled window
+      await cache.getOverview(tmpDir);
+      expect(mockFetchPRList).toHaveBeenCalledTimes(2);
+
+      vi.advanceTimersByTime(61_000); // past it
+      await cache.getOverview(tmpDir);
+      expect(mockFetchPRList).toHaveBeenCalledTimes(3);
+      vi.useRealTimers();
+    });
+
+    it('clears the backoff after a success (#1645)', async () => {
+      mockFetchPRList.mockResolvedValueOnce(null).mockResolvedValue([]);
+      mockFetchIssueList.mockResolvedValue([]);
+
+      const cache = new OverviewCache();
+      await cache.getOverview(tmpDir);
+
+      vi.useFakeTimers();
+      vi.advanceTimersByTime(61_000);
+      await cache.getOverview(tmpDir); // succeeds
+      vi.advanceTimersByTime(121_000);
+      await cache.getOverview(tmpDir); // normal positive TTL, not a backoff
+      vi.useRealTimers();
+
+      expect(mockFetchPRList).toHaveBeenCalledTimes(3);
+    });
+
+    it('spawns nothing at all while a forge rate limit is in force (#1645)', async () => {
+      mockFetchPRList.mockResolvedValue([]);
+      mockFetchIssueList.mockResolvedValue([]);
+      mockFetchRecentlyClosed.mockResolvedValue([]);
+      mockFetchMergedPRs.mockResolvedValue([]);
+      mockFetchCurrentUser.mockResolvedValue('octocat');
+
+      noteRateLimited(Date.now() + 10 * 60 * 1000);
+      expect(isForgeSuspended()).toBe(true);
+
+      const cache = new OverviewCache();
+      await cache.getOverview(tmpDir);
+      await cache.getOverview(tmpDir);
+
+      expect(mockFetchPRList).not.toHaveBeenCalled();
+      expect(mockFetchIssueList).not.toHaveBeenCalled();
+      expect(mockFetchRecentlyClosed).not.toHaveBeenCalled();
+      expect(mockFetchMergedPRs).not.toHaveBeenCalled();
+      expect(mockFetchCurrentUser).not.toHaveBeenCalled();
+    });
+
+    it('reports forgeStatus rate-limited with a reset instant (#1645)', async () => {
+      const resetAt = Date.now() + 10 * 60 * 1000;
+      noteRateLimited(resetAt);
+
+      const cache = new OverviewCache();
+      const data = await cache.getOverview(tmpDir);
+
+      expect(data.forgeStatus).toBe('rate-limited');
+      expect(data.forgeResetAt).toBe(new Date(resetAt).toISOString());
+    });
+
+    it('reports forgeStatus ok when the forge answers, unavailable when it fails (#1645)', async () => {
+      mockFetchPRList.mockResolvedValue([]);
+      mockFetchIssueList.mockResolvedValue([]);
+
+      const okData = await new OverviewCache().getOverview(tmpDir);
+      expect(okData.forgeStatus).toBe('ok');
+      expect(okData.forgeResetAt).toBeUndefined();
+
+      mockFetchIssueList.mockResolvedValue(null);
+      const badData = await new OverviewCache().getOverview(tmpDir);
+      expect(badData.forgeStatus).toBe('unavailable');
+    });
+
+    it('resumes fetching once the suspension lifts (#1645)', async () => {
+      mockFetchPRList.mockResolvedValue([]);
+      mockFetchIssueList.mockResolvedValue([]);
+
+      noteRateLimited(Date.now() + 60_000);
+      const cache = new OverviewCache();
+      await cache.getOverview(tmpDir);
+      expect(mockFetchPRList).not.toHaveBeenCalled();
+
+      vi.useFakeTimers();
+      vi.advanceTimersByTime(61_000);
+      await cache.getOverview(tmpDir);
+      vi.useRealTimers();
+
+      expect(mockFetchPRList).toHaveBeenCalledTimes(1);
     });
 
     it('returns degraded data when gh fails for PRs', async () => {
@@ -1792,8 +1990,10 @@ describe('overview', () => {
       expect(data.errors?.issues).toBeDefined();
     });
 
-    it('does not cache failed fetch results', async () => {
-      // First call: gh fails
+    it('recovers from a failed fetch once its negative window expires', async () => {
+      // #1645 changed *when* the retry happens — a failure is now cached for a
+      // backoff window instead of being retried on the very next request — but a
+      // transient failure must still self-heal.
       mockFetchPRList.mockResolvedValueOnce(null);
       mockFetchIssueList.mockResolvedValue([]);
 
@@ -1806,7 +2006,11 @@ describe('overview', () => {
         { number: 1, title: 'Test', url: 'https://github.com/org/repo/pull/1', reviewDecision: '', body: '', createdAt: '2026-01-01T00:00:00Z' },
       ]);
 
+      vi.useFakeTimers();
+      vi.advanceTimersByTime(61_000);
       const data2 = await cache.getOverview(tmpDir);
+      vi.useRealTimers();
+
       expect(data2.errors?.prs).toBeUndefined();
       expect(data2.pendingPRs).toHaveLength(1);
     });

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -31,8 +31,15 @@ import {
   noteRateLimited,
   resetForgeRateLimit,
   isForgeSuspended,
-  DEFAULT_PROVIDER,
 } from '../../lib/forge-rate-limit.js';
+import { resolveConceptBackend } from '../../lib/forge.js';
+
+/**
+ * The backend the overview's list concepts resolve to in these tests — the
+ * github scripts, so `gh`. Rate-limit state is keyed by backend (#1645), not by
+ * the workspace's configured provider.
+ */
+const OVERVIEW_BACKEND = resolveConceptBackend('issue-list', null);
 import { projectHourlyGraphqlPoints, GRAPHQL_POINTS_PER_CALL } from '../servers/overview-budget.js';
 
 // ============================================================================
@@ -1892,8 +1899,8 @@ describe('overview', () => {
       mockFetchMergedPRs.mockResolvedValue([]);
       mockFetchCurrentUser.mockResolvedValue('octocat');
 
-      noteRateLimited(DEFAULT_PROVIDER, Date.now() + 10 * 60 * 1000);
-      expect(isForgeSuspended(DEFAULT_PROVIDER)).toBe(true);
+      noteRateLimited(OVERVIEW_BACKEND, Date.now() + 10 * 60 * 1000);
+      expect(isForgeSuspended(OVERVIEW_BACKEND)).toBe(true);
 
       const cache = new OverviewCache();
       await cache.getOverview(tmpDir);
@@ -1908,7 +1915,7 @@ describe('overview', () => {
 
     it('reports forgeStatus rate-limited with a reset instant (#1645)', async () => {
       const resetAt = Date.now() + 10 * 60 * 1000;
-      noteRateLimited(DEFAULT_PROVIDER, resetAt);
+      noteRateLimited(OVERVIEW_BACKEND, resetAt);
 
       const cache = new OverviewCache();
       const data = await cache.getOverview(tmpDir);
@@ -1934,7 +1941,7 @@ describe('overview', () => {
       // The dashboard renders errors.prs/errors.issues verbatim (WorkView's
       // `work-unavailable`), so "GitHub CLI unavailable" during a rate limit
       // sent people looking for a broken gh install.
-      noteRateLimited(DEFAULT_PROVIDER, Date.now() + 10 * 60 * 1000);
+      noteRateLimited(OVERVIEW_BACKEND, Date.now() + 10 * 60 * 1000);
 
       const data = await new OverviewCache().getOverview(tmpDir);
 
@@ -1957,7 +1964,7 @@ describe('overview', () => {
       // in forge-rate-limit.test.ts, since it turns on dispatch ordering this
       // test cannot control.
       mockFetchPRList.mockImplementation(async () => {
-        noteRateLimited(DEFAULT_PROVIDER, Date.now() + 10 * 60 * 1000);
+        noteRateLimited(OVERVIEW_BACKEND, Date.now() + 10 * 60 * 1000);
         return null;
       });
       mockFetchIssueList.mockResolvedValue(null);
@@ -1968,7 +1975,7 @@ describe('overview', () => {
       const cache = new OverviewCache();
       const data = await cache.getOverview(tmpDir);
 
-      expect(isForgeSuspended(DEFAULT_PROVIDER)).toBe(true);
+      expect(isForgeSuspended(OVERVIEW_BACKEND)).toBe(true);
       expect(data.forgeStatus).toBe('rate-limited');
       expect(mockFetchCurrentUser).not.toHaveBeenCalled();
     });
@@ -1999,13 +2006,13 @@ describe('overview', () => {
       mockFetchPRList.mockResolvedValue([]);
       mockFetchIssueList.mockResolvedValue([]);
 
-      noteRateLimited(DEFAULT_PROVIDER, Date.now() + 10 * 60 * 1000);
+      noteRateLimited(OVERVIEW_BACKEND, Date.now() + 10 * 60 * 1000);
       const cache = new OverviewCache();
       await cache.getOverview(tmpDir);
       expect(mockFetchPRList).not.toHaveBeenCalled();
 
       cache.invalidate(); // POST /api/overview/refresh
-      expect(isForgeSuspended(DEFAULT_PROVIDER)).toBe(false);
+      expect(isForgeSuspended(OVERVIEW_BACKEND)).toBe(false);
 
       await cache.getOverview(tmpDir);
       expect(mockFetchPRList).toHaveBeenCalledTimes(1);
@@ -2025,7 +2032,7 @@ describe('overview', () => {
       mockFetchPRList.mockResolvedValue([]);
       mockFetchIssueList.mockResolvedValue([]);
 
-      noteRateLimited(DEFAULT_PROVIDER, Date.now() + 60_000);
+      noteRateLimited(OVERVIEW_BACKEND, Date.now() + 60_000);
       const cache = new OverviewCache();
       await cache.getOverview(tmpDir);
       expect(mockFetchPRList).not.toHaveBeenCalled();

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -2089,6 +2089,37 @@ describe('overview', () => {
       }
     });
 
+    it('re-checks the suspension after waiting on a queued fetch (#1645)', async () => {
+      // The suspension is checked when a fetch is dispatched. A queued fetch
+      // can wait 30s behind the one ahead of it, and the forge may start
+      // refusing us in that window — spawning anyway would be the one command
+      // the suspension exists to prevent.
+      let release: (v: unknown) => void = () => {};
+      const gate = new Promise(r => { release = r; });
+      mockFetchPRList.mockImplementationOnce(async () => {
+        await gate;
+        return [];
+      });
+      mockFetchIssueList.mockResolvedValue([]);
+
+      const tick = (): Promise<unknown> => new Promise(r => setTimeout(r, 0));
+
+      const cache = new OverviewCache();
+      const first = cache.getOverview(tmpDir);
+      await tick();          // let the first fetch actually start
+      cache.invalidate();
+      const queued = cache.getOverview(tmpDir);
+      await tick();          // let the queued one reach its wait
+
+      // The forge starts refusing us while the queued fetch is still waiting.
+      noteRateLimited(OVERVIEW_BACKEND, Date.now() + 10 * 60 * 1000);
+      release(null);
+      await Promise.all([first, queued]);
+
+      // Only the first command ran; the queued one saw the suspension.
+      expect(mockFetchPRList).toHaveBeenCalledTimes(1);
+    });
+
     it('bounds concurrency across repeated invalidations (#1645)', async () => {
       // porch fires invalidate() after every mutating command, so in a busy
       // workspace they arrive constantly. Each one must not be licence to start
@@ -2116,6 +2147,11 @@ describe('overview', () => {
       await Promise.all(calls);
 
       expect(maxConcurrent).toBe(1);
+      // And — the part that matters for the API budget — six invalidations do
+      // not buy six commands. One runs, one is queued behind it, and every
+      // later caller joins that queued one. Asserting only `maxConcurrent` hid
+      // six serial executions costing exactly what the fan-out would have.
+      expect(mockFetchPRList).toHaveBeenCalledTimes(2);
     });
 
     it('does not hand a post-refresh caller a result fetched before it (#1645)', async () => {

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -32,6 +32,7 @@ import {
   resetForgeRateLimit,
   isForgeSuspended,
 } from '../../lib/forge-rate-limit.js';
+import { projectHourlyGraphqlPoints, GRAPHQL_POINTS_PER_CALL } from '../servers/overview-budget.js';
 
 // ============================================================================
 // Mocks
@@ -1939,6 +1940,84 @@ describe('overview', () => {
       expect(data.errors?.prs).toContain('rate limit exhausted');
       expect(data.errors?.issues).toContain('rate limit exhausted');
       expect(data.errors?.prs).not.toContain('GitHub CLI unavailable');
+    });
+
+    it('keeps the suspension when the REST identity call still succeeds (#1645)', async () => {
+      // `user-identity` is REST (`gh api user`), charged to a different budget,
+      // so it keeps succeeding while its GraphQL siblings are refused. A
+      // refresh that hits the limit must stay suspended afterwards.
+      //
+      // Two mechanisms hold that, and they are pinned in different places.
+      // Here: `fetchCached` re-checks the suspension synchronously as each
+      // fetch is dispatched, so once a sibling has recorded the limit the
+      // identity call is not dispatched at all. The other — a success that was
+      // already in flight when the limit landed must not clear it — is pinned
+      // by "ignores a success from a command dispatched BEFORE the suspension"
+      // in forge-rate-limit.test.ts, since it turns on dispatch ordering this
+      // test cannot control.
+      mockFetchPRList.mockImplementation(async () => {
+        noteRateLimited(Date.now() + 10 * 60 * 1000);
+        return null;
+      });
+      mockFetchIssueList.mockResolvedValue(null);
+      mockFetchRecentlyClosed.mockResolvedValue(null);
+      mockFetchMergedPRs.mockResolvedValue(null);
+      mockFetchCurrentUser.mockResolvedValue('octocat');
+
+      const cache = new OverviewCache();
+      const data = await cache.getOverview(tmpDir);
+
+      expect(isForgeSuspended()).toBe(true);
+      expect(data.forgeStatus).toBe('rate-limited');
+      expect(mockFetchCurrentUser).not.toHaveBeenCalled();
+    });
+
+    it('coalesces concurrent requests into one forge call (#1645)', async () => {
+      // A cache entry is only written once its fetch resolves. With the
+      // dashboard polling every 2.5s and `gh` hanging for tens of seconds
+      // during an incident, every poll and every extra client would otherwise
+      // start another duplicate batch.
+      let release: (v: unknown) => void = () => {};
+      const gate = new Promise(r => { release = r; });
+      mockFetchPRList.mockImplementation(async () => { await gate; return []; });
+      mockFetchIssueList.mockResolvedValue([]);
+
+      const cache = new OverviewCache();
+      const all = Promise.all([
+        cache.getOverview(tmpDir),
+        cache.getOverview(tmpDir),
+        cache.getOverview(tmpDir),
+      ]);
+      release(null);
+      await all;
+
+      expect(mockFetchPRList).toHaveBeenCalledTimes(1);
+    });
+
+    it('lets an explicit refresh lift a rate-limit suspension (#1645)', async () => {
+      mockFetchPRList.mockResolvedValue([]);
+      mockFetchIssueList.mockResolvedValue([]);
+
+      noteRateLimited(Date.now() + 10 * 60 * 1000);
+      const cache = new OverviewCache();
+      await cache.getOverview(tmpDir);
+      expect(mockFetchPRList).not.toHaveBeenCalled();
+
+      cache.invalidate(); // POST /api/overview/refresh
+      expect(isForgeSuspended()).toBe(false);
+
+      await cache.getOverview(tmpDir);
+      expect(mockFetchPRList).toHaveBeenCalledTimes(1);
+    });
+
+    it('projects spend in GraphQL points, not calls (#1645)', () => {
+      // Points, not calls: reporting 676 calls against a 5,000-*point* budget
+      // reads as 14% when the real figure is 41%, which would suppress the
+      // warning the doctor check exists to raise.
+      expect(projectHourlyGraphqlPoints(13)).toBe(676 * GRAPHQL_POINTS_PER_CALL);
+      expect(projectHourlyGraphqlPoints(13)).toBeGreaterThan(projectHourlyForgeCalls(13));
+      // And the shipped TTLs must keep 13 watched workspaces under half the budget.
+      expect(projectHourlyGraphqlPoints(13)).toBeLessThan(0.5 * 5000);
     });
 
     it('resumes fetching once the suspension lifts (#1645)', async () => {

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -1721,9 +1721,9 @@ describe('overview', () => {
     });
 
     it('projects the hourly forge spend from the TTLs (#1645)', () => {
-      // 2 list calls per 120s window (60/h) + 2 search calls per 600s window (12/h).
-      expect(projectHourlyForgeCalls(1)).toBe(72);
-      expect(projectHourlyForgeCalls(13)).toBe(936);
+      // 2 list calls per 180s window (40/h) + 2 search calls per 600s window (12/h).
+      expect(projectHourlyForgeCalls(1)).toBe(52);
+      expect(projectHourlyForgeCalls(13)).toBe(676);
       expect(projectHourlyForgeCalls(0)).toBe(0);
     });
 
@@ -1759,9 +1759,9 @@ describe('overview', () => {
       await cache.getOverview(tmpDir);
       expect(mockFetchPRList).toHaveBeenCalledTimes(1);
 
-      // Advance time past the 120s positive TTL (raised from 30s in #1645)
+      // Advance time past the 180s positive TTL (raised from 30s in #1645)
       vi.useFakeTimers();
-      vi.advanceTimersByTime(121_000);
+      vi.advanceTimersByTime(181_000);
 
       await cache.getOverview(tmpDir);
       expect(mockFetchPRList).toHaveBeenCalledTimes(2);
@@ -1769,7 +1769,7 @@ describe('overview', () => {
       vi.useRealTimers();
     });
 
-    it('holds the positive TTL for 120s, not 30s (#1645)', async () => {
+    it('holds the positive TTL for 180s, not 30s (#1645)', async () => {
       mockFetchPRList.mockResolvedValue([]);
       mockFetchIssueList.mockResolvedValue([]);
 
@@ -1777,7 +1777,7 @@ describe('overview', () => {
       await cache.getOverview(tmpDir);
 
       vi.useFakeTimers();
-      vi.advanceTimersByTime(90_000);
+      vi.advanceTimersByTime(150_000);
       await cache.getOverview(tmpDir);
       vi.useRealTimers();
 
@@ -1794,7 +1794,7 @@ describe('overview', () => {
       await cache.getOverview(tmpDir);
 
       vi.useFakeTimers();
-      // Past the 120s list TTL, well inside the 600s search TTL.
+      // Past the 180s list TTL, well inside the 600s search TTL.
       vi.advanceTimersByTime(300_000);
       await cache.getOverview(tmpDir);
       vi.useRealTimers();
@@ -1876,7 +1876,7 @@ describe('overview', () => {
       vi.useFakeTimers();
       vi.advanceTimersByTime(61_000);
       await cache.getOverview(tmpDir); // succeeds
-      vi.advanceTimersByTime(121_000);
+      vi.advanceTimersByTime(181_000);
       await cache.getOverview(tmpDir); // normal positive TTL, not a backoff
       vi.useRealTimers();
 

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -1956,6 +1956,68 @@ describe('overview', () => {
       expect(data.errors?.prs).not.toContain('GitHub CLI unavailable');
     });
 
+    it('does not force the long TTLs on an invalidation (#1645)', async () => {
+      // A refresh means "the open PRs or issues may have changed". Dropping the
+      // search and identity caches too let a 60s debounce override a 600s and a
+      // 3600s TTL — forcing the 24h retrospective windows ten times more often
+      // than their own TTL, for events that cannot have changed them.
+      mockFetchPRList.mockResolvedValue([]);
+      mockFetchIssueList.mockResolvedValue([]);
+      mockFetchRecentlyClosed.mockResolvedValue([]);
+      mockFetchMergedPRs.mockResolvedValue([]);
+      mockFetchCurrentUser.mockResolvedValue('octocat');
+
+      const cache = new OverviewCache();
+      await cache.getOverview(tmpDir);
+      cache.invalidate();
+      await cache.getOverview(tmpDir);
+
+      // The open lists refresh...
+      expect(mockFetchPRList).toHaveBeenCalledTimes(2);
+      expect(mockFetchIssueList).toHaveBeenCalledTimes(2);
+      // ...the long-TTL ones do not.
+      expect(mockFetchRecentlyClosed).toHaveBeenCalledTimes(1);
+      expect(mockFetchMergedPRs).toHaveBeenCalledTimes(1);
+      expect(mockFetchCurrentUser).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports forgeStatus rate-limited with a reset instant (#1645)', async () => {
+      const resetAt = Date.now() + 10 * 60 * 1000;
+      noteRateLimited(OVERVIEW_BACKEND, resetAt);
+
+      const cache = new OverviewCache();
+      const data = await cache.getOverview(tmpDir);
+
+      expect(data.forgeStatus).toBe('rate-limited');
+      expect(data.forgeResetAt).toBe(new Date(resetAt).toISOString());
+    });
+
+    it('reports forgeStatus ok when the forge answers, unavailable when it fails (#1645)', async () => {
+      mockFetchPRList.mockResolvedValue([]);
+      mockFetchIssueList.mockResolvedValue([]);
+
+      const okData = await new OverviewCache().getOverview(tmpDir);
+      expect(okData.forgeStatus).toBe('ok');
+      expect(okData.forgeResetAt).toBeUndefined();
+
+      mockFetchIssueList.mockResolvedValue(null);
+      const badData = await new OverviewCache().getOverview(tmpDir);
+      expect(badData.forgeStatus).toBe('unavailable');
+    });
+
+    it('says the forge is rate-limited, not that gh is missing (#1645)', async () => {
+      // The dashboard renders errors.prs/errors.issues verbatim (WorkView's
+      // `work-unavailable`), so "GitHub CLI unavailable" during a rate limit
+      // sent people looking for a broken gh install.
+      noteRateLimited(OVERVIEW_BACKEND, Date.now() + 10 * 60 * 1000);
+
+      const data = await new OverviewCache().getOverview(tmpDir);
+
+      expect(data.errors?.prs).toContain('rate limit exhausted');
+      expect(data.errors?.issues).toContain('rate limit exhausted');
+      expect(data.errors?.prs).not.toContain('GitHub CLI unavailable');
+    });
+
     it('keeps the suspension when the REST identity call still succeeds (#1645)', async () => {
       // `user-identity` is REST (`gh api user`), charged to a different budget,
       // so it keeps succeeding while its GraphQL siblings are refused. A

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -1956,14 +1956,13 @@ describe('overview', () => {
       // so it keeps succeeding while its GraphQL siblings are refused. A
       // refresh that hits the limit must stay suspended afterwards.
       //
-      // Two mechanisms hold that, and they are pinned in different places.
-      // Here: `fetchCached` re-checks the suspension synchronously as each
-      // fetch is dispatched, so once a sibling has recorded the limit the
-      // identity call is not dispatched at all. The other — a success that was
-      // already in flight when the limit landed must not clear it — is pinned
-      // by "ignores a success from a command dispatched BEFORE the suspension"
-      // in forge-rate-limit.test.ts, since it turns on dispatch ordering this
-      // test cannot control.
+      // What holds this is `countsAsRecovery`: the identity call runs and
+      // succeeds, and its success is simply not treated as evidence the
+      // GraphQL budget recovered. Deliberately NOT asserted here: that the
+      // identity call goes undispatched. An earlier revision did assert that,
+      // relying on `fetchCached` re-checking the suspension synchronously
+      // before a sibling's fetcher had returned — an artifact of mocks
+      // resolving in the same tick, which real subprocesses never do.
       mockFetchPRList.mockImplementation(async () => {
         noteRateLimited(OVERVIEW_BACKEND, Date.now() + 10 * 60 * 1000);
         return null;
@@ -1978,7 +1977,6 @@ describe('overview', () => {
 
       expect(isForgeSuspended(OVERVIEW_BACKEND)).toBe(true);
       expect(data.forgeStatus).toBe('rate-limited');
-      expect(mockFetchCurrentUser).not.toHaveBeenCalled();
     });
 
     it('coalesces concurrent requests into one forge call (#1645)', async () => {
@@ -2064,6 +2062,35 @@ describe('overview', () => {
       await Promise.all([second, third]);
 
       expect(mockFetchPRList).toHaveBeenCalledTimes(2);
+    });
+
+    it('bounds concurrency across repeated invalidations (#1645)', async () => {
+      // porch fires invalidate() after every mutating command, so in a busy
+      // workspace they arrive constantly. Each one must not be licence to start
+      // another parallel forge command: at most one runs, at most one waits.
+      let inFlight = 0;
+      let maxConcurrent = 0;
+      let release: (v: unknown) => void = () => {};
+      const gate = new Promise(r => { release = r; });
+      mockFetchPRList.mockImplementation(async () => {
+        inFlight++;
+        maxConcurrent = Math.max(maxConcurrent, inFlight);
+        await gate;
+        inFlight--;
+        return [];
+      });
+      mockFetchIssueList.mockResolvedValue([]);
+
+      const cache = new OverviewCache();
+      const calls: Promise<unknown>[] = [];
+      for (let i = 0; i < 6; i++) {
+        calls.push(cache.getOverview(tmpDir));
+        cache.invalidate();
+      }
+      release(null);
+      await Promise.all(calls);
+
+      expect(maxConcurrent).toBe(1);
     });
 
     it('does not hand a post-refresh caller a result fetched before it (#1645)', async () => {

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -1956,9 +1956,11 @@ describe('overview', () => {
       // so it keeps succeeding while its GraphQL siblings are refused. A
       // refresh that hits the limit must stay suspended afterwards.
       //
-      // What holds this is `countsAsRecovery`: the identity call runs and
-      // succeeds, and its success is simply not treated as evidence the
-      // GraphQL budget recovered. Deliberately NOT asserted here: that the
+      // Two things hold this, and both matter: `countsAsRecovery` (the identity
+      // call's success is never evidence the GraphQL budget recovered) and the
+      // dispatch-time guard in `noteForgeSuccess` (a command dispatched at or
+      // before the suspension proves nothing). In this test the batch shares a
+      // millisecond, so the timestamp guard is what fires. Deliberately NOT asserted here: that the
       // identity call goes undispatched. An earlier revision did assert that,
       // relying on `fetchCached` re-checking the suspension synchronously
       // before a sibling's fetcher had returned — an artifact of mocks
@@ -2087,6 +2089,45 @@ describe('overview', () => {
       } finally {
         process.off('unhandledRejection', onUnhandled);
       }
+    });
+
+    it('keeps the failure record across a cache refresh (#1645)', async () => {
+      // A refresh means "my data may be stale", never "the forge has
+      // recovered" — and porch fires one after every mutating command. If it
+      // cleared failures too, a plainly broken forge (`gh` missing, not
+      // authenticated) would be re-spawned as fast as invalidations arrive.
+      mockFetchPRList.mockResolvedValue(null);
+      mockFetchIssueList.mockResolvedValue([]);
+
+      const cache = new OverviewCache();
+      await cache.getOverview(tmpDir);
+      expect(mockFetchPRList).toHaveBeenCalledTimes(1);
+
+      cache.invalidate();
+      await cache.getOverview(tmpDir);
+
+      // Still inside the 60s negative window: the refresh did not buy a retry.
+      expect(mockFetchPRList).toHaveBeenCalledTimes(1);
+    });
+
+    it('escalates the backoff even when a failure is written by a queued flight (#1645)', async () => {
+      // The failure count used to be read at dispatch and written minutes
+      // later, so consecutive failures never escalated past the first step.
+      mockFetchPRList.mockResolvedValue(null);
+      mockFetchIssueList.mockResolvedValue([]);
+
+      const cache = new OverviewCache();
+      await cache.getOverview(tmpDir);
+
+      vi.useFakeTimers();
+      vi.advanceTimersByTime(61_000);       // past window 1 (60s)
+      await cache.getOverview(tmpDir);      // 2nd failure -> window 2 (120s)
+      vi.advanceTimersByTime(61_000);       // inside window 2
+      await cache.getOverview(tmpDir);
+      vi.useRealTimers();
+
+      // Two fetches, not three: the second failure escalated the window.
+      expect(mockFetchPRList).toHaveBeenCalledTimes(2);
     });
 
     it('re-checks the suspension after waiting on a queued fetch (#1645)', async () => {

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -31,6 +31,7 @@ import {
   noteRateLimited,
   resetForgeRateLimit,
   isForgeSuspended,
+  DEFAULT_PROVIDER,
 } from '../../lib/forge-rate-limit.js';
 import { projectHourlyGraphqlPoints, GRAPHQL_POINTS_PER_CALL } from '../servers/overview-budget.js';
 
@@ -1891,8 +1892,8 @@ describe('overview', () => {
       mockFetchMergedPRs.mockResolvedValue([]);
       mockFetchCurrentUser.mockResolvedValue('octocat');
 
-      noteRateLimited(Date.now() + 10 * 60 * 1000);
-      expect(isForgeSuspended()).toBe(true);
+      noteRateLimited(DEFAULT_PROVIDER, Date.now() + 10 * 60 * 1000);
+      expect(isForgeSuspended(DEFAULT_PROVIDER)).toBe(true);
 
       const cache = new OverviewCache();
       await cache.getOverview(tmpDir);
@@ -1907,7 +1908,7 @@ describe('overview', () => {
 
     it('reports forgeStatus rate-limited with a reset instant (#1645)', async () => {
       const resetAt = Date.now() + 10 * 60 * 1000;
-      noteRateLimited(resetAt);
+      noteRateLimited(DEFAULT_PROVIDER, resetAt);
 
       const cache = new OverviewCache();
       const data = await cache.getOverview(tmpDir);
@@ -1933,7 +1934,7 @@ describe('overview', () => {
       // The dashboard renders errors.prs/errors.issues verbatim (WorkView's
       // `work-unavailable`), so "GitHub CLI unavailable" during a rate limit
       // sent people looking for a broken gh install.
-      noteRateLimited(Date.now() + 10 * 60 * 1000);
+      noteRateLimited(DEFAULT_PROVIDER, Date.now() + 10 * 60 * 1000);
 
       const data = await new OverviewCache().getOverview(tmpDir);
 
@@ -1956,7 +1957,7 @@ describe('overview', () => {
       // in forge-rate-limit.test.ts, since it turns on dispatch ordering this
       // test cannot control.
       mockFetchPRList.mockImplementation(async () => {
-        noteRateLimited(Date.now() + 10 * 60 * 1000);
+        noteRateLimited(DEFAULT_PROVIDER, Date.now() + 10 * 60 * 1000);
         return null;
       });
       mockFetchIssueList.mockResolvedValue(null);
@@ -1967,7 +1968,7 @@ describe('overview', () => {
       const cache = new OverviewCache();
       const data = await cache.getOverview(tmpDir);
 
-      expect(isForgeSuspended()).toBe(true);
+      expect(isForgeSuspended(DEFAULT_PROVIDER)).toBe(true);
       expect(data.forgeStatus).toBe('rate-limited');
       expect(mockFetchCurrentUser).not.toHaveBeenCalled();
     });
@@ -1998,13 +1999,13 @@ describe('overview', () => {
       mockFetchPRList.mockResolvedValue([]);
       mockFetchIssueList.mockResolvedValue([]);
 
-      noteRateLimited(Date.now() + 10 * 60 * 1000);
+      noteRateLimited(DEFAULT_PROVIDER, Date.now() + 10 * 60 * 1000);
       const cache = new OverviewCache();
       await cache.getOverview(tmpDir);
       expect(mockFetchPRList).not.toHaveBeenCalled();
 
       cache.invalidate(); // POST /api/overview/refresh
-      expect(isForgeSuspended()).toBe(false);
+      expect(isForgeSuspended(DEFAULT_PROVIDER)).toBe(false);
 
       await cache.getOverview(tmpDir);
       expect(mockFetchPRList).toHaveBeenCalledTimes(1);
@@ -2024,7 +2025,7 @@ describe('overview', () => {
       mockFetchPRList.mockResolvedValue([]);
       mockFetchIssueList.mockResolvedValue([]);
 
-      noteRateLimited(Date.now() + 60_000);
+      noteRateLimited(DEFAULT_PROVIDER, Date.now() + 60_000);
       const cache = new OverviewCache();
       await cache.getOverview(tmpDir);
       expect(mockFetchPRList).not.toHaveBeenCalled();

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -2002,7 +2002,31 @@ describe('overview', () => {
       expect(mockFetchPRList).toHaveBeenCalledTimes(1);
     });
 
-    it('lets an explicit refresh lift a rate-limit suspension (#1645)', async () => {
+    it('does not hand a post-refresh caller a result fetched before it (#1645)', async () => {
+      // A fetch already in flight was made under the previous config. Callers
+      // already awaiting it still get it, but someone who asked *after* the
+      // Refresh must trigger a fresh fetch rather than join the stale one.
+      let release: (v: unknown) => void = () => {};
+      const gate = new Promise(r => { release = r; });
+      mockFetchPRList.mockImplementationOnce(async () => { await gate; return []; });
+      mockFetchIssueList.mockResolvedValue([]);
+
+      const cache = new OverviewCache();
+      const before = cache.getOverview(tmpDir);
+      cache.invalidate();
+      const after = cache.getOverview(tmpDir);
+      release(null);
+      await Promise.all([before, after]);
+
+      expect(mockFetchPRList).toHaveBeenCalledTimes(2);
+    });
+
+    it('does NOT let a cache refresh lift a rate-limit suspension (#1645)', async () => {
+      // `POST /api/overview/refresh` is not a human signal: porch fires it after
+      // every mutating command, VSCode on every review-queue mutation, and
+      // cleanup too. With a dozen builders that is constant, and clearing the
+      // suspension here would reset the escalating backoff over and over in
+      // exactly the busy workspace this fix exists for.
       mockFetchPRList.mockResolvedValue([]);
       mockFetchIssueList.mockResolvedValue([]);
 
@@ -2011,11 +2035,11 @@ describe('overview', () => {
       await cache.getOverview(tmpDir);
       expect(mockFetchPRList).not.toHaveBeenCalled();
 
-      cache.invalidate(); // POST /api/overview/refresh
-      expect(isForgeSuspended(OVERVIEW_BACKEND)).toBe(false);
+      cache.invalidate();
 
+      expect(isForgeSuspended(OVERVIEW_BACKEND)).toBe(true);
       await cache.getOverview(tmpDir);
-      expect(mockFetchPRList).toHaveBeenCalledTimes(1);
+      expect(mockFetchPRList).not.toHaveBeenCalled();
     });
 
     it('projects spend in GraphQL points, not calls (#1645)', () => {

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -1928,6 +1928,19 @@ describe('overview', () => {
       expect(badData.forgeStatus).toBe('unavailable');
     });
 
+    it('says the forge is rate-limited, not that gh is missing (#1645)', async () => {
+      // The dashboard renders errors.prs/errors.issues verbatim (WorkView's
+      // `work-unavailable`), so "GitHub CLI unavailable" during a rate limit
+      // sent people looking for a broken gh install.
+      noteRateLimited(Date.now() + 10 * 60 * 1000);
+
+      const data = await new OverviewCache().getOverview(tmpDir);
+
+      expect(data.errors?.prs).toContain('rate limit exhausted');
+      expect(data.errors?.issues).toContain('rate limit exhausted');
+      expect(data.errors?.prs).not.toContain('GitHub CLI unavailable');
+    });
+
     it('resumes fetching once the suspension lifts (#1645)', async () => {
       mockFetchPRList.mockResolvedValue([]);
       mockFetchIssueList.mockResolvedValue([]);

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -2115,6 +2115,30 @@ describe('overview', () => {
       expect(mockFetchPRList).toHaveBeenCalledTimes(1);
     });
 
+    it('caps forge spend under sustained invalidation, not just a burst (#1645)', async () => {
+      // The burst test above is synchronous — every invalidation lands while
+      // one flight is queued, so collapsing handles it. Sustained invalidation
+      // is the real shape: porch fires one after every mutating command, spread
+      // over time, each arriving after the previous fetch has already started.
+      // Without a debounce the TTLs stop governing spend entirely and the
+      // invalidation rate governs it instead.
+      mockFetchPRList.mockResolvedValue([]);
+      mockFetchIssueList.mockResolvedValue([]);
+
+      const cache = new OverviewCache();
+      await cache.getOverview(tmpDir);
+      const afterFirst = mockFetchPRList.mock.calls.length;
+
+      // Ten invalidations, each with its fetch fully settling in between.
+      for (let i = 0; i < 10; i++) {
+        cache.invalidate();
+        await cache.getOverview(tmpDir);
+      }
+
+      // At most one of them forced a refresh; the rest were debounced.
+      expect(mockFetchPRList.mock.calls.length - afterFirst).toBeLessThanOrEqual(1);
+    });
+
     it('re-checks the suspension after waiting on a queued fetch (#1645)', async () => {
       // The suspension is checked when a fetch is dispatched. A queued fetch
       // can wait 30s behind the one ahead of it, and the forge may start

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -2064,6 +2064,31 @@ describe('overview', () => {
       expect(mockFetchPRList).toHaveBeenCalledTimes(2);
     });
 
+    it('does not orphan a rejection when a fetcher throws (#1645)', async () => {
+      // `executeForgeCommand` resolves forge config OUTSIDE its own try, and
+      // `loadConfig` fails fast, so a fetcher really can reject. A chained
+      // `.finally()` would leave that rejection on a derived promise nobody
+      // awaits — and Tower's `unhandledRejection` handler calls
+      // `process.exit(1)`. The whole cache going down beats a stale PR list,
+      // so this must stay caught.
+      const unhandled: unknown[] = [];
+      const onUnhandled = (r: unknown): void => { unhandled.push(r); };
+      process.on('unhandledRejection', onUnhandled);
+      try {
+        mockFetchPRList.mockRejectedValue(new Error('malformed .codev/config.json'));
+        mockFetchIssueList.mockResolvedValue([]);
+
+        const cache = new OverviewCache();
+        await expect(cache.getOverview(tmpDir)).rejects.toThrow('malformed');
+        // Let any orphaned derived promise surface.
+        await new Promise(r => setTimeout(r, 10));
+
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+      }
+    });
+
     it('bounds concurrency across repeated invalidations (#1645)', async () => {
       // porch fires invalidate() after every mutating command, so in a busy
       // workspace they arrive constantly. Each one must not be licence to start

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -1907,11 +1907,16 @@ describe('overview', () => {
       await cache.getOverview(tmpDir);
       await cache.getOverview(tmpDir);
 
+      // The four GraphQL-backed lists: nothing spawned at all.
       expect(mockFetchPRList).not.toHaveBeenCalled();
       expect(mockFetchIssueList).not.toHaveBeenCalled();
       expect(mockFetchRecentlyClosed).not.toHaveBeenCalled();
       expect(mockFetchMergedPRs).not.toHaveBeenCalled();
-      expect(mockFetchCurrentUser).not.toHaveBeenCalled();
+
+      // But `user-identity` is REST, on a budget the suspension is not
+      // protecting. Blocking it would save no GraphQL points and would drop
+      // `currentUser` from the overview for the whole window, so it still runs.
+      expect(mockFetchCurrentUser).toHaveBeenCalled();
     });
 
     it('reports forgeStatus rate-limited with a reset instant (#1645)', async () => {
@@ -2108,50 +2113,6 @@ describe('overview', () => {
 
       // Still inside the 60s negative window: the refresh did not buy a retry.
       expect(mockFetchPRList).toHaveBeenCalledTimes(1);
-    });
-
-    it('escalates the backoff even when a failure is written by a queued flight (#1645)', async () => {
-      // The failure count used to be read at dispatch and written minutes
-      // later, so consecutive failures never escalated past the first step.
-      mockFetchPRList.mockResolvedValue(null);
-      mockFetchIssueList.mockResolvedValue([]);
-
-      const cache = new OverviewCache();
-      await cache.getOverview(tmpDir);
-
-      vi.useFakeTimers();
-      vi.advanceTimersByTime(61_000);       // past window 1 (60s)
-      await cache.getOverview(tmpDir);      // 2nd failure -> window 2 (120s)
-      vi.advanceTimersByTime(61_000);       // inside window 2
-      await cache.getOverview(tmpDir);
-      vi.useRealTimers();
-
-      // Two fetches, not three: the second failure escalated the window.
-      expect(mockFetchPRList).toHaveBeenCalledTimes(2);
-    });
-
-    it('caps forge spend under sustained invalidation, not just a burst (#1645)', async () => {
-      // The burst test above is synchronous — every invalidation lands while
-      // one flight is queued, so collapsing handles it. Sustained invalidation
-      // is the real shape: porch fires one after every mutating command, spread
-      // over time, each arriving after the previous fetch has already started.
-      // Without a debounce the TTLs stop governing spend entirely and the
-      // invalidation rate governs it instead.
-      mockFetchPRList.mockResolvedValue([]);
-      mockFetchIssueList.mockResolvedValue([]);
-
-      const cache = new OverviewCache();
-      await cache.getOverview(tmpDir);
-      const afterFirst = mockFetchPRList.mock.calls.length;
-
-      // Ten invalidations, each with its fetch fully settling in between.
-      for (let i = 0; i < 10; i++) {
-        cache.invalidate();
-        await cache.getOverview(tmpDir);
-      }
-
-      // At most one of them forced a refresh; the rest were debounced.
-      expect(mockFetchPRList.mock.calls.length - afterFirst).toBeLessThanOrEqual(1);
     });
 
     it('re-checks the suspension after waiting on a queued fetch (#1645)', async () => {

--- a/packages/codev/src/agent-farm/servers/overview-budget.ts
+++ b/packages/codev/src/agent-farm/servers/overview-budget.ts
@@ -1,0 +1,51 @@
+/**
+ * Cache windows for the overview's forge-backed fetches, and the API spend they
+ * imply (Issue #1645).
+ *
+ * A standalone, dependency-free module so `codev doctor` can report the same
+ * numbers `OverviewCache` actually spends without importing the whole Tower
+ * graph behind `overview.ts`.
+ */
+
+/**
+ * Positive TTL for the two per-request forge lists (open PRs, open issues).
+ * Raised from 30 s (#1645): the dashboard polls `/api/overview` every 2.5 s
+ * (`apps/web/src/hooks/useOverview.ts`), so the TTL — not the poll — is what
+ * sets the API spend. Explicit user actions bypass it via
+ * `POST /api/overview/refresh`, which invalidates the whole cache.
+ */
+export const POSITIVE_TTL_MS = 120_000;
+
+/**
+ * Positive TTL for the two `--search`-backed 24 h windows (recently closed
+ * issues, recently merged PRs). Far longer than POSITIVE_TTL_MS because a 24 h
+ * window barely moves minute to minute, and these are the most expensive
+ * queries of the four (`--limit 1000`, multi-page).
+ */
+export const SEARCH_TTL_MS = 600_000;
+
+/** First negative-cache window after a failure. Doubles per consecutive failure. */
+export const NEGATIVE_TTL_BASE_MS = 60_000;
+
+/** Ceiling for the negative-cache backoff. */
+export const NEGATIVE_TTL_MAX_MS = 900_000;
+
+/** How long a failed fetch is remembered before it is retried. */
+export function negativeTtlMs(failures: number): number {
+  const exponent = Math.max(0, failures - 1);
+  return Math.min(NEGATIVE_TTL_BASE_MS * 2 ** exponent, NEGATIVE_TTL_MAX_MS);
+}
+
+/**
+ * Worst-case forge commands per hour for `workspaceCount` workspaces, each with
+ * a client polling `/api/overview` continuously (#1645).
+ *
+ * Two calls (`pr-list`, `issue-list`) per POSITIVE_TTL_MS window plus two
+ * (`recently-closed`, `recently-merged`) per SEARCH_TTL_MS window. The
+ * once-an-hour `user-identity` call is REST and charged to a different budget,
+ * so it is left out.
+ */
+export function projectHourlyForgeCalls(workspaceCount: number): number {
+  const perWorkspace = 2 * (3_600_000 / POSITIVE_TTL_MS) + 2 * (3_600_000 / SEARCH_TTL_MS);
+  return Math.round(workspaceCount * perWorkspace);
+}

--- a/packages/codev/src/agent-farm/servers/overview-budget.ts
+++ b/packages/codev/src/agent-farm/servers/overview-budget.ts
@@ -56,3 +56,27 @@ export function projectHourlyForgeCalls(workspaceCount: number): number {
   const perWorkspace = 2 * (3_600_000 / POSITIVE_TTL_MS) + 2 * (3_600_000 / SEARCH_TTL_MS);
   return Math.round(workspaceCount * perWorkspace);
 }
+
+/**
+ * GraphQL points charged per forge call, estimated (#1645).
+ *
+ * A call is not one point. GitHub charges `max(1, nodes/100)` per request, and
+ * `gh` paginates: `issue-list` is `--limit 200` (two pages of ~100 nodes each,
+ * with author/assignee/label expansions), and the two search concepts are
+ * `--limit 1000`. Three is a deliberately conservative middle estimate — the
+ * exact figure could not be measured, because the account's budget was pinned
+ * at zero by the very bug this fixes for the whole session.
+ *
+ * Used only to report spend as a share of the point budget. If it is wrong it
+ * is wrong in the safe direction: over-estimating warns early.
+ */
+export const GRAPHQL_POINTS_PER_CALL = 3;
+
+/**
+ * Projected GraphQL *points* per hour — the unit the 5,000/h budget is actually
+ * denominated in. Reporting calls against that limit understates spend roughly
+ * threefold, which is enough to suppress the warning this exists to raise.
+ */
+export function projectHourlyGraphqlPoints(workspaceCount: number): number {
+  return projectHourlyForgeCalls(workspaceCount) * GRAPHQL_POINTS_PER_CALL;
+}

--- a/packages/codev/src/agent-farm/servers/overview-budget.ts
+++ b/packages/codev/src/agent-farm/servers/overview-budget.ts
@@ -9,12 +9,19 @@
 
 /**
  * Positive TTL for the two per-request forge lists (open PRs, open issues).
+ *
  * Raised from 30 s (#1645): the dashboard polls `/api/overview` every 2.5 s
  * (`apps/web/src/hooks/useOverview.ts`), so the TTL — not the poll — is what
- * sets the API spend. Explicit user actions bypass it via
- * `POST /api/overview/refresh`, which invalidates the whole cache.
+ * sets the API spend. At 30 s the list pair alone cost 240 calls/h per watched
+ * workspace; at 180 s it costs 40, which is what keeps 13 watched workspaces
+ * under half the account's hourly GraphQL budget.
+ *
+ * A PR/issue list up to 3 minutes stale is the deliberate trade. Everything
+ * that actually moves — builder phase, gates, progress — is filesystem-derived
+ * and still refreshes on every 2.5 s poll, and `POST /api/overview/refresh`
+ * bypasses this TTL entirely after a user action.
  */
-export const POSITIVE_TTL_MS = 120_000;
+export const POSITIVE_TTL_MS = 180_000;
 
 /**
  * Positive TTL for the two `--search`-backed 24 h windows (recently closed
@@ -41,9 +48,9 @@ export function negativeTtlMs(failures: number): number {
  * a client polling `/api/overview` continuously (#1645).
  *
  * Two calls (`pr-list`, `issue-list`) per POSITIVE_TTL_MS window plus two
- * (`recently-closed`, `recently-merged`) per SEARCH_TTL_MS window. The
- * once-an-hour `user-identity` call is REST and charged to a different budget,
- * so it is left out.
+ * (`recently-closed`, `recently-merged`) per SEARCH_TTL_MS window — 52/h per
+ * watched workspace at the current TTLs. The once-an-hour `user-identity` call
+ * is REST and charged to a different budget, so it is left out.
  */
 export function projectHourlyForgeCalls(workspaceCount: number): number {
   const perWorkspace = 2 * (3_600_000 / POSITIVE_TTL_MS) + 2 * (3_600_000 / SEARCH_TTL_MS);

--- a/packages/codev/src/agent-farm/servers/overview-budget.ts
+++ b/packages/codev/src/agent-farm/servers/overview-budget.ts
@@ -87,3 +87,39 @@ export const GRAPHQL_POINTS_PER_CALL = 3;
 export function projectHourlyGraphqlPoints(workspaceCount: number): number {
   return projectHourlyForgeCalls(workspaceCount) * GRAPHQL_POINTS_PER_CALL;
 }
+
+/**
+ * How often an *invalidation* may actually force a forge refresh.
+ *
+ * `invalidate()` bypasses the TTLs by design — that is what a refresh is. But
+ * `POST /api/overview/refresh` is fired automatically after every mutating
+ * porch command, every VSCode review-queue mutation and every cleanup, so in a
+ * busy workspace the TTLs stopped governing spend at all: the invalidation rate
+ * did. Honouring at most one invalidation per minute keeps a porch action
+ * visible promptly while putting a ceiling back on.
+ *
+ * Note what this does not fix: most of those invalidations cannot have changed
+ * the forge lists at all (a phase transition moves builder state, which is
+ * filesystem-derived and refreshes every poll anyway). Only PR/issue mutations
+ * genuinely need one. Telling those apart needs porch to say which it did —
+ * tracked separately.
+ */
+export const INVALIDATION_MIN_INTERVAL_MS = 60_000;
+
+/**
+ * Projected calls/hour when invalidations arrive constantly — the ceiling that
+ * matches `projectHourlyForgeCalls`'s floor (#1645).
+ *
+ * `POST /api/overview/refresh` bypasses the TTLs, and porch fires it after
+ * every mutating command, so under churn the two open lists refresh at the
+ * debounce rate rather than their own TTL. The two 24 h search windows are not
+ * dropped by an invalidation, so they stay on SEARCH_TTL_MS.
+ */
+export function projectHourlyForgeCallsUnderChurn(
+  workspaceCount: number,
+  invalidationDebounceMs: number,
+): number {
+  const lists = 2 * (3_600_000 / invalidationDebounceMs);
+  const searches = 2 * (3_600_000 / SEARCH_TTL_MS);
+  return Math.round(workspaceCount * (lists + searches));
+}

--- a/packages/codev/src/agent-farm/servers/overview-budget.ts
+++ b/packages/codev/src/agent-farm/servers/overview-budget.ts
@@ -51,6 +51,13 @@ export function negativeTtlMs(failures: number): number {
  * (`recently-closed`, `recently-merged`) per SEARCH_TTL_MS window — 52/h per
  * watched workspace at the current TTLs. The once-an-hour `user-identity` call
  * is REST and charged to a different budget, so it is left out.
+ *
+ * This is a **floor, not a worst case**. It counts TTL-driven refreshes only;
+ * `POST /api/overview/refresh` bypasses the TTLs, and porch fires it after
+ * every mutating command. Actual spend in a busy workspace is higher — bounded
+ * by the single-flight and queue-collapsing in `OverviewCache`, not by this
+ * number. Read it as "the least this will cost", which is what makes it useful
+ * as a warning threshold.
  */
 export function projectHourlyForgeCalls(workspaceCount: number): number {
   const perWorkspace = 2 * (3_600_000 / POSITIVE_TTL_MS) + 2 * (3_600_000 / SEARCH_TTL_MS);

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -883,6 +883,24 @@ function dropSucceeded<T>(cache: Map<string, CacheEntry<T>>): void {
  */
 const PREDECESSOR_WAIT_CAP_MS = 35_000;
 
+/**
+ * How often an *invalidation* may actually force a forge refresh.
+ *
+ * `invalidate()` bypasses the TTLs by design — that is what a refresh is. But
+ * `POST /api/overview/refresh` is fired automatically after every mutating
+ * porch command, every VSCode review-queue mutation and every cleanup, so in a
+ * busy workspace the TTLs stopped governing spend at all: the invalidation rate
+ * did. Honouring at most one invalidation per minute keeps a porch action
+ * visible promptly while putting a ceiling back on.
+ *
+ * Note what this does not fix: most of those invalidations cannot have changed
+ * the forge lists at all (a phase transition moves builder state, which is
+ * filesystem-derived and refreshes every poll anyway). Only PR/issue mutations
+ * genuinely need one. Telling those apart needs porch to say which it did —
+ * tracked separately.
+ */
+const INVALIDATION_MIN_INTERVAL_MS = 60_000;
+
 interface CacheEntry<T> {
   data: T | null;
   fetchedAt: number;
@@ -927,6 +945,8 @@ export class OverviewCache {
    * backend the workspace no longer uses.
    */
   private generation = 0;
+  /** When an invalidation last actually forced a forge refresh (debounce). */
+  private lastForcedRefreshAt = 0;
   private readonly USER_TTL = 3_600_000; // 1h — GitHub identity is session-stable
 
   constructor() {
@@ -1182,15 +1202,22 @@ export class OverviewCache {
    * Invalidate all cached data.
    */
   invalidate(): void {
+    this.backendCache.clear();
+    // The resolver memoizes across every cache instance and reads concept
+    // scripts off disk, so an edited script would survive this invalidation.
+    clearForgeBackendCache();
+
+    // Debounced: see INVALIDATION_MIN_INTERVAL_MS. Everything above is local
+    // and free; everything below spends forge commands.
+    const now = Date.now();
+    if (now - this.lastForcedRefreshAt < INVALIDATION_MIN_INTERVAL_MS) return;
+    this.lastForcedRefreshAt = now;
+
     dropSucceeded(this.prCache);
     dropSucceeded(this.issueCache);
     dropSucceeded(this.closedCache);
     dropSucceeded(this.mergedPRCache);
     dropSucceeded(this.currentUserCache);
-    this.backendCache.clear();
-    // The resolver memoizes across every cache instance and reads concept
-    // scripts off disk, so an edited script would survive this invalidation.
-    clearForgeBackendCache();
     // The join table is deliberately NOT cleared. A caller arriving after this
     // point must not be handed a result fetched under the previous config, and
     // the generation bump sees to that: they chain a fresh fetch behind the

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -22,6 +22,7 @@ import {
 } from '../../lib/github.js';
 import type { ForgePR, ForgeIssueListItem } from '../../lib/github.js';
 import {
+  clearForgeSuspension,
   getForgeRateLimit,
   installForgeRateLimitWatch,
   isForgeSuspended,
@@ -875,6 +876,15 @@ export class OverviewCache {
   // Intentionally NOT cleared by invalidate(): surviving cache invalidation is
   // the whole point. See ResolvedEnrichmentCache.
   private resolvedEnrichment = new ResolvedEnrichmentCache();
+  /**
+   * In-flight fetches, keyed `<concept>:<workspace>` (#1645). A cache entry is
+   * only written once its fetch resolves, so without this a `gh` call slower
+   * than the dashboard's 2.5 s poll — and they hang for tens of seconds when
+   * GitHub is struggling, which is exactly when this matters — lets every
+   * subsequent poll, and every additional client, start another duplicate
+   * batch. Callers arriving mid-flight join the existing promise instead.
+   */
+  private inflight = new Map<string, Promise<unknown>>();
   private readonly USER_TTL = 3_600_000; // 1h — GitHub identity is session-stable
 
   constructor() {
@@ -1134,6 +1144,11 @@ export class OverviewCache {
     this.closedCache.clear();
     this.mergedPRCache.clear();
     this.currentUserCache.clear();
+    // #1645: an explicit human Refresh also lifts a rate-limit suspension.
+    // invalidate() is only reached from POST /api/overview/refresh, never from
+    // the 2.5s poll, so this cannot reintroduce the hammering — and without it
+    // Refresh was a no-op for up to 15 minutes after GitHub had recovered.
+    clearForgeSuspension();
     // Note: resolvedEnrichment is deliberately NOT cleared here. It must survive
     // invalidation so a cleanup-triggered refresh (which calls invalidate()) can
     // still fall back to a builder's resolved area instead of UNCATEGORIZED
@@ -1157,7 +1172,8 @@ export class OverviewCache {
    *   resets (`isForgeSuspended`), because the budget is charged per account
    *   and retrying only digs deeper.
    */
-  private async fetchCached<T>(
+  private fetchCached<T>(
+    concept: string,
     cache: Map<string, CacheEntry<T>>,
     cwd: string,
     ttl: number,
@@ -1167,31 +1183,45 @@ export class OverviewCache {
     const cached = cache.get(cwd);
     if (cached) {
       const age = now - cached.fetchedAt;
-      if (cached.data !== null && age < ttl) return cached.data;
-      if (cached.data === null && age < negativeTtlMs(cached.failures)) return null;
+      if (cached.data !== null && age < ttl) return Promise.resolve(cached.data);
+      if (cached.data === null && age < negativeTtlMs(cached.failures)) return Promise.resolve(null);
     }
 
-    if (isForgeSuspended(now)) return null;
+    if (isForgeSuspended(now)) return Promise.resolve(null);
 
-    const data = await fetcher();
-    if (data !== null) {
-      cache.set(cwd, { data, fetchedAt: now, failures: 0 });
-      noteForgeSuccess();
-    } else {
-      cache.set(cwd, { data: null, fetchedAt: now, failures: (cached?.failures ?? 0) + 1 });
-      // If that failure was a rate limit, learn when it lifts — at most one
-      // probe per suspension window, and only where it has been enabled.
-      void maybeProbeReset(cwd);
-    }
-    return data;
+    const key = `${concept}:${cwd}`;
+    const existing = this.inflight.get(key);
+    if (existing) return existing as Promise<T | null>;
+
+    const flight = (async () => {
+      const data = await fetcher();
+      if (data !== null) {
+        cache.set(cwd, { data, fetchedAt: now, failures: 0 });
+        // `now` is when this command was dispatched. A command dispatched
+        // before the current suspension began proves nothing about the forge
+        // having recovered — see noteForgeSuccess.
+        noteForgeSuccess(now);
+      } else {
+        cache.set(cwd, { data: null, fetchedAt: now, failures: (cached?.failures ?? 0) + 1 });
+        // If that failure was a rate limit, learn when it lifts — once per
+        // suspension window, and only where the probe has been enabled.
+        void maybeProbeReset(cwd);
+      }
+      return data;
+    })().finally(() => {
+      this.inflight.delete(key);
+    });
+
+    this.inflight.set(key, flight);
+    return flight;
   }
 
   private fetchPRsCached(cwd: string): Promise<ForgePR[] | null> {
-    return this.fetchCached(this.prCache, cwd, POSITIVE_TTL_MS, () => fetchPRList(cwd));
+    return this.fetchCached('pr-list', this.prCache, cwd, POSITIVE_TTL_MS, () => fetchPRList(cwd));
   }
 
   private fetchIssuesCached(cwd: string): Promise<ForgeIssueListItem[] | null> {
-    return this.fetchCached(this.issueCache, cwd, POSITIVE_TTL_MS, () => fetchIssueList(cwd));
+    return this.fetchCached('issue-list', this.issueCache, cwd, POSITIVE_TTL_MS, () => fetchIssueList(cwd));
   }
 
   /**
@@ -1199,14 +1229,14 @@ export class OverviewCache {
    * Long TTL — identity is stable for the lifetime of a Tower session.
    */
   private fetchCurrentUserCached(cwd: string): Promise<string | null> {
-    return this.fetchCached(this.currentUserCache, cwd, this.USER_TTL, () => fetchCurrentUser(cwd));
+    return this.fetchCached('user-identity', this.currentUserCache, cwd, this.USER_TTL, () => fetchCurrentUser(cwd));
   }
 
   private fetchRecentlyClosedCached(cwd: string): Promise<ForgeIssueListItem[] | null> {
-    return this.fetchCached(this.closedCache, cwd, SEARCH_TTL_MS, () => fetchRecentlyClosed(cwd));
+    return this.fetchCached('recently-closed', this.closedCache, cwd, SEARCH_TTL_MS, () => fetchRecentlyClosed(cwd));
   }
 
   private fetchMergedPRsCached(cwd: string): Promise<ForgePR[] | null> {
-    return this.fetchCached(this.mergedPRCache, cwd, SEARCH_TTL_MS, () => fetchRecentMergedPRs(cwd));
+    return this.fetchCached('recently-merged', this.mergedPRCache, cwd, SEARCH_TTL_MS, () => fetchRecentMergedPRs(cwd));
   }
 }

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -1257,7 +1257,13 @@ export class OverviewCache {
       ? existing.promise.then(() => undefined, () => undefined)
       : Promise.resolve();
 
-    const flight = (async () => {
+    // The entry is created first so the cleanup below can compare identity
+    // without referencing a promise from inside its own initializer.
+    const entry: { promise: Promise<T | null>; generation: number } =
+      { promise: undefined as unknown as Promise<T | null>, generation };
+
+    entry.promise = (async () => {
+      try {
       await predecessor;
       const data = await fetcher();
       // An invalidate() while this was in flight means the result was fetched
@@ -1287,18 +1293,23 @@ export class OverviewCache {
         void maybeProbeReset(backend, cwd);
       }
       return data;
+      } finally {
+        // Cleanup lives INSIDE the async function, not on a chained
+        // `.finally()`. A chained one returns a derived promise that nobody
+        // awaits, so a rejecting fetcher — reachable, since
+        // `executeForgeCommand` resolves forge config outside its own try and
+        // `loadConfig` fails fast — would surface as an unhandled rejection,
+        // and Tower's handler for those calls `process.exit(1)`.
+        //
+        // Identity check, because a newer entry may already be registered under
+        // this key: deleting that one would let the next caller start yet
+        // another fetch, the fan-out single-flight exists to prevent.
+        if (this.inflight.get(key) === entry) this.inflight.delete(key);
+      }
     })();
-    // Delete only if *this* flight is still the registered one. `invalidate()`
-    // clears the join table, so a newer flight can already be registered under
-    // this key by the time an older one settles — and deleting that entry would
-    // let the next caller start yet another fetch, the fan-out single-flight
-    // exists to prevent.
-    void flight.finally(() => {
-      if (this.inflight.get(key)?.promise === flight) this.inflight.delete(key);
-    });
 
-    this.inflight.set(key, { promise: flight, generation });
-    return flight;
+    this.inflight.set(key, entry as { promise: Promise<unknown>; generation: number });
+    return entry.promise;
   }
 
   /** The backend one concept runs against in this workspace, memoized (#1645). */
@@ -1309,7 +1320,11 @@ export class OverviewCache {
       try {
         backend = resolveConceptBackend(concept, loadForgeConfig(cwd));
       } catch {
-        backend = DEFAULT_PROVIDER;
+        // Resolve with no config rather than falling back to the raw provider
+        // name. `DEFAULT_PROVIDER` is `github`, but every write keys the
+        // *executable* (`gh`) — a workspace whose config load threw would key
+        // `github` and never honour its own suspension.
+        backend = resolveConceptBackend(concept, null);
       }
       this.backendCache.set(key, backend);
     }

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -844,6 +844,14 @@ export function deriveBacklog(
 // OverviewCache
 // =============================================================================
 
+/** Local wall-clock time of an ISO instant, for the rate-limit message (#1645). */
+function formatResetTime(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime())
+    ? iso
+    : d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+}
+
 /**
  * One cached forge result. `data === null` records a *failure* — the entry that
  * did not exist before #1645, and whose absence let every failing poll re-spawn
@@ -956,10 +964,20 @@ export class OverviewCache {
       this.fetchCurrentUserCached(workspaceRoot),
     ]);
 
+    // #1645: name the real reason. Before this, a rate-limited forge reported
+    // "GitHub CLI unavailable", which sent people looking for a broken `gh`
+    // install instead of an exhausted API budget. The dashboard already renders
+    // these strings (`WorkView`'s `work-unavailable`), so the explanation lands
+    // without a UI change.
+    const rateLimit = getForgeRateLimit();
+    const unavailable = (what: string): string => rateLimit.resetAt
+      ? `GitHub API rate limit exhausted — ${what} paused until ${formatResetTime(rateLimit.resetAt)}`
+      : `GitHub CLI unavailable — could not fetch ${what}`;
+
     // 3. Process PRs
     let pendingPRs: OverviewPR[] = [];
     if (prs === null) {
-      errors.prs = 'GitHub CLI unavailable — could not fetch PRs';
+      errors.prs = unavailable('PRs');
     } else {
       pendingPRs = prs.map(pr => ({
         id: String(pr.number),
@@ -988,7 +1006,7 @@ export class OverviewCache {
       ? new Map(issues.map(i => [String(i.number), parseArea(i.labels)]))
       : null;
     if (issues === null) {
-      errors.issues = 'GitHub CLI unavailable — could not fetch issues';
+      errors.issues = unavailable('issues');
     } else {
       backlog = deriveBacklog(issues, workspaceRoot, activeBuilderIssues, prLinkedIssues);
 
@@ -1090,7 +1108,6 @@ export class OverviewCache {
     // deliberately not spawning anything until `forgeResetAt`; `unavailable`
     // means the commands ran and failed for some other reason. Without this the
     // dashboard could only show an empty list and a generic "gh unavailable".
-    const rateLimit = getForgeRateLimit();
     const forgeStatus: OverviewData['forgeStatus'] = rateLimit.limited
       ? 'rate-limited'
       : Object.keys(errors).length > 0 ? 'unavailable' : 'ok';

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -21,8 +21,16 @@ import {
   parseArea,
 } from '../../lib/github.js';
 import type { ForgePR, ForgeIssueListItem } from '../../lib/github.js';
+import {
+  getForgeRateLimit,
+  installForgeRateLimitWatch,
+  isForgeSuspended,
+  maybeProbeReset,
+  noteForgeSuccess,
+} from '../../lib/forge-rate-limit.js';
 import { loadProtocol } from '../../commands/porch/protocol.js';
 import { ResolvedEnrichmentCache } from './resolved-enrichment-cache.js';
+import { POSITIVE_TTL_MS, SEARCH_TTL_MS, negativeTtlMs } from './overview-budget.js';
 import type {
   PlanPhase,
   OverviewBuilder,
@@ -836,20 +844,36 @@ export function deriveBacklog(
 // OverviewCache
 // =============================================================================
 
+/**
+ * One cached forge result. `data === null` records a *failure* — the entry that
+ * did not exist before #1645, and whose absence let every failing poll re-spawn
+ * the command. `failures` drives the negative-cache backoff.
+ */
+interface CacheEntry<T> {
+  data: T | null;
+  fetchedAt: number;
+  failures: number;
+}
+
 export class OverviewCache {
-  private prCache = new Map<string, { data: ForgePR[]; fetchedAt: number }>();
-  private issueCache = new Map<string, { data: ForgeIssueListItem[]; fetchedAt: number }>();
-  private closedCache = new Map<string, { data: ForgeIssueListItem[]; fetchedAt: number }>();
-  private mergedPRCache = new Map<string, { data: ForgePR[]; fetchedAt: number }>();
-  private currentUserCache = new Map<string, { data: string; fetchedAt: number }>();
+  private prCache = new Map<string, CacheEntry<ForgePR[]>>();
+  private issueCache = new Map<string, CacheEntry<ForgeIssueListItem[]>>();
+  private closedCache = new Map<string, CacheEntry<ForgeIssueListItem[]>>();
+  private mergedPRCache = new Map<string, CacheEntry<ForgePR[]>>();
+  private currentUserCache = new Map<string, CacheEntry<string>>();
   // Cache of issue-derived builder fields (today: `area`) keyed by worktreePath,
   // so they survive refreshes where the source issue is unreachable rather than
   // snapping back to their default while the builder is still listed (PIR #907).
   // Intentionally NOT cleared by invalidate(): surviving cache invalidation is
   // the whole point. See ResolvedEnrichmentCache.
   private resolvedEnrichment = new ResolvedEnrichmentCache();
-  private readonly TTL = 30_000;
   private readonly USER_TTL = 3_600_000; // 1h — GitHub identity is session-stable
+
+  constructor() {
+    // Idempotent: subscribes this process to forge rate-limit failures so
+    // fetchCached can stop spawning commands the forge is refusing (#1645).
+    installForgeRateLimitWatch();
+  }
 
   /**
    * Build the overview response. Aggregates builder state, PRs, and backlog.
@@ -1062,7 +1086,19 @@ export class OverviewCache {
     // has no view of the live terminal sessions. `handleOverview` (tower-routes.ts)
     // injects the real architect list via `liveArchitects` before serialization,
     // mirroring how it enriches `lastDataAt`.
-    const result: OverviewData = { builders, pendingPRs, backlog, recentlyClosed, architects: [], heldCount, mailboxEscalated, queuedFeedback, feedbackMode };
+    // #1645: say *why* the forge data is missing. `rate-limited` means Tower is
+    // deliberately not spawning anything until `forgeResetAt`; `unavailable`
+    // means the commands ran and failed for some other reason. Without this the
+    // dashboard could only show an empty list and a generic "gh unavailable".
+    const rateLimit = getForgeRateLimit();
+    const forgeStatus: OverviewData['forgeStatus'] = rateLimit.limited
+      ? 'rate-limited'
+      : Object.keys(errors).length > 0 ? 'unavailable' : 'ok';
+
+    const result: OverviewData = { builders, pendingPRs, backlog, recentlyClosed, architects: [], heldCount, mailboxEscalated, queuedFeedback, feedbackMode, forgeStatus };
+    if (rateLimit.resetAt) {
+      result.forgeResetAt = rateLimit.resetAt;
+    }
     if (currentUser) {
       result.currentUser = currentUser;
     }
@@ -1091,79 +1127,69 @@ export class OverviewCache {
   // Private cache helpers
   // ===========================================================================
 
-  private async fetchPRsCached(cwd: string): Promise<ForgePR[] | null> {
+  /**
+   * Shared read-through cache for every forge-backed fetch (#1645).
+   *
+   * Three windows, not one:
+   * - a success is served from cache for `ttl`;
+   * - a **failure is cached too**, for a doubling `negativeTtlMs` window. This
+   *   is the fix: before it, `null` was never stored, so each 2.5 s dashboard
+   *   poll re-spawned every forge command — measured at 180 `gh` processes in
+   *   60 s once GitHub started refusing them;
+   * - while a forge rate limit is in force, nothing is spawned at all until it
+   *   resets (`isForgeSuspended`), because the budget is charged per account
+   *   and retrying only digs deeper.
+   */
+  private async fetchCached<T>(
+    cache: Map<string, CacheEntry<T>>,
+    cwd: string,
+    ttl: number,
+    fetcher: () => Promise<T | null>,
+  ): Promise<T | null> {
     const now = Date.now();
-    const cached = this.prCache.get(cwd);
-    if (cached && (now - cached.fetchedAt) < this.TTL) {
-      return cached.data;
+    const cached = cache.get(cwd);
+    if (cached) {
+      const age = now - cached.fetchedAt;
+      if (cached.data !== null && age < ttl) return cached.data;
+      if (cached.data === null && age < negativeTtlMs(cached.failures)) return null;
     }
 
-    const data = await fetchPRList(cwd);
+    if (isForgeSuspended(now)) return null;
+
+    const data = await fetcher();
     if (data !== null) {
-      this.prCache.set(cwd, { data, fetchedAt: now });
+      cache.set(cwd, { data, fetchedAt: now, failures: 0 });
+      noteForgeSuccess();
+    } else {
+      cache.set(cwd, { data: null, fetchedAt: now, failures: (cached?.failures ?? 0) + 1 });
+      // If that failure was a rate limit, learn when it lifts — at most one
+      // probe per suspension window, and only where it has been enabled.
+      void maybeProbeReset(cwd);
     }
     return data;
   }
 
-  private async fetchIssuesCached(cwd: string): Promise<ForgeIssueListItem[] | null> {
-    const now = Date.now();
-    const cached = this.issueCache.get(cwd);
-    if (cached && (now - cached.fetchedAt) < this.TTL) {
-      return cached.data;
-    }
+  private fetchPRsCached(cwd: string): Promise<ForgePR[] | null> {
+    return this.fetchCached(this.prCache, cwd, POSITIVE_TTL_MS, () => fetchPRList(cwd));
+  }
 
-    const data = await fetchIssueList(cwd);
-    if (data !== null) {
-      this.issueCache.set(cwd, { data, fetchedAt: now });
-    }
-    return data;
+  private fetchIssuesCached(cwd: string): Promise<ForgeIssueListItem[] | null> {
+    return this.fetchCached(this.issueCache, cwd, POSITIVE_TTL_MS, () => fetchIssueList(cwd));
   }
 
   /**
    * Resolve the current user's forge login via the `user-identity` concept.
    * Long TTL — identity is stable for the lifetime of a Tower session.
-   * Only successful resolutions are cached, so a transient failure (gh
-   * logged out, offline) self-heals on the next overview poll.
    */
-  private async fetchCurrentUserCached(cwd: string): Promise<string | null> {
-    const now = Date.now();
-    const cached = this.currentUserCache.get(cwd);
-    if (cached && (now - cached.fetchedAt) < this.USER_TTL) {
-      return cached.data;
-    }
-
-    const login = await fetchCurrentUser(cwd);
-    if (login !== null) {
-      this.currentUserCache.set(cwd, { data: login, fetchedAt: now });
-    }
-    return login;
+  private fetchCurrentUserCached(cwd: string): Promise<string | null> {
+    return this.fetchCached(this.currentUserCache, cwd, this.USER_TTL, () => fetchCurrentUser(cwd));
   }
 
-  private async fetchRecentlyClosedCached(cwd: string): Promise<ForgeIssueListItem[] | null> {
-    const now = Date.now();
-    const cached = this.closedCache.get(cwd);
-    if (cached && (now - cached.fetchedAt) < this.TTL) {
-      return cached.data;
-    }
-
-    const data = await fetchRecentlyClosed(cwd);
-    if (data !== null) {
-      this.closedCache.set(cwd, { data, fetchedAt: now });
-    }
-    return data;
+  private fetchRecentlyClosedCached(cwd: string): Promise<ForgeIssueListItem[] | null> {
+    return this.fetchCached(this.closedCache, cwd, SEARCH_TTL_MS, () => fetchRecentlyClosed(cwd));
   }
 
-  private async fetchMergedPRsCached(cwd: string): Promise<ForgePR[] | null> {
-    const now = Date.now();
-    const cached = this.mergedPRCache.get(cwd);
-    if (cached && (now - cached.fetchedAt) < this.TTL) {
-      return cached.data;
-    }
-
-    const data = await fetchRecentMergedPRs(cwd);
-    if (data !== null) {
-      this.mergedPRCache.set(cwd, { data, fetchedAt: now });
-    }
-    return data;
+  private fetchMergedPRsCached(cwd: string): Promise<ForgePR[] | null> {
+    return this.fetchCached(this.mergedPRCache, cwd, SEARCH_TTL_MS, () => fetchRecentMergedPRs(cwd));
   }
 }

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -1181,9 +1181,13 @@ export class OverviewCache {
     // deliberately not spawning anything until `forgeResetAt`; `unavailable`
     // means the commands ran and failed for some other reason. Without this the
     // dashboard could only show an empty list and a generic "gh unavailable".
+    // `errors` only covers PRs and issues, so a failure confined to the two
+    // 24h search concepts would otherwise report `ok` with an empty
+    // "recently closed" list and no explanation.
+    const anyForgeFailure = Object.keys(errors).length > 0 || closed === null || mergedPRs === null;
     const forgeStatus: OverviewData['forgeStatus'] = rateLimit.limited
       ? 'rate-limited'
-      : Object.keys(errors).length > 0 ? 'unavailable' : 'ok';
+      : anyForgeFailure ? 'unavailable' : 'ok';
 
     const result: OverviewData = { builders, pendingPRs, backlog, recentlyClosed, architects: [], heldCount, mailboxEscalated, queuedFeedback, feedbackMode, forgeStatus };
     if (rateLimit.resetAt) {
@@ -1267,15 +1271,20 @@ export class OverviewCache {
     ttl: number,
     fetcher: () => Promise<T | null>,
     /**
-     * Whether this concept succeeding is evidence the backend has recovered.
+     * Whether this concept shares the budget the suspension is protecting.
      *
      * False for `user-identity`: it is `gh api user`, REST, charged to a budget
-     * separate from the GraphQL one the lists spend, but resolving to the same
-     * `gh` backend key. Letting it clear the suspension would reset the
-     * escalating backoff every time a window expired — the doubling would never
-     * get past its first step, however hard the forge was refusing us.
+     * separate from the GraphQL one the lists spend, while resolving to the
+     * same `gh` backend key. That cuts both ways, and both directions matter:
+     *
+     * - its success is not evidence the GraphQL budget recovered — letting it
+     *   clear the suspension would reset the escalating backoff every time a
+     *   window expired, so the doubling would never get past its first step;
+     * - and it must not be *blocked* by that suspension either. Blocking it
+     *   saves no GraphQL points and costs the UI its `currentUser` for the
+     *   whole window.
      */
-    countsAsRecovery = true,
+    sharesRateLimitedBudget = true,
   ): Promise<T | null> {
     const dispatchedAt = Date.now();
     const cached = cache.get(cwd);
@@ -1286,7 +1295,9 @@ export class OverviewCache {
     }
 
     const backend = this.backendFor(cwd, concept);
-    if (isForgeSuspended(backend, dispatchedAt)) return Promise.resolve(null);
+    if (sharesRateLimitedBudget && isForgeSuspended(backend, dispatchedAt)) {
+      return Promise.resolve(null);
+    }
 
     const key = `${concept}:${cwd}`;
     const generation = this.generation;
@@ -1333,7 +1344,7 @@ export class OverviewCache {
       await predecessor;
 
       // The forge may have refused someone else while we waited.
-      if (isForgeSuspended(backend)) return null;
+      if (sharesRateLimitedBudget && isForgeSuspended(backend)) return null;
 
       entry.queued = false; // from here we are the one holding the command
       const data = await fetcher();
@@ -1356,13 +1367,14 @@ export class OverviewCache {
         // `dispatchedAt`, not `fetchedAt`: a command dispatched before the
         // current suspension began proves nothing about the forge having
         // recovered — see noteForgeSuccess.
-        if (countsAsRecovery) noteForgeSuccess(backend, dispatchedAt);
+        if (sharesRateLimitedBudget) noteForgeSuccess(backend, dispatchedAt);
       } else {
-        // Re-read rather than reusing the dispatch-time snapshot: a chained
-        // flight can be minutes behind its own `cached`, and counting from a
-        // stale value means consecutive failures never escalate the backoff.
-        const priorFailures = cache.get(cwd)?.failures ?? cached?.failures ?? 0;
-        cache.set(cwd, { data: null, fetchedAt, failures: priorFailures + 1 });
+        // `cached` is the dispatch-time snapshot, and that is sound: a flight
+        // from an older generation returns above without writing, and
+        // single-flight means no other writer for this key. A re-read here was
+        // added in review and removed again — it could never differ, and the
+        // test written to justify it passed with it reverted.
+        cache.set(cwd, { data: null, fetchedAt, failures: (cached?.failures ?? 0) + 1 });
         // If that failure was a rate limit, learn when it lifts — once per
         // suspension window, and only where the probe has been enabled.
         void maybeProbeReset(backend, cwd);
@@ -1446,7 +1458,7 @@ export class OverviewCache {
   private fetchCurrentUserCached(cwd: string): Promise<string | null> {
     return this.fetchCached(
       'user-identity', this.currentUserCache, cwd, this.USER_TTL, () => fetchCurrentUser(cwd),
-      false, // REST — its success says nothing about the GraphQL budget
+      false, // REST — a different budget: neither governed by it nor evidence for it
     );
   }
 

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -32,7 +32,12 @@ import {
 import { loadProtocol } from '../../commands/porch/protocol.js';
 import { clearForgeBackendCache, loadForgeConfig, resolveConceptBackend } from '../../lib/forge.js';
 import { ResolvedEnrichmentCache } from './resolved-enrichment-cache.js';
-import { POSITIVE_TTL_MS, SEARCH_TTL_MS, negativeTtlMs } from './overview-budget.js';
+import {
+  INVALIDATION_MIN_INTERVAL_MS,
+  POSITIVE_TTL_MS,
+  SEARCH_TTL_MS,
+  negativeTtlMs,
+} from './overview-budget.js';
 import type {
   PlanPhase,
   OverviewBuilder,
@@ -883,23 +888,7 @@ function dropSucceeded<T>(cache: Map<string, CacheEntry<T>>): void {
  */
 const PREDECESSOR_WAIT_CAP_MS = 35_000;
 
-/**
- * How often an *invalidation* may actually force a forge refresh.
- *
- * `invalidate()` bypasses the TTLs by design — that is what a refresh is. But
- * `POST /api/overview/refresh` is fired automatically after every mutating
- * porch command, every VSCode review-queue mutation and every cleanup, so in a
- * busy workspace the TTLs stopped governing spend at all: the invalidation rate
- * did. Honouring at most one invalidation per minute keeps a porch action
- * visible promptly while putting a ceiling back on.
- *
- * Note what this does not fix: most of those invalidations cannot have changed
- * the forge lists at all (a phase transition moves builder state, which is
- * filesystem-derived and refreshes every poll anyway). Only PR/issue mutations
- * genuinely need one. Telling those apart needs porch to say which it did —
- * tracked separately.
- */
-const INVALIDATION_MIN_INTERVAL_MS = 60_000;
+
 
 interface CacheEntry<T> {
   data: T | null;
@@ -1217,11 +1206,17 @@ export class OverviewCache {
     if (now - this.lastForcedRefreshAt < INVALIDATION_MIN_INTERVAL_MS) return;
     this.lastForcedRefreshAt = now;
 
+    // Only the two *open* lists. A refresh means "the open PRs or issues may
+    // have changed", which is what a porch action or a merge affects.
+    //
+    // The other three are deliberately left alone. Dropping them let a 60 s
+    // debounce override a 600 s search TTL and a 3600 s identity TTL — forcing
+    // the two 24 h retrospective windows ten times more often than their own
+    // TTL, and the user's login sixty times, for events that cannot have
+    // changed either. Measured at 305 calls/h/workspace against the 52 the
+    // doctor was projecting, with the doctor showing green.
     dropSucceeded(this.prCache);
     dropSucceeded(this.issueCache);
-    dropSucceeded(this.closedCache);
-    dropSucceeded(this.mergedPRCache);
-    dropSucceeded(this.currentUserCache);
     // The join table is deliberately NOT cleared. A caller arriving after this
     // point must not be handed a result fetched under the previous config, and
     // the generation bump sees to that: they chain a fresh fetch behind the

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -860,6 +860,22 @@ function formatResetTime(iso: string): string {
  * the command. `failures` drives the negative-cache backoff.
  */
 /**
+ * Drop only the *successful* entries, keeping the failure record.
+ *
+ * A refresh means "my data may be stale", never "the forge has recovered", and
+ * porch fires one after every mutating command. Clearing failures too would
+ * reset the negative-cache backoff on every one of them, so a forge that is
+ * simply broken — `gh` missing, not authenticated — would be re-spawned as
+ * fast as invalidations arrive. That is the original bug wearing a different
+ * hat.
+ */
+function dropSucceeded<T>(cache: Map<string, CacheEntry<T>>): void {
+  for (const [key, entry] of cache) {
+    if (entry.data !== null) cache.delete(key);
+  }
+}
+
+/**
  * How long a queued fetch waits on the one ahead of it before giving up and
  * serving what is cached. Just past `executeForgeCommand`'s own 30 s timeout,
  * so it only fires for a child that outlived that — without it, one hung `gh`
@@ -1166,11 +1182,11 @@ export class OverviewCache {
    * Invalidate all cached data.
    */
   invalidate(): void {
-    this.prCache.clear();
-    this.issueCache.clear();
-    this.closedCache.clear();
-    this.mergedPRCache.clear();
-    this.currentUserCache.clear();
+    dropSucceeded(this.prCache);
+    dropSucceeded(this.issueCache);
+    dropSucceeded(this.closedCache);
+    dropSucceeded(this.mergedPRCache);
+    dropSucceeded(this.currentUserCache);
     this.backendCache.clear();
     // The resolver memoizes across every cache instance and reads concept
     // scripts off disk, so an edited script would survive this invalidation.
@@ -1315,7 +1331,11 @@ export class OverviewCache {
         // recovered — see noteForgeSuccess.
         if (countsAsRecovery) noteForgeSuccess(backend, dispatchedAt);
       } else {
-        cache.set(cwd, { data: null, fetchedAt, failures: (cached?.failures ?? 0) + 1 });
+        // Re-read rather than reusing the dispatch-time snapshot: a chained
+        // flight can be minutes behind its own `cached`, and counting from a
+        // stale value means consecutive failures never escalate the backoff.
+        const priorFailures = cache.get(cwd)?.failures ?? cached?.failures ?? 0;
+        cache.set(cwd, { data: null, fetchedAt, failures: priorFailures + 1 });
         // If that failure was a rate limit, learn when it lifts — once per
         // suspension window, and only where the probe has been enabled.
         void maybeProbeReset(backend, cwd);

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -31,7 +31,7 @@ import {
   noteForgeSuccess,
 } from '../../lib/forge-rate-limit.js';
 import { loadProtocol } from '../../commands/porch/protocol.js';
-import { loadForgeConfig } from '../../lib/forge.js';
+import { loadForgeConfig, resolveConceptBackend } from '../../lib/forge.js';
 import { ResolvedEnrichmentCache } from './resolved-enrichment-cache.js';
 import { POSITIVE_TTL_MS, SEARCH_TTL_MS, negativeTtlMs } from './overview-budget.js';
 import type {
@@ -888,11 +888,22 @@ export class OverviewCache {
    */
   private inflight = new Map<string, Promise<unknown>>();
   /**
-   * Resolved forge provider per workspace. Read from `.codev/config.json`,
-   * which the 2.5 s poll should not re-read on every request; cleared by
-   * `invalidate()`, which is what a config change is followed by.
+   * Resolved backend per `<workspace>:<concept>` — the executable that concept
+   * will actually run (`gh`, `glab`, …). Per concept, not per workspace,
+   * because providers are hybrid: a Linear workspace's `pr-list` falls through
+   * to `gh` while its `issue-list` runs a Linear script, so the two answer to
+   * different rate-limit budgets. Memoized because resolving reads
+   * `.codev/config.json` and the concept script; cleared by `invalidate()`,
+   * which is what a config change is followed by.
    */
-  private providerCache = new Map<string, string>();
+  private backendCache = new Map<string, string>();
+  /**
+   * Bumped by `invalidate()`. A fetch already in flight when the cache is
+   * invalidated must not write its result afterwards: it was made under the
+   * previous config, and could file a result — or a rate limit — against a
+   * backend the workspace no longer uses.
+   */
+  private generation = 0;
   private readonly USER_TTL = 3_600_000; // 1h — GitHub identity is session-stable
 
   constructor() {
@@ -984,13 +995,14 @@ export class OverviewCache {
 
     // #1645: name the real reason. Before this, a rate-limited forge reported
     // "GitHub CLI unavailable", which sent people looking for a broken `gh`
-    // install instead of an exhausted API budget. The dashboard already renders
-    // these strings (`WorkView`'s `work-unavailable`), so the explanation lands
-    // without a UI change.
-    const rateLimit = getForgeRateLimit(this.providerFor(workspaceRoot));
+    // install instead of an exhausted API budget — and said "GitHub" even on a
+    // GitLab workspace. The dashboard already renders these strings
+    // (`WorkView`'s `work-unavailable`), so the explanation lands without a UI
+    // change.
+    const rateLimit = this.listForgeRateLimit(workspaceRoot);
     const unavailable = (what: string): string => rateLimit.resetAt
-      ? `GitHub API rate limit exhausted — ${what} paused until ${formatResetTime(rateLimit.resetAt)}`
-      : `GitHub CLI unavailable — could not fetch ${what}`;
+      ? `Forge API rate limit exhausted — ${what} paused until ${formatResetTime(rateLimit.resetAt)}`
+      : `Forge CLI unavailable — could not fetch ${what}`;
 
     // 3. Process PRs
     let pendingPRs: OverviewPR[] = [];
@@ -1152,7 +1164,8 @@ export class OverviewCache {
     this.closedCache.clear();
     this.mergedPRCache.clear();
     this.currentUserCache.clear();
-    this.providerCache.clear();
+    this.backendCache.clear();
+    this.generation++;
     // #1645: an explicit human Refresh also lifts a rate-limit suspension.
     // invalidate() is only reached from POST /api/overview/refresh, never from
     // the 2.5s poll, so this cannot reintroduce the hammering — and without it
@@ -1196,15 +1209,20 @@ export class OverviewCache {
       if (cached.data === null && age < negativeTtlMs(cached.failures)) return Promise.resolve(null);
     }
 
-    const provider = this.providerFor(cwd);
-    if (isForgeSuspended(provider, dispatchedAt)) return Promise.resolve(null);
+    const backend = this.backendFor(cwd, concept);
+    if (isForgeSuspended(backend, dispatchedAt)) return Promise.resolve(null);
 
     const key = `${concept}:${cwd}`;
     const existing = this.inflight.get(key);
     if (existing) return existing as Promise<T | null>;
 
+    const generation = this.generation;
     const flight = (async () => {
       const data = await fetcher();
+      // An invalidate() while this was in flight means the result was fetched
+      // under the previous config: return it to this caller, but do not write
+      // it, and do not credit or blame a backend that may no longer apply.
+      if (generation !== this.generation) return data;
       // Stamp the entry with *completion* time, not dispatch time: a forge
       // command can sit for its full 30 s timeout, and dating the entry from
       // dispatch would burn half the 60 s negative window before it is even
@@ -1215,12 +1233,12 @@ export class OverviewCache {
         // `dispatchedAt`, not `fetchedAt`: a command dispatched before the
         // current suspension began proves nothing about the forge having
         // recovered — see noteForgeSuccess.
-        noteForgeSuccess(provider, dispatchedAt);
+        noteForgeSuccess(backend, dispatchedAt);
       } else {
         cache.set(cwd, { data: null, fetchedAt, failures: (cached?.failures ?? 0) + 1 });
         // If that failure was a rate limit, learn when it lifts — once per
         // suspension window, and only where the probe has been enabled.
-        void maybeProbeReset(provider, cwd);
+        void maybeProbeReset(backend, cwd);
       }
       return data;
     })().finally(() => {
@@ -1231,18 +1249,44 @@ export class OverviewCache {
     return flight;
   }
 
-  /** The workspace's forge provider, read once and memoized (#1645). */
-  private providerFor(cwd: string): string {
-    let provider = this.providerCache.get(cwd);
-    if (provider === undefined) {
+  /** The backend one concept runs against in this workspace, memoized (#1645). */
+  private backendFor(cwd: string, concept: string): string {
+    const key = `${cwd}:${concept}`;
+    let backend = this.backendCache.get(key);
+    if (backend === undefined) {
       try {
-        provider = loadForgeConfig(cwd)?.provider ?? DEFAULT_PROVIDER;
+        backend = resolveConceptBackend(concept, loadForgeConfig(cwd));
       } catch {
-        provider = DEFAULT_PROVIDER;
+        backend = DEFAULT_PROVIDER;
       }
-      this.providerCache.set(cwd, provider);
+      this.backendCache.set(key, backend);
     }
-    return provider;
+    return backend;
+  }
+
+  /**
+   * The forge concepts backing the overview's lists. `user-identity` is left
+   * out on purpose: it is REST, charged to a different budget, and its being
+   * fine says nothing about whether the lists can be fetched.
+   */
+  private static readonly LIST_CONCEPTS = [
+    'pr-list', 'issue-list', 'recently-closed', 'recently-merged',
+  ] as const;
+
+  /**
+   * Rate-limit state across every backend the overview's lists depend on.
+   * Reports limited if *any* of them is suspended, with the latest reset among
+   * those — a workspace whose issues come from Linear and whose PRs come from
+   * GitHub can have one suspended and not the other.
+   */
+  private listForgeRateLimit(cwd: string): { limited: boolean; resetAt: string | null } {
+    let resetAt: string | null = null;
+    for (const concept of OverviewCache.LIST_CONCEPTS) {
+      const state = getForgeRateLimit(this.backendFor(cwd, concept));
+      if (!state.limited || state.resetAt === null) continue;
+      if (resetAt === null || state.resetAt > resetAt) resetAt = state.resetAt;
+    }
+    return { limited: resetAt !== null, resetAt };
   }
 
   private fetchPRsCached(cwd: string): Promise<ForgePR[] | null> {

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -23,6 +23,7 @@ import {
 import type { ForgePR, ForgeIssueListItem } from '../../lib/github.js';
 import {
   clearForgeSuspension,
+  DEFAULT_PROVIDER,
   getForgeRateLimit,
   installForgeRateLimitWatch,
   isForgeSuspended,
@@ -30,6 +31,7 @@ import {
   noteForgeSuccess,
 } from '../../lib/forge-rate-limit.js';
 import { loadProtocol } from '../../commands/porch/protocol.js';
+import { loadForgeConfig } from '../../lib/forge.js';
 import { ResolvedEnrichmentCache } from './resolved-enrichment-cache.js';
 import { POSITIVE_TTL_MS, SEARCH_TTL_MS, negativeTtlMs } from './overview-budget.js';
 import type {
@@ -885,6 +887,12 @@ export class OverviewCache {
    * batch. Callers arriving mid-flight join the existing promise instead.
    */
   private inflight = new Map<string, Promise<unknown>>();
+  /**
+   * Resolved forge provider per workspace. Read from `.codev/config.json`,
+   * which the 2.5 s poll should not re-read on every request; cleared by
+   * `invalidate()`, which is what a config change is followed by.
+   */
+  private providerCache = new Map<string, string>();
   private readonly USER_TTL = 3_600_000; // 1h — GitHub identity is session-stable
 
   constructor() {
@@ -979,7 +987,7 @@ export class OverviewCache {
     // install instead of an exhausted API budget. The dashboard already renders
     // these strings (`WorkView`'s `work-unavailable`), so the explanation lands
     // without a UI change.
-    const rateLimit = getForgeRateLimit();
+    const rateLimit = getForgeRateLimit(this.providerFor(workspaceRoot));
     const unavailable = (what: string): string => rateLimit.resetAt
       ? `GitHub API rate limit exhausted — ${what} paused until ${formatResetTime(rateLimit.resetAt)}`
       : `GitHub CLI unavailable — could not fetch ${what}`;
@@ -1144,6 +1152,7 @@ export class OverviewCache {
     this.closedCache.clear();
     this.mergedPRCache.clear();
     this.currentUserCache.clear();
+    this.providerCache.clear();
     // #1645: an explicit human Refresh also lifts a rate-limit suspension.
     // invalidate() is only reached from POST /api/overview/refresh, never from
     // the 2.5s poll, so this cannot reintroduce the hammering — and without it
@@ -1179,15 +1188,16 @@ export class OverviewCache {
     ttl: number,
     fetcher: () => Promise<T | null>,
   ): Promise<T | null> {
-    const now = Date.now();
+    const dispatchedAt = Date.now();
     const cached = cache.get(cwd);
     if (cached) {
-      const age = now - cached.fetchedAt;
+      const age = dispatchedAt - cached.fetchedAt;
       if (cached.data !== null && age < ttl) return Promise.resolve(cached.data);
       if (cached.data === null && age < negativeTtlMs(cached.failures)) return Promise.resolve(null);
     }
 
-    if (isForgeSuspended(now)) return Promise.resolve(null);
+    const provider = this.providerFor(cwd);
+    if (isForgeSuspended(provider, dispatchedAt)) return Promise.resolve(null);
 
     const key = `${concept}:${cwd}`;
     const existing = this.inflight.get(key);
@@ -1195,17 +1205,22 @@ export class OverviewCache {
 
     const flight = (async () => {
       const data = await fetcher();
+      // Stamp the entry with *completion* time, not dispatch time: a forge
+      // command can sit for its full 30 s timeout, and dating the entry from
+      // dispatch would burn half the 60 s negative window before it is even
+      // written.
+      const fetchedAt = Date.now();
       if (data !== null) {
-        cache.set(cwd, { data, fetchedAt: now, failures: 0 });
-        // `now` is when this command was dispatched. A command dispatched
-        // before the current suspension began proves nothing about the forge
-        // having recovered — see noteForgeSuccess.
-        noteForgeSuccess(now);
+        cache.set(cwd, { data, fetchedAt, failures: 0 });
+        // `dispatchedAt`, not `fetchedAt`: a command dispatched before the
+        // current suspension began proves nothing about the forge having
+        // recovered — see noteForgeSuccess.
+        noteForgeSuccess(provider, dispatchedAt);
       } else {
-        cache.set(cwd, { data: null, fetchedAt: now, failures: (cached?.failures ?? 0) + 1 });
+        cache.set(cwd, { data: null, fetchedAt, failures: (cached?.failures ?? 0) + 1 });
         // If that failure was a rate limit, learn when it lifts — once per
         // suspension window, and only where the probe has been enabled.
-        void maybeProbeReset(cwd);
+        void maybeProbeReset(provider, cwd);
       }
       return data;
     })().finally(() => {
@@ -1214,6 +1229,20 @@ export class OverviewCache {
 
     this.inflight.set(key, flight);
     return flight;
+  }
+
+  /** The workspace's forge provider, read once and memoized (#1645). */
+  private providerFor(cwd: string): string {
+    let provider = this.providerCache.get(cwd);
+    if (provider === undefined) {
+      try {
+        provider = loadForgeConfig(cwd)?.provider ?? DEFAULT_PROVIDER;
+      } catch {
+        provider = DEFAULT_PROVIDER;
+      }
+      this.providerCache.set(cwd, provider);
+    }
+    return provider;
   }
 
   private fetchPRsCached(cwd: string): Promise<ForgePR[] | null> {

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -859,6 +859,14 @@ function formatResetTime(iso: string): string {
  * did not exist before #1645, and whose absence let every failing poll re-spawn
  * the command. `failures` drives the negative-cache backoff.
  */
+/**
+ * How long a queued fetch waits on the one ahead of it before giving up and
+ * serving what is cached. Just past `executeForgeCommand`'s own 30 s timeout,
+ * so it only fires for a child that outlived that — without it, one hung `gh`
+ * would wedge every later request for that concept behind it.
+ */
+const PREDECESSOR_WAIT_CAP_MS = 35_000;
+
 interface CacheEntry<T> {
   data: T | null;
   fetchedAt: number;
@@ -885,7 +893,7 @@ export class OverviewCache {
    * subsequent poll, and every additional client, start another duplicate
    * batch. Callers arriving mid-flight join the existing promise instead.
    */
-  private inflight = new Map<string, { promise: Promise<unknown>; generation: number }>();
+  private inflight = new Map<string, { promise: Promise<unknown>; generation: number; queued: boolean }>();
   /**
    * Resolved backend per `<workspace>:<concept>` — the executable that concept
    * will actually run (`gh`, `glab`, …). Per concept, not per workspace,
@@ -1246,25 +1254,45 @@ export class OverviewCache {
     }
 
     // Older generation: an invalidate() landed while that one was running, so
-    // its result is stale — but we must not just start a parallel command.
-    // porch fires invalidate after *every* mutating command, so in a busy
-    // workspace parallel flights would pile up per concept per workspace
-    // without bound: the exact fan-out this whole fix exists to stop. Chain
-    // instead — wait for the stale one, then fetch once. Callers arriving
-    // meanwhile join this chained flight, so at most one command runs and at
-    // most one waits behind it, however many invalidations arrive.
+    // its result is stale. Two things must both hold here.
+    //
+    // We must not start a parallel command — porch fires invalidate after
+    // *every* mutating command, so in a busy workspace parallel flights would
+    // pile up per concept per workspace without bound, the exact fan-out this
+    // fix exists to stop. So: chain behind the running one.
+    //
+    // And we must not queue a *new* command per invalidation either, or a burst
+    // of them costs the same as the fan-out, just spread out. So: if a chained
+    // flight is already queued and has not begun its command, join that one
+    // instead of adding another. A burst of any size therefore costs at most
+    // two commands — the one running and the one waiting — and every caller
+    // still gets real data rather than an empty list.
+    if (existing && existing.queued) {
+      return existing.promise as Promise<T | null>;
+    }
     const predecessor = existing
-      ? existing.promise.then(() => undefined, () => undefined)
+      ? Promise.race([
+          existing.promise.then(() => undefined, () => undefined),
+          new Promise<void>(resolve => {
+            const t = setTimeout(resolve, PREDECESSOR_WAIT_CAP_MS);
+            if (typeof t.unref === 'function') t.unref();
+          }),
+        ])
       : Promise.resolve();
 
     // The entry is created first so the cleanup below can compare identity
     // without referencing a promise from inside its own initializer.
-    const entry: { promise: Promise<T | null>; generation: number } =
-      { promise: undefined as unknown as Promise<T | null>, generation };
+    const entry: { promise: Promise<T | null>; generation: number; queued: boolean } =
+      { promise: undefined as unknown as Promise<T | null>, generation, queued: existing !== undefined };
 
     entry.promise = (async () => {
       try {
       await predecessor;
+
+      // The forge may have refused someone else while we waited.
+      if (isForgeSuspended(backend)) return null;
+
+      entry.queued = false; // from here we are the one holding the command
       const data = await fetcher();
       // An invalidate() while this was in flight means the result was fetched
       // under the previous config: return it to this caller, but do not write
@@ -1308,7 +1336,7 @@ export class OverviewCache {
       }
     })();
 
-    this.inflight.set(key, entry as { promise: Promise<unknown>; generation: number });
+    this.inflight.set(key, entry as { promise: Promise<unknown>; generation: number; queued: boolean });
     return entry.promise;
   }
 

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -885,7 +885,7 @@ export class OverviewCache {
    * subsequent poll, and every additional client, start another duplicate
    * batch. Callers arriving mid-flight join the existing promise instead.
    */
-  private inflight = new Map<string, Promise<unknown>>();
+  private inflight = new Map<string, { promise: Promise<unknown>; generation: number }>();
   /**
    * Resolved backend per `<workspace>:<concept>` — the executable that concept
    * will actually run (`gh`, `glab`, …). Per concept, not per workspace,
@@ -1167,12 +1167,12 @@ export class OverviewCache {
     // The resolver memoizes across every cache instance and reads concept
     // scripts off disk, so an edited script would survive this invalidation.
     clearForgeBackendCache();
-    // Drop in-flight fetches from the join table. They still run — and their
-    // results still reach the callers already awaiting them — but a caller
-    // arriving *after* an explicit Refresh must not be handed a result fetched
-    // under the previous config. The generation bump below stops the old flight
-    // writing anything.
-    this.inflight.clear();
+    // The join table is deliberately NOT cleared. A caller arriving after this
+    // point must not be handed a result fetched under the previous config, and
+    // the generation bump sees to that: they chain a fresh fetch behind the
+    // running one rather than joining it. Clearing outright was worse — it let
+    // a new flight start beside every still-running one, and porch fires this
+    // path after every mutating command.
     this.generation++;
     // Deliberately NOT clearing the rate-limit suspension here.
     //
@@ -1238,11 +1238,27 @@ export class OverviewCache {
     if (isForgeSuspended(backend, dispatchedAt)) return Promise.resolve(null);
 
     const key = `${concept}:${cwd}`;
-    const existing = this.inflight.get(key);
-    if (existing) return existing as Promise<T | null>;
-
     const generation = this.generation;
+    const existing = this.inflight.get(key);
+    // Same generation: join it. That is single-flight doing its job.
+    if (existing && existing.generation === generation) {
+      return existing.promise as Promise<T | null>;
+    }
+
+    // Older generation: an invalidate() landed while that one was running, so
+    // its result is stale — but we must not just start a parallel command.
+    // porch fires invalidate after *every* mutating command, so in a busy
+    // workspace parallel flights would pile up per concept per workspace
+    // without bound: the exact fan-out this whole fix exists to stop. Chain
+    // instead — wait for the stale one, then fetch once. Callers arriving
+    // meanwhile join this chained flight, so at most one command runs and at
+    // most one waits behind it, however many invalidations arrive.
+    const predecessor = existing
+      ? existing.promise.then(() => undefined, () => undefined)
+      : Promise.resolve();
+
     const flight = (async () => {
+      await predecessor;
       const data = await fetcher();
       // An invalidate() while this was in flight means the result was fetched
       // under the previous config: return it to this caller, but do not write
@@ -1278,10 +1294,10 @@ export class OverviewCache {
     // let the next caller start yet another fetch, the fan-out single-flight
     // exists to prevent.
     void flight.finally(() => {
-      if (this.inflight.get(key) === flight) this.inflight.delete(key);
+      if (this.inflight.get(key)?.promise === flight) this.inflight.delete(key);
     });
 
-    this.inflight.set(key, flight);
+    this.inflight.set(key, { promise: flight, generation });
     return flight;
   }
 

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -1215,6 +1215,16 @@ export class OverviewCache {
     cwd: string,
     ttl: number,
     fetcher: () => Promise<T | null>,
+    /**
+     * Whether this concept succeeding is evidence the backend has recovered.
+     *
+     * False for `user-identity`: it is `gh api user`, REST, charged to a budget
+     * separate from the GraphQL one the lists spend, but resolving to the same
+     * `gh` backend key. Letting it clear the suspension would reset the
+     * escalating backoff every time a window expired — the doubling would never
+     * get past its first step, however hard the forge was refusing us.
+     */
+    countsAsRecovery = true,
   ): Promise<T | null> {
     const dispatchedAt = Date.now();
     const cached = cache.get(cwd);
@@ -1253,7 +1263,7 @@ export class OverviewCache {
         // `dispatchedAt`, not `fetchedAt`: a command dispatched before the
         // current suspension began proves nothing about the forge having
         // recovered — see noteForgeSuccess.
-        noteForgeSuccess(backend, dispatchedAt);
+        if (countsAsRecovery) noteForgeSuccess(backend, dispatchedAt);
       } else {
         cache.set(cwd, { data: null, fetchedAt, failures: (cached?.failures ?? 0) + 1 });
         // If that failure was a rate limit, learn when it lifts — once per
@@ -1261,8 +1271,14 @@ export class OverviewCache {
         void maybeProbeReset(backend, cwd);
       }
       return data;
-    })().finally(() => {
-      this.inflight.delete(key);
+    })();
+    // Delete only if *this* flight is still the registered one. `invalidate()`
+    // clears the join table, so a newer flight can already be registered under
+    // this key by the time an older one settles — and deleting that entry would
+    // let the next caller start yet another fetch, the fan-out single-flight
+    // exists to prevent.
+    void flight.finally(() => {
+      if (this.inflight.get(key) === flight) this.inflight.delete(key);
     });
 
     this.inflight.set(key, flight);
@@ -1322,7 +1338,10 @@ export class OverviewCache {
    * Long TTL — identity is stable for the lifetime of a Tower session.
    */
   private fetchCurrentUserCached(cwd: string): Promise<string | null> {
-    return this.fetchCached('user-identity', this.currentUserCache, cwd, this.USER_TTL, () => fetchCurrentUser(cwd));
+    return this.fetchCached(
+      'user-identity', this.currentUserCache, cwd, this.USER_TTL, () => fetchCurrentUser(cwd),
+      false, // REST — its success says nothing about the GraphQL budget
+    );
   }
 
   private fetchRecentlyClosedCached(cwd: string): Promise<ForgeIssueListItem[] | null> {

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -22,7 +22,6 @@ import {
 } from '../../lib/github.js';
 import type { ForgePR, ForgeIssueListItem } from '../../lib/github.js';
 import {
-  clearForgeSuspension,
   DEFAULT_PROVIDER,
   getForgeRateLimit,
   installForgeRateLimitWatch,
@@ -31,7 +30,7 @@ import {
   noteForgeSuccess,
 } from '../../lib/forge-rate-limit.js';
 import { loadProtocol } from '../../commands/porch/protocol.js';
-import { loadForgeConfig, resolveConceptBackend } from '../../lib/forge.js';
+import { clearForgeBackendCache, loadForgeConfig, resolveConceptBackend } from '../../lib/forge.js';
 import { ResolvedEnrichmentCache } from './resolved-enrichment-cache.js';
 import { POSITIVE_TTL_MS, SEARCH_TTL_MS, negativeTtlMs } from './overview-budget.js';
 import type {
@@ -1165,12 +1164,28 @@ export class OverviewCache {
     this.mergedPRCache.clear();
     this.currentUserCache.clear();
     this.backendCache.clear();
+    // The resolver memoizes across every cache instance and reads concept
+    // scripts off disk, so an edited script would survive this invalidation.
+    clearForgeBackendCache();
+    // Drop in-flight fetches from the join table. They still run — and their
+    // results still reach the callers already awaiting them — but a caller
+    // arriving *after* an explicit Refresh must not be handed a result fetched
+    // under the previous config. The generation bump below stops the old flight
+    // writing anything.
+    this.inflight.clear();
     this.generation++;
-    // #1645: an explicit human Refresh also lifts a rate-limit suspension.
-    // invalidate() is only reached from POST /api/overview/refresh, never from
-    // the 2.5s poll, so this cannot reintroduce the hammering — and without it
-    // Refresh was a no-op for up to 15 minutes after GitHub had recovered.
-    clearForgeSuspension();
+    // Deliberately NOT clearing the rate-limit suspension here.
+    //
+    // An earlier revision did, on the theory that `POST /api/overview/refresh`
+    // means a human asked. It does not: porch calls it after *every* mutating
+    // command (commands/porch/index.ts), VSCode calls it on every review-queue
+    // mutation (review-queue/overview-nudge.ts) and cleanup calls it too. With
+    // a dozen builders running porch, that fires constantly — it would lift the
+    // suspension and reset the escalating backoff to 60s over and over, in
+    // exactly the busy workspace this fix exists for.
+    //
+    // The suspension is time-bounded anyway: at most 15 minutes, and the true
+    // reset instant whenever the probe resolves it.
     // Note: resolvedEnrichment is deliberately NOT cleared here. It must survive
     // invalidation so a cleanup-triggered refresh (which calls invalidate()) can
     // still fall back to a builder's resolved area instead of UNCATEGORIZED
@@ -1222,6 +1237,11 @@ export class OverviewCache {
       // An invalidate() while this was in flight means the result was fetched
       // under the previous config: return it to this caller, but do not write
       // it, and do not credit or blame a backend that may no longer apply.
+      //
+      // A *rate limit* observed by such a flight is still honoured, because the
+      // forge genuinely refused us: that happens in the `onForgeFailure` watch,
+      // outside this guard, and suspending on an observed refusal is correct
+      // however stale the config that prompted it.
       if (generation !== this.generation) return data;
       // Stamp the entry with *completion* time, not dispatch time: a forge
       // command can sit for its full 30 s timeout, and dating the entry from

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -99,6 +99,7 @@ import {
   removeArchitect,
 } from './tower-instances.js';
 import { OverviewCache } from './overview.js';
+import { enableResetProbe } from '../../lib/forge-rate-limit.js';
 import {
   fetchIssue,
   fetchPR,
@@ -147,6 +148,9 @@ const __dirname = path.dirname(__filename);
 
 // Singleton cache for overview endpoint (Spec 0126 Phase 4)
 const overviewCache = new OverviewCache();
+// #1645: Tower is long-lived, so it is worth one REST call to learn exactly when
+// an exhausted GraphQL budget resets instead of relying on the backoff alone.
+enableResetProbe();
 
 // Spec 1313: the in-memory SendBuffer (Spec 403) is retired. Every send is now
 // persisted to the durable `mailbox` table before the response and delivered only
@@ -1151,7 +1155,7 @@ async function handleOverview(res: http.ServerResponse, url: URL, workspaceOverr
     // every collection field is required ('never undefined' for `architects`,
     // Issue 1104), so emit them all empty rather than a partial payload.
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ builders: [], pendingPRs: [], backlog: [], recentlyClosed: [], architects: [], heldCount: 0, mailboxEscalated: false, queuedFeedback: {}, feedbackMode: 'forward' }));
+    res.end(JSON.stringify({ builders: [], pendingPRs: [], backlog: [], recentlyClosed: [], architects: [], heldCount: 0, mailboxEscalated: false, queuedFeedback: {}, feedbackMode: 'forward', forgeStatus: 'ok' }));
     return;
   }
 

--- a/packages/codev/src/commands/doctor.ts
+++ b/packages/codev/src/commands/doctor.ts
@@ -819,13 +819,29 @@ interface WarningInfo {
  * Read-only against the shared global DB — doctor must never create or migrate
  * it. Returns 1 (this workspace) when the DB is absent or unreadable.
  */
+/** Only workspaces launched this recently count toward the spend projection. */
+const ACTIVE_WORKSPACE_DAYS = 7;
+
+/**
+ * Count workspaces Tower has launched recently, for the #1645 forge-spend
+ * projection. Read-only against the shared global DB — doctor must never create
+ * or migrate it. Returns 1 (this workspace) when the DB is absent or unreadable.
+ *
+ * Recent, not lifetime: `known_workspaces` is never pruned, so counting every
+ * row would project spend for workspaces nobody has opened in months and pin
+ * the warning on permanently for anyone with a long history — a warning that
+ * cannot be cleared is a warning that gets ignored.
+ */
 function countKnownWorkspaces(): number {
   try {
     const dbPath = getGlobalDbPath();
     if (!existsSync(dbPath)) return 1;
     const db = new Database(dbPath, { readonly: true });
     try {
-      const row = db.prepare('SELECT COUNT(*) AS n FROM known_workspaces').get() as { n: number } | undefined;
+      const row = db.prepare(
+        `SELECT COUNT(*) AS n FROM known_workspaces
+         WHERE last_launched_at >= datetime('now', ?)`,
+      ).get(`-${ACTIVE_WORKSPACE_DAYS} days`) as { n: number } | undefined;
       return row && row.n > 0 ? row.n : 1;
     } finally {
       db.close();
@@ -1308,7 +1324,10 @@ export async function doctor(): Promise<number> {
       const budget = parseBudget(executeForgeCommandSync('rate-limit', {}, { cwd: workspaceRoot }));
       if (budget) {
         const resetIn = Math.max(0, Math.round((budget.reset * 1000 - Date.now()) / 60_000));
-        const label = `${budget.used}/${budget.limit} used, resets in ${resetIn}m`;
+        // Reported, not measured. `gh api rate_limit` was observed reporting a
+        // fully-exhausted GraphQL budget as untouched (#1645), so a healthy
+        // reading here is weaker evidence than an exhausted one.
+        const label = `${budget.used}/${budget.limit} used (reported), resets in ${resetIn}m`;
         if (budget.remaining === 0) {
           console.log(`  ${chalk.red('✗')} ${'graphql budget'.padEnd(20)} ${chalk.red(label)}`);
           warnings++;
@@ -1329,7 +1348,7 @@ export async function doctor(): Promise<number> {
         const calls = projectHourlyForgeCalls(workspaceCount);
         const projected = projectHourlyGraphqlPoints(workspaceCount);
         const share = Math.round((projected / budget.limit) * 100);
-        const projLabel = `${calls} calls/h for ${workspaceCount} workspace(s) ≈ ${projected} pts/h `
+        const projLabel = `≥${calls} calls/h for ${workspaceCount} recent workspace(s) ≈ ${projected} pts/h `
           + `(@${GRAPHQL_POINTS_PER_CALL} pts/call) — ${share}% of ${budget.limit}/h`;
         if (share > 50) {
           console.log(`  ${chalk.yellow('⚠')} ${'projected spend'.padEnd(20)} ${chalk.yellow(projLabel)}`);

--- a/packages/codev/src/commands/doctor.ts
+++ b/packages/codev/src/commands/doctor.ts
@@ -1347,7 +1347,9 @@ export async function doctor(): Promise<number> {
         const workspaceCount = countKnownWorkspaces();
         const calls = projectHourlyForgeCalls(workspaceCount);
         const projected = projectHourlyGraphqlPoints(workspaceCount);
-        const share = Math.round((projected / budget.limit) * 100);
+        // Guard the divisor: a forge reporting `limit: 0` would otherwise
+        // render `Infinity%`.
+        const share = budget.limit > 0 ? Math.round((projected / budget.limit) * 100) : 0;
         const projLabel = `≥${calls} calls/h for ${workspaceCount} recent workspace(s) ≈ ${projected} pts/h `
           + `(@${GRAPHQL_POINTS_PER_CALL} pts/call) — ${share}% of ${budget.limit}/h`;
         if (share > 50) {

--- a/packages/codev/src/commands/doctor.ts
+++ b/packages/codev/src/commands/doctor.ts
@@ -31,6 +31,10 @@ import {
 import { resolveAgyBin, AGY_OAUTH_MARKERS } from './consult/index.js';
 import { checkCachedAgyAuth, recordAgyAuthState } from './consult/agy-auth-cache.js';
 import { AGENT_FARM_DIR } from '@cluesmith/codev-core/constants';
+import Database from 'better-sqlite3';
+import { parseBudget } from '../lib/forge-rate-limit.js';
+import { getGlobalDbPath } from '../agent-farm/db/index.js';
+import { projectHourlyForgeCalls } from '../agent-farm/servers/overview-budget.js';
 import { findClaudeSessionMarkers } from '../lib/agent-env.js';
 import { getProcessesOnPort } from '../agent-farm/utils/port.js';
 import { DEFAULT_TOWER_PORT } from '@cluesmith/codev-sdk/constants';
@@ -806,6 +810,27 @@ interface WarningInfo {
 /**
  * Main doctor function
  */
+/**
+ * Count workspaces Tower knows about, for the #1645 forge-spend projection.
+ * Read-only against the shared global DB — doctor must never create or migrate
+ * it. Returns 1 (this workspace) when the DB is absent or unreadable.
+ */
+function countKnownWorkspaces(): number {
+  try {
+    const dbPath = getGlobalDbPath();
+    if (!existsSync(dbPath)) return 1;
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      const row = db.prepare('SELECT COUNT(*) AS n FROM known_workspaces').get() as { n: number } | undefined;
+      return row && row.n > 0 ? row.n : 1;
+    } finally {
+      db.close();
+    }
+  } catch {
+    return 1;
+  }
+}
+
 export async function doctor(): Promise<number> {
   let errors = 0;
   let warnings = 0;
@@ -1201,7 +1226,7 @@ export async function doctor(): Promise<number> {
       console.log('');
     }
 
-    // Full forge concept reporting: all 18 concepts with resolution source and executable check
+    // Full forge concept reporting: every concept with resolution source and executable check
     const forgeConfig = loadForgeConfig(workspaceRoot);
     const provider = forgeConfig?.provider ?? 'github';
     console.log(chalk.bold('Forge Concepts') + ` (provider: ${provider})`);
@@ -1219,7 +1244,7 @@ export async function doctor(): Promise<number> {
       }
     }
 
-    // Report all 18 concepts with source and executable availability
+    // Report every concept with source and executable availability
     const resolutions = resolveAllConcepts(forgeConfig);
     const missingExecs = new Set<string>();
 
@@ -1268,6 +1293,45 @@ export async function doctor(): Promise<number> {
         console.log(`  ${chalk.yellow('⚠')} ${'gh auth'.padEnd(20)} not authenticated`);
         warnings++;
         warningDetails.push({ name: 'gh auth', issue: 'not authenticated', recommendation: 'run: gh auth login' });
+      }
+    }
+
+
+    // GraphQL budget + projected Tower spend (#1645). The overview cache backs
+    // every workspace with forge commands on a timer, so the interesting number
+    // is not "is there budget left" but "will Tower's steady state consume it".
+    if (provider === 'github' && commandExists('gh')) {
+      const budget = parseBudget(executeForgeCommandSync('rate-limit', {}, { cwd: workspaceRoot }));
+      if (budget) {
+        const resetIn = Math.max(0, Math.round((budget.reset * 1000 - Date.now()) / 60_000));
+        const label = `${budget.used}/${budget.limit} used, resets in ${resetIn}m`;
+        if (budget.remaining === 0) {
+          console.log(`  ${chalk.red('✗')} ${'graphql budget'.padEnd(20)} ${chalk.red(label)}`);
+          warnings++;
+          warningDetails.push({
+            name: 'GraphQL budget',
+            issue: `exhausted (${label})`,
+            recommendation: 'Tower suspends forge refreshes until reset; close unused dashboards',
+          });
+        } else {
+          console.log(`  ${chalk.green('✓')} ${'graphql budget'.padEnd(20)} ${label}`);
+        }
+
+        const workspaceCount = countKnownWorkspaces();
+        const projected = projectHourlyForgeCalls(workspaceCount);
+        const share = Math.round((projected / budget.limit) * 100);
+        const projLabel = `${projected} calls/h for ${workspaceCount} workspace(s) — ${share}% of ${budget.limit}/h`;
+        if (share > 50) {
+          console.log(`  ${chalk.yellow('⚠')} ${'projected spend'.padEnd(20)} ${chalk.yellow(projLabel)}`);
+          warnings++;
+          warningDetails.push({
+            name: 'Forge API spend',
+            issue: projLabel,
+            recommendation: 'Too many active workspaces for the hourly budget — close dashboards or reduce workspaces',
+          });
+        } else {
+          console.log(`  ${chalk.green('✓')} ${'projected spend'.padEnd(20)} ${projLabel}`);
+        }
       }
     }
 

--- a/packages/codev/src/commands/doctor.ts
+++ b/packages/codev/src/commands/doctor.ts
@@ -34,7 +34,11 @@ import { AGENT_FARM_DIR } from '@cluesmith/codev-core/constants';
 import Database from 'better-sqlite3';
 import { parseBudget } from '../lib/forge-rate-limit.js';
 import { getGlobalDbPath } from '../agent-farm/db/index.js';
-import { projectHourlyForgeCalls } from '../agent-farm/servers/overview-budget.js';
+import {
+  GRAPHQL_POINTS_PER_CALL,
+  projectHourlyForgeCalls,
+  projectHourlyGraphqlPoints,
+} from '../agent-farm/servers/overview-budget.js';
 import { findClaudeSessionMarkers } from '../lib/agent-env.js';
 import { getProcessesOnPort } from '../agent-farm/utils/port.js';
 import { DEFAULT_TOWER_PORT } from '@cluesmith/codev-sdk/constants';
@@ -1317,10 +1321,16 @@ export async function doctor(): Promise<number> {
           console.log(`  ${chalk.green('✓')} ${'graphql budget'.padEnd(20)} ${label}`);
         }
 
+        // Compare points with points: the 5,000/h budget is denominated in
+        // GraphQL points, and a forge call costs several (#1645). Dividing
+        // calls by the point limit understates spend ~3x and would suppress
+        // the warning this check exists to raise.
         const workspaceCount = countKnownWorkspaces();
-        const projected = projectHourlyForgeCalls(workspaceCount);
+        const calls = projectHourlyForgeCalls(workspaceCount);
+        const projected = projectHourlyGraphqlPoints(workspaceCount);
         const share = Math.round((projected / budget.limit) * 100);
-        const projLabel = `${projected} calls/h for ${workspaceCount} workspace(s) — ${share}% of ${budget.limit}/h`;
+        const projLabel = `${calls} calls/h for ${workspaceCount} workspace(s) ≈ ${projected} pts/h `
+          + `(@${GRAPHQL_POINTS_PER_CALL} pts/call) — ${share}% of ${budget.limit}/h`;
         if (share > 50) {
           console.log(`  ${chalk.yellow('⚠')} ${'projected spend'.padEnd(20)} ${chalk.yellow(projLabel)}`);
           warnings++;

--- a/packages/codev/src/commands/doctor.ts
+++ b/packages/codev/src/commands/doctor.ts
@@ -36,8 +36,9 @@ import { parseBudget } from '../lib/forge-rate-limit.js';
 import { getGlobalDbPath } from '../agent-farm/db/index.js';
 import {
   GRAPHQL_POINTS_PER_CALL,
+  INVALIDATION_MIN_INTERVAL_MS,
   projectHourlyForgeCalls,
-  projectHourlyGraphqlPoints,
+  projectHourlyForgeCallsUnderChurn,
 } from '../agent-farm/servers/overview-budget.js';
 import { findClaudeSessionMarkers } from '../lib/agent-env.js';
 import { getProcessesOnPort } from '../agent-farm/utils/port.js';
@@ -1344,14 +1345,20 @@ export async function doctor(): Promise<number> {
         // GraphQL points, and a forge call costs several (#1645). Dividing
         // calls by the point limit understates spend ~3x and would suppress
         // the warning this check exists to raise.
+        // Report the range and warn on the CEILING. Reporting only the idle
+        // floor showed green while the figure under constant porch churn was
+        // several times higher — the check would have missed the very
+        // situation it exists for.
         const workspaceCount = countKnownWorkspaces();
-        const calls = projectHourlyForgeCalls(workspaceCount);
-        const projected = projectHourlyGraphqlPoints(workspaceCount);
+        const idleCalls = projectHourlyForgeCalls(workspaceCount);
+        const churnCalls = projectHourlyForgeCallsUnderChurn(workspaceCount, INVALIDATION_MIN_INTERVAL_MS);
+        const projected = churnCalls * GRAPHQL_POINTS_PER_CALL;
         // Guard the divisor: a forge reporting `limit: 0` would otherwise
         // render `Infinity%`.
         const share = budget.limit > 0 ? Math.round((projected / budget.limit) * 100) : 0;
-        const projLabel = `≥${calls} calls/h for ${workspaceCount} recent workspace(s) ≈ ${projected} pts/h `
-          + `(@${GRAPHQL_POINTS_PER_CALL} pts/call) — ${share}% of ${budget.limit}/h`;
+        const projLabel = `${idleCalls}-${churnCalls} calls/h for ${workspaceCount} recent workspace(s) `
+          + `≈ ${projected} pts/h under churn (@${GRAPHQL_POINTS_PER_CALL} pts/call) `
+          + `— ${share}% of ${budget.limit}/h`;
         if (share > 50) {
           console.log(`  ${chalk.yellow('⚠')} ${'projected spend'.padEnd(20)} ${chalk.yellow(projLabel)}`);
           warnings++;

--- a/packages/codev/src/lib/forge-rate-limit.ts
+++ b/packages/codev/src/lib/forge-rate-limit.ts
@@ -1,0 +1,206 @@
+/**
+ * Forge rate-limit awareness (Issue #1645).
+ *
+ * Tower's overview cache backs every workspace with GitHub-API-backed forge
+ * commands. When the account's GraphQL budget is exhausted every one of those
+ * commands fails instantly, and — before this module existed — Tower answered
+ * by spawning them again on the next poll, 2.5 s later. Measured on a real
+ * machine: 180 `gh` processes in 60 s, which keeps the budget at zero for the
+ * rest of the hour and takes down every other `gh` user on the box.
+ *
+ * So: when a forge command reports a rate limit, suspend *all* forge-backed
+ * refreshes process-wide until the limit resets. The state is deliberately
+ * global rather than per-workspace — a GitHub rate limit is charged to the
+ * account, so a second workspace hitting the same API would only dig deeper.
+ *
+ * The suspension is time-bounded, never permanent: it lifts at `resetAt`, and
+ * the next successful command clears it outright.
+ */
+
+import { onForgeFailure, executeForgeCommand, type ForgeFailure } from './forge.js';
+
+// =============================================================================
+// Detection
+// =============================================================================
+
+/**
+ * Substrings GitHub/`gh` use when a limit is hit. Matched case-insensitively
+ * against stderr.
+ *
+ * - "api rate limit already exceeded" — the primary GraphQL/REST limit, and
+ *   the exact wording `gh` prints (`GraphQL: API rate limit already exceeded
+ *   for user ID N.`).
+ * - "api rate limit exceeded" — the REST wording.
+ * - "rate_limit" forms — the GraphQL error `type`.
+ * - "secondary rate limit" — GitHub's abuse-detection throttle, which wants
+ *   backing off just as much.
+ */
+const RATE_LIMIT_MARKERS = [
+  'api rate limit already exceeded',
+  'api rate limit exceeded',
+  'graphql_rate_limit',
+  'rate_limited',
+  'secondary rate limit',
+  'was submitted too quickly',
+];
+
+/** True when `text` (typically a command's stderr) reports a forge rate limit. */
+export function isRateLimitError(text: string): boolean {
+  const haystack = text.toLowerCase();
+  return RATE_LIMIT_MARKERS.some(marker => haystack.includes(marker));
+}
+
+// =============================================================================
+// Suspension state
+// =============================================================================
+
+/** First suspension when the reset instant is unknown. */
+export const BACKOFF_BASE_MS = 60_000;
+/** Ceiling for both the doubling backoff and any reported reset instant. */
+export const BACKOFF_MAX_MS = 900_000;
+/**
+ * Hard cap on a suspension. GitHub's GraphQL budget is an hourly rolling
+ * window, so a reported reset further out than this is a misread, not a fact.
+ */
+export const SUSPEND_CAP_MS = 3_600_000;
+
+let suspendedUntilMs = 0;
+let consecutiveHits = 0;
+/** Set while a reset probe is in flight, so a burst of failures probes once. */
+let probing = false;
+
+export interface ForgeRateLimitState {
+  /** True while forge-backed refreshes are suspended. */
+  limited: boolean;
+  /** ISO instant the suspension lifts, or null when not suspended. */
+  resetAt: string | null;
+}
+
+/** Current suspension state. */
+export function getForgeRateLimit(now: number = Date.now()): ForgeRateLimitState {
+  if (suspendedUntilMs <= now) return { limited: false, resetAt: null };
+  return { limited: true, resetAt: new Date(suspendedUntilMs).toISOString() };
+}
+
+/** True while forge-backed refreshes should not be attempted at all. */
+export function isForgeSuspended(now: number = Date.now()): boolean {
+  return suspendedUntilMs > now;
+}
+
+/**
+ * Record a rate-limit hit and suspend until `resetAtMs`.
+ *
+ * With no reset instant the suspension follows a doubling backoff
+ * (60 s → 15 min), so a forge that is merely flaky recovers quickly while one
+ * that is genuinely throttled is left alone.
+ */
+export function noteRateLimited(resetAtMs: number | null, now: number = Date.now()): void {
+  const backoff = Math.min(BACKOFF_BASE_MS * 2 ** consecutiveHits, BACKOFF_MAX_MS);
+  consecutiveHits++;
+  const until = resetAtMs !== null && resetAtMs > now
+    ? Math.min(resetAtMs, now + SUSPEND_CAP_MS)
+    : now + backoff;
+  // Never shorten a suspension already in force.
+  suspendedUntilMs = Math.max(suspendedUntilMs, until);
+}
+
+/** Clear the suspension — called when a forge command succeeds. */
+export function noteForgeSuccess(): void {
+  suspendedUntilMs = 0;
+  consecutiveHits = 0;
+}
+
+/** Reset all state. Tests only. */
+export function resetForgeRateLimit(): void {
+  suspendedUntilMs = 0;
+  consecutiveHits = 0;
+  probing = false;
+  probeEnabled = false;
+}
+
+// =============================================================================
+// Budget probe
+// =============================================================================
+
+/** GitHub's per-resource rate-limit budget, as reported by the `rate-limit` concept. */
+export interface ForgeBudget {
+  limit: number;
+  remaining: number;
+  used: number;
+  /** Unix seconds. */
+  reset: number;
+}
+
+/** Parse the `rate-limit` concept's output. Returns null on any shape mismatch. */
+export function parseBudget(raw: unknown): ForgeBudget | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const nums = ['limit', 'remaining', 'used', 'reset'] as const;
+  if (!nums.every(k => typeof r[k] === 'number')) return null;
+  return { limit: r.limit as number, remaining: r.remaining as number, used: r.used as number, reset: r.reset as number };
+}
+
+/**
+ * Read the account's GraphQL budget via the `rate-limit` concept.
+ * Returns null when the concept is unavailable or its output is unparseable.
+ */
+export async function fetchForgeBudget(cwd?: string): Promise<ForgeBudget | null> {
+  const raw = await executeForgeCommand('rate-limit', {}, { cwd });
+  return parseBudget(raw);
+}
+
+let probeEnabled = false;
+
+/**
+ * Turn the reset probe on. Off by default so importing this module never
+ * shells out: only a long-lived process that actually benefits from a precise
+ * reset instant (Tower) opts in, and unit tests stay hermetic.
+ */
+export function enableResetProbe(enabled = true): void {
+  probeEnabled = enabled;
+}
+
+/**
+ * Learn the reset instant for a suspension already in force — at most one probe
+ * per suspension window, and only when enabled.
+ *
+ * Advisory only. Measured on a genuinely-exhausted account (#1645),
+ * `gh api rate_limit` reported `graphql` as `{limit:5000, remaining:5000,
+ * used:0}` while the live GraphQL response headers said `Used: 5000,
+ * Remaining: 0` — so the probe's reset instant is trusted **only when it agrees
+ * that the budget is gone**. Otherwise the doubling backoff stands.
+ */
+export async function maybeProbeReset(cwd?: string): Promise<void> {
+  if (!probeEnabled || probing || !isForgeSuspended()) return;
+  probing = true;
+  try {
+    const budget = await fetchForgeBudget(cwd);
+    if (budget && budget.remaining === 0 && budget.reset > 0) {
+      noteRateLimited(budget.reset * 1000);
+    }
+  } catch {
+    // Probe failures are non-events — the backoff already covers us.
+  } finally {
+    probing = false;
+  }
+}
+
+// =============================================================================
+// Wiring
+// =============================================================================
+
+let installed = false;
+
+/**
+ * Subscribe to forge failures and suspend on a rate limit. Idempotent, so any
+ * module that depends on the suspension can call it without coordinating.
+ */
+export function installForgeRateLimitWatch(): void {
+  if (installed) return;
+  installed = true;
+  onForgeFailure((failure: ForgeFailure) => {
+    if (failure.concept === 'rate-limit') return; // never suspend on the probe itself
+    if (!isRateLimitError(failure.message)) return;
+    noteRateLimited(null);
+  });
+}

--- a/packages/codev/src/lib/forge-rate-limit.ts
+++ b/packages/codev/src/lib/forge-rate-limit.ts
@@ -120,11 +120,20 @@ function backendKey(backend: string): string {
   return backend.trim().toLowerCase();
 }
 
+const FRESH_STATE: Readonly<ProviderState> =
+  { suspendedUntilMs: 0, suspendedSinceMs: 0, consecutiveHits: 0, probedSuspensionMs: -1 };
+
+/** Read-only view. Never allocates — a query must not grow the map (#1645). */
+function readState(backend: string): Readonly<ProviderState> {
+  return providerStates.get(backendKey(backend)) ?? FRESH_STATE;
+}
+
+/** Mutable view, allocating on first write for this backend. */
 function stateFor(backend: string): ProviderState {
   const key = backendKey(backend);
   let state = providerStates.get(key);
   if (!state) {
-    state = { suspendedUntilMs: 0, suspendedSinceMs: 0, consecutiveHits: 0, probedSuspensionMs: -1 };
+    state = { ...FRESH_STATE };
     providerStates.set(key, state);
   }
   return state;
@@ -145,7 +154,7 @@ export function getForgeRateLimit(
   provider: string,
   now: number = Date.now(),
 ): ForgeRateLimitState {
-  const { suspendedUntilMs } = stateFor(provider);
+  const { suspendedUntilMs } = readState(provider);
   if (suspendedUntilMs <= now) return { limited: false, resetAt: null };
   return { limited: true, resetAt: new Date(suspendedUntilMs).toISOString() };
 }
@@ -155,7 +164,7 @@ export function isForgeSuspended(
   provider: string,
   now: number = Date.now(),
 ): boolean {
-  return stateFor(provider).suspendedUntilMs > now;
+  return readState(provider).suspendedUntilMs > now;
 }
 
 /**
@@ -204,7 +213,7 @@ export function noteForgeSuccess(
   provider: string,
   startedAt: number = Date.now(),
 ): void {
-  const state = stateFor(provider);
+  const state = readState(provider);
   // `<=`, not `<`: the overview dispatches its commands in one tick, so they
   // share a millisecond, and a limit recorded in that same millisecond would
   // otherwise let a sibling's success clear it — the exact race this guards.
@@ -302,11 +311,12 @@ export async function maybeProbeReset(
   // not two — `resolveConceptBackend` maps the `github` provider to `gh` so the
   // readable and unreadable paths cannot key an account twice.
   if (backendKey(provider) !== 'gh') return;
-  if (!probeEnabled || probing.has(provider) || !isForgeSuspended(provider)) return;
+  const probeKey = backendKey(provider);
+  if (!probeEnabled || probing.has(probeKey) || !isForgeSuspended(provider)) return;
   const state = stateFor(provider);
   if (state.probedSuspensionMs === state.suspendedSinceMs) return; // already probed this window
   state.probedSuspensionMs = state.suspendedSinceMs;
-  probing.add(provider);
+  probing.add(probeKey);
   try {
     const budget = await fetchForgeBudget(cwd);
     if (budget && budget.remaining === 0 && budget.reset > 0) {
@@ -315,7 +325,7 @@ export async function maybeProbeReset(
   } catch {
     // Probe failures are non-events — the backoff already covers us.
   } finally {
-    probing.delete(provider);
+    probing.delete(probeKey);
   }
 }
 

--- a/packages/codev/src/lib/forge-rate-limit.ts
+++ b/packages/codev/src/lib/forge-rate-limit.ts
@@ -8,16 +8,26 @@
  * machine: 180 `gh` processes in 60 s, which keeps the budget at zero for the
  * rest of the hour and takes down every other `gh` user on the box.
  *
- * So: when a forge command reports a rate limit, suspend *all* forge-backed
- * refreshes process-wide until the limit resets. The state is deliberately
- * global rather than per-workspace — a GitHub rate limit is charged to the
- * account, so a second workspace hitting the same API would only dig deeper.
+ * So: when a forge command reports a rate limit, suspend every refresh that
+ * would go to **that same backend** until the limit resets. The state is keyed
+ * by backend rather than by workspace — a GitHub rate limit is charged to the
+ * account, so a second workspace hitting the same API would only dig deeper —
+ * and by *backend* rather than by configured provider, because providers are
+ * hybrid: a Linear workspace's PR concepts fall through to `gh` and spend
+ * GitHub's budget. A limit on one forge never suspends another.
  *
  * The suspension is time-bounded, never permanent: it lifts at `resetAt`, and
  * the next successful command clears it outright.
  */
 
-import { onForgeFailure, executeForgeCommand, type ForgeFailure } from './forge.js';
+import {
+  DEFAULT_PROVIDER,
+  executeForgeCommand,
+  onForgeFailure,
+  type ForgeFailure,
+} from './forge.js';
+
+export { DEFAULT_PROVIDER };
 
 // =============================================================================
 // Detection
@@ -75,29 +85,35 @@ interface ProviderState {
 }
 
 /**
- * Suspension state **keyed by forge provider**, not process-global.
+ * Suspension state **keyed by resolved backend**, not process-global.
  *
- * A rate limit is charged to one forge's account. Suspending every provider on
- * a GitHub limit would blank a GitLab, Gitea or Linear workspace's Work view
- * for the whole backoff window over an outage that has nothing to do with it.
+ * A rate limit is charged to one forge's account. Suspending every backend on
+ * a GitHub limit would blank a GitLab or Gitea workspace's Work view for the
+ * whole backoff window over an outage that has nothing to do with it.
  */
 const providerStates = new Map<string, ProviderState>();
 
 /**
- * The provider a forge command resolves to when config names none.
- *
- * Every function below takes `provider` as a **required first argument**, with
+ * Every function below takes the backend as a **required first argument**, with
  * no default. An earlier revision defaulted it and put it last, which let
- * `isForgeSuspended(now)` read a timestamp as a provider name and silently
+ * `isForgeSuspended(now)` read a timestamp as a backend name and silently
  * answer about the wrong forge. Required-and-first makes that a type error.
+ *
+ * Keys are lowercased on the way in, so a config that spells its provider
+ * `GitHub` cannot end up with state separate from one that spells it `github`.
  */
-export const DEFAULT_PROVIDER = 'github';
 
-function stateFor(provider: string): ProviderState {
-  let state = providerStates.get(provider);
+/** Normalize a backend key. Casing must never split one forge's state in two. */
+function backendKey(backend: string): string {
+  return backend.trim().toLowerCase();
+}
+
+function stateFor(backend: string): ProviderState {
+  const key = backendKey(backend);
+  let state = providerStates.get(key);
   if (!state) {
     state = { suspendedUntilMs: 0, suspendedSinceMs: 0, consecutiveHits: 0, probedSuspensionMs: -1 };
-    providerStates.set(provider, state);
+    providerStates.set(key, state);
   }
   return state;
 }
@@ -186,12 +202,12 @@ export function noteForgeSuccess(
  * Refresh — which should not have to wait out a backoff window after the forge
  * has recovered. Omit `provider` to clear every provider.
  */
-export function clearForgeSuspension(provider?: string): void {
-  if (provider === undefined) {
+export function clearForgeSuspension(backend?: string): void {
+  if (backend === undefined) {
     providerStates.clear();
     return;
   }
-  providerStates.delete(provider);
+  providerStates.delete(backendKey(backend));
 }
 
 /** Reset all state. Tests only. */
@@ -257,10 +273,10 @@ export async function maybeProbeReset(
   provider: string,
   cwd?: string,
 ): Promise<void> {
-  // GitHub only: the `rate-limit` concept has no script outside the github
-  // preset, so on any other provider it would fall through to the github
+  // `gh` only: the `rate-limit` concept has no script outside the github
+  // preset, so for any other backend it would fall through to the github
   // default and shell out to `gh` for a forge that does not use it.
-  if (provider !== DEFAULT_PROVIDER) return;
+  if (backendKey(provider) !== 'gh' && backendKey(provider) !== DEFAULT_PROVIDER) return;
   if (!probeEnabled || probing.has(provider) || !isForgeSuspended(provider)) return;
   const state = stateFor(provider);
   if (state.probedSuspensionMs === state.suspendedSinceMs) return; // already probed this window
@@ -301,8 +317,8 @@ export function installForgeRateLimitWatch(): void {
   onForgeFailure((failure: ForgeFailure) => {
     if (failure.concept === 'rate-limit') return; // never suspend on the probe itself
     if (!isRateLimitError(failure.message)) return;
-    // Suspend only the provider that was refused. A GitHub limit says nothing
-    // about a GitLab workspace's forge.
-    noteRateLimited(failure.provider, null);
+    // Suspend only the backend that was refused. A `gh` limit says nothing
+    // about a workspace whose concepts run `glab`.
+    noteRateLimited(failure.backend, null);
   });
 }

--- a/packages/codev/src/lib/forge-rate-limit.ts
+++ b/packages/codev/src/lib/forge-rate-limit.ts
@@ -64,35 +64,74 @@ export const BACKOFF_MAX_MS = 900_000;
  */
 export const SUSPEND_CAP_MS = 3_600_000;
 
-let suspendedUntilMs = 0;
-/** When the current suspension began. Guards success/probe races — see below. */
-let suspendedSinceMs = 0;
-let consecutiveHits = 0;
-/** Set while a reset probe is in flight. */
-let probing = false;
-/** `suspendedSinceMs` of the suspension the reset probe has already run for. */
-let probedSuspensionMs = -1;
+/** Per-provider suspension state. */
+interface ProviderState {
+  suspendedUntilMs: number;
+  /** When the current suspension began. Guards the success/probe races below. */
+  suspendedSinceMs: number;
+  consecutiveHits: number;
+  /** `suspendedSinceMs` of the suspension the reset probe has already run for. */
+  probedSuspensionMs: number;
+}
+
+/**
+ * Suspension state **keyed by forge provider**, not process-global.
+ *
+ * A rate limit is charged to one forge's account. Suspending every provider on
+ * a GitHub limit would blank a GitLab, Gitea or Linear workspace's Work view
+ * for the whole backoff window over an outage that has nothing to do with it.
+ */
+const providerStates = new Map<string, ProviderState>();
+
+/**
+ * The provider a forge command resolves to when config names none.
+ *
+ * Every function below takes `provider` as a **required first argument**, with
+ * no default. An earlier revision defaulted it and put it last, which let
+ * `isForgeSuspended(now)` read a timestamp as a provider name and silently
+ * answer about the wrong forge. Required-and-first makes that a type error.
+ */
+export const DEFAULT_PROVIDER = 'github';
+
+function stateFor(provider: string): ProviderState {
+  let state = providerStates.get(provider);
+  if (!state) {
+    state = { suspendedUntilMs: 0, suspendedSinceMs: 0, consecutiveHits: 0, probedSuspensionMs: -1 };
+    providerStates.set(provider, state);
+  }
+  return state;
+}
+
+/** Set while a reset probe is in flight, keyed by provider. */
+const probing = new Set<string>();
 
 export interface ForgeRateLimitState {
-  /** True while forge-backed refreshes are suspended. */
+  /** True while this provider's forge-backed refreshes are suspended. */
   limited: boolean;
   /** ISO instant the suspension lifts, or null when not suspended. */
   resetAt: string | null;
 }
 
-/** Current suspension state. */
-export function getForgeRateLimit(now: number = Date.now()): ForgeRateLimitState {
+/** Current suspension state for one provider. */
+export function getForgeRateLimit(
+  provider: string,
+  now: number = Date.now(),
+): ForgeRateLimitState {
+  const { suspendedUntilMs } = stateFor(provider);
   if (suspendedUntilMs <= now) return { limited: false, resetAt: null };
   return { limited: true, resetAt: new Date(suspendedUntilMs).toISOString() };
 }
 
-/** True while forge-backed refreshes should not be attempted at all. */
-export function isForgeSuspended(now: number = Date.now()): boolean {
-  return suspendedUntilMs > now;
+/** True while this provider's forge-backed refreshes should not be attempted. */
+export function isForgeSuspended(
+  provider: string,
+  now: number = Date.now(),
+): boolean {
+  return stateFor(provider).suspendedUntilMs > now;
 }
 
 /**
- * Record a rate-limit hit and suspend until `resetAtMs`.
+ * Record a rate-limit hit for `provider` and suspend it until `resetAtMs`.
  *
  * With no reset instant the suspension follows a doubling backoff
  * (60 s → 15 min), so a forge that is merely flaky recovers quickly while one
@@ -103,22 +142,27 @@ export function isForgeSuspended(now: number = Date.now()): boolean {
  * four fail together; counting each would jump straight from 60 s to 8 minutes
  * on the very first refresh.
  */
-export function noteRateLimited(resetAtMs: number | null, now: number = Date.now()): void {
-  const alreadySuspended = suspendedUntilMs > now;
+export function noteRateLimited(
+  provider: string,
+  resetAtMs: number | null,
+  now: number = Date.now(),
+): void {
+  const state = stateFor(provider);
+  const alreadySuspended = state.suspendedUntilMs > now;
   if (!alreadySuspended) {
-    consecutiveHits++;
-    suspendedSinceMs = now;
+    state.consecutiveHits++;
+    state.suspendedSinceMs = now;
   }
-  const backoff = Math.min(BACKOFF_BASE_MS * 2 ** (consecutiveHits - 1), BACKOFF_MAX_MS);
+  const backoff = Math.min(BACKOFF_BASE_MS * 2 ** (state.consecutiveHits - 1), BACKOFF_MAX_MS);
   const until = resetAtMs !== null && resetAtMs > now
     ? Math.min(resetAtMs, now + SUSPEND_CAP_MS)
     : now + backoff;
   // Never shorten a suspension already in force.
-  suspendedUntilMs = Math.max(suspendedUntilMs, until);
+  state.suspendedUntilMs = Math.max(state.suspendedUntilMs, until);
 }
 
 /**
- * Clear the suspension after a forge command succeeded.
+ * Clear `provider`'s suspension after one of its commands succeeded.
  *
  * `startedAt` is when that command was dispatched, and it matters: an overview
  * refresh dispatches its forge commands in parallel, and one of them
@@ -128,27 +172,32 @@ export function noteRateLimited(resetAtMs: number | null, now: number = Date.now
  * the hammering would continue. Only a command dispatched *after* the current
  * suspension began is evidence that the forge has actually recovered.
  */
-export function noteForgeSuccess(startedAt: number = Date.now()): void {
-  if (suspendedUntilMs > 0 && startedAt < suspendedSinceMs) return;
-  clearForgeSuspension();
+export function noteForgeSuccess(
+  provider: string,
+  startedAt: number = Date.now(),
+): void {
+  const state = stateFor(provider);
+  if (state.suspendedUntilMs > 0 && startedAt < state.suspendedSinceMs) return;
+  clearForgeSuspension(provider);
 }
 
 /**
- * Drop the suspension outright. For an explicit human action — a dashboard
- * Refresh — which should not have to wait out a backoff window after GitHub
- * has recovered.
+ * Drop a suspension outright. For an explicit human action — a dashboard
+ * Refresh — which should not have to wait out a backoff window after the forge
+ * has recovered. Omit `provider` to clear every provider.
  */
-export function clearForgeSuspension(): void {
-  suspendedUntilMs = 0;
-  suspendedSinceMs = 0;
-  consecutiveHits = 0;
-  probedSuspensionMs = -1;
+export function clearForgeSuspension(provider?: string): void {
+  if (provider === undefined) {
+    providerStates.clear();
+    return;
+  }
+  providerStates.delete(provider);
 }
 
 /** Reset all state. Tests only. */
 export function resetForgeRateLimit(): void {
-  clearForgeSuspension();
-  probing = false;
+  providerStates.clear();
+  probing.clear();
   probeEnabled = false;
 }
 
@@ -204,20 +253,28 @@ export function enableResetProbe(enabled = true): void {
  * Remaining: 0` — so the probe's reset instant is trusted **only when it agrees
  * that the budget is gone**. Otherwise the doubling backoff stands.
  */
-export async function maybeProbeReset(cwd?: string): Promise<void> {
-  if (!probeEnabled || probing || !isForgeSuspended()) return;
-  if (probedSuspensionMs === suspendedSinceMs) return; // already probed this window
-  probedSuspensionMs = suspendedSinceMs;
-  probing = true;
+export async function maybeProbeReset(
+  provider: string,
+  cwd?: string,
+): Promise<void> {
+  // GitHub only: the `rate-limit` concept has no script outside the github
+  // preset, so on any other provider it would fall through to the github
+  // default and shell out to `gh` for a forge that does not use it.
+  if (provider !== DEFAULT_PROVIDER) return;
+  if (!probeEnabled || probing.has(provider) || !isForgeSuspended(provider)) return;
+  const state = stateFor(provider);
+  if (state.probedSuspensionMs === state.suspendedSinceMs) return; // already probed this window
+  state.probedSuspensionMs = state.suspendedSinceMs;
+  probing.add(provider);
   try {
     const budget = await fetchForgeBudget(cwd);
     if (budget && budget.remaining === 0 && budget.reset > 0) {
-      noteRateLimited(budget.reset * 1000);
+      noteRateLimited(provider, budget.reset * 1000);
     }
   } catch {
     // Probe failures are non-events — the backoff already covers us.
   } finally {
-    probing = false;
+    probing.delete(provider);
   }
 }
 
@@ -244,6 +301,8 @@ export function installForgeRateLimitWatch(): void {
   onForgeFailure((failure: ForgeFailure) => {
     if (failure.concept === 'rate-limit') return; // never suspend on the probe itself
     if (!isRateLimitError(failure.message)) return;
-    noteRateLimited(null);
+    // Suspend only the provider that was refused. A GitHub limit says nothing
+    // about a GitLab workspace's forge.
+    noteRateLimited(failure.provider, null);
   });
 }

--- a/packages/codev/src/lib/forge-rate-limit.ts
+++ b/packages/codev/src/lib/forge-rate-limit.ts
@@ -275,8 +275,10 @@ export async function maybeProbeReset(
 ): Promise<void> {
   // `gh` only: the `rate-limit` concept has no script outside the github
   // preset, so for any other backend it would fall through to the github
-  // default and shell out to `gh` for a forge that does not use it.
-  if (backendKey(provider) !== 'gh' && backendKey(provider) !== DEFAULT_PROVIDER) return;
+  // default and shell out to `gh` for a forge that does not use it. One name,
+  // not two — `resolveConceptBackend` maps the `github` provider to `gh` so the
+  // readable and unreadable paths cannot key an account twice.
+  if (backendKey(provider) !== 'gh') return;
   if (!probeEnabled || probing.has(provider) || !isForgeSuspended(provider)) return;
   const state = stateFor(provider);
   if (state.probedSuspensionMs === state.suspendedSinceMs) return; // already probed this window

--- a/packages/codev/src/lib/forge-rate-limit.ts
+++ b/packages/codev/src/lib/forge-rate-limit.ts
@@ -205,7 +205,10 @@ export function noteForgeSuccess(
   startedAt: number = Date.now(),
 ): void {
   const state = stateFor(provider);
-  if (state.suspendedUntilMs > 0 && startedAt < state.suspendedSinceMs) return;
+  // `<=`, not `<`: the overview dispatches its commands in one tick, so they
+  // share a millisecond, and a limit recorded in that same millisecond would
+  // otherwise let a sibling's success clear it — the exact race this guards.
+  if (state.suspendedUntilMs > 0 && startedAt <= state.suspendedSinceMs) return;
   clearForgeSuspension(provider);
 }
 

--- a/packages/codev/src/lib/forge-rate-limit.ts
+++ b/packages/codev/src/lib/forge-rate-limit.ts
@@ -65,9 +65,13 @@ export const BACKOFF_MAX_MS = 900_000;
 export const SUSPEND_CAP_MS = 3_600_000;
 
 let suspendedUntilMs = 0;
+/** When the current suspension began. Guards success/probe races — see below. */
+let suspendedSinceMs = 0;
 let consecutiveHits = 0;
-/** Set while a reset probe is in flight, so a burst of failures probes once. */
+/** Set while a reset probe is in flight. */
 let probing = false;
+/** `suspendedSinceMs` of the suspension the reset probe has already run for. */
+let probedSuspensionMs = -1;
 
 export interface ForgeRateLimitState {
   /** True while forge-backed refreshes are suspended. */
@@ -93,10 +97,19 @@ export function isForgeSuspended(now: number = Date.now()): boolean {
  * With no reset instant the suspension follows a doubling backoff
  * (60 s → 15 min), so a forge that is merely flaky recovers quickly while one
  * that is genuinely throttled is left alone.
+ *
+ * The backoff escalates **once per suspension window, not once per failed
+ * command**. An overview refresh fires four forge commands in parallel and all
+ * four fail together; counting each would jump straight from 60 s to 8 minutes
+ * on the very first refresh.
  */
 export function noteRateLimited(resetAtMs: number | null, now: number = Date.now()): void {
-  const backoff = Math.min(BACKOFF_BASE_MS * 2 ** consecutiveHits, BACKOFF_MAX_MS);
-  consecutiveHits++;
+  const alreadySuspended = suspendedUntilMs > now;
+  if (!alreadySuspended) {
+    consecutiveHits++;
+    suspendedSinceMs = now;
+  }
+  const backoff = Math.min(BACKOFF_BASE_MS * 2 ** (consecutiveHits - 1), BACKOFF_MAX_MS);
   const until = resetAtMs !== null && resetAtMs > now
     ? Math.min(resetAtMs, now + SUSPEND_CAP_MS)
     : now + backoff;
@@ -104,16 +117,37 @@ export function noteRateLimited(resetAtMs: number | null, now: number = Date.now
   suspendedUntilMs = Math.max(suspendedUntilMs, until);
 }
 
-/** Clear the suspension — called when a forge command succeeds. */
-export function noteForgeSuccess(): void {
+/**
+ * Clear the suspension after a forge command succeeded.
+ *
+ * `startedAt` is when that command was dispatched, and it matters: an overview
+ * refresh dispatches its forge commands in parallel, and one of them
+ * (`user-identity`) is a REST call charged to a *different* budget. Without
+ * this guard that REST success would wipe the suspension its GraphQL siblings
+ * had just set — the very first failing refresh would un-suspend itself and
+ * the hammering would continue. Only a command dispatched *after* the current
+ * suspension began is evidence that the forge has actually recovered.
+ */
+export function noteForgeSuccess(startedAt: number = Date.now()): void {
+  if (suspendedUntilMs > 0 && startedAt < suspendedSinceMs) return;
+  clearForgeSuspension();
+}
+
+/**
+ * Drop the suspension outright. For an explicit human action — a dashboard
+ * Refresh — which should not have to wait out a backoff window after GitHub
+ * has recovered.
+ */
+export function clearForgeSuspension(): void {
   suspendedUntilMs = 0;
+  suspendedSinceMs = 0;
   consecutiveHits = 0;
+  probedSuspensionMs = -1;
 }
 
 /** Reset all state. Tests only. */
 export function resetForgeRateLimit(): void {
-  suspendedUntilMs = 0;
-  consecutiveHits = 0;
+  clearForgeSuspension();
   probing = false;
   probeEnabled = false;
 }
@@ -172,6 +206,8 @@ export function enableResetProbe(enabled = true): void {
  */
 export async function maybeProbeReset(cwd?: string): Promise<void> {
   if (!probeEnabled || probing || !isForgeSuspended()) return;
+  if (probedSuspensionMs === suspendedSinceMs) return; // already probed this window
+  probedSuspensionMs = suspendedSinceMs;
   probing = true;
   try {
     const budget = await fetchForgeBudget(cwd);
@@ -194,6 +230,13 @@ let installed = false;
 /**
  * Subscribe to forge failures and suspend on a rate limit. Idempotent, so any
  * module that depends on the suspension can call it without coordinating.
+ *
+ * Note what "suspend" does and does not mean: this module only *records* the
+ * suspension. Honouring it is up to each caller, and today the only caller that
+ * does is `OverviewCache.fetchCached` — the one on a 2.5 s timer, and so the
+ * one that turns a transient limit into a permanent one. A one-off command
+ * (`afx spawn` fetching an issue) still runs and still fails fast, which is
+ * what a human at a prompt wants.
  */
 export function installForgeRateLimitWatch(): void {
   if (installed) return;

--- a/packages/codev/src/lib/forge-rate-limit.ts
+++ b/packages/codev/src/lib/forge-rate-limit.ts
@@ -87,6 +87,18 @@ interface ProviderState {
 /**
  * Suspension state **keyed by resolved backend**, not process-global.
  *
+ * Known limitation: the key is the *tool*, not the account. Two workspaces
+ * pointed at different GitHub hosts or accounts both resolve to `gh`, so one's
+ * limit suspends the other. That errs toward over-suspension — conservative,
+ * never a runaway — and the alternative needs per-host credential
+ * introspection, which is out of scope here. Conversely a concept wrapped in a
+ * differently-named script keys separately from a bare `gh`, costing one extra
+ * batch before it suspends itself.
+ */
+
+/**
+ * Per-backend state.
+ *
  * A rate limit is charged to one forge's account. Suspending every backend on
  * a GitHub limit would blank a GitLab or Gitea workspace's Work view for the
  * whole backoff window over an outage that has nothing to do with it.
@@ -198,9 +210,17 @@ export function noteForgeSuccess(
 }
 
 /**
- * Drop a suspension outright. For an explicit human action — a dashboard
- * Refresh — which should not have to wait out a backoff window after the forge
- * has recovered. Omit `provider` to clear every provider.
+ * Drop a suspension outright, skipping the remaining backoff.
+ *
+ * **Nothing in the product calls this**, deliberately. It was wired to
+ * `OverviewCache.invalidate()` on the theory that `POST /api/overview/refresh`
+ * means a human asked; it does not — porch, VSCode and cleanup all fire that
+ * route automatically, so clearing here reset the escalating backoff
+ * continuously in a busy workspace. A suspension is time-bounded anyway
+ * (≤ 15 minutes, or the probe's true reset instant).
+ *
+ * Kept for tests and for a future genuinely-human signal, if one ever exists.
+ * Omit `backend` to clear every backend.
  */
 export function clearForgeSuspension(backend?: string): void {
   if (backend === undefined) {

--- a/packages/codev/src/lib/forge.ts
+++ b/packages/codev/src/lib/forge.ts
@@ -65,7 +65,7 @@ const KNOWN_CONCEPTS = [
   'issue-view', 'pr-list', 'issue-list', 'issue-search', 'issue-comment', 'pr-exists',
   'recently-closed', 'recently-merged', 'user-identity', 'team-activity',
   'on-it-timestamps', 'pr-create', 'pr-merge', 'pr-search', 'pr-view', 'pr-diff',
-  'auth-status', 'repo-archive',
+  'auth-status', 'repo-archive', 'rate-limit',
 ] as const;
 
 // =============================================================================
@@ -310,6 +310,56 @@ export function isConceptDisabled(
 }
 
 // =============================================================================
+// Failure notification (Issue #1645)
+// =============================================================================
+
+/** A forge concept command that exited non-zero, with the detail the catch block discards. */
+export interface ForgeFailure {
+  concept: string;
+  /** stderr when the child produced any, else the Error message. Never null. */
+  message: string;
+  /** Child exit code when Node reported one. */
+  exitCode: number | null;
+}
+
+type ForgeFailureListener = (failure: ForgeFailure) => void;
+
+const failureListeners = new Set<ForgeFailureListener>();
+
+/**
+ * Observe every forge concept failure in this process.
+ *
+ * `executeForgeCommand` collapses every failure mode to `null`, which is all
+ * most callers need — but it means nothing downstream can tell "gh is not
+ * installed" from "the GitHub API rate limit is exhausted". Tower needs that
+ * distinction to stop hammering a forge that is refusing it (#1645), so the
+ * detail is published here instead of being widened into every return type.
+ *
+ * @returns an unsubscribe function.
+ */
+export function onForgeFailure(listener: ForgeFailureListener): () => void {
+  failureListeners.add(listener);
+  return () => failureListeners.delete(listener);
+}
+
+/** Build a ForgeFailure from a child_process rejection and publish it. */
+function notifyFailure(concept: string, err: unknown): void {
+  if (failureListeners.size === 0) return;
+  const e = err as { stderr?: unknown; code?: unknown; message?: unknown };
+  const stderr = typeof e?.stderr === 'string' ? e.stderr.trim() : '';
+  const message = stderr || (err instanceof Error ? err.message : String(err));
+  const exitCode = typeof e?.code === 'number' ? e.code : null;
+  const failure: ForgeFailure = { concept, message, exitCode };
+  for (const listener of failureListeners) {
+    try {
+      listener(failure);
+    } catch {
+      // A listener must never break the command path it is observing.
+    }
+  }
+}
+
+// =============================================================================
 // Execution
 // =============================================================================
 
@@ -349,6 +399,7 @@ export async function executeForgeCommand(
     return parseOutput(stdout, options?.raw);
   } catch (err: unknown) {
     logDebug(concept, err);
+    notifyFailure(concept, err);
     return null;
   }
 }
@@ -386,6 +437,7 @@ export function executeForgeCommandSync(
     return parseOutput(stdout, options?.raw);
   } catch (err: unknown) {
     logDebug(concept, err, true);
+    notifyFailure(concept, err);
     return null;
   }
 }

--- a/packages/codev/src/lib/forge.ts
+++ b/packages/codev/src/lib/forge.ts
@@ -396,7 +396,12 @@ export function resolveConceptBackend(
   const unknownTool =
     basename === null
     || basename.endsWith('.sh')
-    || (bareScriptRef && basename === trimmed.split('/').pop());
+    || (bareScriptRef && basename === trimmed.split('/').pop())
+    // A file named after the concept is a per-concept script, not a tool —
+    // `/opt/forge/issue-list --json …` names no CLI. Keying on it would give
+    // every concept a backend of its own and fragment one account across all
+    // of them, arguments or no arguments.
+    || basename === concept;
   const fallback = PROVIDER_EXECUTABLES[provider.toLowerCase()] ?? provider;
   const backend = (
     unknownTool || GENERIC_TRANSPORTS.has(basename!.toLowerCase()) ? fallback : basename!

--- a/packages/codev/src/lib/forge.ts
+++ b/packages/codev/src/lib/forge.ts
@@ -161,13 +161,13 @@ function getProviderPresets(): Record<string, Record<string, string | null>> {
   if (_providerPresets) return _providerPresets;
   _providerPresets = {
     github: getDefaultCommands(),
-    gitlab: buildPresetFromScripts('gitlab', ['team-activity', 'on-it-timestamps']),
-    gitea: buildPresetFromScripts('gitea', ['team-activity', 'on-it-timestamps', 'pr-search', 'pr-diff']),
+    gitlab: buildPresetFromScripts('gitlab', ['team-activity', 'on-it-timestamps', 'rate-limit']),
+    gitea: buildPresetFromScripts('gitea', ['team-activity', 'on-it-timestamps', 'pr-search', 'pr-diff', 'rate-limit']),
     // Linear is a hybrid forge (spec 719): it owns *issues*, while every PR
     // concept — pr-create included — deliberately falls through to the github
     // default. Disabling pr-create here would leave Linear the one provider
     // that can merge a PR but not open one.
-    linear: buildPresetFromScripts('linear', ['team-activity', 'on-it-timestamps']),
+    linear: buildPresetFromScripts('linear', ['team-activity', 'on-it-timestamps', 'rate-limit']),
   };
   return _providerPresets;
 }

--- a/packages/codev/src/lib/forge.ts
+++ b/packages/codev/src/lib/forge.ts
@@ -61,6 +61,17 @@ const PROVIDER_EXECUTABLES: Record<string, string> = {
   gitea: 'tea',
 };
 
+/**
+ * Tools that identify a transport rather than a forge account.
+ *
+ * Linear's concepts run `curl` against its GraphQL API, so `curl` says nothing
+ * about *whose* budget was spent — and any future curl-based provider would
+ * collide with it. For these, the configured provider is the better key, which
+ * also keeps Linear's healthy resolve (`curl`) and its fallback (`linear`) from
+ * becoming two suspension states for one account.
+ */
+const GENERIC_TRANSPORTS = new Set(['curl', 'wget', 'http', 'https', 'sh', 'bash', 'jq', 'python', 'python3', 'node']);
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -363,22 +374,33 @@ export function resolveConceptBackend(
   const cached = _backendCache.get(key);
   if (cached !== undefined) return cached;
 
-  // Two different path shapes come back from `extractExecutable`, and they mean
-  // opposite things:
+  // Three shapes come back from `extractExecutable`, and they mean different
+  // things:
   //
-  // - `/usr/local/bin/gh` — a real executable given by absolute path. Its
-  //   basename is the backend: an override spelling `gh` in full must key the
-  //   same as one spelling it bare, or the two fragment the suspension.
-  // - `/…/scripts/forge/github/pr-list.sh` — the command returned verbatim
-  //   because the concept script could not be read. That names no tool at all,
-  //   and keying on it would give every concept a backend of its own, so fall
-  //   back to the configured provider: less precise, but it keeps concepts that
-  //   share an account sharing a key.
+  // - `gh`, or `/usr/local/bin/gh` from `"/usr/local/bin/gh issue list"` — a
+  //   real executable. Its basename is the backend: an override spelling the
+  //   tool in full must key the same as one spelling it bare.
+  // - the command echoed back, because it is a bare path to a script that could
+  //   not be read (`…/pr-list.sh`, or an extensionless `/opt/forge/issue-list`).
+  //   That names no tool, and keying on it would give every concept a backend of
+  //   its own — so fall back to the configured provider instead. Less precise,
+  //   but it keeps concepts that share an account sharing a key.
+  // - a generic transport (`curl`), which names a protocol rather than an
+  //   account. The provider is the better key. See GENERIC_TRANSPORTS.
+  const trimmed = command.trim();
   const executable = extractExecutable(command);
   const basename = executable?.split('/').pop() || null;
-  const unreadableScript = basename === null || basename.endsWith('.sh');
+  // A bare path with no arguments is a script reference; if the extractor just
+  // handed it back, it read nothing useful out of the file.
+  const bareScriptRef = !/\s/.test(trimmed) && (trimmed.includes('/') || trimmed.endsWith('.sh'));
+  const unknownTool =
+    basename === null
+    || basename.endsWith('.sh')
+    || (bareScriptRef && basename === trimmed.split('/').pop());
   const fallback = PROVIDER_EXECUTABLES[provider.toLowerCase()] ?? provider;
-  const backend = (unreadableScript ? fallback : basename).toLowerCase();
+  const backend = (
+    unknownTool || GENERIC_TRANSPORTS.has(basename!.toLowerCase()) ? fallback : basename!
+  ).toLowerCase();
   _backendCache.set(key, backend);
   return backend;
 }

--- a/packages/codev/src/lib/forge.ts
+++ b/packages/codev/src/lib/forge.ts
@@ -47,6 +47,20 @@ const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024;
  */
 export const DEFAULT_PROVIDER = 'github';
 
+/**
+ * The CLI each built-in provider drives.
+ *
+ * Backend keys must live in one namespace: healthy resolution yields the
+ * executable (`gh`), while the unreadable-script fallback yields the provider
+ * (`github`), and without this map one account would hold two independent
+ * suspension states under the two spellings.
+ */
+const PROVIDER_EXECUTABLES: Record<string, string> = {
+  github: 'gh',
+  gitlab: 'glab',
+  gitea: 'tea',
+};
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -312,6 +326,18 @@ export function getForgeCommand(
 const _backendCache = new Map<string, string>();
 
 /**
+ * Drop memoized backend resolutions.
+ *
+ * Resolution reads the concept script off disk, so an edited script — or an
+ * added `# forge-executable:` line — would otherwise not take effect until the
+ * process restarted. Called from `OverviewCache.invalidate()`, which is what a
+ * config or script change is followed by.
+ */
+export function clearForgeBackendCache(): void {
+  _backendCache.clear();
+}
+
+/**
  * The backend a concept will actually run against: the resolved command's
  * executable, lowercased. Falls back to the configured provider, then to
  * `DEFAULT_PROVIDER`.
@@ -337,14 +363,22 @@ export function resolveConceptBackend(
   const cached = _backendCache.get(key);
   if (cached !== undefined) return cached;
 
-  // `extractExecutable` returns the command verbatim when it cannot read the
-  // script — a missing or unreadable concept script yields its own path. Keying
-  // on that would give every concept a *different* backend and fragment the
-  // suspension across them, so fall back to the configured provider instead:
-  // less precise, but it keeps concepts that share an account sharing a key.
+  // Two different path shapes come back from `extractExecutable`, and they mean
+  // opposite things:
+  //
+  // - `/usr/local/bin/gh` — a real executable given by absolute path. Its
+  //   basename is the backend: an override spelling `gh` in full must key the
+  //   same as one spelling it bare, or the two fragment the suspension.
+  // - `/…/scripts/forge/github/pr-list.sh` — the command returned verbatim
+  //   because the concept script could not be read. That names no tool at all,
+  //   and keying on it would give every concept a backend of its own, so fall
+  //   back to the configured provider: less precise, but it keeps concepts that
+  //   share an account sharing a key.
   const executable = extractExecutable(command);
-  const looksLikePath = executable !== null && (executable.includes('/') || executable.endsWith('.sh'));
-  const backend = (looksLikePath || executable === null ? provider : executable).toLowerCase();
+  const basename = executable?.split('/').pop() || null;
+  const unreadableScript = basename === null || basename.endsWith('.sh');
+  const fallback = PROVIDER_EXECUTABLES[provider.toLowerCase()] ?? provider;
+  const backend = (unreadableScript ? fallback : basename).toLowerCase();
   _backendCache.set(key, backend);
   return backend;
 }

--- a/packages/codev/src/lib/forge.ts
+++ b/packages/codev/src/lib/forge.ts
@@ -329,7 +329,11 @@ export function resolveConceptBackend(
   const command = getForgeCommand(concept, forgeConfig);
   if (command === null) return provider.toLowerCase();
 
-  const key = `${concept}\u0000${command}`;
+  // `provider` belongs in the key, not just `command`: two workspaces can
+  // resolve the same default script while naming different providers, and the
+  // path-like fallback below answers with the *provider*. Keying on the command
+  // alone would let the first caller's provider bleed into the second's.
+  const key = `${concept}\u0000${command}\u0000${provider}`;
   const cached = _backendCache.get(key);
   if (cached !== undefined) return cached;
 

--- a/packages/codev/src/lib/forge.ts
+++ b/packages/codev/src/lib/forge.ts
@@ -320,6 +320,12 @@ export interface ForgeFailure {
   message: string;
   /** Child exit code when Node reported one. */
   exitCode: number | null;
+  /**
+   * The forge provider this command resolved against ('github' when config
+   * names none). A rate limit is charged to one forge's account, so observers
+   * must be able to scope their response to it rather than to every provider.
+   */
+  provider: string;
 }
 
 type ForgeFailureListener = (failure: ForgeFailure) => void;
@@ -343,13 +349,14 @@ export function onForgeFailure(listener: ForgeFailureListener): () => void {
 }
 
 /** Build a ForgeFailure from a child_process rejection and publish it. */
-function notifyFailure(concept: string, err: unknown): void {
+function notifyFailure(concept: string, err: unknown, forgeConfig: ForgeConfig | null): void {
   if (failureListeners.size === 0) return;
   const e = err as { stderr?: unknown; code?: unknown; message?: unknown };
   const stderr = typeof e?.stderr === 'string' ? e.stderr.trim() : '';
   const message = stderr || (err instanceof Error ? err.message : String(err));
   const exitCode = typeof e?.code === 'number' ? e.code : null;
-  const failure: ForgeFailure = { concept, message, exitCode };
+  const provider = forgeConfig?.provider ?? 'github';
+  const failure: ForgeFailure = { concept, message, exitCode, provider };
   for (const listener of failureListeners) {
     try {
       listener(failure);
@@ -399,7 +406,7 @@ export async function executeForgeCommand(
     return parseOutput(stdout, options?.raw);
   } catch (err: unknown) {
     logDebug(concept, err);
-    notifyFailure(concept, err);
+    notifyFailure(concept, err, forgeConfig);
     return null;
   }
 }
@@ -437,7 +444,7 @@ export function executeForgeCommandSync(
     return parseOutput(stdout, options?.raw);
   } catch (err: unknown) {
     logDebug(concept, err, true);
-    notifyFailure(concept, err);
+    notifyFailure(concept, err, forgeConfig);
     return null;
   }
 }

--- a/packages/codev/src/lib/forge.ts
+++ b/packages/codev/src/lib/forge.ts
@@ -363,8 +363,12 @@ export function resolveConceptBackend(
   forgeConfig?: ForgeConfig | null,
 ): string {
   const provider = forgeConfig?.provider ?? DEFAULT_PROVIDER;
+  const providerBackend = (PROVIDER_EXECUTABLES[provider.toLowerCase()] ?? provider).toLowerCase();
   const command = getForgeCommand(concept, forgeConfig);
-  if (command === null) return provider.toLowerCase();
+  // A disabled concept still has to answer in the same namespace as every
+  // other: returning the bare provider name here was the one place the alias
+  // map was bypassed, so `github` could key separately from `gh`.
+  if (command === null) return providerBackend;
 
   // `provider` belongs in the key, not just `command`: two workspaces can
   // resolve the same default script while naming different providers, and the
@@ -402,10 +406,9 @@ export function resolveConceptBackend(
     // every concept a backend of its own and fragment one account across all
     // of them, arguments or no arguments.
     || basename === concept;
-  const fallback = PROVIDER_EXECUTABLES[provider.toLowerCase()] ?? provider;
   const backend = (
-    unknownTool || GENERIC_TRANSPORTS.has(basename!.toLowerCase()) ? fallback : basename!
-  ).toLowerCase();
+    unknownTool || GENERIC_TRANSPORTS.has(basename!.toLowerCase()) ? providerBackend : basename!.toLowerCase()
+  );
   _backendCache.set(key, backend);
   return backend;
 }

--- a/packages/codev/src/lib/forge.ts
+++ b/packages/codev/src/lib/forge.ts
@@ -36,6 +36,17 @@ function resolveScriptPath(provider: string, concept: string): string {
 /** Default maxBuffer for forge commands (10MB). Prevents truncation for large diffs. */
 const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024;
 
+/**
+ * The provider a concept resolves against when config names none, and the
+ * fallback backend key when a command's executable cannot be determined.
+ *
+ * Defined here rather than in forge-rate-limit.ts because that module imports
+ * this one; the reverse would be a cycle. It was briefly duplicated as a bare
+ * `'github'` literal in both, which would have keyed rate-limit writes and
+ * reads differently the moment either changed.
+ */
+export const DEFAULT_PROVIDER = 'github';
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -298,6 +309,42 @@ export function getForgeCommand(
   return getDefaultCommands()[concept] ?? null;
 }
 
+const _backendCache = new Map<string, string>();
+
+/**
+ * The backend a concept will actually run against: the resolved command's
+ * executable, lowercased. Falls back to the configured provider, then to
+ * `DEFAULT_PROVIDER`.
+ *
+ * This is the correct key for anything accounted per-forge (rate limits), and
+ * it is deliberately *not* the workspace's configured provider — see
+ * `ForgeFailure.backend`. Memoized because resolution reads the script's first
+ * substantive line off disk.
+ */
+export function resolveConceptBackend(
+  concept: string,
+  forgeConfig?: ForgeConfig | null,
+): string {
+  const provider = forgeConfig?.provider ?? DEFAULT_PROVIDER;
+  const command = getForgeCommand(concept, forgeConfig);
+  if (command === null) return provider.toLowerCase();
+
+  const key = `${concept}\u0000${command}`;
+  const cached = _backendCache.get(key);
+  if (cached !== undefined) return cached;
+
+  // `extractExecutable` returns the command verbatim when it cannot read the
+  // script — a missing or unreadable concept script yields its own path. Keying
+  // on that would give every concept a *different* backend and fragment the
+  // suspension across them, so fall back to the configured provider instead:
+  // less precise, but it keeps concepts that share an account sharing a key.
+  const executable = extractExecutable(command);
+  const looksLikePath = executable !== null && (executable.includes('/') || executable.endsWith('.sh'));
+  const backend = (looksLikePath || executable === null ? provider : executable).toLowerCase();
+  _backendCache.set(key, backend);
+  return backend;
+}
+
 /**
  * Check if a concept is explicitly disabled (set to null in config).
  */
@@ -321,11 +368,18 @@ export interface ForgeFailure {
   /** Child exit code when Node reported one. */
   exitCode: number | null;
   /**
-   * The forge provider this command resolved against ('github' when config
-   * names none). A rate limit is charged to one forge's account, so observers
-   * must be able to scope their response to it rather than to every provider.
+   * The **backend** this command actually ran against — the executable the
+   * concept resolved to (`gh`, `glab`, `tea`, …), lowercased, falling back to
+   * the configured provider name.
+   *
+   * The resolved backend, not the configured provider: a rate limit is charged
+   * to whatever account made the call, and providers are hybrid. A Linear
+   * workspace has no `pr-list` script of its own, so that concept falls through
+   * to the github default and spends *GitHub's* budget (spec 719). Keying on
+   * the workspace's configured provider would file that limit under `linear`
+   * and leave a real GitHub workspace to discover it all over again.
    */
-  provider: string;
+  backend: string;
 }
 
 type ForgeFailureListener = (failure: ForgeFailure) => void;
@@ -349,14 +403,13 @@ export function onForgeFailure(listener: ForgeFailureListener): () => void {
 }
 
 /** Build a ForgeFailure from a child_process rejection and publish it. */
-function notifyFailure(concept: string, err: unknown, forgeConfig: ForgeConfig | null): void {
+function notifyFailure(concept: string, err: unknown, backend: string): void {
   if (failureListeners.size === 0) return;
   const e = err as { stderr?: unknown; code?: unknown; message?: unknown };
   const stderr = typeof e?.stderr === 'string' ? e.stderr.trim() : '';
   const message = stderr || (err instanceof Error ? err.message : String(err));
   const exitCode = typeof e?.code === 'number' ? e.code : null;
-  const provider = forgeConfig?.provider ?? 'github';
-  const failure: ForgeFailure = { concept, message, exitCode, provider };
+  const failure: ForgeFailure = { concept, message, exitCode, backend };
   for (const listener of failureListeners) {
     try {
       listener(failure);
@@ -406,7 +459,7 @@ export async function executeForgeCommand(
     return parseOutput(stdout, options?.raw);
   } catch (err: unknown) {
     logDebug(concept, err);
-    notifyFailure(concept, err, forgeConfig);
+    notifyFailure(concept, err, resolveConceptBackend(concept, forgeConfig));
     return null;
   }
 }
@@ -444,7 +497,7 @@ export function executeForgeCommandSync(
     return parseOutput(stdout, options?.raw);
   } catch (err: unknown) {
     logDebug(concept, err, true);
-    notifyFailure(concept, err, forgeConfig);
+    notifyFailure(concept, err, resolveConceptBackend(concept, forgeConfig));
     return null;
   }
 }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -362,9 +362,14 @@ export interface OverviewData {
   /**
    * Issue 1645: ISO instant the rate-limit suspension lifts. Present only while
    * `forgeStatus === 'rate-limited'`, so the UI can say "retrying at 14:05"
-   * instead of leaving the user staring at an empty backlog. A human can end
-   * the wait early with `POST /api/overview/refresh`, which clears the
-   * suspension along with the cache.
+   * instead of leaving the user staring at an empty backlog.
+   *
+   * There is deliberately **no way to end the wait early**. The obvious
+   * candidate, `POST /api/overview/refresh`, is not a human signal: porch fires
+   * it after every mutating command, VSCode on every review-queue mutation, and
+   * cleanup too, so honouring it would reset the escalating backoff
+   * continuously in a busy workspace. The wait is bounded at 15 minutes, and is
+   * the forge's own reset instant whenever that could be read.
    */
   forgeResetAt?: string;
   /** Auto-detected GitHub login of the current user (via the user-identity forge concept). */

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -348,10 +348,12 @@ export interface OverviewData {
    * - `'ok'` — the forge answered.
    * - `'rate-limited'` — the forge's API budget is exhausted and Tower has
    *   **deliberately suspended** that provider's commands until `forgeResetAt`.
-   *   The lists come back **empty**, not stale — nothing is fetched at all
-   *   while suspended, because the budget is charged per account and shared
-   *   with every other tool on the machine, so retrying would only extend the
-   *   outage. This field is what tells the UI the emptiness is deliberate.
+   *   Nothing is fetched while suspended, because the budget is charged per
+   *   account and shared with every other tool on the machine, so retrying
+   *   would only extend the outage. A list whose cached copy is still within
+   *   its TTL is therefore served **stale**; one whose copy has expired or was
+   *   never fetched comes back **empty**. This field is what tells the UI that
+   *   either is deliberate rather than a bug.
    * - `'unavailable'` — the commands ran and failed for some other reason
    *   (`gh` missing, not authenticated, offline).
    *

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -341,6 +341,29 @@ export interface OverviewData {
    * `'forward'` (the setting's own default) when unreadable.
    */
   feedbackMode: 'forward' | 'queue';
+  /**
+   * Issue 1645: why the forge-backed sections (`pendingPRs`, `backlog`,
+   * `recentlyClosed`) may be empty.
+   *
+   * - `'ok'` — the forge answered.
+   * - `'rate-limited'` — the account's API budget is exhausted and Tower has
+   *   **deliberately suspended** all forge commands until `forgeResetAt`. The
+   *   lists are stale on purpose; retrying would only extend the outage, since
+   *   the budget is charged per account and shared with every other tool on the
+   *   machine.
+   * - `'unavailable'` — the commands ran and failed for some other reason
+   *   (`gh` missing, not authenticated, offline).
+   *
+   * Distinct from `errors`, which carries the human-readable per-section
+   * message. Never `undefined`, so consumers don't branch.
+   */
+  forgeStatus: 'ok' | 'rate-limited' | 'unavailable';
+  /**
+   * Issue 1645: ISO instant the rate-limit suspension lifts. Present only while
+   * `forgeStatus === 'rate-limited'`, so the UI can say "retrying at 14:05"
+   * instead of leaving the user staring at an empty backlog.
+   */
+  forgeResetAt?: string;
   /** Auto-detected GitHub login of the current user (via the user-identity forge concept). */
   currentUser?: string;
   errors?: { prs?: string; issues?: string };

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -346,11 +346,12 @@ export interface OverviewData {
    * `recentlyClosed`) may be empty.
    *
    * - `'ok'` — the forge answered.
-   * - `'rate-limited'` — the account's API budget is exhausted and Tower has
-   *   **deliberately suspended** all forge commands until `forgeResetAt`. The
-   *   lists are stale on purpose; retrying would only extend the outage, since
-   *   the budget is charged per account and shared with every other tool on the
-   *   machine.
+   * - `'rate-limited'` — the forge's API budget is exhausted and Tower has
+   *   **deliberately suspended** that provider's commands until `forgeResetAt`.
+   *   The lists come back **empty**, not stale — nothing is fetched at all
+   *   while suspended, because the budget is charged per account and shared
+   *   with every other tool on the machine, so retrying would only extend the
+   *   outage. This field is what tells the UI the emptiness is deliberate.
    * - `'unavailable'` — the commands ran and failed for some other reason
    *   (`gh` missing, not authenticated, offline).
    *
@@ -361,7 +362,9 @@ export interface OverviewData {
   /**
    * Issue 1645: ISO instant the rate-limit suspension lifts. Present only while
    * `forgeStatus === 'rate-limited'`, so the UI can say "retrying at 14:05"
-   * instead of leaving the user staring at an empty backlog.
+   * instead of leaving the user staring at an empty backlog. A human can end
+   * the wait early with `POST /api/overview/refresh`, which clears the
+   * suspension along with the cache.
    */
   forgeResetAt?: string;
   /** Auto-detected GitHub login of the current user (via the user-identity forge concept). */


### PR DESCRIPTION
Fixes #1645

## Problem

Every `gh` GraphQL call on this machine — `gh pr view/list/checks`, `gh issue view`,
`consult`'s PR search, `afx spawn`'s issue fetch — failed with
`API rate limit already exceeded` for most of every hour, while `gh api rate_limit`
misleadingly reported `5000/5000`. Builders could not run CMAP PR reviews, the architect
could not merge, and the dashboard "timed out" waiting on hanging `gh` spawns.

**Measured on the production Tower, read-only** (`pgrep -P <tower-pid>` at 2 Hz for
10 minutes): **1,515 distinct `gh` processes → ≈9,090/hour.** Also observed live: the
GraphQL budget was re-exhausted within seconds of every hourly reset, so
`X-Ratelimit-Reset` stayed pinned in the past with `Used: 5000`.

## Root cause

Three parts, all confirmed by tracing the failure path rather than by inspection:

1. **Failures were never cached.** `servers/overview.ts` — all four cache helpers ended
   with `if (data !== null) cache.set(...)`. `null` means failure, so a failing workspace
   re-spawned all four forge commands on *every* request. The 30 s TTL throttled only
   successes.

2. **The poll is 2.5 s, not 30 s.** `apps/web/src/hooks/useOverview.ts` —
   `POLL_INTERVAL_MS = 2500`. So the failing steady state was
   `4 gh × 1440 polls/hour = 5,760 spawns/hour per open dashboard`. This is the amplifier
   that turned a transient 429 into a permanent one.

3. **No rate-limit awareness anywhere.** `lib/forge.ts` — `executeForgeCommand` caught
   everything and returned `null`, discarding stderr and the exit code, so nothing
   downstream could tell "gh is not installed" from "the budget is gone".

Found while implementing, not in the issue: **`pr-list.sh` ran `gh` straight into a `jq`
pipe**, which handed the caller *jq's* exit status. A rate-limited `gh` therefore looked
like a successful empty result and its stderr — the only place the rate limit is named —
was discarded. That is why the error never reached any caller for the most frequently
spawned of the four commands.

There is no Tower-side background overview poller; every fetch is demand-driven from
`/api/overview`. Issue item 3's "only refresh watched workspaces" was therefore already
true — the missing pieces were the TTL and the negative cache.

## Fix

| Change | File |
|---|---|
| Negative caching with a 60 s → 15 min doubling backoff | `servers/overview.ts` |
| Positive TTL 30 s → 180 s; 600 s for the two 24 h `--search` windows | `servers/overview-budget.ts` |
| Rate-limit detection + process-global suspension until reset | `lib/forge-rate-limit.ts` (new) |
| `onForgeFailure` hook publishing the stderr/exit code that was discarded | `lib/forge.ts` |
| `rate-limit` forge concept (`gh api rate_limit --jq .resources.graphql`) | `scripts/forge/github/rate-limit.sh` (new) |
| `gh` into a variable, not into the `jq` pipe, so the exit code propagates | `scripts/forge/github/pr-list.sh` |
| `forgeStatus` + `forgeResetAt` on `OverviewData` | `packages/types/src/api.ts` |
| GraphQL budget + projected hourly spend, warning above 50 % | `commands/doctor.ts` |

250 lines of production code added, 58 removed (excluding comments, blanks and tests).

## What the 3-way review caught

Five CMAP rounds. Rounds 2-4 each found a real bug in code added to satisfy the round
before, so the loop ran until a round came back clean rather than until the previous
round's notes were addressed. The original defect — uncached failures re-spawning `gh` on
a 2.5 s poll — was fixed in the first commit and never regressed; everything below was in
the hardening around it.

### The one that would have quietly undone the fix in production

`invalidate()` cleared the rate-limit suspension, justified by a code comment asserting
that *"invalidate() is only reached from `POST /api/overview/refresh`, never from the 2.5 s
poll."* **That comment was false.** `refreshOverview()` is called automatically after every
mutating porch command (`commands/porch/index.ts`), on every VSCode review-queue mutation
(`review-queue/overview-nudge.ts`) and by `cleanup.ts`. In a workspace with a dozen
builders that fires constantly — the suspension would have been lifted and the escalating
backoff reset to 60 s over and over, in exactly the busy workspace this fix is for, with
every test green.

It was added to satisfy an earlier review note that a suspension had no manual escape. The
suspension is time-bounded anyway (≤ 15 min, or the probe's true reset), so it is no longer
cleared there, and the test asserts the suspension **survives** a refresh.

### A concurrent REST success was clearing a genuine GraphQL suspension The five forge
fetches are dispatched together, and `user-identity` is REST (`gh api user`) — charged to
a *different* budget, so it keeps succeeding while its GraphQL siblings are being refused.
Its `noteForgeSuccess()` therefore wiped the suspension the GraphQL failures had just set,
and the very first failing refresh would have un-suspended itself.

The five forge fetches are dispatched together, and `user-identity` is REST (`gh api
user`) — charged to a *different* budget, so it keeps succeeding while its GraphQL
siblings are refused.

**My own end-to-end test could not see it**, because the fake `gh` failed for every
subcommand, `api user` included — the one shape production never takes. The fake is now
production-shaped (`api user` and `api rate_limit` succeed), a success only clears a
suspension if it was *dispatched after* that suspension began, and the guard is pinned by
a unit test verified to fail without it.

### The rest

- **No in-flight coalescing.** Nothing was cached until a fetch *resolved*, so a `gh` call
  slower than the 2.5 s poll let every poll and every extra client start another duplicate
  batch — very likely a real part of the measured 180 spawns/60 s. Fixed with single-flight
  per concept per workspace.
- **Suspension was provider-blind**, then **provider-keyed rather than backend-keyed.**
  Providers are hybrid: a Linear workspace's `pr-list` falls through to `gh` and spends
  GitHub's budget (spec 719). Now keyed by resolved backend, per `<workspace>:<concept>`.
- **`codev doctor` compared calls against a points budget** — 676 read as 14 % when the
  real figure is 41 %, enough to suppress its own warning.
- **The backoff escalated per failed command, not per window**, so four parallel failures
  jumped 60 s straight to ~8 min on the first refresh.
- **Backend-cache key omitted the provider**, so two workspaces resolving the same default
  script under different providers shared the first one's answer.
- **Absolute executable paths fragmented the suspension** (`/usr/local/bin/gh` vs `gh`),
  and the unreadable-script fallback keyed under `github` while a healthy resolve keyed
  under `gh` — two suspension states for one account.
- **Stale memoization and in-flight join across an invalidate**, so an edited concept
  script needed a restart and a post-refresh caller could be handed pre-refresh data.
- **Chaining bounded concurrency but not spend.** Six invalidations still ran six commands,
  serially — the same budget the fan-out would have cost. porch fires invalidate after
  *every* mutating command, so this was constant in a busy workspace. A burst of any size
  now costs at most two commands, and the test asserts total calls rather than concurrency,
  which is what hid it.
- **A queued fetch never re-checked the suspension** after waiting up to 30 s behind the
  command ahead of it, and an uncapped wait let one hung `gh` wedge a concept.
- **An orphaned promise rejection would have crashed Tower.** `void p.finally(...)` leaves a
  derived promise nobody awaits; `executeForgeCommand` resolves forge config outside its own
  try and `loadConfig` fails fast, so one malformed `.codev/config.json` would have reached
  tower-server's `unhandledRejection` handler and its `process.exit(1)`.

## Eight shipped forge scripts misresolved their own CLI (#1455)

Not adjacent — **this determines rate-limit keying**, so it is correctness for this fix.

`extractExecutable` infers a concept's CLI from the first substantive line of its script.
For 7 Linear concepts that line is the API-key guard, so they resolved to **`echo`**; for
gitlab's `issue-search` it is a `case` statement, so it resolved to **`case`**. Two
consequences, one old and one new:

- **Old (#1455, live in shipped code):** `codev doctor` has been reporting `echo` as
  Linear's forge executable, so a missing `curl` went unreported — precisely the silent
  success #1455 exists to prevent.
- **New (this PR):** suspension is keyed by resolved backend, so those concepts' rate
  limits would have been filed under `echo` rather than alongside the rest of the account.

Fixed with the `# forge-executable:` declarations that mechanism already provides, plus a
test asserting **no built-in provider resolves to a shell builtin** — so this cannot creep
back for a fourth provider.

The same heuristic bit this PR's own `pr-list.sh`: capturing `gh` into a variable so its
exit status propagates made the first substantive line an assignment, and the concept
started resolving to `printf`. Same declaration, same test.

## Testing

Full suite: **5,798 passed / 48 skipped, 0 failed.** Build green.

**Regression tests** (`overview.test.ts`, `forge-rate-limit.test.ts`) — 43 new cases
covering negative caching, backoff doubling and its cap, per-window (not per-command)
escalation, the dispatch-time success guard, REST calls not counting as recovery,
single-flight coalescing across an invalidate, suspension survival across a refresh,
`forgeStatus` transitions, the message wording, the two TTLs, the points projection,
backend keying across providers/transports/path shapes, and the failure hook.

**Every behavioural guard was verified failing with its own fix reverted**, individually:

| guard | observed with the fix reverted |
|---|---|
| negative caching | spawn count returns to 5 per poll (200 for 40 polls) |
| dispatch-time success guard | `ignores a success from a command dispatched BEFORE the suspension` fails |
| backend cache key includes provider | `expected 'gitlab' not to be 'gitlab'` |
| REST identity not counted as recovery | `expected 60000 to be greater than 60000` |
| stale flight cannot unregister the live one | `called 2 times, but got 3` |
| burst of invalidations costs at most 2 commands | `expected 2, got 6` |
| queued fetch re-checks the suspension | `expected 1, got 2` |
| fetcher rejection is not orphaned | `expected [ Error: malformed .codev/config.json ] to deeply equal []` |

Each check was a scripted revert → run → restore, with a clean `git diff` against HEAD
confirmed afterwards.

> **A note on review hygiene.** Partway through this PR a CMAP reviewer lane was found
> editing the worktree directly — reverting fixes to test their vacuity, its `allowedTools`
> list defeated by `bypassPermissions`. Its instinct was right, but a reviewer mutating the
> code under test is not. From that point on: commit before running consult, and after each
> lane `git status` / `git diff` and restore only reviewer-touched paths. Every verification
> in the table above was produced by a scripted revert→restore of my own and re-confirmed
> against HEAD.

**Five of this PR's own tests were vacuous or asserted harness artifacts** and were caught
only by that check — including one whose fix turned out to be dead code (the generation guard
already made it unreachable); both were removed. The pattern was consistent: a test written to
satisfy a review finding gets written to pass. The check is therefore unconditional here, not
reserved for tests that look risky.

That check is not ceremony. **Two regression tests added mid-review passed with their own
fixes reverted** — the escalation test never re-ran the identity call (its 1 h TTL kept it
cached) and the coalescing test had every caller join before the stale cleanup fired. Both
were rewritten; the table above is the re-verification. Green tests were a bad signal
throughout this PR, twice over.

**End-to-end, real forge path, no Tower started.** The real `OverviewCache` driven for
40 polls against a fake `gh` on `PATH` that always returns the GraphQL rate-limit error:

| | `gh` invocations for 40 polls |
|---|---|
| pre-fix | **200** — 5 every poll, indefinitely |
| with the fix | **5** — one batch, then zero until reset |

The payload came back `forgeStatus=rate-limited` with a populated `forgeResetAt`. That
is acceptance criterion (i), demonstrated. The fake `gh` is production-shaped: REST
`api user` and `api rate_limit` succeed while every GraphQL command is refused.

## Budget

Healthy steady state per *watched* workspace (a workspace nobody is looking at costs
zero — fetches are demand-driven):

```
2 calls / 180 s = 40/h   (pr-list, issue-list)
2 calls / 600 s = 12/h   (recently-closed, recently-merged)
                = 52/h   vs ≈9,090/h measured before
```

**These are idle-state figures, and the PR reports the ceiling too.** `POST /api/overview/refresh` bypasses
the TTLs by design, and it is fired *automatically* after every mutating porch command,
every VSCode review-queue mutation and every cleanup. So in a busy workspace the
invalidation rate — not the TTL — was governing spend. This PR adds a **60 s debounce** on
invalidation-driven refreshes to put a ceiling back on; scoping those invalidations to
events that can actually have changed the forge lists is #1650.

Under **constant churn**, the busiest single workspace:

```
60 honoured invalidations/h x 2 open lists = 120 calls/h
2 search calls / 600 s                     =  12 calls/h
                                           = 132 calls/h  (~2.5x the 52 idle)
132 calls/h @ ~3 points/call               = 396 points/h (~8% of 5,000/h)
```

An invalidation drops **only the two open lists** — which is what a refresh means. An
earlier revision of this PR dropped all five caches, which let the 60 s debounce override a
600 s search TTL and a 3600 s identity TTL: the 24 h retrospective windows were being forced
ten times more often than their own TTL, measured at 305 calls/h/workspace while
`codev doctor` reported 52 and showed green. Both the behaviour and the check are fixed —
doctor now reports the **range** and warns on the **ceiling**.

A realistic mix — one workspace churning, a few idle ones watched — stays well inside the
budget. And if it ever does not, the rate-limit suspension is the backstop: spend goes to
zero until the forge's own reset, which is the property this PR exists to guarantee.

Cost per call is above 1 GraphQL point — `issue-list` is `--limit 200` (2 pages) and the
two searches are `--limit 1000` — so this budgets **~3 points/call**. The exact figure
could not be measured: the account's GraphQL budget sat at `Used: 5000, Remaining: 0` for
the whole session, re-exhausted within seconds of every hourly reset by the very bug this
fixes.

| positive TTL | per watched workspace | 13 workspaces | points/h @3 | share of 5,000/h |
|---|---|---|---|---|
| 30 s (before) | 252/h | 3,276/h | ~9,828 | 197 % — the bug |
| 120 s | 72/h | 936/h | ~2,808 | 56 % |
| **180 s (shipped)** | **52/h** | **676/h** | **~2,028** | **41 %** |

180 s is the architect's call: a PR/issue list up to 3 minutes stale is fine, because
everything that actually moves — builder phase, gates, progress — is filesystem-derived
and still refreshes on every 2.5 s poll, and `POST /api/overview/refresh` bypasses the
TTL after a user action.

## Scope and acceptance

Issue item 4 — collapse the three calls into one `gh api graphql` query — is
**deliberately out of this PR** (architect decision). It needs a new forge concept, a
script per provider, contract types, doctor wiring and fallbacks for gitlab/gitea/linear;
it changes the forge abstraction shipped to adopters. Filed as #1647.

The issue's original "≤ 60 `gh`/hour across 13 workspaces" was written against the design
item 4 delivers, so it now belongs to #1647. This PR's acceptance, amended on the issue:

1. **Zero further spawns while rate-limited, until reset** — demonstrated above.
2. **≤ 50 % of the GraphQL budget at 13 watched workspaces** — 41 % at the shipped TTLs.
3. **Single-flight**, so a slow `gh` can never fan out across polls or clients.

Two gaps are deliberately deferred, both architect decisions:

- **#1647** — collapse the four per-workspace calls into one GraphQL query, which is what
  the issue's original ≤ 60/h-across-13-workspaces number depends on.
- **#1651** — the remaining forge concept scripts that pipe a CLI into `jq` and so swallow
  its exit status. Those forges get negative caching but can never trigger a suspension. The
  overview-path ones are fixed here; the Linear scripts nest `$(jq -n …)` inside curl's `-d`
  argument and need care with quoting, so they are filed rather than rewritten unverified.
- **#1650** — scope invalidation to forge-visible events, so the TTLs above become true
  steady-state numbers instead of an idle floor. The 60 s debounce here is a cap on the
  symptom.
- **#1648** — let a *human* dashboard refresh clear a suspension early. Removing the
  suspension-clear from `invalidate()` was necessary (porch, VSCode and cleanup all fire
  that route automatically), and it left no early escape. The wait is bounded at 15 minutes
  or the forge's own reset instant, which is acceptable in the meantime.

## Correction to the issue text

The issue suggests moving the two `--search` calls to REST `gh api search/issues` for
"a separate 5,000 budget". That would not help: the GitHub **search** resource is
**30 requests per minute**, not 5,000 per hour — measured on this account,
`{"limit":30,"remaining":30}`. Collapsing into one GraphQL query is the right direction;
REST search is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HrpRHxzFGiBM4YoycZN8i
