### PR TITLE
Fix #1641: default the claude consult lane to the 1M context window

### DIFF
--- a/codev-skeleton/resources/commands/consult.md
+++ b/codev-skeleton/resources/commands/consult.md
@@ -43,12 +43,18 @@ consult -m codex --model-id gpt-5.6-sol --prompt "Review this design"
 |-------|-------|---------|--------------------------|-------|
 | `gemini` | `pro` | Antigravity CLI (`agy`) | *(agy's own default — no pinned id)* | Agentic file access (`--sandbox --add-dir`), OAuth/subscription login. Skips non-blockingly if `agy` is missing/unauthed. |
 | `codex` | `gpt` | @openai/codex | `gpt-5.6-sol` (medium reasoning effort) | Read-only sandbox, thorough |
-| `claude` | `opus` | Claude Agent SDK | `claude-opus-5` | Balanced analysis with tool use |
+| `claude` | `opus` | Claude Agent SDK | `claude-opus-5[1m]` | 1M context window with tool use |
 | `hermes` | - | hermes CLI (`hermes chat -q`) | *(hermes' own default)* | Uses Hermes agent as consult backend |
 
 > **The codex lane's `-sol` suffix is load-bearing.** Plain `gpt-5.6` and `gpt-5.6-codex` are both
 > rejected by Codex when running on a ChatGPT account (`The '<id>' model is not supported when
 > using Codex with a ChatGPT account.`). Don't "simplify" the id — a unit test pins it.
+
+The Claude default explicitly selects the 1M context window. Older Agent SDK runtimes budget
+the bare `claude-opus-5` id at 200K. Configured model ids are passed unchanged; to request extended
+context in an override, use `"claude-opus-5[1m]"` (quote it in shell commands). See
+[Claude's extended-context documentation](https://code.claude.com/docs/en/model-config#extended-context)
+for model and account availability. `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` still disables 1M context.
 
 ### Cost reporting
 
@@ -78,7 +84,7 @@ either without touching a checked-in file.
 
 | Axis | Key | Answers |
 |------|-----|---------|
-| *Which model* a lane runs | `consult.models` | "run `claude-opus-5` on the claude lane" |
+| *Which model* a lane runs | `consult.models` | "run `claude-opus-5[1m]` on the claude lane" |
 | *Which lanes* run at all | `porch.consultation.*` | "review PIR with two lanes, not three" |
 
 ### `consult.models`
@@ -87,7 +93,7 @@ Per-lane model id. Absent → the shipped default in the [Models](#models) table
 single invocation by [`--model-id`](#model-selection-options).
 
 ```json
-{ "consult": { "models": { "claude": "claude-opus-5", "codex": "gpt-5.6-sol" } } }
+{ "consult": { "models": { "claude": "claude-opus-5[1m]", "codex": "gpt-5.6-sol" } } }
 ```
 
 Valid lanes: `claude`, `codex`, `gemini`. **`hermes` is rejected** — it is invoked as
@@ -207,8 +213,9 @@ offending key and the valid alternatives. Nothing falls back to a default on err
 | `reasoningEffort` | **Codev**, against a closed enum | Config load, before anything runs |
 | Model ids | **The provider** | When the lane runs |
 
-Codev checks a model id's *syntax* only (ASCII alphanumerics plus `. _ : / @ + -`, 1–200 characters,
-no leading punctuation) — never its existence. **There is no allowlist of model ids anywhere in
+Codev checks a model id's *syntax* only (ASCII alphanumerics plus `. _ : / @ + -`, an optional
+Claude `[1m]` suffix, 1–200 characters total, no leading punctuation) — never its existence.
+**There is no allowlist of model ids anywhere in
 Codev, by design**: a new model must work the day the provider ships it, without a Codev release.
 
 So a typo'd model id is not caught at config time. It reaches the backend, which rejects it; that

--- a/codev/projects/bugfix-1641-consult-m-claude-fails-with-pr/status.yaml
+++ b/codev/projects/bugfix-1641-consult-m-claude-fails-with-pr/status.yaml
@@ -11,4 +11,9 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-08T23:31:58.758Z'
-updated_at: '2026-09-08T23:38:21.319Z'
+updated_at: '2026-09-08T23:38:42.628Z'
+pr_history:
+  - phase: pr
+    pr_number: 1657
+    branch: builder/bugfix-1641
+    created_at: '2026-09-08T23:38:42.627Z'

--- a/codev/projects/bugfix-1641-consult-m-claude-fails-with-pr/status.yaml
+++ b/codev/projects/bugfix-1641-consult-m-claude-fails-with-pr/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1641
 title: consult-m-claude-fails-with-pr
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-08T23:31:58.758Z'
-updated_at: '2026-09-08T23:35:17.979Z'
+updated_at: '2026-09-08T23:38:21.319Z'

--- a/codev/projects/bugfix-1641-consult-m-claude-fails-with-pr/status.yaml
+++ b/codev/projects/bugfix-1641-consult-m-claude-fails-with-pr/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-1641
 title: consult-m-claude-fails-with-pr
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates:
@@ -11,4 +11,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-08T23:31:58.758Z'
-updated_at: '2026-09-08T23:31:58.759Z'
+updated_at: '2026-09-08T23:35:17.979Z'

--- a/codev/projects/bugfix-1641-consult-m-claude-fails-with-pr/status.yaml
+++ b/codev/projects/bugfix-1641-consult-m-claude-fails-with-pr/status.yaml
@@ -6,14 +6,16 @@ plan_phases: []
 current_plan_phase: null
 gates:
   pr:
-    status: pending
+    status: approved
+    approved_at: '2026-09-09T00:02:45.566Z'
 iteration: 1
 build_complete: false
 history: []
 started_at: '2026-09-08T23:31:58.758Z'
-updated_at: '2026-09-08T23:38:42.628Z'
+updated_at: '2026-09-09T00:02:45.566Z'
 pr_history:
   - phase: pr
     pr_number: 1657
     branch: builder/bugfix-1641
     created_at: '2026-09-08T23:38:42.627Z'
+pr_ready_for_human: false

--- a/codev/projects/bugfix-1641-consult-m-claude-fails-with-pr/status.yaml
+++ b/codev/projects/bugfix-1641-consult-m-claude-fails-with-pr/status.yaml
@@ -1,0 +1,14 @@
+id: bugfix-1641
+title: consult-m-claude-fails-with-pr
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates:
+  pr:
+    status: pending
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-09-08T23:31:58.758Z'
+updated_at: '2026-09-08T23:31:58.759Z'

--- a/codev/resources/commands/consult.md
+++ b/codev/resources/commands/consult.md
@@ -43,12 +43,18 @@ consult -m codex --model-id gpt-5.6-sol --prompt "Review this design"
 |-------|-------|---------|--------------------------|-------|
 | `gemini` | `pro` | Antigravity CLI (`agy`) | *(agy's own default — no pinned id)* | Agentic file access (`--sandbox --add-dir`), OAuth/subscription login. Skips non-blockingly if `agy` is missing/unauthed. |
 | `codex` | `gpt` | @openai/codex | `gpt-5.6-sol` (medium reasoning effort) | Read-only sandbox, thorough |
-| `claude` | `opus` | Claude Agent SDK | `claude-opus-5` | Balanced analysis with tool use |
+| `claude` | `opus` | Claude Agent SDK | `claude-opus-5[1m]` | 1M context window with tool use |
 | `hermes` | - | hermes CLI (`hermes chat -q`) | *(hermes' own default)* | Uses Hermes agent as consult backend |
 
 > **The codex lane's `-sol` suffix is load-bearing.** Plain `gpt-5.6` and `gpt-5.6-codex` are both
 > rejected by Codex when running on a ChatGPT account (`The '<id>' model is not supported when
 > using Codex with a ChatGPT account.`). Don't "simplify" the id — a unit test pins it.
+
+The Claude default explicitly selects the 1M context window. Older Agent SDK runtimes budget
+the bare `claude-opus-5` id at 200K. Configured model ids are passed unchanged; to request extended
+context in an override, use `"claude-opus-5[1m]"` (quote it in shell commands). See
+[Claude's extended-context documentation](https://code.claude.com/docs/en/model-config#extended-context)
+for model and account availability. `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` still disables 1M context.
 
 ### Cost reporting
 
@@ -78,7 +84,7 @@ either without touching a checked-in file.
 
 | Axis | Key | Answers |
 |------|-----|---------|
-| *Which model* a lane runs | `consult.models` | "run `claude-opus-5` on the claude lane" |
+| *Which model* a lane runs | `consult.models` | "run `claude-opus-5[1m]` on the claude lane" |
 | *Which lanes* run at all | `porch.consultation.*` | "review PIR with two lanes, not three" |
 
 ### `consult.models`
@@ -87,7 +93,7 @@ Per-lane model id. Absent → the shipped default in the [Models](#models) table
 single invocation by [`--model-id`](#model-selection-options).
 
 ```json
-{ "consult": { "models": { "claude": "claude-opus-5", "codex": "gpt-5.6-sol" } } }
+{ "consult": { "models": { "claude": "claude-opus-5[1m]", "codex": "gpt-5.6-sol" } } }
 ```
 
 Valid lanes: `claude`, `codex`, `gemini`. **`hermes` is rejected** — it is invoked as
@@ -207,8 +213,9 @@ offending key and the valid alternatives. Nothing falls back to a default on err
 | `reasoningEffort` | **Codev**, against a closed enum | Config load, before anything runs |
 | Model ids | **The provider** | When the lane runs |
 
-Codev checks a model id's *syntax* only (ASCII alphanumerics plus `. _ : / @ + -`, 1–200 characters,
-no leading punctuation) — never its existence. **There is no allowlist of model ids anywhere in
+Codev checks a model id's *syntax* only (ASCII alphanumerics plus `. _ : / @ + -`, an optional
+Claude `[1m]` suffix, 1–200 characters total, no leading punctuation) — never its existence.
+**There is no allowlist of model ids anywhere in
 Codev, by design**: a new model must work the day the provider ships it, without a Codev release.
 
 So a typo'd model id is not caught at config time. It reaches the backend, which rejects it; that

--- a/codev/state/bugfix-1641_thread.md
+++ b/codev/state/bugfix-1641_thread.md
@@ -208,3 +208,37 @@ It also found something that corrected **my** narrative, which is worth recordin
    `e339b399f`. Resolved.
 
 CI on head `e339b399f`: **all 7 checks pass**.
+
+## Architect disposition of the CMAP advisories (PR #1657 comment 5593577902)
+
+Four of Claude's advisory assertions are false. I verified each before correcting the
+record; the architect was right on all four. **No seeded-file change** — this supersedes
+the two items I had referred upward, both of which rested on false premises.
+
+1. **Disable-context — WITHDRAWN.** The reviewer claimed that with
+   `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` a concrete id keeps `[1m]` on the wire. False:
+   `UT(q) = q.replace(/\[(1|2)m\]/gi,"")` takes no argument but the id, consults neither
+   `ZG()` nor the env var, and its call site is an unguarded
+   `beta.messages.create({...P, model: UT(P.model)})`. The strip is unconditional, so the
+   marker never reaches the wire either way. The shipped doc line needs no fix.
+2. **Pricing — WITHDRAWN.** I had imported "premium >200K input pricing" into the PR body
+   from the review. Anthropic documents standard model pricing for the 1M window. Replaced
+   with the accurate note: longer reviews can consume more total tokens, and the
+   `maxBudgetUsd: 25` per-consultation cap is unchanged.
+3. **`consult stats` split — WITHDRAWN.** `MetricsDB.summary()` groups by `model` (the
+   lane) at `metrics.ts:371`, not `model_id`. Recorded concrete ids change as intended, but
+   lane totals do not split. Verified by reading the query.
+4. **Runtime packaging — CORRECTED.** My own phrasing ("a runtime-resolved binary this repo
+   does not pin") implied an arbitrary, unversioned system CLI. It is not: 0.2.141 pins
+   every `@anthropic-ai/claude-agent-sdk-<platform>` optional dependency to exactly
+   `0.2.141`, and SDK resolution locates that package's binary. The 0.2.105-JS /
+   0.2.141-native layout distinction is real; both are SDK-distributed and version-locked.
+
+The lesson repeats itself in a third variation. I was careful with the seeded patch and the
+SDK internals, then relayed a reviewer's advisory claims into the PR body without applying
+the same standard — the same shortcut that produced the gemini and the 0.2.141 errors. A
+reviewer's summary is evidence, not ground truth, exactly like an issue's prose or a
+plan's claims.
+
+Retaining the corrected PR summary rather than the reviewer's generated PR_SUMMARY, which
+repeats the original overclaims.

--- a/codev/state/bugfix-1641_thread.md
+++ b/codev/state/bugfix-1641_thread.md
@@ -6,36 +6,43 @@ Base commit: `c4ad613fcda59ad4c996eb59c66794a80e57e7c2`.
 ## Investigate
 
 Reproduced the failure mechanism from evidence rather than by burning subscription
-quota on another 5-minute review: the two saved failing sessions cited in the
-architect's prior investigation show 29 and 51 tool calls with last-successful
-input of 174,521 and 175,930 tokens respectively, then `Prompt is too long`. That
-is a context-window ceiling at ~200K, not an oversized opening prompt. (The
-opening prompt for `--protocol pir --type impl --project-id 1481` inlines
-spec 2.5K + plan 34K ≈ 10K tokens — nowhere near a limit.)
+quota on another 5-minute review.
+
+**What the five attempts actually show** (corrected after architect review — see below):
+four of the five ended in `Prompt is too long`; the third builder-side attempt hit a
+separate subscription usage limit and is not evidence of this bug. The two saved failing
+sessions show 29 and 51 tool calls with last-successful inputs of 174,521 and 175,930
+tokens before the error. That is accumulated review-context exhaustion surfacing as
+`Prompt is too long` — it does not establish where the request was refused, nor that
+every changed file was read in full. It is not an oversized opening prompt: the opening
+prompt for `--protocol pir --type impl --project-id 1481` inlines spec 2.5K + plan 34K,
+roughly 10K tokens.
 
 Root cause, verified against the actual source and the bundled runtime:
 
 1. `packages/codev/src/commands/consult/index.ts:419` —
    `DEFAULT_CLAUDE_MODEL = 'claude-opus-5'` (a bare id, no context suffix).
-2. The Agent SDK bundles a Claude Code runtime whose context budget is
-   `function jk(q,K){ ... if(ZG(q))return 1e6; ... return qh1}` with
-   `qh1=200000` and `ZG(q)=/\[1m\]/i.test(q)`. A bare `claude-opus-5` is
-   therefore budgeted at **200,000** tokens; `claude-opus-5[1m]` at
-   **1,000,000**. Confirmed by inspecting the bundled `cli.js` in
-   `@anthropic-ai/claude-agent-sdk@0.2.105` (the checkout's locked version);
-   the installed 0.2.141 behaves the same.
+2. The Agent SDK's bundled runtime derives the context budget from the model id. Its
+   window function `jk(q,K)` has four branches — a `DISABLE_COMPACT` +
+   `CLAUDE_CODE_MAX_CONTEXT_TOKENS` env override, `ZG(q)` (the `[1m]` suffix),
+   `K?.includes(jo)&&UT1(q)` (beta header), and `TV8(q)` (gated, requires
+   `sonnet-4-6`) — before falling through to `qh1 = 200000`. So there is **no** universal
+   "1M with a suffix, 200K otherwise" rule. The scoped, verified fact is narrower:
+   under SDK **0.2.105** (this repo's lockfile) and **0.2.141** (the installed build),
+   bare `claude-opus-5` budgets **200,000** and `claude-opus-5[1m]` budgets **1,000,000**.
 3. `runClaudeConsultation` gives the lane `allowedTools: ['Read','Glob','Grep']`
-   and `maxTurns: 200`, so an impl/integration review of a 41-file PR reads
-   dozens of files and accumulates past 200K → the API returns
-   `Prompt is too long`.
+   and `maxTurns: 200`, so a review of a 41-file PR accumulates context until the 200K
+   budget is exhausted.
 4. `packages/codev/src/lib/consult-lanes.ts:77` —
    `MODEL_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,199}$/` rejects `[` and `]`,
    so **no user could work around it** via `consult.models.claude` or
    `--model-id claude-opus-5[1m]`. That is why the failure was unrecoverable
-   across 5 attempts and 2 callers.
+   across the attempts rather than merely inconvenient.
 
-Why gemini and codex were unaffected: different backends, different context
-budgets — neither routes through the Agent SDK's model-id → window mapping.
+Other lanes against the same target: **codex** completed (239.4s, `REQUEST_CHANGES`).
+**gemini** did *not* review — I opened its 358-byte artifact and it is a non-blocking
+skip notice (`Gemini lane skipped — agy exited with code 1`), so it is no evidence the
+target was reviewable either.
 
 Scope: 8 files, +68/−25. Comfortably inside BUGFIX's ~300 LOC ceiling.
 
@@ -74,3 +81,83 @@ Verification:
 - Only production consumer of `MODEL_ID_RE` is `validateModelId` — blast radius contained.
 
 Fix is 8 files, +68/−25. Well inside BUGFIX's ~300 LOC ceiling.
+
+## PR
+
+PR **#1657** — https://github.com/cluesmith/codev/pull/1657 (branch `builder/bugfix-1641`).
+Recorded with `porch done bugfix-1641 --pr 1657 --branch builder/bugfix-1641`.
+
+Porch's own phase checks passed: build 13.2s, tests 28.6s.
+
+CMAP note: the first dispatch of all three lanes failed identically with
+`Multiple projects found: …` — from a builder worktree `consult` still needs
+`--project-id` when the repo carries many project directories. Re-dispatched as
+`consult -m <lane> --protocol bugfix --type pr --project-id bugfix-1641 --output …`.
+Not a finding against this PR; noting it because the porch PR-phase prompt's
+example omits the flag.
+
+### CMAP verdicts (PR #1657)
+
+- **gemini** — `APPROVE`, confidence HIGH, KEY_ISSUES: None (49.1s). Independently
+  re-derived the regex against every boundary case and reached the same results I did.
+  Noted that `/i` is a no-op on the character class (both cases already listed) and
+  affects only the `\[1m\]` suffix — which is the intent. Not a defect.
+- **codex** — `APPROVE`, confidence HIGH, KEY_ISSUES: None (148.0s). No security or
+  scope concerns; called the validation boundaries and doc sync correct.
+- **claude** — pending. (This run is itself an end-to-end exercise of the fix: it goes
+  through the installed consult, which now carries the `[1m]` default.)
+
+## Narrative corrections (architect review, PR #1657 comment 5593490746)
+
+Three factual corrections to my review record. All three were right; none required a code
+change, and the eight seeded files are untouched. Applied to the PR body and to the
+Investigate section above.
+
+1. **Over-broad framing of the five attempts.** I wrote that the bug hit "any large
+   review" and implied all five attempts were context failures. Four were; the third
+   builder-side attempt was a subscription usage limit. Scoped to the observed repeated
+   failures on PR #1640.
+2. **Over-broad runtime claim.** I wrote that the SDK returns 1M "only when the id carries
+   a `[1m]` suffix, and 200K otherwise." The window function has four branches before the
+   200K fallback, so that is not universal. Rewritten as the narrower claim I actually
+   verified: bare `claude-opus-5` → 200K, `claude-opus-5[1m]` → 1M, under SDK 0.2.105
+   and 0.2.141.
+3. **Over-claimed mechanism.** I wrote that the model "reads its way past 200K and the API
+   rejects the request." The saved sessions establish substantial prior tool activity and
+   accumulated-context exhaustion surfacing as `Prompt is too long` — not a specific
+   client-vs-server rejection point, and not that all 41 files were read in full.
+
+The gemini correction is the one worth keeping: I asserted "gemini completed normally"
+straight from the issue text without opening the artifact. It is a 358-byte skip notice.
+That is exactly the `lessons-critical.md` line about verifying claims against the actual
+file rather than trusting a summary — and I had already applied that discipline to the
+seeded patch while skipping it on the issue's own prose.
+
+**Outstanding:** commit `b73c5d21d`'s message carries corrections 2 and 3 in its original
+wording. Correcting it means an amend + force-push, which would invalidate the seven green
+CI checks and the completed reviews. Flagged to the architect rather than decided here.
+
+## Architect integration review — disposition (PR #1657 comment 5593523517)
+
+Independent Claude integration review: **COMMENT**, 254.0s, no implementation blocker.
+The architect adjudicated its findings against the SDK rather than accepting them:
+
+1. **"`[1m]` reaches the provider as part of the model id" — rejected.** The reviewer
+   stopped at internal normalization (`X5`). I re-verified the architect's counter-evidence
+   in the locked SDK 0.2.105: `UT(q) = q.replace(/\[(1|2)m\]/gi, "")`, applied at
+   `beta.messages.create({...P, model: UT(P.model)})`, at `countTokens`, and on the bedrock
+   path. Internal normalization keeps the marker; request construction strips it. The
+   context budget and the beta header are separate effects. My PR statement was correct.
+2. **Account/provider availability — advisory, not demonstrated breakage.** Added the
+   explicit opt-out to the PR record as asked: `consult.models.claude: "claude-opus-5"`
+   retains the previous selection and 200K budget on the inspected runtimes, alongside
+   `--model-id` and `CLAUDE_CODE_DISABLE_1M_CONTEXT=1`. No automatic fallback and no
+   entitlement-policy change requested or made.
+3. **Version wording / reflow — non-blocking.** No rewrite of the seeded patch.
+
+Direction taken: correct the narrative in a **new commit**; do not amend or force-push
+`b73c5d21d` to revise historical wording. The corrected PR body and this committed
+narrative are the durable correction — which also resolves the decision I had referred
+upward. The seven green CI checks and completed reviews stay valid.
+
+All eight seeded files remain unchanged and still hash-match the handoff manifest.

--- a/codev/state/bugfix-1641_thread.md
+++ b/codev/state/bugfix-1641_thread.md
@@ -1,0 +1,76 @@
+# bugfix-1641 — `consult -m claude` fails with "Prompt is too long"
+
+Issue: #1641. Protocol: BUGFIX (strict). Branch: `builder/bugfix-1641`.
+Base commit: `c4ad613fcda59ad4c996eb59c66794a80e57e7c2`.
+
+## Investigate
+
+Reproduced the failure mechanism from evidence rather than by burning subscription
+quota on another 5-minute review: the two saved failing sessions cited in the
+architect's prior investigation show 29 and 51 tool calls with last-successful
+input of 174,521 and 175,930 tokens respectively, then `Prompt is too long`. That
+is a context-window ceiling at ~200K, not an oversized opening prompt. (The
+opening prompt for `--protocol pir --type impl --project-id 1481` inlines
+spec 2.5K + plan 34K ≈ 10K tokens — nowhere near a limit.)
+
+Root cause, verified against the actual source and the bundled runtime:
+
+1. `packages/codev/src/commands/consult/index.ts:419` —
+   `DEFAULT_CLAUDE_MODEL = 'claude-opus-5'` (a bare id, no context suffix).
+2. The Agent SDK bundles a Claude Code runtime whose context budget is
+   `function jk(q,K){ ... if(ZG(q))return 1e6; ... return qh1}` with
+   `qh1=200000` and `ZG(q)=/\[1m\]/i.test(q)`. A bare `claude-opus-5` is
+   therefore budgeted at **200,000** tokens; `claude-opus-5[1m]` at
+   **1,000,000**. Confirmed by inspecting the bundled `cli.js` in
+   `@anthropic-ai/claude-agent-sdk@0.2.105` (the checkout's locked version);
+   the installed 0.2.141 behaves the same.
+3. `runClaudeConsultation` gives the lane `allowedTools: ['Read','Glob','Grep']`
+   and `maxTurns: 200`, so an impl/integration review of a 41-file PR reads
+   dozens of files and accumulates past 200K → the API returns
+   `Prompt is too long`.
+4. `packages/codev/src/lib/consult-lanes.ts:77` —
+   `MODEL_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,199}$/` rejects `[` and `]`,
+   so **no user could work around it** via `consult.models.claude` or
+   `--model-id claude-opus-5[1m]`. That is why the failure was unrecoverable
+   across 5 attempts and 2 callers.
+
+Why gemini and codex were unaffected: different backends, different context
+budgets — neither routes through the Agent SDK's model-id → window mapping.
+
+Scope: 8 files, +68/−25. Comfortably inside BUGFIX's ~300 LOC ceiling.
+
+## Seeded fix
+
+Architect `main` instructed (2026-09-08T23:32Z) that a tested fix already exists
+and must be imported rather than rewritten:
+`/tmp/codev-1641-builder-handoff-bfow5fso/fix.patch`.
+
+Verified before accepting it:
+- `sha256 = 7c11c00c…33b21` matches `manifest.json`.
+- `git apply --check` clean against my HEAD.
+- Its base commit matches my branch base.
+- Re-derived the new `MODEL_ID_RE` behavior in node against all 15 cases the
+  new tests assert — accepted/rejected sets match exactly, including the
+  200-char total-length boundary (196+`[1m]` ok, 197+`[1m]` rejected) and
+  `opus\n` (JS `$` has no Perl trailing-newline exemption, so it is rejected).
+
+
+## Fix
+
+Imported the seeded patch in two steps so the regression was demonstrated, not asserted:
+
+1. Applied **test files only** (`git apply --include=…` × 4). Baseline run:
+   **13 failed / 345 passed** — `expected 'claude-opus-5' to be 'claude-opus-5[1m]'`
+   and `Invalid model id "claude-opus-5[1m]"` from `validateModelId`.
+2. Applied the **production + docs** files. Same command: **358 passed / 358**.
+
+Verification:
+- All 8 files hash-match `manifest.json` after apply (patch sha256 also matched).
+- `pnpm build` — passed. The 2 residual failures in the first post-fix run were
+  `resolveCodevFile` skeleton-fallback tests that need `copy-skeleton`; they
+  cleared once the build ran. Unrelated to this change.
+- Full `@cluesmith/codev` suite: **5754 passed, 48 skipped, 0 failed** (288 files).
+- `git diff --check` clean; `codev/` and `codev-skeleton/` consult.md byte-identical.
+- Only production consumer of `MODEL_ID_RE` is `validateModelId` — blast radius contained.
+
+Fix is 8 files, +68/−25. Well inside BUGFIX's ~300 LOC ceiling.

--- a/codev/state/bugfix-1641_thread.md
+++ b/codev/state/bugfix-1641_thread.md
@@ -161,3 +161,50 @@ narrative are the durable correction — which also resolves the decision I had 
 upward. The seven green CI checks and completed reviews stay valid.
 
 All eight seeded files remain unchanged and still hash-match the handoff manifest.
+
+## Final CMAP verdicts (PR #1657)
+
+All three lanes returned. **gemini APPROVE/HIGH**, **codex APPROVE/HIGH**,
+**claude APPROVE/HIGH** (750.4s) — no blocking issues from any lane.
+
+Claude's review was the substantive one. It independently confirmed the root cause, the
+regex (superset of the old pattern, ReDoS-safe, 200-char bound correct), and — the check
+I had not thought to make — that admitting `[` and `]` into a validated identifier opens
+no injection surface: the gemini lane passes the id through `spawn(bin, args)` as an argv
+element with no `shell: true`, and `computePersistentOutputPath` keys on the lane name,
+not the model id, so the suffix never reaches a filename.
+
+It also found something that corrected **my** narrative, which is worth recording:
+
+- I wrote that the mechanism was "verified against the bundled runtime in SDK 0.2.105 and
+  0.2.141". That is wrong for 0.2.141 — **it has no bundled runtime**. 0.2.105 ships the
+  whole thing as `cli.js`; 0.2.141 is a thin client with no `[1m]` logic of its own that
+  delegates to a runtime-resolved native binary from
+  `@anthropic-ai/claude-agent-sdk-<platform>`. I had taken the 0.2.141 half from the
+  handoff's investigation rather than checking it. Verified it myself now: the native
+  binary carries the identical gate `rG(H) = /\[1m\]/i.test(H)`, plus
+  `context-1m-2025-08-07` (4×) and `CLAUDE_CODE_DISABLE_1M_CONTEXT` (2×). The claim was
+  true; my description of *how* it was true was not. PR body corrected.
+- Consequence worth knowing, not a blocker: on 0.2.141+ the `[1m]` semantics live in a
+  runtime-resolved binary this repo does not pin (`^0.2.41` spans the architectural
+  shift). If the lane ever regresses to `Prompt is too long` again, check the installed
+  runtime version before the Codev source.
+
+### Claude's minor items — disposition
+
+1. **"Could not verify the suffix-strip claim."** Already adjudicated by the architect and
+   re-verified by me on *both* runtimes: `UT(q)` in 0.2.105 and `KL(H)` in the 0.2.141
+   native binary, both `replace(/\[(1|2)m\]/gi,"")`, applied at request construction. The
+   reviewer stopped at `X5` normalization, which re-attaches the marker. Not a defect;
+   the PR body now shows the evidence on both runtimes rather than asserting it.
+2. **`CLAUDE_CODE_DISABLE_1M_CONTEXT` nuance** (concrete ids keep the suffix on the wire
+   with no beta header; aliases are stripped). Doc line is incomplete, not wrong. Touching
+   it means editing a seeded doc file — referred to the architect, not done unilaterally.
+3. **Premium >200K pricing exposure.** Added a line to the PR body noting `maxBudgetUsd: 25`
+   still caps each consultation and that the exposure exists only where the lane previously
+   hard-failed. A line in shipped `consult.md` would need a seeded-file edit — referred up.
+4. **`consult stats` splits claude history across two model ids.** Cosmetic; noted, not fixed.
+5. **"25 uncommitted lines in the thread log."** True at review time; committed since in
+   `e339b399f`. Resolved.
+
+CI on head `e339b399f`: **all 7 checks pass**.

--- a/packages/codev/src/__tests__/consult-lanes.test.ts
+++ b/packages/codev/src/__tests__/consult-lanes.test.ts
@@ -72,6 +72,10 @@ describe('model id syntax (scenario 10)', () => {
   const accepted = [
     'claude-opus-4-6',
     'claude-opus-5',
+    'claude-opus-5[1m]',            // #1641: explicit extended context
+    'claude-opus-5[1M]',            // Claude treats the suffix case-insensitively
+    'opus[1m]',
+    'us.anthropic.claude-opus-5[1m]',
     'gpt-5.4',
     'gpt-5.6-sol',                  // #1288: the -sol suffix is load-bearing
     'us.anthropic.claude-opus-5',   // namespaced
@@ -110,6 +114,18 @@ describe('model id syntax (scenario 10)', () => {
     // The whole point: Codev never asserts a model does not exist.
     expect(() => validateModelId('totally-made-up-model-2099', 'consult.models.claude')).not.toThrow();
   });
+
+  it('counts the context suffix toward the 200-character limit (#1641)', () => {
+    expect(() => validateModelId('a'.repeat(200), 'consult.models.claude')).not.toThrow();
+    expect(() => validateModelId('a'.repeat(196) + '[1m]', 'consult.models.claude')).not.toThrow();
+    expect(() => validateModelId('a'.repeat(197) + '[1m]', 'consult.models.claude')).toThrow();
+  });
+
+  it.each(['[1m]', 'opus[1m]extra', 'opus[1m][1m]', 'opus[2m]', 'opus[', 'opus\n'])(
+    'rejects malformed context model id %j', (id) => {
+      expect(() => validateModelId(id, 'consult.models.claude')).toThrow();
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/codev/src/__tests__/consult.test.ts
+++ b/packages/codev/src/__tests__/consult.test.ts
@@ -549,7 +549,7 @@ describe('consult command', () => {
       expect(mockQueryFn).toHaveBeenCalledTimes(1);
       const callArgs = mockQueryFn.mock.calls[0][0];
       expect(callArgs.options.allowedTools).toEqual(['Read', 'Glob', 'Grep']);
-      expect(callArgs.options.model).toBe('claude-opus-5');
+      expect(callArgs.options.model).toBe('claude-opus-5[1m]');
       expect(callArgs.options.maxTurns).toBe(200);
       expect(callArgs.options.maxBudgetUsd).toBe(25);
       expect(callArgs.options.permissionMode).toBe('bypassPermissions');

--- a/packages/codev/src/commands/consult/__tests__/default-models.test.ts
+++ b/packages/codev/src/commands/consult/__tests__/default-models.test.ts
@@ -18,8 +18,8 @@ import {
  * CI-safe: no network, no model CLIs, no API calls.
  */
 describe('shipped consult lane defaults', () => {
-  it('pins the claude lane to claude-opus-5', () => {
-    expect(DEFAULT_CLAUDE_MODEL).toBe('claude-opus-5');
+  it('pins the claude lane to Opus 5 with the 1M context window (#1641)', () => {
+    expect(DEFAULT_CLAUDE_MODEL).toBe('claude-opus-5[1m]');
   });
 
   it('pins the codex lane to gpt-5.6-sol at medium reasoning effort', () => {

--- a/packages/codev/src/commands/consult/__tests__/lane-models.test.ts
+++ b/packages/codev/src/commands/consult/__tests__/lane-models.test.ts
@@ -112,11 +112,13 @@ describe('configured lane models reach the SDK (scenarios 1, 2)', () => {
     expect(mockStartThreadArgs?.model).toBe('gpt-5.6-sol');
   });
 
-  it('claude runs the configured model id', async () => {
-    writeConfig({ consult: { models: { claude: 'claude-opus-5' } } });
-    await runClaudeConsultation('q', 'role', tmpDir);
-    expect(mockClaudeOptions?.model).toBe('claude-opus-5');
-  });
+  it.each(['claude-opus-5', 'claude-opus-5[1m]', 'sonnet[1m]'])(
+    'claude passes configured model %s unchanged to the SDK', async (model) => {
+      writeConfig({ consult: { models: { claude: model } } });
+      await runClaudeConsultation('q', 'role', tmpDir);
+      expect(mockClaudeOptions?.model).toBe(model);
+    },
+  );
 
   it('codex runs the configured reasoning effort', async () => {
     writeConfig({ consult: { models: { codex: 'gpt-5.6-sol' }, reasoningEffort: { codex: 'high' } } });
@@ -159,7 +161,7 @@ describe('shipped defaults (Layer B — update this test when defaults change)',
     // #1288 landed on main mid-branch and changed both defaults. This is the ONE line the
     // two-layer design exists to make it — every other assertion reads the constants and needed
     // no edit. `default-models.test.ts` (from #1288) is the primary guard; this is the local one.
-    expect(DEFAULT_CLAUDE_MODEL).toBe('claude-opus-5');
+    expect(DEFAULT_CLAUDE_MODEL).toBe('claude-opus-5[1m]');
     expect(DEFAULT_CODEX_MODEL).toBe('gpt-5.6-sol');
     expect(DEFAULT_CODEX_REASONING_EFFORT).toBe('medium');
   });
@@ -180,6 +182,13 @@ describe('--model-id overrides config (scenario 12)', () => {
     const choice = resolveLaneModelChoice(tmpDir, 'claude', DEFAULT_CLAUDE_MODEL, 'claude-from-flag');
     await runClaudeConsultation('q', 'role', tmpDir, undefined, undefined, choice);
     expect(mockClaudeOptions?.model).toBe('claude-from-flag');
+  });
+
+  it('passes an explicit 1M context override to the Claude SDK (#1641)', async () => {
+    writeConfig({ consult: { models: { claude: 'claude-opus-5' } } });
+    const choice = resolveLaneModelChoice(tmpDir, 'claude', DEFAULT_CLAUDE_MODEL, 'claude-opus-5[1m]');
+    await runClaudeConsultation('q', 'role', tmpDir, undefined, undefined, choice);
+    expect(mockClaudeOptions?.model).toBe('claude-opus-5[1m]');
   });
 
   it('applies where no config exists at all', () => {

--- a/packages/codev/src/commands/consult/index.ts
+++ b/packages/codev/src/commands/consult/index.ts
@@ -415,8 +415,11 @@ export const DEFAULT_CODEX_MODEL = 'gpt-5.6-sol';
 /** Shipped default reasoning effort for the codex consult lane. */
 export const DEFAULT_CODEX_REASONING_EFFORT = 'medium' as const;
 
-/** Shipped default model id for the claude consult lane (#1288). */
-export const DEFAULT_CLAUDE_MODEL = 'claude-opus-5';
+/**
+ * Request the 1M window explicitly: older Agent SDK runtimes budget the bare
+ * Opus 5 id at 200K, causing large reviews to exhaust context (#1641).
+ */
+export const DEFAULT_CLAUDE_MODEL = 'claude-opus-5[1m]';
 
 interface CodexModelPricing {
   inputPer1M: number;

--- a/packages/codev/src/lib/consult-lanes.ts
+++ b/packages/codev/src/lib/consult-lanes.ts
@@ -63,8 +63,8 @@ export const VALID_LANE_NAMES = ['gemini', 'codex', 'claude', 'hermes'];
 export const SPECIAL_MODES = ['none', 'parent'] as const;
 
 /**
- * Model-id syntax. Deliberately permissive: ASCII alphanumerics plus `. _ : / @ + -`, 1–200 chars,
- * not starting with `-`.
+ * Model-id syntax. Deliberately permissive: ASCII alphanumerics plus `. _ : / @ + -`,
+ * with an optional Claude `[1m]` context suffix. 1–200 chars total, not starting with `-`.
  *
  * Covers the id conventions in use across providers — dotted/namespaced
  * (`us.anthropic.claude-opus-5`), vendor-prefixed (`openai/gpt-5.6`), tagged (`gpt-5.6:latest`),
@@ -74,7 +74,7 @@ export const SPECIAL_MODES = ['none', 'parent'] as const;
  * If a provider ever adopts a character outside this set, widen the class. That is a change to
  * SYNTAX (slow, safe) rather than to a catalog of IDS (stale immediately).
  */
-export const MODEL_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,199}$/;
+export const MODEL_ID_RE = /^(?=.{1,200}$)[A-Za-z0-9][A-Za-z0-9._:/@+-]*(?:\[1m\])?$/i;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -136,7 +136,8 @@ export function validateModelId(id: unknown, key: string): asserts id is string 
   if (!MODEL_ID_RE.test(id)) {
     fail(
       `Invalid model id ${JSON.stringify(id)} for ${key}${location}.\n` +
-      `Model ids must be 1-200 characters of letters, digits, and ". _ : / @ + -", ` +
+      `Model ids must be 1-200 characters total: letters, digits, and ". _ : / @ + -", ` +
+      `optionally followed by the Claude "[1m]" context suffix, ` +
       `and must not start with "-".\n` +
       `Note: Codev does not check whether a model exists — the provider does. This is a syntax error.`
     );


### PR DESCRIPTION
Fixes #1641

## The bug

`consult -m claude` failed repeatedly on PR #1640 (41 files, +4877/−110). Five attempts
across two independent callers — one architect-side (`--type integration`), four
builder-side (`--protocol pir --type impl`) — produced no claude review file, leaving
`porch next 1481` blocked on `Run remaining consultations (claude)`.

Four of those five ended in `Prompt is too long`; the third builder-side attempt hit a
separate subscription usage limit and is not evidence of this bug. Of the other lanes run
against the same target, **codex** completed (239.4s, `REQUEST_CHANGES`); **gemini** did
*not* review — its artifact is a non-blocking skip notice (`Gemini lane skipped — agy
exited with code 1`), so it is not evidence that the target was reviewable either.

## Root cause

The claude lane shipped the **bare** model id `claude-opus-5`.

The Agent SDK's bundled Claude Code runtime derives its context budget from the model id.
Its window function has several branches — an env override, the `[1m]` suffix, a
beta-header branch, and a `sonnet-4-6`-gated branch — before falling through to a 200,000
default, so this is **not** a universal "1M with a suffix, 200K otherwise" rule. The scoped
fact that matters here, verified on both runtimes this repo runs against — **SDK 0.2.105**
(the lockfile version, which bundles the runtime as `cli.js`) and **0.2.141** (the globally
installed build, whose JS package is a thin client over a separately packaged native
runtime). Both layouts are SDK-distributed and version-locked: 0.2.141 pins every
`@anthropic-ai/claude-agent-sdk-<platform>` optional dependency to exactly `0.2.141`, and
SDK resolution locates that package's binary — it is not an arbitrary system CLI.

| Model id | Budget |
|---|---|
| `claude-opus-5` | 200,000 |
| `claude-opus-5[1m]` | 1,000,000 |

`runClaudeConsultation` runs the lane agentically — `allowedTools: ['Read','Glob','Grep']`,
`maxTurns: 200` — so a review of a PR this size accumulates review context until the 200K
budget is exhausted, which surfaces as `Prompt is too long`. The two saved failing sessions
show substantial prior tool activity before the error: 29 and 51 tool calls, with
last-successful inputs of 174,521 and 175,930 tokens. That establishes accumulated-context
exhaustion; it does not establish where exactly the request was refused, nor that every
changed file was read in full. It is not an oversized opening prompt — the opening prompt
for issue 1481 inlines a 2.5K spec and a 34K plan, roughly 10K tokens.

The second half of the bug is why it was *unrecoverable*: `MODEL_ID_RE` rejected `[` and
`]`, so neither `consult.models.claude` nor `--model-id claude-opus-5[1m]` could work
around it.

## The fix

- `DEFAULT_CLAUDE_MODEL` → `claude-opus-5[1m]`.
- `MODEL_ID_RE` accepts one optional, case-insensitive `[1m]` suffix. The 1–200 character
  bound now applies to the id **as a whole**, via a lookahead, so the suffix counts toward
  the limit rather than escaping it.
- Validator error message updated to describe the suffix.
- Consult docs updated and kept byte-identical across `codev/` and `codev-skeleton/`.

Explicitly configured model ids still pass through unchanged and `--model-id` still takes
precedence over config, so anyone pinning a bare id keeps today's behavior.

**Opt-out.** Setting `consult.models.claude: "claude-opus-5"` retains the previous
selection and its 200,000-token budget on the inspected runtimes. `--model-id
claude-opus-5` does the same for a single invocation, and
`CLAUDE_CODE_DISABLE_1M_CONTEXT=1` disables 1M context at the runtime level. There is no
automatic fallback and no change to entitlement policy: extended context depends on
model and account availability, which the shipped docs link to.

On cost: Anthropic documents standard model pricing for the 1M window, so this is not a
move into a premium tier. Longer reviews can consume more total tokens; the existing
`maxBudgetUsd: 25` per-consultation cap is unchanged.

**The suffix does not reach the provider.** Internal normalization (`X5`) re-attaches the
marker for concrete ids, so it is visible right up to the request — but the strip happens at
the API boundary itself, on **both** runtimes:

- 0.2.105 (`cli.js`): `UT(q) = q.replace(/\[(1|2)m\]/gi, "")`, applied at
  `beta.messages.create({...P, model: UT(P.model)})`, at `countTokens`, and on the bedrock path.
- 0.2.141 (native binary): the same function, minified as
  `KL(H) = H.replace(/\[(1|2)m\]/gi, "")`, applied as `model: KL(A.model)`.

The context budget and the `context-1m-2025-08-07` beta header are separate effects of the
suffix; the native binary carries that header (4 occurrences) and
`CLAUDE_CODE_DISABLE_1M_CONTEXT` alongside the same
`rG(H) = /\[1m\]/i.test(H)` gate.

8 files, +68/−25 (excluding the builder thread log).

## Regression evidence

The tests were applied **alone** first, against the unfixed production code:

| | Result |
|---|---|
| Test files only (no production fix) | **13 failed** / 345 passed |
| Full fix applied | **358 passed** / 358 |

Failures on baseline were exactly the expected ones —
`expected 'claude-opus-5' to be 'claude-opus-5[1m]'` and
`Invalid model id "claude-opus-5[1m]"` thrown from `validateModelId`.

Coverage: the shipped default, the SDK boundary (what actually reaches `options.model`),
configured ids including `[1m]`, `--model-id` override resolution, the 200-character
total-length boundary (196+`[1m]` accepted, 197+`[1m]` rejected), and malformed suffixes
(`[1m]` alone, `opus[1m]extra`, `opus[1m][1m]`, `opus[2m]`, `opus[`).

## Verification

- `pnpm build` — passed.
- Full `@cluesmith/codev` suite — **5754 passed, 48 skipped, 0 failed** (288 files).
- All 7 GitHub checks pass.
- `git diff --check` clean; the two `consult.md` copies verified byte-identical.
- `validateModelId` is the only production consumer of `MODEL_ID_RE`.
- Live confirmation (from the prior investigation, before this branch): with the `[1m]`
  default installed, the original PR #1640 review completed in 356.7s across 41 tool calls
  at 188,387 input tokens with no context error, and a separate bounded test processed
  **465,431 input tokens in a single request**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
