### PR TITLE
Fix #1645: stop the overview cache from burning the GitHub GraphQL quota

### DIFF
--- a/apps/web/src/components/WorkView.tsx
+++ b/apps/web/src/components/WorkView.tsx
@@ -112,6 +112,13 @@ export function WorkView({ state, onRefresh, onSelectTab }: WorkViewProps) {
           onSelectTab={id => onSelectTab?.(id)}
         />
 
+        {overview?.forgeStatus === 'rate-limited' && (
+          <p className="work-unavailable">
+            Forge rate limited — PRs, backlog and recently closed are stale until{' '}
+            {overview.forgeResetAt ? new Date(overview.forgeResetAt).toLocaleTimeString() : 'the budget resets'}
+          </p>
+        )}
+
         {/* Needs Attention */}
         <section className="work-section">
           <h3 className="work-section-title">Needs Attention</h3>

--- a/apps/web/src/components/WorkView.tsx
+++ b/apps/web/src/components/WorkView.tsx
@@ -114,7 +114,7 @@ export function WorkView({ state, onRefresh, onSelectTab }: WorkViewProps) {
 
         {overview?.forgeStatus === 'rate-limited' && (
           <p className="work-unavailable">
-            Forge rate limited — PRs, backlog and recently closed are stale until{' '}
+            Forge rate limited — PRs, backlog and recently closed may be stale until{' '}
             {overview.forgeResetAt ? new Date(overview.forgeResetAt).toLocaleTimeString() : 'the budget resets'}
           </p>
         )}

--- a/codev/projects/bugfix-1645-tower-overview-cache-burns-the/status.yaml
+++ b/codev/projects/bugfix-1645-tower-overview-cache-burns-the/status.yaml
@@ -7,8 +7,10 @@ current_plan_phase: null
 gates:
   pr:
     status: pending
+    requested_at: '2026-09-08T08:39:17.850Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-08T08:02:34.019Z'
-updated_at: '2026-09-08T08:30:45.538Z'
+updated_at: '2026-09-08T08:39:17.852Z'
+pr_ready_for_human: true

--- a/codev/projects/bugfix-1645-tower-overview-cache-burns-the/status.yaml
+++ b/codev/projects/bugfix-1645-tower-overview-cache-burns-the/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1645
 title: tower-overview-cache-burns-the
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-08T08:02:34.019Z'
-updated_at: '2026-09-08T08:02:34.021Z'
+updated_at: '2026-09-08T08:09:59.820Z'

--- a/codev/projects/bugfix-1645-tower-overview-cache-burns-the/status.yaml
+++ b/codev/projects/bugfix-1645-tower-overview-cache-burns-the/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1645
 title: tower-overview-cache-burns-the
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-08T08:02:34.019Z'
-updated_at: '2026-09-08T08:09:59.820Z'
+updated_at: '2026-09-08T08:30:45.538Z'

--- a/codev/projects/bugfix-1645-tower-overview-cache-burns-the/status.yaml
+++ b/codev/projects/bugfix-1645-tower-overview-cache-burns-the/status.yaml
@@ -12,5 +12,10 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-08T08:02:34.019Z'
-updated_at: '2026-09-08T08:39:17.852Z'
+updated_at: '2026-09-08T08:39:30.355Z'
 pr_ready_for_human: true
+pr_history:
+  - phase: pr
+    pr_number: 1652
+    branch: builder/bugfix-1645
+    created_at: '2026-09-08T08:39:30.354Z'

--- a/codev/projects/bugfix-1645-tower-overview-cache-burns-the/status.yaml
+++ b/codev/projects/bugfix-1645-tower-overview-cache-burns-the/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1645
+title: tower-overview-cache-burns-the
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-09-08T08:02:34.019Z'
+updated_at: '2026-09-08T08:02:34.021Z'

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -1,0 +1,42 @@
+# bugfix-1645 — builder thread (rebuild lane)
+
+Issue #1645: Tower's OverviewCache burns the whole GitHub GraphQL quota.
+Spec = architect's rebuild prescription on the issue (comment 5581422713) + the
+46-item pitfall list (comment 5581455959). PR #1646 is superseded; not building on it.
+
+## 2026-09-08 — investigate
+
+### Reproduced (read-only against the production Tower, pid 21829)
+- Sampled `gh` descendants of the Tower pid at ~1 Hz: 30 distinct spawns in ~14 s
+  (≈ 2/s ≈ 7,000/h). Every spawn is one of the four overview concepts
+  (`gh issue list --limit 200`, `gh issue list --state closed --search closed:>…`,
+  `gh pr list --state merged --search merged:>…`, `gh pr list --json …`).
+- Real GraphQL budget, from `gh api graphql -i` headers: `X-Ratelimit-Used: 1420,
+  Remaining: 3580` five minutes into the window (reset 1788858149). `gh api rate_limit
+  --jq .resources.graphql` reported `used: 0, remaining: 5000` at the same instant —
+  confirms the "misleading REST probe" note; a healthy reading from it is worthless.
+- The dashboard polls `/api/overview` every 2.5 s (`apps/web/src/hooks/useOverview.ts`),
+  the VS Code sidebar every 60 s; the 30 s TTL governs spend, the poll governs the
+  failure-amplifier.
+
+### Root cause (packages/codev)
+1. `src/agent-farm/servers/overview.ts` `OverviewCache.fetch*Cached`: `if (data !== null) cache.set(...)`
+   — failures are never cached, so while gh fails every poll re-spawns all four commands.
+2. `src/lib/forge.ts` `executeForgeCommand`: every failure collapses to `null`; stderr/exit
+   code never reach the caller, so nothing can tell "rate limited" from "gh missing".
+3. No single-flight: concurrent polls (2.5 s dashboard + VS Code + cloud) each start their
+   own batch while a previous one is in flight.
+4. `invalidate()` (called by porch after every mutating command, by VS Code, by cleanup)
+   clears every cache for every workspace, so churn bypasses the TTL entirely.
+5. TTL 30 s × 4 concepts × 13 workspaces ≈ 6,240 calls/h even with everything healthy.
+
+### Measured GraphQL cost (for the record; collapse is #1647, out of scope)
+A single combined GraphQL query (open PRs + open issues + closed-24h search + merged-24h
+search, first:100 each) costs **4 points** per `rateLimit.cost`. `{owner}`/`{repo}`
+placeholders work in `gh api graphql -F` and inside REST `search/issues?q=`.
+
+### Scope decision
+Frozen to the architect's six items (negative cache+backoff, per-backend suspension,
+single-flight w/ generation tag, TTLs 180/600/3600 + list-only debounced invalidate,
+forgeStatus/forgeResetAt payload, `# forge-executable:` on the 8 builtin-resolving
+scripts). Doctor check, #1647, #1648, #1650 are out. Estimated production diff ≈ 300 lines.

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -40,3 +40,38 @@ Frozen to the architect's six items (negative cache+backoff, per-backend suspens
 single-flight w/ generation tag, TTLs 180/600/3600 + list-only debounced invalidate,
 forgeStatus/forgeResetAt payload, `# forge-executable:` on the 8 builtin-resolving
 scripts). Doctor check, #1647, #1648, #1650 are out. Estimated production diff ≈ 300 lines.
+
+## 2026-09-08 — fix (commit 92b5881f8, pushed)
+
+Shape, in dependency order (all inside the architect's six-item scope):
+- `lib/forge.ts`: `executeForgeCommandDetailed` keeps `{stderr, exitCode}` and never rejects
+  (config resolution moved inside the try — a malformed `.codev/config.json` used to be
+  reachable as an unhandled rejection, which tower-server turns into `process.exit(1)`).
+  `resolveForgeBackend` keys a concept by its resolved executable basename (`gh`), falling
+  back to the provider for generic transports (`curl`) and custom script paths.
+- `lib/forge-rate-limit.ts` (new): `ForgeRateLimiter` — per-budget suspension, 15 min
+  fallback, one advisory `gh api rate_limit` probe per fresh suspension (trusted only when
+  it reports `remaining === 0`), strict-`>` success clearing. Budget key: `gh` for the four
+  lists, `gh:rest` for `user-identity`/`auth-status`.
+- `servers/overview.ts`: one `cachedFetch` path — TTL 180/600/3600 s, negative entries with
+  a per-`<workspace>:<budget>` window (60 s doubling to 15 min, once per elapsed window),
+  suspension gate before any spawn, single-flight per `<workspace>:<concept>` with an
+  identity-checked cleanup, `invalidate()` = epoch stamp honoured by positive open-list
+  entries only, debounced 60 s per entry (hence per workspace). Payload gains
+  `forgeStatus` + `forgeResetAt`; error text names the real backend.
+- Scripts: `github/pr-list` no longer pipes gh into jq (POSIX sh has no pipefail);
+  `# forge-executable:` on gitlab/issue-search + the 7 linear scripts.
+- Dashboard: WorkView shows a rate-limited banner with the reset time.
+
+Surprise caught by my own Linear pitfall test: a *success* from the same batch that
+triggered the suspension (recently-merged succeeded while pr-list was rate-limited)
+cleared it, because `startedAt <= dispatchedAt` was true in the same millisecond. Pitfall
+B10 in the list is exactly this; comparison is now strict `>`.
+
+Production diff: 448+/125− over 17 files (overview.ts 163+/91−, forge-rate-limit.ts 105,
+forge.ts 76+/11−, github.ts 69+/18−). Tests: 17 new (10 cache-level pitfall tests, 6
+limiter unit tests, 1 real-`gh`-on-PATH harness) + 5 forge tests, 7 existing tests
+re-pinned to the new TTL/debounce semantics with an injected clock.
+
+Full suite first run: 67 failures in 12 files, all "embedded skeleton not found" — the
+worktree had no `dist/` (skeleton bundle). Rebuilding the package and re-running.

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -75,3 +75,20 @@ re-pinned to the new TTL/debounce semantics with an injected clock.
 
 Full suite first run: 67 failures in 12 files, all "embedded skeleton not found" — the
 worktree had no `dist/` (skeleton bundle). Rebuilding the package and re-running.
+
+### Verification (fix phase close)
+- Full suite after `pnpm --filter @cluesmith/codev build`: 288 files / 5767 tests passed,
+  48 skipped, 0 failed. (The earlier 67 failures were the unbuilt worktree: embedded
+  skeleton missing from `dist/`.) `tsc --noEmit` clean for packages/codev and apps/web.
+- Revert-based vacuity check (HEAD committed + pushed first; each guard patched in place,
+  test run, file restored from HEAD, tree confirmed clean): 16 guards → 16 RED. Table in the
+  PR body. One design item has no reachable red state: the identity check on single-flight
+  cleanup (`inflight.get(key) === flight`) is defensive only — nothing in this design can
+  register a newer flight while an older one is still in the map, because invalidate()
+  never touches `inflight`. Kept as a two-line guard; stated, not faked.
+- Dashboard banner rendered in Chromium via Playwright against the vite dev server on
+  :5199 with `/api/**` intercepted (overview fixture `forgeStatus: 'rate-limited'`), so no
+  request reached the live Tower. Banner text and the per-section messages visible.
+- `gh api rate_limit` misreport confirmed on this account during the investigation:
+  REST said `used: 0` while `gh api graphql -i` headers said `Used: 1420`. The probe is
+  therefore advisory (trusted only on `remaining === 0`), exactly as prescribed.

--- a/codev/state/bugfix-1645_thread.md
+++ b/codev/state/bugfix-1645_thread.md
@@ -92,3 +92,17 @@ worktree had no `dist/` (skeleton bundle). Rebuilding the package and re-running
 - `gh api rate_limit` misreport confirmed on this account during the investigation:
   REST said `used: 0` while `gh api graphql -i` headers said `Used: 1420`. The probe is
   therefore advisory (trusted only on `remaining === 0`), exactly as prescribed.
+
+## 2026-09-08 — pr phase
+
+PR #1652 opened via REST (`gh api repos/…/pulls`): the `pr-create` concept failed on the
+exhausted GraphQL bucket — the bug itself. Same for CMAP: `consult --type pr` resolves the
+PR through `pr-search` (`gh pr list --search`, GraphQL) and `pr-view`/`pr-diff`, so all
+three lanes first returned "No PR found". Re-ran them with a REST-only `gh` shim on PATH
+(scratchpad only, nothing committed) answering `pr list/view/diff` from `gh api`.
+
+CMAP round 1: gemini APPROVE, codex APPROVE, claude APPROVE. Tree clean after every lane.
+Claude's non-blocking notes: banner copy over-claimed staleness (fixed: "may be stale");
+freshness trade-off (lists 180 s, searches 600 s never invalidated) wants an architect ack;
+`isRateLimitError` doesn't match the abuse-detection 403 (falls to backoff — acceptable);
+pre-existing missing `Array.isArray` before `prs.map` (same on main; follow-up material).

--- a/packages/codev/scripts/forge/github/pr-list.sh
+++ b/packages/codev/scripts/forge/github/pr-list.sh
@@ -7,5 +7,9 @@
 # as objects (users carry `login`; teams carry `slug`/`name` and no `login`), so
 # `.login // empty` keeps user reviewers and drops team reviewers — matching the
 # `reviewRequests: string[]` contract in PrListItem (forge-contracts.ts).
-exec gh pr list --json number,title,url,reviewDecision,body,createdAt,author,reviewRequests,isDraft \
-  | jq '[.[] | .reviewRequests = [.reviewRequests[].login // empty]]'
+#
+# Not `gh … | jq`: POSIX sh has no pipefail, so the caller would see jq's exit
+# status and a rate-limited gh would look like a successful empty list (#1645).
+# forge-executable: gh
+out="$(gh pr list --json number,title,url,reviewDecision,body,createdAt,author,reviewRequests,isDraft)" || exit 1
+printf '%s' "$out" | jq '[.[] | .reviewRequests = [.reviewRequests[].login // empty]]'

--- a/packages/codev/scripts/forge/gitlab/issue-search.sh
+++ b/packages/codev/scripts/forge/gitlab/issue-search.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Forge concept: issue-search (GitLab via glab CLI)
+# forge-executable: glab
 #
 # ⚠️ UNVERIFIED — mirrors gitlab/issue-list.sh (raw `glab ... --output json`,
 #    no field normalization) plus a state flag and a `body` field surfaced from

--- a/packages/codev/scripts/forge/linear/auth-status.sh
+++ b/packages/codev/scripts/forge/linear/auth-status.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Forge concept: auth-status (Linear via GraphQL API)
+# forge-executable: curl
 # Output: exit code (0 = authenticated)
 set -e
 

--- a/packages/codev/scripts/forge/linear/issue-comment.sh
+++ b/packages/codev/scripts/forge/linear/issue-comment.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Forge concept: issue-comment (Linear via GraphQL API)
+# forge-executable: curl
 # Input: CODEV_ISSUE_ID, CODEV_COMMENT_BODY
 # Output: exit code only
 set -e

--- a/packages/codev/scripts/forge/linear/issue-list.sh
+++ b/packages/codev/scripts/forge/linear/issue-list.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Forge concept: issue-list (Linear via GraphQL API)
+# forge-executable: curl
 # Input: CODEV_LINEAR_TEAM (team key, e.g. "ENG")
 # Output: JSON [{number, title, url, labels, createdAt, author, assignees}]
 set -e

--- a/packages/codev/scripts/forge/linear/issue-search.sh
+++ b/packages/codev/scripts/forge/linear/issue-search.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Forge concept: issue-search (Linear via GraphQL API)
+# forge-executable: curl
 #
 # ⚠️ UNVERIFIED — mirrors linear/issue-list.sh with `description` added to the
 #    query (mapped to `body`) and the state filter parameterized. No Linear

--- a/packages/codev/scripts/forge/linear/issue-view.sh
+++ b/packages/codev/scripts/forge/linear/issue-view.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Forge concept: issue-view (Linear via GraphQL API)
+# forge-executable: curl
 # Input: CODEV_ISSUE_ID (e.g. "ENG-123")
 # Output: JSON {title, body, state, url, author, createdAt, assignees, labels, milestone, comments[]}
 #

--- a/packages/codev/scripts/forge/linear/recently-closed.sh
+++ b/packages/codev/scripts/forge/linear/recently-closed.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Forge concept: recently-closed (Linear via GraphQL API)
+# forge-executable: curl
 # Input: CODEV_LINEAR_TEAM, CODEV_SINCE_DATE (optional, ISO date)
 # Output: JSON [{number, title, url, labels, createdAt, closedAt}]
 set -e

--- a/packages/codev/scripts/forge/linear/user-identity.sh
+++ b/packages/codev/scripts/forge/linear/user-identity.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Forge concept: user-identity (Linear via GraphQL API)
+# forge-executable: curl
 # Output: plain text display name
 set -e
 

--- a/packages/codev/src/__tests__/forge-rate-limit.test.ts
+++ b/packages/codev/src/__tests__/forge-rate-limit.test.ts
@@ -1,0 +1,62 @@
+/**
+ * #1645: ForgeRateLimiter — what may set and clear a per-budget suspension.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ForgeRateLimiter, budgetKeyFor, isRateLimitError, SUSPENSION_FALLBACK_MS } from '../lib/forge-rate-limit.js';
+
+const GRAPHQL = 'gh: API rate limit already exceeded for user ID 1';
+
+describe('ForgeRateLimiter (#1645)', () => {
+  it('recognises GitHub rate-limit errors and nothing else', () => {
+    expect(isRateLimitError(GRAPHQL)).toBe(true);
+    expect(isRateLimitError('{"errors":[{"type":"RATE_LIMITED"}]}')).toBe(true);
+    expect(isRateLimitError('You have exceeded a secondary rate limit')).toBe(true);
+    expect(isRateLimitError('no git remotes found')).toBe(false);
+    expect(isRateLimitError('gh: command not found')).toBe(false);
+  });
+
+  it('keys gh REST concepts on their own budget; other backends are one budget', () => {
+    expect(budgetKeyFor('gh', 'user-identity')).toBe('gh:rest');
+    expect(budgetKeyFor('GH', 'pr-list')).toBe('gh');
+    expect(budgetKeyFor('linear', 'user-identity')).toBe('linear');
+  });
+
+  it('suspends only on a rate-limit error, for the fallback window, without a probe', () => {
+    const limiter = new ForgeRateLimiter();
+    expect(limiter.noteFailure('gh', 'gh', '/ws', 'no git remotes found', 1000)).toBe(false);
+    expect(limiter.isSuspended('gh', 1000)).toBe(false);
+    expect(limiter.noteFailure('gh', 'gh', '/ws', GRAPHQL, 1000)).toBe(true);
+    expect(limiter.isSuspended('gh', 1000)).toBe(true);
+    expect(limiter.resetAt('gh', 1000)).toBe(1000 + SUSPENSION_FALLBACK_MS);
+    expect(limiter.isSuspended('gh', 1000 + SUSPENSION_FALLBACK_MS)).toBe(false);
+  });
+
+  it('a success from the same tick as the suspension does not clear it; a later one does', () => {
+    const limiter = new ForgeRateLimiter();
+    limiter.noteFailure('gh', 'gh', '/ws', GRAPHQL, 5000);
+    limiter.noteSuccess('gh', 5000);
+    expect(limiter.isSuspended('gh', 5001)).toBe(true);
+    limiter.noteSuccess('gh', 4000);
+    expect(limiter.isSuspended('gh', 5001)).toBe(true);
+    limiter.noteSuccess('gh', 5001);
+    expect(limiter.isSuspended('gh', 5002)).toBe(false);
+  });
+
+  it('a success on another budget never clears this one', () => {
+    const limiter = new ForgeRateLimiter();
+    limiter.noteFailure('gh', 'gh', '/ws', GRAPHQL, 1000);
+    limiter.noteSuccess('gh:rest', 9000);
+    expect(limiter.isSuspended('gh', 9001)).toBe(true);
+  });
+
+  it('runs the probe once per fresh suspension and only for gh', async () => {
+    const calls: string[] = [];
+    const limiter = new ForgeRateLimiter(async (backend) => { calls.push(backend); return null; });
+    limiter.noteFailure('gh', 'gh', '/ws', GRAPHQL, 1000);
+    limiter.noteFailure('gh', 'gh', '/ws', GRAPHQL, 1001);
+    limiter.noteFailure('glab', 'glab', '/ws', GRAPHQL, 1002);
+    await new Promise(r => setTimeout(r, 0));
+    expect(calls).toEqual(['gh']);
+  });
+});

--- a/packages/codev/src/__tests__/forge.test.ts
+++ b/packages/codev/src/__tests__/forge.test.ts
@@ -20,6 +20,8 @@ import {
   validateForgeConfig,
   loadForgeConfig,
   resolveAllConcepts,
+  executeForgeCommandDetailed,
+  resolveForgeBackend,
 } from '../lib/forge.js';
 
 // =============================================================================
@@ -691,5 +693,75 @@ describe('resolveAllConcepts', () => {
     const config = { 'issue-view': './bin/my-forge issue view "$1"' };
     const issueView = resolveAllConcepts(config).find(r => r.concept === 'issue-view');
     expect(issueView?.executable).toBe('./bin/my-forge');
+  });
+});
+
+// =============================================================================
+// #1645: failures keep their stderr/exit code; budgets key by resolved backend
+// =============================================================================
+
+describe('executeForgeCommandDetailed (#1645)', () => {
+  const SCRIPT = join(MOCK_SCRIPTS_DIR, 'rate-limited.sh');
+  beforeAll(() => {
+    writeFileSync(SCRIPT, '#!/bin/sh\necho "gh: API rate limit already exceeded for user ID 1" >&2\nexit 1\n');
+    chmodSync(SCRIPT, 0o755);
+  });
+
+  it('surfaces stderr and the exit code of a failing concept', async () => {
+    const result = await executeForgeCommandDetailed('issue-view', {}, { forgeConfig: { 'issue-view': SCRIPT } });
+    expect(result.data).toBeNull();
+    expect(result.error?.exitCode).toBe(1);
+    expect(result.error?.stderr).toContain('rate limit already exceeded');
+  });
+
+  it('reports a disabled concept as an error without executing', async () => {
+    const result = await executeForgeCommandDetailed('issue-view', {}, { forgeConfig: { 'issue-view': null } });
+    expect(result).toEqual({ data: null, error: { message: expect.stringContaining('disabled'), stderr: '', exitCode: null } });
+  });
+
+  it('reports a malformed .codev/config.json as an error instead of rejecting', async () => {
+    const broken = join(TEST_DIR, 'broken-config');
+    mkdirSync(join(broken, '.codev'), { recursive: true });
+    writeFileSync(join(broken, '.codev', 'config.json'), '{ not json');
+    await expect(executeForgeCommandDetailed('pr-list', {}, { workspaceRoot: broken })).resolves.toMatchObject({ data: null });
+  });
+});
+
+describe('resolveForgeBackend (#1645)', () => {
+  it('keys the github default scripts by their CLI, gh', () => {
+    expect(resolveForgeBackend('pr-list', { forgeConfig: null })).toBe('gh');
+    expect(resolveForgeBackend('user-identity', { forgeConfig: null })).toBe('gh');
+  });
+
+  it("keys a Linear workspace's pr-list (falls through to github) by gh, and its issue-list by provider", () => {
+    expect(resolveForgeBackend('pr-list', { forgeConfig: { provider: 'linear' } })).toBe('gh');
+    expect(resolveForgeBackend('issue-list', { forgeConfig: { provider: 'linear' } })).toBe('linear');
+  });
+
+  it('keys an absolute CLI path like the bare command, lowercased', () => {
+    expect(resolveForgeBackend('pr-list', { forgeConfig: { 'pr-list': '/usr/local/bin/GH pr list --json number' } })).toBe('gh');
+  });
+
+  it('keys generic transports and custom script paths by provider', () => {
+    expect(resolveForgeBackend('pr-list', { forgeConfig: { provider: 'gitlab', 'pr-list': 'curl -s https://forge.example/prs' } })).toBe('gitlab');
+    expect(resolveForgeBackend('pr-list', { forgeConfig: { 'pr-list': '/home/me/my-forge-script' } })).toBe('github');
+  });
+
+  it('returns null for a disabled concept', () => {
+    expect(resolveForgeBackend('pr-list', { forgeConfig: { 'pr-list': null } })).toBeNull();
+  });
+});
+
+describe('shipped provider scripts declare their executable (#1645)', () => {
+  const BUILTINS = new Set(['set', 'if', 'case', 'echo', 'printf', 'test', '[', 'exit', 'export', 'local', '.', 'source']);
+
+  it('no built-in provider resolves a concept to a shell builtin', () => {
+    for (const provider of getKnownProviders()) {
+      for (const r of resolveAllConcepts({ provider })) {
+        if (r.command === null) continue;
+        expect(r.executable, `${provider}/${r.concept} resolved to '${r.executable}'`).not.toBeNull();
+        expect(BUILTINS.has(r.executable as string), `${provider}/${r.concept} resolved to builtin '${r.executable}'`).toBe(false);
+      }
+    }
   });
 });

--- a/packages/codev/src/agent-farm/__tests__/bugfix-1645-gh-quota.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-1645-gh-quota.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Issue #1645 regression harness — the real OverviewCache, the real forge
+ * layer and the shipped github concept scripts, against a fake `gh` on PATH
+ * that is permanently rate-limited. Before the fix every poll re-spawned the
+ * four list commands (≈200 spawns for 40 polls); after it: one batch of four,
+ * then zero until the suspension lifts.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const { dbState } = vi.hoisted(() => ({ dbState: { globalDbPath: '' } }));
+vi.mock('../db/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db/index.js')>();
+  return { ...actual, getGlobalDbPath: () => dbState.globalDbPath };
+});
+
+import { OverviewCache } from '../servers/overview.js';
+
+let tmpDir: string;
+let callLog: string;
+const originalPath = process.env.PATH;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bugfix-1645-'));
+  dbState.globalDbPath = path.join(tmpDir, 'global.db');
+  callLog = path.join(tmpDir, 'gh-calls.log');
+  const bin = path.join(tmpDir, 'bin');
+  fs.mkdirSync(bin);
+  // `gh api user` (REST) succeeds; every GraphQL-backed command is rate-limited.
+  fs.writeFileSync(path.join(bin, 'gh'), [
+    '#!/bin/sh',
+    `echo "$*" >> "${callLog}"`,
+    'if [ "$1 $2" = "api user" ]; then echo octocat; exit 0; fi',
+    'echo "gh: API rate limit already exceeded for user ID 12345" >&2',
+    'exit 1',
+  ].join('\n'));
+  fs.chmodSync(path.join(bin, 'gh'), 0o755);
+  process.env.PATH = `${bin}${path.delimiter}${originalPath ?? ''}`;
+});
+
+afterAll(() => {
+  process.env.PATH = originalPath;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const spawns = () => (fs.existsSync(callLog) ? fs.readFileSync(callLog, 'utf-8').trim().split('\n').filter(Boolean) : []);
+
+describe('Tower gh spawns under a rate-limited gh (#1645)', () => {
+  it('40 dashboard polls at 2.5 s spawn one batch, then nothing until the suspension lifts', async () => {
+    const workspace = path.join(tmpDir, 'workspace');
+    fs.mkdirSync(workspace);
+    let clock = Date.now();
+    const cache = new OverviewCache({ now: () => clock });
+
+    let data = await cache.getOverview(workspace);
+    for (let i = 1; i < 40; i++) {
+      clock += 2_500;
+      data = await cache.getOverview(workspace);
+    }
+    const batch = spawns();
+    expect(batch).toHaveLength(5);
+    expect(batch.filter(l => l.startsWith('api user'))).toHaveLength(1);
+    expect(data.forgeStatus).toBe('rate-limited');
+    expect(data.forgeResetAt).toBeDefined();
+    expect(data.pendingPRs).toEqual([]);
+    expect(data.errors?.prs).toMatch(/^gh rate limited until/);
+
+    // Suspension over (no probe here → 15 min fallback): exactly one more batch.
+    clock += 15 * 60_000 + 1_000;
+    await cache.getOverview(workspace);
+    expect(spawns()).toHaveLength(9);
+  });
+});

--- a/packages/codev/src/agent-farm/__tests__/bugfix-1645-gh-quota.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/bugfix-1645-gh-quota.test.ts
@@ -18,6 +18,7 @@ vi.mock('../db/index.js', async (importOriginal) => {
 });
 
 import { OverviewCache } from '../servers/overview.js';
+import { executeForgeCommandDetailed } from '../../lib/forge.js';
 
 let tmpDir: string;
 let callLog: string;
@@ -72,5 +73,12 @@ describe('Tower gh spawns under a rate-limited gh (#1645)', () => {
     clock += 15 * 60_000 + 1_000;
     await cache.getOverview(workspace);
     expect(spawns()).toHaveLength(9);
+  });
+
+  it("github/pr-list propagates gh's exit status instead of jq's (POSIX sh has no pipefail)", async () => {
+    const result = await executeForgeCommandDetailed('pr-list', {}, { cwd: tmpDir, forgeConfig: null });
+    expect(result.data).toBeNull();
+    expect(result.error?.exitCode).toBe(1);
+    expect(result.error?.stderr).toContain('rate limit already exceeded');
   });
 });

--- a/packages/codev/src/agent-farm/__tests__/overview-rate-limit.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview-rate-limit.test.ts
@@ -105,17 +105,22 @@ describe('OverviewCache spend controls (#1645)', () => {
   it('a REST success does not reset the GraphQL failure backoff', async () => {
     for (const c of LISTS) fake.behaviour[c] = async () => fail('no git remotes found');
     const cache = new OverviewCache({ now });
-    await cache.getOverview(tmpDir);            // window 1: 60 s
+    // t0: lists fail (window 1: 60 s); identity succeeds in the same batch — REST evidence,
+    // which must leave the gh window alone. Were it reset, window 2 would be 60 s, not 120 s.
+    await cache.getOverview(tmpDir);
     clock += 61_000;
-    await cache.getOverview(tmpDir);            // window 2: 120 s (identity served from cache)
+    await cache.getOverview(tmpDir);            // t0+61: window 2 (120 s)
     expect(listCalls()).toBe(8);
-    clock += 3_540_000;                          // identity TTL expires → REST success
+    clock += 3_540_000;                          // t0+3601: identity TTL expires → REST success; window 3 (240 s)
     await cache.getOverview(tmpDir);
     expect(count('user-identity')).toBe(2);
-    expect(listCalls()).toBe(12);               // 1 h later: a fresh window, level keeps climbing
-    clock += 61_000;                             // inside the 240 s window: no retry
+    expect(listCalls()).toBe(12);
+    clock += 121_000;                            // t0+3722: inside window 3 — a reset chain would retry here
     await cache.getOverview(tmpDir);
     expect(listCalls()).toBe(12);
+    clock += 120_000;                            // t0+3842: window 3 elapsed → one retry
+    await cache.getOverview(tmpDir);
+    expect(listCalls()).toBe(16);
   });
 
   it('a REST failure does not suspend the GraphQL backend', async () => {

--- a/packages/codev/src/agent-farm/__tests__/overview-rate-limit.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview-rate-limit.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Issue #1645 — OverviewCache spend controls: negative cache with backoff,
+ * per-backend rate-limit suspension, single-flight, debounced list-only
+ * invalidation. Each test pins one pitfall from the rebuild prescription and
+ * goes red with its guard removed.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveForgeBackend, type ForgeCommandResult } from '../../lib/forge.js';
+
+type Concept = 'pr-list' | 'issue-list' | 'recently-closed' | 'recently-merged' | 'user-identity';
+const LISTS: Concept[] = ['pr-list', 'issue-list', 'recently-closed', 'recently-merged'];
+const RATE_LIMITED = 'gh: API rate limit already exceeded for user ID 12345';
+
+const { fake, dbState } = vi.hoisted(() => ({
+  fake: {
+    backend: ((_concept: string, _cwd: string) => 'gh') as (concept: string, cwd: string) => string | null,
+    behaviour: {} as Record<string, (cwd: string) => Promise<ForgeCommandResult>>,
+    calls: [] as Array<{ concept: string; cwd: string }>,
+  },
+  dbState: { globalDbPath: '' },
+}));
+
+vi.mock('../../lib/github.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/github.js')>();
+  return {
+    ...actual,
+    overviewBackend: (concept: string, cwd: string) => fake.backend(concept, cwd),
+    fetchForOverview: (concept: string, cwd: string) => {
+      fake.calls.push({ concept, cwd });
+      return fake.behaviour[concept](cwd);
+    },
+  };
+});
+vi.mock('../db/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db/index.js')>();
+  return { ...actual, getGlobalDbPath: () => dbState.globalDbPath };
+});
+
+import { OverviewCache } from '../servers/overview.js';
+
+const realOverviewBackend = (concept: string, cwd: string) => resolveForgeBackend(concept, { cwd });
+
+const ok = (data: unknown = []): ForgeCommandResult => ({ data, error: null });
+const fail = (stderr: string): ForgeCommandResult => ({ data: null, error: { message: `Command failed: ${stderr}`, stderr, exitCode: 1 } });
+const succeedAll = () => { for (const c of [...LISTS, 'user-identity']) fake.behaviour[c] = async () => ok(c === 'user-identity' ? 'octocat' : []); };
+const rateLimitLists = () => { for (const c of LISTS) fake.behaviour[c] = async () => fail(RATE_LIMITED); };
+const count = (concept: Concept, cwd?: string) => fake.calls.filter(c => c.concept === concept && (cwd === undefined || c.cwd === cwd)).length;
+const listCalls = (cwd?: string) => LISTS.reduce((n, c) => n + count(c, cwd), 0);
+
+let tmpDir: string;
+let clock: number;
+const now = () => clock;
+
+describe('OverviewCache spend controls (#1645)', () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'overview-1645-'));
+    dbState.globalDbPath = path.join(tmpDir, 'global.db');
+    clock = 1_700_000_000_000;
+    fake.calls.length = 0;
+    fake.backend = () => 'gh';
+    succeedAll();
+  });
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  it('40 polls at 2.5 s against a rate-limited gh: one batch, then zero until reset', async () => {
+    rateLimitLists();
+    const cache = new OverviewCache({ now });
+    let data = await cache.getOverview(tmpDir);
+    for (let i = 1; i < 40; i++) {
+      clock += 2_500;
+      data = await cache.getOverview(tmpDir);
+    }
+    expect(listCalls()).toBe(4);
+    expect(count('user-identity')).toBe(1);
+    expect(data.forgeStatus).toBe('rate-limited');
+    expect(data.forgeResetAt).toBeDefined();
+    expect(data.errors?.prs).toMatch(/gh rate limited until/);
+
+    // Past the 15 min fallback: exactly one more batch.
+    clock += 15 * 60_000;
+    await cache.getOverview(tmpDir);
+    expect(listCalls()).toBe(8);
+  });
+
+  it('a REST success (user-identity) does not clear a GraphQL suspension', async () => {
+    rateLimitLists();
+    const probe = async () => ({ remaining: 0, resetAt: clock + 2 * 3_600_000 });
+    const cache = new OverviewCache({ now, probe });
+    await cache.getOverview(tmpDir);
+    await Promise.resolve();
+    expect(count('user-identity')).toBe(1);
+
+    // Identity TTL (1 h) expires inside the 2 h suspension; its success is REST evidence only.
+    clock += 3_601_000;
+    const data = await cache.getOverview(tmpDir);
+    expect(count('user-identity')).toBe(2);
+    expect(listCalls()).toBe(4);
+    expect(data.forgeStatus).toBe('rate-limited');
+  });
+
+  it('a REST success does not reset the GraphQL failure backoff', async () => {
+    for (const c of LISTS) fake.behaviour[c] = async () => fail('no git remotes found');
+    const cache = new OverviewCache({ now });
+    await cache.getOverview(tmpDir);            // window 1: 60 s
+    clock += 61_000;
+    await cache.getOverview(tmpDir);            // window 2: 120 s (identity served from cache)
+    expect(listCalls()).toBe(8);
+    clock += 3_540_000;                          // identity TTL expires → REST success
+    await cache.getOverview(tmpDir);
+    expect(count('user-identity')).toBe(2);
+    expect(listCalls()).toBe(12);               // 1 h later: a fresh window, level keeps climbing
+    clock += 61_000;                             // inside the 240 s window: no retry
+    await cache.getOverview(tmpDir);
+    expect(listCalls()).toBe(12);
+  });
+
+  it('a REST failure does not suspend the GraphQL backend', async () => {
+    fake.behaviour['user-identity'] = async () => fail(RATE_LIMITED);
+    const cache = new OverviewCache({ now });
+    const first = await cache.getOverview(tmpDir);
+    expect(first.forgeStatus).toBe('ok');
+    clock += 181_000;
+    await cache.getOverview(tmpDir);
+    expect(count('pr-list')).toBe(2);
+    expect(count('issue-list')).toBe(2);
+  });
+
+  it('invalidate() clears neither a suspension nor the search and identity caches', async () => {
+    const cache = new OverviewCache({ now });
+    await cache.getOverview(tmpDir);
+    clock += 181_000;
+    rateLimitLists();
+    const suspended = await cache.getOverview(tmpDir);
+    expect(suspended.forgeStatus).toBe('rate-limited');
+    expect(listCalls()).toBe(6);                 // pr-list + issue-list refetched; searches cached
+
+    clock += 61_000;
+    cache.invalidate();
+    const after = await cache.getOverview(tmpDir);
+    expect(after.forgeStatus).toBe('rate-limited');
+    expect(after.forgeResetAt).toBe(suspended.forgeResetAt);
+    expect(listCalls()).toBe(6);
+    expect(count('user-identity')).toBe(1);
+    expect(count('recently-closed')).toBe(1);
+    expect(count('recently-merged')).toBe(1);
+  });
+
+  it('sustained invalidation (1/s for 5 min, two workspaces) stays under the debounced ceiling per workspace', async () => {
+    const wsA = path.join(tmpDir, 'a'); fs.mkdirSync(wsA);
+    const wsB = path.join(tmpDir, 'b'); fs.mkdirSync(wsB);
+    const cache = new OverviewCache({ now });
+    await cache.getOverview(wsA);
+    await cache.getOverview(wsB);
+    for (let s = 1; s <= 300; s++) {
+      clock += 1_000;
+      cache.invalidate();
+      await cache.getOverview(wsA);
+      if (s === 100 || s === 300) await cache.getOverview(wsB);
+    }
+    // Ceiling: one refetch per open list per 60 s per workspace, plus the initial batch.
+    for (const ws of [wsA, wsB]) {
+      expect(count('pr-list', ws)).toBeLessThanOrEqual(6);
+      expect(count('recently-closed', ws)).toBe(1);
+      expect(count('recently-merged', ws)).toBe(1);
+      expect(count('user-identity', ws)).toBe(1);
+    }
+    expect(count('pr-list', wsA)).toBe(6);
+    // B was invalidated and polled at 100 s and 300 s: A's refetch clock must not suppress it.
+    expect(count('pr-list', wsB)).toBe(3);
+  });
+
+  it('two pollers plus an invalidation mid-flight produce one fetch per concept', async () => {
+    const release: Array<() => void> = [];
+    for (const c of [...LISTS, 'user-identity']) {
+      fake.behaviour[c] = () => new Promise(resolve => release.push(() => resolve(ok(c === 'user-identity' ? 'octocat' : []))));
+    }
+    const cache = new OverviewCache({ now });
+    const a = cache.getOverview(tmpDir);
+    const b = cache.getOverview(tmpDir);
+    await Promise.resolve();
+    clock += 1;
+    cache.invalidate();
+    const c = cache.getOverview(tmpDir);
+    expect(release).toHaveLength(5);
+    release.forEach(r => r());
+    await Promise.all([a, b, c]);
+    succeedAll();
+    clock += 2_500;
+    await cache.getOverview(tmpDir);
+    for (const concept of [...LISTS, 'user-identity'] as Concept[]) expect(count(concept)).toBe(1);
+  });
+
+  it("a Linear workspace's pr-list (falls through to gh) suspends gh, not linear", async () => {
+    fs.mkdirSync(path.join(tmpDir, '.codev'));
+    fs.writeFileSync(path.join(tmpDir, '.codev', 'config.json'), JSON.stringify({ forge: { provider: 'linear' } }));
+    fake.backend = realOverviewBackend;
+    expect(realOverviewBackend('pr-list', tmpDir)).toBe('gh');
+    expect(realOverviewBackend('issue-list', tmpDir)).toBe('linear');
+    fake.behaviour['pr-list'] = async () => fail(RATE_LIMITED);
+
+    const cache = new OverviewCache({ now });
+    const first = await cache.getOverview(tmpDir);
+    expect(first.forgeStatus).toBe('rate-limited');
+    clock += 181_000;
+    await cache.getOverview(tmpDir);
+    expect(count('issue-list')).toBe(2);         // linear budget untouched
+    expect(count('pr-list')).toBe(1);            // gh suspended
+  });
+
+  it('a later credible probe with an earlier reset shortens the suspension', async () => {
+    rateLimitLists();
+    let resolveProbe!: (r: { remaining: number; resetAt: number }) => void;
+    const probe = () => new Promise<{ remaining: number; resetAt: number }>(resolve => { resolveProbe = resolve; });
+    const cache = new OverviewCache({ now, probe });
+    const start = clock;
+    const first = await cache.getOverview(tmpDir);
+    expect(first.forgeResetAt).toBe(new Date(start + 15 * 60_000).toISOString());
+
+    resolveProbe({ remaining: 0, resetAt: start + 5 * 60_000 });
+    await new Promise(r => setTimeout(r, 0));
+    clock += 2_500;
+    const shortened = await cache.getOverview(tmpDir);
+    expect(shortened.forgeResetAt).toBe(new Date(start + 5 * 60_000).toISOString());
+
+    clock = start + 5 * 60_000 + 1_000;
+    await cache.getOverview(tmpDir);
+    expect(listCalls()).toBe(8);
+  });
+
+  it('ignores a probe that claims budget remains (gh api rate_limit misreports a healthy bucket)', async () => {
+    rateLimitLists();
+    const cache = new OverviewCache({ now, probe: async () => ({ remaining: 5000, resetAt: clock + 60_000 }) });
+    const start = clock;
+    await cache.getOverview(tmpDir);
+    await new Promise(r => setTimeout(r, 0));
+    clock += 120_000;
+    const data = await cache.getOverview(tmpDir);
+    expect(data.forgeResetAt).toBe(new Date(start + 15 * 60_000).toISOString());
+    expect(listCalls()).toBe(4);
+  });
+});

--- a/packages/codev/src/agent-farm/__tests__/overview.test.ts
+++ b/packages/codev/src/agent-farm/__tests__/overview.test.ts
@@ -45,6 +45,16 @@ const { mockFetchPRList, mockFetchIssueList, mockFetchRecentlyClosed, mockFetchM
 
 vi.mock('../../lib/github.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../lib/github.js')>();
+  // #1645: OverviewCache reads through fetchForOverview/overviewBackend; route
+  // each concept to the per-fetcher mocks so tests keep their mockResolvedValue
+  // idiom. A `null` from a mock is reported as a failed command.
+  const byConcept: Record<string, (cwd: string) => Promise<unknown>> = {
+    'pr-list': mockFetchPRList,
+    'issue-list': mockFetchIssueList,
+    'recently-closed': mockFetchRecentlyClosed,
+    'recently-merged': mockFetchMergedPRs,
+    'user-identity': mockFetchCurrentUser,
+  };
   return {
     ...actual,
     fetchPRList: mockFetchPRList,
@@ -52,6 +62,13 @@ vi.mock('../../lib/github.js', async (importOriginal) => {
     fetchRecentlyClosed: mockFetchRecentlyClosed,
     fetchRecentMergedPRs: mockFetchMergedPRs,
     fetchCurrentUser: mockFetchCurrentUser,
+    overviewBackend: () => 'gh',
+    fetchForOverview: async (concept: string, cwd: string) => {
+      const data = await byConcept[concept](cwd);
+      return data === null
+        ? { data: null, error: { message: 'mock failure', stderr: '', exitCode: 1 } }
+        : { data, error: null };
+    },
   };
 });
 
@@ -1715,20 +1732,32 @@ describe('overview', () => {
       expect(mockFetchCurrentUser).toHaveBeenCalledTimes(1);
     });
 
-    it('invalidates cache on refresh', async () => {
+    it('invalidates the open lists on refresh, debounced to once a minute (#1645)', async () => {
       mockFetchPRList.mockResolvedValue([]);
       mockFetchIssueList.mockResolvedValue([]);
 
-      const cache = new OverviewCache();
+      let clock = 1_000_000;
+      const cache = new OverviewCache({ now: () => clock });
       await cache.getOverview(tmpDir);
 
+      // Invalidated 10 s after the fetch: still inside the debounce, served from cache.
+      clock += 10_000;
       cache.invalidate();
       await cache.getOverview(tmpDir);
+      expect(mockFetchPRList).toHaveBeenCalledTimes(1);
 
+      // Once the entry is a minute old the invalidation takes effect.
+      clock += 51_000;
+      await cache.getOverview(tmpDir);
       expect(mockFetchPRList).toHaveBeenCalledTimes(2);
+      expect(mockFetchIssueList).toHaveBeenCalledTimes(2);
+      // The searches and identity are not owned by invalidation.
+      expect(mockFetchRecentlyClosed).toHaveBeenCalledTimes(1);
+      expect(mockFetchMergedPRs).toHaveBeenCalledTimes(1);
+      expect(mockFetchCurrentUser).toHaveBeenCalledTimes(1);
     });
 
-    it('re-fetches after 30s TTL expires (Bugfix #388)', async () => {
+    it('re-fetches after the 180 s list TTL expires (Bugfix #388, #1645)', async () => {
       mockFetchPRList.mockResolvedValue([]);
       mockFetchIssueList.mockResolvedValue([]);
       mockFetchRecentlyClosed.mockResolvedValue([]);
@@ -1737,9 +1766,9 @@ describe('overview', () => {
       await cache.getOverview(tmpDir);
       expect(mockFetchPRList).toHaveBeenCalledTimes(1);
 
-      // Advance time past the 30s TTL
+      // Advance time past the 180 s list TTL
       vi.useFakeTimers();
-      vi.advanceTimersByTime(31_000);
+      vi.advanceTimersByTime(181_000);
 
       await cache.getOverview(tmpDir);
       expect(mockFetchPRList).toHaveBeenCalledTimes(2);
@@ -1792,23 +1821,33 @@ describe('overview', () => {
       expect(data.errors?.issues).toBeDefined();
     });
 
-    it('does not cache failed fetch results', async () => {
+    it('caches a failed fetch for the 60 s failure window, then retries (#1645)', async () => {
       // First call: gh fails
       mockFetchPRList.mockResolvedValueOnce(null);
       mockFetchIssueList.mockResolvedValue([]);
 
-      const cache = new OverviewCache();
+      let clock = 1_000_000;
+      const cache = new OverviewCache({ now: () => clock });
       const data1 = await cache.getOverview(tmpDir);
       expect(data1.errors?.prs).toBeDefined();
+      expect(data1.forgeStatus).toBe('unavailable');
 
-      // Second call: gh succeeds
-      mockFetchPRList.mockResolvedValueOnce([
+      // gh would succeed now, but inside the window the failure is served from cache.
+      mockFetchPRList.mockResolvedValue([
         { number: 1, title: 'Test', url: 'https://github.com/org/repo/pull/1', reviewDecision: '', body: '', createdAt: '2026-01-01T00:00:00Z' },
       ]);
-
+      clock += 30_000;
       const data2 = await cache.getOverview(tmpDir);
-      expect(data2.errors?.prs).toBeUndefined();
-      expect(data2.pendingPRs).toHaveLength(1);
+      expect(data2.errors?.prs).toBeDefined();
+      expect(mockFetchPRList).toHaveBeenCalledTimes(1);
+
+      // Past the window: one retry, which self-heals.
+      clock += 31_000;
+      const data3 = await cache.getOverview(tmpDir);
+      expect(data3.errors?.prs).toBeUndefined();
+      expect(data3.pendingPRs).toHaveLength(1);
+      expect(data3.forgeStatus).toBe('ok');
+      expect(mockFetchPRList).toHaveBeenCalledTimes(2);
     });
 
     it('filters backlog issues that are linked to PRs', async () => {
@@ -1916,11 +1955,13 @@ describe('overview', () => {
       createBuilderWorktree(tmpDir, 'task-AbCd');
 
       // Without filter: all 3 worktrees discovered
-      const cache = new OverviewCache();
+      let clock = 1_000_000;
+      const cache = new OverviewCache({ now: () => clock });
       const unfiltered = await cache.getOverview(tmpDir);
       expect(unfiltered.builders).toHaveLength(3);
 
       // With filter: only spir-42 has an active session
+      clock += 61_000;
       cache.invalidate();
       const activeSet = new Set(['builder-spir-42']);
       const filtered = await cache.getOverview(tmpDir, activeSet);
@@ -2003,7 +2044,8 @@ describe('overview', () => {
         'gates:',
       ].join('\n'), '0907-area-fix');
 
-      const cache = new OverviewCache();
+      let clock = 1_000_000;
+      const cache = new OverviewCache({ now: () => clock });
 
       // First refresh: issue is open and labeled area/vscode.
       mockFetchIssueList.mockResolvedValue([
@@ -2014,6 +2056,7 @@ describe('overview', () => {
       expect(first.builders[0].area).toBe('vscode');
 
       // Issue closes (e.g. PR merged) → drops out of the open-issues list.
+      clock += 61_000;
       cache.invalidate();
       mockFetchIssueList.mockResolvedValue([]);
       const second = await cache.getOverview(tmpDir);
@@ -2031,7 +2074,8 @@ describe('overview', () => {
         'gates:',
       ].join('\n'), '0907-area-fetchfail');
 
-      const cache = new OverviewCache();
+      let clock = 1_000_000;
+      const cache = new OverviewCache({ now: () => clock });
 
       mockFetchIssueList.mockResolvedValue([
         issueItem(907, 'Builder flash bug', [{ name: 'area/vscode' }]),
@@ -2039,6 +2083,7 @@ describe('overview', () => {
       const first = await cache.getOverview(tmpDir);
       expect(first.builders[0].area).toBe('vscode');
 
+      clock += 61_000;
       cache.invalidate();
       mockFetchIssueList.mockResolvedValue(null);
       const second = await cache.getOverview(tmpDir);
@@ -2053,7 +2098,8 @@ describe('overview', () => {
         'gates:',
       ].join('\n'), '0908-no-area');
 
-      const cache = new OverviewCache();
+      let clock = 1_000_000;
+      const cache = new OverviewCache({ now: () => clock });
 
       // Issue is present across two refreshes but carries no area/* label.
       mockFetchIssueList.mockResolvedValue([
@@ -2062,6 +2108,7 @@ describe('overview', () => {
       const first = await cache.getOverview(tmpDir);
       expect(first.builders[0].area).toBe('Uncategorized');
 
+      clock += 61_000;
       cache.invalidate();
       const second = await cache.getOverview(tmpDir);
       expect(second.builders[0].area).toBe('Uncategorized');

--- a/packages/codev/src/agent-farm/servers/overview.ts
+++ b/packages/codev/src/agent-farm/servers/overview.ts
@@ -11,16 +11,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { UNCATEGORIZED_AREA } from '@cluesmith/codev-sdk/constants';
 import {
-  fetchPRList,
-  fetchIssueList,
-  fetchRecentlyClosed,
-  fetchRecentMergedPRs,
-  fetchCurrentUser,
+  fetchForOverview,
+  overviewBackend,
   parseLinkedIssue,
   parseLabelDefaults,
   parseArea,
 } from '../../lib/github.js';
-import type { ForgePR, ForgeIssueListItem } from '../../lib/github.js';
+import type { ForgePR, ForgeIssueListItem, OverviewConcept } from '../../lib/github.js';
+import { ForgeRateLimiter, budgetKeyFor, type RateLimitProbe } from '../../lib/forge-rate-limit.js';
 import { loadProtocol } from '../../commands/porch/protocol.js';
 import { ResolvedEnrichmentCache } from './resolved-enrichment-cache.js';
 import type {
@@ -836,20 +834,60 @@ export function deriveBacklog(
 // OverviewCache
 // =============================================================================
 
+/** One cached concept result per workspace. `data: null` is a cached failure (#1645). */
+interface CacheEntry<T> { data: T | null; fetchedAt: number; expiresAt: number }
+
+interface FetchOutcome<T> {
+  data: T | null;
+  /** Set when the concept's budget was suspended at read time (data, if any, is stale). */
+  rateLimitedUntil: number | null;
+  backend: string | null;
+}
+
+export interface OverviewCacheOptions {
+  /** Clock, injectable for tests. */
+  now?: () => number;
+  /** Reset probe run once per fresh suspension (Tower passes the gh probe). */
+  probe?: RateLimitProbe;
+}
+
+/** Open lists: what porch/VS Code invalidation refreshes. */
+const LIST_TTL_MS = 180_000;
+/** The two 24 h searches: invalidation never touches these. */
+const SEARCH_TTL_MS = 600_000;
+/** GitHub identity is session-stable. */
+const USER_TTL_MS = 3_600_000;
+/** A list refetches at most once per minute per workspace because of invalidation. */
+const INVALIDATE_DEBOUNCE_MS = 60_000;
+/** Failure window: 60 s, doubling per window (not per failed command) to 15 min. */
+const FAILURE_WINDOW_MIN_MS = 60_000;
+const FAILURE_WINDOW_MAX_MS = 15 * 60_000;
+
 export class OverviewCache {
-  private prCache = new Map<string, { data: ForgePR[]; fetchedAt: number }>();
-  private issueCache = new Map<string, { data: ForgeIssueListItem[]; fetchedAt: number }>();
-  private closedCache = new Map<string, { data: ForgeIssueListItem[]; fetchedAt: number }>();
-  private mergedPRCache = new Map<string, { data: ForgePR[]; fetchedAt: number }>();
-  private currentUserCache = new Map<string, { data: string; fetchedAt: number }>();
+  private prCache = new Map<string, CacheEntry<ForgePR[]>>();
+  private issueCache = new Map<string, CacheEntry<ForgeIssueListItem[]>>();
+  private closedCache = new Map<string, CacheEntry<ForgeIssueListItem[]>>();
+  private mergedPRCache = new Map<string, CacheEntry<ForgePR[]>>();
+  private currentUserCache = new Map<string, CacheEntry<string>>();
+  /** Single-flight per `<workspace>:<concept>` (#1645). */
+  private inflight = new Map<string, Promise<FetchOutcome<unknown>>>();
+  /** Escalating failure window per `<workspace>:<budget>`. */
+  private failureWindows = new Map<string, { level: number; startedAt: number; ttl: number }>();
+  /** Epoch of the last invalidate(); open-list entries fetched before it are stale once debounced. */
+  private invalidatedAt = 0;
+  private readonly limiter: ForgeRateLimiter;
+  private readonly now: () => number;
+
+  constructor(options: OverviewCacheOptions = {}) {
+    this.now = options.now ?? (() => Date.now());
+    this.limiter = new ForgeRateLimiter(options.probe);
+  }
   // Cache of issue-derived builder fields (today: `area`) keyed by worktreePath,
   // so they survive refreshes where the source issue is unreachable rather than
   // snapping back to their default while the builder is still listed (PIR #907).
   // Intentionally NOT cleared by invalidate(): surviving cache invalidation is
   // the whole point. See ResolvedEnrichmentCache.
   private resolvedEnrichment = new ResolvedEnrichmentCache();
-  private readonly TTL = 30_000;
-  private readonly USER_TTL = 3_600_000; // 1h — GitHub identity is session-stable
 
   /**
    * Build the overview response. Aggregates builder state, PRs, and backlog.
@@ -924,18 +962,30 @@ export class OverviewCache {
 
     // 2. Fetch PRs, issues, recently closed, merged PRs, and current user in
     //    parallel (each is independently cached)
-    const [prs, issues, closed, mergedPRs, currentUser] = await Promise.all([
-      this.fetchPRsCached(workspaceRoot),
-      this.fetchIssuesCached(workspaceRoot),
-      this.fetchRecentlyClosedCached(workspaceRoot),
-      this.fetchMergedPRsCached(workspaceRoot),
-      this.fetchCurrentUserCached(workspaceRoot),
+    const [prsOutcome, issuesOutcome, closedOutcome, mergedOutcome, userOutcome] = await Promise.all([
+      this.cachedFetch<ForgePR[]>(this.prCache, workspaceRoot, 'pr-list', LIST_TTL_MS, true),
+      this.cachedFetch<ForgeIssueListItem[]>(this.issueCache, workspaceRoot, 'issue-list', LIST_TTL_MS, true),
+      this.cachedFetch<ForgeIssueListItem[]>(this.closedCache, workspaceRoot, 'recently-closed', SEARCH_TTL_MS, false),
+      this.cachedFetch<ForgePR[]>(this.mergedPRCache, workspaceRoot, 'recently-merged', SEARCH_TTL_MS, false),
+      this.cachedFetch<string>(this.currentUserCache, workspaceRoot, 'user-identity', USER_TTL_MS, false),
     ]);
+    const prs = prsOutcome.data;
+    const issues = issuesOutcome.data;
+    const closed = closedOutcome.data;
+    const mergedPRs = mergedOutcome.data;
+    const currentUser = userOutcome.data;
+    // Every forge-backed section counts, the two searches included (#1645).
+    const sections = [prsOutcome, issuesOutcome, closedOutcome, mergedOutcome];
+    const rateLimited = sections.find(o => o.rateLimitedUntil !== null);
+    const forgeStatus: OverviewData['forgeStatus'] = rateLimited
+      ? 'rate-limited'
+      : sections.some(o => o.data === null) ? 'unavailable' : 'ok';
+    const forgeResetAt = rateLimited ? new Date(rateLimited.rateLimitedUntil as number).toISOString() : undefined;
 
     // 3. Process PRs
     let pendingPRs: OverviewPR[] = [];
     if (prs === null) {
-      errors.prs = 'GitHub CLI unavailable — could not fetch PRs';
+      errors.prs = describeMissing(prsOutcome, 'PRs');
     } else {
       pendingPRs = prs.map(pr => ({
         id: String(pr.number),
@@ -964,7 +1014,7 @@ export class OverviewCache {
       ? new Map(issues.map(i => [String(i.number), parseArea(i.labels)]))
       : null;
     if (issues === null) {
-      errors.issues = 'GitHub CLI unavailable — could not fetch issues';
+      errors.issues = describeMissing(issuesOutcome, 'issues');
     } else {
       backlog = deriveBacklog(issues, workspaceRoot, activeBuilderIssues, prLinkedIssues);
 
@@ -1062,7 +1112,10 @@ export class OverviewCache {
     // has no view of the live terminal sessions. `handleOverview` (tower-routes.ts)
     // injects the real architect list via `liveArchitects` before serialization,
     // mirroring how it enriches `lastDataAt`.
-    const result: OverviewData = { builders, pendingPRs, backlog, recentlyClosed, architects: [], heldCount, mailboxEscalated, queuedFeedback, feedbackMode };
+    const result: OverviewData = { builders, pendingPRs, backlog, recentlyClosed, architects: [], heldCount, mailboxEscalated, queuedFeedback, feedbackMode, forgeStatus };
+    if (forgeResetAt) {
+      result.forgeResetAt = forgeResetAt;
+    }
     if (currentUser) {
       result.currentUser = currentUser;
     }
@@ -1073,14 +1126,14 @@ export class OverviewCache {
   }
 
   /**
-   * Invalidate all cached data.
+   * Mark the open lists (PRs, issues) stale. Porch, cleanup and the VS Code
+   * review queue call this after every mutation, so it is not a human signal
+   * (#1645): it never clears a suspension or a cached failure, never touches
+   * the search or identity caches, and a list is refetched for it at most once
+   * per `INVALIDATE_DEBOUNCE_MS` per workspace.
    */
   invalidate(): void {
-    this.prCache.clear();
-    this.issueCache.clear();
-    this.closedCache.clear();
-    this.mergedPRCache.clear();
-    this.currentUserCache.clear();
+    this.invalidatedAt = this.now();
     // Note: resolvedEnrichment is deliberately NOT cleared here. It must survive
     // invalidation so a cleanup-triggered refresh (which calls invalidate()) can
     // still fall back to a builder's resolved area instead of UNCATEGORIZED
@@ -1088,82 +1141,101 @@ export class OverviewCache {
   }
 
   // ===========================================================================
-  // Private cache helpers
+  // Private cache helpers (#1645)
   // ===========================================================================
 
-  private async fetchPRsCached(cwd: string): Promise<ForgePR[] | null> {
-    const now = Date.now();
-    const cached = this.prCache.get(cwd);
-    if (cached && (now - cached.fetchedAt) < this.TTL) {
-      return cached.data;
-    }
-
-    const data = await fetchPRList(cwd);
-    if (data !== null) {
-      this.prCache.set(cwd, { data, fetchedAt: now });
-    }
-    return data;
-  }
-
-  private async fetchIssuesCached(cwd: string): Promise<ForgeIssueListItem[] | null> {
-    const now = Date.now();
-    const cached = this.issueCache.get(cwd);
-    if (cached && (now - cached.fetchedAt) < this.TTL) {
-      return cached.data;
-    }
-
-    const data = await fetchIssueList(cwd);
-    if (data !== null) {
-      this.issueCache.set(cwd, { data, fetchedAt: now });
-    }
-    return data;
-  }
-
   /**
-   * Resolve the current user's forge login via the `user-identity` concept.
-   * Long TTL — identity is stable for the lifetime of a Tower session.
-   * Only successful resolutions are cached, so a transient failure (gh
-   * logged out, offline) self-heals on the next overview poll.
+   * Serve `concept` for `cwd` from cache, or dispatch exactly one fetch.
+   * `listCache` entries additionally honour invalidate() (debounced).
    */
-  private async fetchCurrentUserCached(cwd: string): Promise<string | null> {
-    const now = Date.now();
-    const cached = this.currentUserCache.get(cwd);
-    if (cached && (now - cached.fetchedAt) < this.USER_TTL) {
-      return cached.data;
+  private cachedFetch<T>(
+    cache: Map<string, CacheEntry<T>>,
+    cwd: string,
+    concept: OverviewConcept,
+    ttl: number,
+    listCache: boolean,
+  ): Promise<FetchOutcome<T>> {
+    const now = this.now();
+    const backend = overviewBackend(concept, cwd);
+    const budget = backend === null ? null : budgetKeyFor(backend, concept);
+    const entry = cache.get(cwd);
+    const withinTtl = entry !== undefined && now < entry.expiresAt;
+    // Only a *positive* entry goes stale on invalidation: a refresh means "my
+    // data may be stale", never "the forge has recovered".
+    const invalidated = listCache && entry !== undefined && entry.data !== null
+      && entry.fetchedAt < this.invalidatedAt && now - entry.fetchedAt >= INVALIDATE_DEBOUNCE_MS;
+    const rateLimitedUntil = budget === null ? null : this.limiter.resetAt(budget, now);
+
+    if (withinTtl && !invalidated) {
+      return Promise.resolve({ data: entry.data, rateLimitedUntil, backend });
+    }
+    if (rateLimitedUntil !== null) {
+      // Suspended: a list still inside its TTL is served stale; an expired one is empty.
+      return Promise.resolve({ data: withinTtl ? entry.data : null, rateLimitedUntil, backend });
+    }
+    if (backend === null || budget === null) {
+      return Promise.resolve({ data: null, rateLimitedUntil: null, backend: null });
     }
 
-    const login = await fetchCurrentUser(cwd);
-    if (login !== null) {
-      this.currentUserCache.set(cwd, { data: login, fetchedAt: now });
-    }
-    return login;
+    const key = `${cwd}:${concept}`;
+    const existing = this.inflight.get(key);
+    if (existing) return existing as Promise<FetchOutcome<T>>;
+    const flight = this.dispatch(cache, cwd, concept, ttl, backend, budget).finally(() => {
+      // Identity check: a settling flight must never unregister a newer one.
+      if (this.inflight.get(key) === flight) this.inflight.delete(key);
+    });
+    this.inflight.set(key, flight as Promise<FetchOutcome<unknown>>);
+    return flight;
   }
 
-  private async fetchRecentlyClosedCached(cwd: string): Promise<ForgeIssueListItem[] | null> {
-    const now = Date.now();
-    const cached = this.closedCache.get(cwd);
-    if (cached && (now - cached.fetchedAt) < this.TTL) {
-      return cached.data;
+  /** Run the concept once and record the outcome. Never rejects. */
+  private async dispatch<T>(
+    cache: Map<string, CacheEntry<T>>,
+    cwd: string,
+    concept: OverviewConcept,
+    ttl: number,
+    backend: string,
+    budget: string,
+  ): Promise<FetchOutcome<T>> {
+    const dispatchedAt = this.now();
+    let data: T | null = null;
+    let errorText: string | null = null;
+    try {
+      const result = await fetchForOverview(concept, cwd);
+      data = result.data as T | null;
+      if (result.error) errorText = `${result.error.stderr}\n${result.error.message}`;
+      else if (data === null) errorText = '';
+    } catch (err) {
+      errorText = err instanceof Error ? err.message : String(err);
     }
-
-    const data = await fetchRecentlyClosed(cwd);
-    if (data !== null) {
-      this.closedCache.set(cwd, { data, fetchedAt: now });
+    const now = this.now();
+    if (errorText !== null) {
+      const suspended = this.limiter.noteFailure(budget, backend, cwd, errorText, now);
+      cache.set(cwd, { data: null, fetchedAt: dispatchedAt, expiresAt: now + this.failureWindow(`${cwd}:${budget}`, now) });
+      return { data: null, rateLimitedUntil: suspended ? this.limiter.resetAt(budget, now) : null, backend };
     }
-    return data;
+    this.limiter.noteSuccess(budget, dispatchedAt);
+    this.failureWindows.delete(`${cwd}:${budget}`);
+    cache.set(cwd, { data, fetchedAt: dispatchedAt, expiresAt: now + ttl });
+    return { data, rateLimitedUntil: null, backend };
   }
 
-  private async fetchMergedPRsCached(cwd: string): Promise<ForgePR[] | null> {
-    const now = Date.now();
-    const cached = this.mergedPRCache.get(cwd);
-    if (cached && (now - cached.fetchedAt) < this.TTL) {
-      return cached.data;
-    }
-
-    const data = await fetchRecentMergedPRs(cwd);
-    if (data !== null) {
-      this.mergedPRCache.set(cwd, { data, fetchedAt: now });
-    }
-    return data;
+  /** Current failure window for a key; escalates once per elapsed window, not per failure. */
+  private failureWindow(key: string, now: number): number {
+    const w = this.failureWindows.get(key);
+    if (w && now < w.startedAt + w.ttl) return w.ttl;
+    const level = w ? w.level + 1 : 0;
+    const ttl = Math.min(FAILURE_WINDOW_MIN_MS * 2 ** level, FAILURE_WINDOW_MAX_MS);
+    this.failureWindows.set(key, { level, startedAt: now, ttl });
+    return ttl;
   }
+}
+
+/** Degraded-mode text naming the real reason and the real backend (never "GitHub" on GitLab). */
+function describeMissing(outcome: FetchOutcome<unknown>, what: string): string {
+  if (outcome.rateLimitedUntil !== null) {
+    return `${outcome.backend} rate limited until ${new Date(outcome.rateLimitedUntil).toISOString()} — ${what} unavailable`;
+  }
+  if (outcome.backend === null) return `forge concept disabled — ${what} unavailable`;
+  return `${outcome.backend} CLI unavailable — could not fetch ${what}`;
 }

--- a/packages/codev/src/agent-farm/servers/tower-routes.ts
+++ b/packages/codev/src/agent-farm/servers/tower-routes.ts
@@ -105,6 +105,7 @@ import {
   searchIssues,
   fetchPRList,
   fetchCurrentUser,
+  probeGhGraphqlRateLimit,
   parseLinkedIssue,
   parseArea,
 } from '../../lib/github.js';
@@ -146,7 +147,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Singleton cache for overview endpoint (Spec 0126 Phase 4)
-const overviewCache = new OverviewCache();
+// #1645: the gh reset probe is enabled here, in Tower, and nowhere else.
+const overviewCache = new OverviewCache({ probe: probeGhGraphqlRateLimit });
 
 // Spec 1313: the in-memory SendBuffer (Spec 403) is retired. Every send is now
 // persisted to the durable `mailbox` table before the response and delivered only

--- a/packages/codev/src/lib/forge-rate-limit.ts
+++ b/packages/codev/src/lib/forge-rate-limit.ts
@@ -1,0 +1,105 @@
+/**
+ * Per-backend rate-limit suspension for forge fetches (#1645).
+ *
+ * When a backend (`gh`, `glab`, …) reports that its budget is exhausted, every
+ * fetch that would spend the same budget is suspended until the reset instant.
+ * Importing this module never shells out: the optional reset probe is injected
+ * by the caller that wants it (Tower's overview cache).
+ */
+
+/** GitHub's GraphQL and REST primary-limit messages, and gh's error type. */
+const RATE_LIMIT_PATTERN = /rate limit (?:already )?exceeded|RATE_LIMITED|graphql_rate_limit|secondary rate limit/i;
+
+export function isRateLimitError(text: string): boolean {
+  return RATE_LIMIT_PATTERN.test(text);
+}
+
+/**
+ * Concepts that spend a budget other than the one the backend's list concepts
+ * spend. This is a fact about the backend: on `gh`, `user-identity` is a REST
+ * call outside the GraphQL bucket; on Linear every concept is GraphQL on
+ * Linear's own budget, so nothing is split out there.
+ */
+const OFF_BUDGET_CONCEPTS: Record<string, ReadonlySet<string>> = {
+  gh: new Set(['user-identity', 'auth-status']),
+};
+
+/** The budget a concept spends on its backend, e.g. `gh` or `gh:rest`. */
+export function budgetKeyFor(backend: string, concept: string): string {
+  const key = backend.toLowerCase();
+  return OFF_BUDGET_CONCEPTS[key]?.has(concept) ? `${key}:rest` : key;
+}
+
+/** Result of a reset probe. `remaining === 0` makes the reported reset credible. */
+export interface RateLimitProbeResult {
+  remaining: number;
+  /** Reset instant, epoch milliseconds. */
+  resetAt: number;
+}
+
+export type RateLimitProbe = (backend: string, cwd: string) => Promise<RateLimitProbeResult | null>;
+
+interface Suspension {
+  startedAt: number;
+  until: number;
+}
+
+export const SUSPENSION_FALLBACK_MS = 15 * 60_000;
+
+export class ForgeRateLimiter {
+  private readonly suspensions = new Map<string, Suspension>();
+
+  constructor(private readonly probe?: RateLimitProbe) {}
+
+  /** Read-only: never allocates, so polling it every 2.5 s costs nothing. */
+  isSuspended(budget: string, now: number): boolean {
+    const s = this.suspensions.get(budget);
+    return s !== undefined && now < s.until;
+  }
+
+  /** Reset instant (epoch ms) of an active suspension, else null. */
+  resetAt(budget: string, now: number): number | null {
+    const s = this.suspensions.get(budget);
+    return s !== undefined && now < s.until ? s.until : null;
+  }
+
+  /**
+   * Record a failure. Only a rate-limit error suspends, and only the failing
+   * budget: a REST failure never suspends the GraphQL bucket. A fresh
+   * suspension runs the reset probe at most once; a credible probe result
+   * (budget confirmed gone) sets the true reset instant, even if that is
+   * earlier than the fallback window.
+   */
+  noteFailure(budget: string, backend: string, cwd: string, errorText: string, now: number): boolean {
+    if (!isRateLimitError(errorText)) return false;
+    const existing = this.suspensions.get(budget);
+    if (existing && now < existing.until) return true;
+    const suspension: Suspension = { startedAt: now, until: now + SUSPENSION_FALLBACK_MS };
+    this.suspensions.set(budget, suspension);
+    const probe = this.probe;
+    if (probe && backend === 'gh') {
+      Promise.resolve()
+        .then(() => probe(backend, cwd))
+        .then(result => this.applyProbe(budget, suspension, result))
+        .catch(() => { /* probe is advisory; keep the fallback window */ });
+    }
+    return true;
+  }
+
+  /**
+   * A success clears a suspension only if it was dispatched strictly after the
+   * suspension began: a batch dispatched in one tick shares a millisecond with
+   * the failure that suspended it, and its successes are not evidence of recovery.
+   */
+  noteSuccess(budget: string, dispatchedAt: number): void {
+    const s = this.suspensions.get(budget);
+    if (s && dispatchedAt > s.startedAt) this.suspensions.delete(budget);
+  }
+
+  /** Honour a credible probe: the true reset instant wins over the fallback in both directions. */
+  private applyProbe(budget: string, suspension: Suspension, result: RateLimitProbeResult | null): void {
+    if (!result || result.remaining > 0) return;
+    if (this.suspensions.get(budget) !== suspension) return;
+    if (result.resetAt > suspension.startedAt) suspension.until = result.resetAt;
+  }
+}

--- a/packages/codev/src/lib/forge.ts
+++ b/packages/codev/src/lib/forge.ts
@@ -15,7 +15,7 @@
 import { exec, execSync } from 'node:child_process';
 import { promisify } from 'node:util';
 import { existsSync, readFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { resolve, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadConfig as loadCodevConfig } from './config.js';
 
@@ -329,28 +329,93 @@ export async function executeForgeCommand(
   env?: Record<string, string>,
   options?: ForgeCommandOptions,
 ): Promise<unknown | null> {
-  const forgeConfig = resolveForgeConfig(options);
-  const command = getForgeCommand(concept, forgeConfig);
+  return (await executeForgeCommandDetailed(concept, env, options)).data;
+}
 
-  if (command === null) {
-    return null;
-  }
+/** Why a forge command produced no data (#1645). `null` on the result means it exited 0. */
+export interface ForgeCommandError {
+  message: string;
+  stderr: string;
+  /** Process exit code; null when the command was disabled, timed out, or config failed to load. */
+  exitCode: number | null;
+}
 
-  const forgeEnv = buildForgeEnv(forgeConfig);
+export interface ForgeCommandResult {
+  data: unknown | null;
+  error: ForgeCommandError | null;
+}
 
+/**
+ * Like `executeForgeCommand`, but keeps the failure (#1645). Callers that must
+ * tell "rate limited" from "CLI missing" need stderr and the exit code; the
+ * plain variant collapses every failure to `null`. Never throws — a malformed
+ * `.codev/config.json` is reported as an error, not raised into Tower's
+ * `unhandledRejection` handler.
+ */
+export async function executeForgeCommandDetailed(
+  concept: string,
+  env?: Record<string, string>,
+  options?: ForgeCommandOptions,
+): Promise<ForgeCommandResult> {
   try {
+    const forgeConfig = resolveForgeConfig(options);
+    const command = getForgeCommand(concept, forgeConfig);
+    if (command === null) {
+      return { data: null, error: { message: `concept '${concept}' is disabled or unknown`, stderr: '', exitCode: null } };
+    }
+
     const { stdout } = await execAsync(command, {
       cwd: options?.cwd,
-      env: { ...process.env, ...forgeEnv, ...env },
+      env: { ...process.env, ...buildForgeEnv(forgeConfig), ...env },
       timeout: 30_000,
       maxBuffer: options?.maxBuffer ?? DEFAULT_MAX_BUFFER,
     });
-
-    return parseOutput(stdout, options?.raw);
+    return { data: parseOutput(stdout, options?.raw), error: null };
   } catch (err: unknown) {
     logDebug(concept, err);
-    return null;
+    const e = err as { message?: string; stderr?: string; code?: unknown };
+    return {
+      data: null,
+      error: {
+        message: e?.message ?? String(err),
+        stderr: typeof e?.stderr === 'string' ? e.stderr : '',
+        exitCode: typeof e?.code === 'number' ? e.code : null,
+      },
+    };
   }
+}
+
+/**
+ * Executables that name a transport, not a forge account. A concept run through
+ * one of these is keyed by its provider (`linear`), because `curl` has no budget.
+ */
+const GENERIC_TRANSPORTS = new Set(['curl', 'wget', 'sh', 'bash', 'zsh', 'node', 'python', 'python3', 'npx', 'env']);
+const FORGE_CLIS = new Set(['gh', 'glab', 'tea']);
+
+/**
+ * The backend a concept actually spends budget on (#1645): the resolved
+ * executable's lowercased basename (`gh`, whether configured as `gh` or
+ * `/usr/local/bin/gh`), never the configured provider — a Linear workspace's
+ * `pr-list` falls through to the GitHub script and spends GitHub's budget.
+ * Generic transports and custom script paths key by provider instead.
+ * Returns null when the concept is disabled or unknown.
+ */
+export function resolveForgeBackend(concept: string, options?: ForgeCommandOptions): string | null {
+  let forgeConfig: ForgeConfig | null;
+  try {
+    forgeConfig = resolveForgeConfig(options);
+  } catch {
+    forgeConfig = null;
+  }
+  const command = getForgeCommand(concept, forgeConfig);
+  if (command === null) return null;
+  const provider = (forgeConfig?.provider ?? 'github').toLowerCase();
+  const executable = extractExecutable(command);
+  if (!executable) return provider;
+  const base = basename(executable).toLowerCase();
+  if (GENERIC_TRANSPORTS.has(base)) return provider;
+  if (executable.includes('/') && !FORGE_CLIS.has(base)) return provider;
+  return base;
 }
 
 /**

--- a/packages/codev/src/lib/github.ts
+++ b/packages/codev/src/lib/github.ts
@@ -9,8 +9,10 @@
  * @see codev/specs/589-non-github-repository-support.md
  */
 
+import { execFile } from 'node:child_process';
 import { UNCATEGORIZED_AREA } from '@cluesmith/codev-sdk/constants';
-import { executeForgeCommand, type ForgeConfig } from './forge.js';
+import { executeForgeCommand, executeForgeCommandDetailed, resolveForgeBackend, type ForgeConfig, type ForgeCommandResult } from './forge.js';
+import type { RateLimitProbeResult } from './forge-rate-limit.js';
 import { getRepoInfo } from './team-github.js';
 import type { IssueViewResult, PrListItem, PrViewResult, IssueListItem } from './forge-contracts.js';
 
@@ -200,20 +202,28 @@ export async function fetchRecentlyClosed(
   // entire sinceDate day, collapsing the 24h window to "since UTC midnight"
   // (≈0h just after 00:00Z) and silently hiding genuinely-recent closures.
   // Seconds precision (no millis) matches GitHub's documented format.
-  const since = new Date(Date.now() - 24 * 60 * 60 * 1000)
-    .toISOString().replace(/\.\d{3}Z$/, 'Z');
   const result = await executeForgeCommand('recently-closed', {
-    CODEV_SINCE_DATE: since,
+    CODEV_SINCE_DATE: sinceTimestamp24h(),
   }, {
     cwd,
     forgeConfig,
   });
-  if (!result || !Array.isArray(result)) return result as ForgeIssueListItem[] | null;
+  return withinLast24h(result, 'closedAt') as ForgeIssueListItem[] | null;
+}
 
-  // Filter to last 24 hours (concept command may return more)
-  const cutoff = Date.now() - 24 * 60 * 60 * 1000;
-  return (result as ForgeIssueListItem[]).filter(
-    i => i.closedAt && new Date(i.closedAt).getTime() >= cutoff,
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** ISO-8601 at seconds precision, 24 h ago (GitHub's documented datetime format). */
+function sinceTimestamp24h(): string {
+  return new Date(Date.now() - DAY_MS).toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+/** Filter concept output to the last 24 hours (a concept command may return more). */
+function withinLast24h(result: unknown, field: 'closedAt' | 'mergedAt'): unknown {
+  if (!result || !Array.isArray(result)) return result;
+  const cutoff = Date.now() - DAY_MS;
+  return (result as Array<Record<string, string | undefined>>).filter(
+    item => item[field] && new Date(item[field] as string).getTime() >= cutoff,
   );
 }
 
@@ -229,21 +239,62 @@ export async function fetchRecentMergedPRs(
   // Full ISO-8601 timestamp (seconds precision), not a bare date — same
   // GitHub bare-date `>` day-exclusion bug as fetchRecentlyClosed.
   // `merged:>$CODEV_SINCE_DATE` against a precise timestamp is exact.
-  const since = new Date(Date.now() - 24 * 60 * 60 * 1000)
-    .toISOString().replace(/\.\d{3}Z$/, 'Z');
   const result = await executeForgeCommand('recently-merged', {
-    CODEV_SINCE_DATE: since,
+    CODEV_SINCE_DATE: sinceTimestamp24h(),
   }, {
     cwd,
     forgeConfig,
   });
-  if (!result || !Array.isArray(result)) return result as ForgePR[] | null;
+  return withinLast24h(result, 'mergedAt') as ForgePR[] | null;
+}
 
-  // Filter to last 24 hours (concept command may return more)
-  const cutoff = Date.now() - 24 * 60 * 60 * 1000;
-  return (result as ForgePR[]).filter(
-    pr => pr.mergedAt && new Date(pr.mergedAt).getTime() >= cutoff,
-  );
+// =============================================================================
+// Overview fetches (#1645) — keep the failure so the cache can tell a rate
+// limit from a missing CLI, and know which backend each concept spends on.
+// =============================================================================
+
+export type OverviewConcept = 'pr-list' | 'issue-list' | 'recently-closed' | 'recently-merged' | 'user-identity';
+
+/** Resolved backend key for an overview concept in `cwd` (see `resolveForgeBackend`). */
+export function overviewBackend(concept: OverviewConcept, cwd: string): string | null {
+  return resolveForgeBackend(concept, { cwd });
+}
+
+/** Run one overview concept, post-processed exactly like its `fetch*` counterpart. */
+export async function fetchForOverview(concept: OverviewConcept, cwd: string): Promise<ForgeCommandResult> {
+  switch (concept) {
+    case 'user-identity': {
+      const r = await executeForgeCommandDetailed(concept, {}, { cwd, raw: true });
+      return { ...r, data: typeof r.data === 'string' && r.data.trim() ? r.data.trim() : null };
+    }
+    case 'recently-closed':
+    case 'recently-merged': {
+      const r = await executeForgeCommandDetailed(concept, { CODEV_SINCE_DATE: sinceTimestamp24h() }, { cwd });
+      return { ...r, data: withinLast24h(r.data, concept === 'recently-closed' ? 'closedAt' : 'mergedAt') };
+    }
+    default:
+      return executeForgeCommandDetailed(concept, {}, { cwd });
+  }
+}
+
+/**
+ * Ask gh for the GraphQL bucket's reset instant. `gh api rate_limit` is free
+ * (it spends no quota) but is known to misreport a healthy bucket, so callers
+ * only trust it when it agrees the budget is gone (`remaining === 0`).
+ */
+export function probeGhGraphqlRateLimit(_backend: string, cwd: string): Promise<RateLimitProbeResult | null> {
+  return new Promise(resolvePromise => {
+    execFile('gh', ['api', 'rate_limit', '--jq', '.resources.graphql'], { cwd, timeout: 15_000 }, (err, stdout) => {
+      if (err) return resolvePromise(null);
+      try {
+        const parsed = JSON.parse(stdout) as { remaining?: unknown; reset?: unknown };
+        if (typeof parsed.remaining !== 'number' || typeof parsed.reset !== 'number') return resolvePromise(null);
+        resolvePromise({ remaining: parsed.remaining, resetAt: parsed.reset * 1000 });
+      } catch {
+        resolvePromise(null);
+      }
+    });
+  });
 }
 
 // =============================================================================

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -343,6 +343,15 @@ export interface OverviewData {
   feedbackMode: 'forward' | 'queue';
   /** Auto-detected GitHub login of the current user (via the user-identity forge concept). */
   currentUser?: string;
+  /**
+   * Issue #1645: why forge-backed sections (PRs, backlog, recently closed/merged)
+   * may be stale or empty. `rate-limited` = the backend's budget is exhausted and
+   * Tower has suspended fetches until `forgeResetAt`; `unavailable` = at least one
+   * section could not be fetched for another reason (CLI missing, offline).
+   */
+  forgeStatus?: 'ok' | 'rate-limited' | 'unavailable';
+  /** ISO instant the rate-limit suspension lifts; present only when `forgeStatus` is `rate-limited`. */
+  forgeResetAt?: string;
   errors?: { prs?: string; issues?: string };
 }
 


### PR DESCRIPTION
Fixes #1645

Rebuild lane per the architect's prescription on the issue (supersedes #1646). Scope is the six frozen items; the doctor budget check, the single-query collapse (#1647), manual escape (#1648) and workspace-scoped invalidation (#1650) are out.

## Problem

Tower's `OverviewCache` never cached a failed forge fetch, so once `gh` started failing every 2.5 s dashboard poll re-spawned all four list commands. Healthy, it still cost 4 GraphQL calls × N workspaces every 30 s. Measured on the production Tower during investigation: ~2 `gh` spawns/s, and the real GraphQL bucket (from `gh api graphql -i` headers) at 1,420 points used five minutes into the window while `gh api rate_limit` reported `used: 0`.

## Root cause

- `overview.ts`: `if (data !== null) cache.set(...)` — failures uncached.
- `forge.ts`: `executeForgeCommand` collapsed every failure to `null`; nothing could tell "rate limited" from "gh missing".
- No single-flight; concurrent pollers each started a batch.
- `invalidate()` (porch after every mutating command, VS Code, cleanup) cleared every cache for every workspace.

## Fix

1. **Negative cache with backoff** — per `<workspace>:<budget>` window, 60 s doubling per *elapsed window* to 15 min. Four parallel failures share one window.
2. **Rate-limit suspension per resolved backend** — `resolveForgeBackend` keys by the executable's lowercased basename (`gh` for `/usr/local/bin/gh`; a Linear workspace's `pr-list` keys `gh`), provider for generic transports (`curl`) and custom script paths. `ForgeRateLimiter` suspends the budget until the reset from one advisory `gh api rate_limit` probe (trusted only when it reports `remaining === 0`, because it misreports a healthy bucket) or 15 min. `user-identity`/`auth-status` on `gh` are their own budget (`gh:rest`) in every direction. Only a success dispatched strictly after the suspension began clears it.
3. **Single-flight** per `<workspace>:<concept>`, identity-checked cleanup.
4. **TTLs** 180 s lists / 600 s searches / 3600 s identity. `invalidate()` stamps an epoch honoured only by positive open-list entries, debounced 60 s per entry (so per workspace); never touches a suspension, a cached failure, or the search/identity caches.
5. **Payload** `forgeStatus: 'ok' | 'rate-limited' | 'unavailable'` + `forgeResetAt`; error text names the real backend. Dashboard shows a banner (rendered in Chromium via Playwright against an intercepted `/api/overview`).
6. **Scripts** — `# forge-executable:` on the 8 scripts whose first line is a builtin (gitlab/issue-search, 7 linear); `github/pr-list` no longer pipes gh into jq (POSIX sh has no pipefail, so a rate-limited gh looked like a successful empty list).

Also: `executeForgeCommandDetailed` resolves config *inside* its try, so a malformed `.codev/config.json` no longer reaches tower-server's `unhandledRejection` → `process.exit(1)`.

## Tests

New: `overview-rate-limit.test.ts` (10), `bugfix-1645-gh-quota.test.ts` (real `OverviewCache` + real forge scripts + fake permanently-rate-limited `gh` on PATH: 40 polls → 5 spawns, then 4 more only after the suspension lifts), `forge-rate-limit.test.ts` (6), 5 additions to `forge.test.ts`. Seven existing overview tests re-pinned to the new semantics with an injected clock.

### Pitfall tests verified failing with their guard removed

Process: HEAD committed and pushed; each guard patched in place, the named test run, the file restored from HEAD, tree confirmed clean.

| Prescribed test | Guard removed | Result |
|---|---|---|
| REST success (`user-identity`) does not clear a GraphQL suspension | `budgetKeyFor` REST split | RED |
| REST failure does not suspend the GraphQL backend | `budgetKeyFor` REST split | RED |
| REST success does not reset the GraphQL backoff | failure window keyed by budget | RED |
| `invalidate()` clears neither a suspension nor the search/identity caches | invalidate() epoch-only | RED |
| Sustained invalidation, two workspaces: ≤ debounced ceiling | 60 s debounce | RED |
| … and A's invalidations don't suppress B's | per-entry (per-workspace) debounce vs global scalar | RED |
| 40 polls at 2.5 s against a rate-limited gh: one batch then zero | suspension gate | RED |
| Same, real `gh` harness | suspension gate | RED |
| Two pollers + invalidation mid-flight: one fetch per concept | single-flight | RED |
| Linear `pr-list` suspends `gh`, not `linear` | backend by executable | RED |
| Later credible probe with an earlier reset shortens the suspension | honour earlier reset | RED |
| Healthy probe reading ignored | `remaining === 0` credibility | RED |
| Same-tick success does not clear (strict `>`) | strict comparison | RED |
| No built-in provider resolves to a shell builtin | `# forge-executable:` declaration | RED |
| `github/pr-list` propagates gh's exit status | jq pipe removed | RED |
| Negative cache (failure cached for the window) | failure `cache.set` | RED |

Not red-able: the identity check on single-flight cleanup. In this design `invalidate()` never touches the in-flight map, so no path can register a newer flight while an older one is still registered; the check is two lines of defence, stated here rather than covered by a test that would have to introduce the race.

## Checks

- `pnpm --filter @cluesmith/codev build`, then full suite: 288 files, 5,767 passed, 48 skipped, 0 failed.
- `tsc --noEmit` clean for packages/codev, packages/types, apps/web.
- Production diff (excluding tests and the thread log): 448+ / 125− across 17 files.

## Acceptance (architect's amended criteria)

- Zero further `gh` spawns while rate-limited: harness test above.
- ≤ 50 % of the GraphQL budget at 13 watched workspaces: 4 concepts at 180/180/600/600 s = 52 calls/h per workspace → 676/h at 13; single-flight and the negative cache hold that under churn; invalidation ceiling 132/h per workspace (2 lists × 60/h + 2 searches × 6/h).
- Single-flight: pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JccuXX8YQhT57jC69X82ax
