### PR TITLE
cron: deliver team-update only when the hour had events

### DIFF
--- a/.af-cron/team-update.yaml
+++ b/.af-cron/team-update.yaml
@@ -3,4 +3,5 @@ schedule: "0 * * * *"
 enabled: true
 command: "team update"
 timeout: 30
+condition: "exitCode == 0 && output.trim().length > 0"
 message: "team update: ${output}"


### PR DESCRIPTION
The `team update` command exits silently (exit 0, no output) when the last hour had no notable events. After PR #1643 added the required `message` field, the hourly cron began delivering an empty "team update:" line to the architect on every quiet hour.

This adds a `condition` so the message is delivered only when the command succeeded and produced output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)